### PR TITLE
Change apply_tx to accept a ShellParams containing wasm_dir

### DIFF
--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -116,17 +116,8 @@ where
                                     .expect(
                                         "Should be able to write to storage.",
                                     );
-                                let tx_result = protocol::apply_tx(
-                                    tx_type,
-                                    0, /*  this is used to compute the fee
-                                        * based on the code size. We dont
-                                        * need it here. */
-                                    &mut BlockGasMeter::default(),
-                                    &mut self.write_log,
-                                    &self.storage,
-                                    &mut self.vp_wasm_cache,
-                                    &mut self.tx_wasm_cache,
-                                );
+                                let tx_result =
+                                    protocol::apply_tx(tx_type, 0, self.into());
                                 self.storage
                                     .delete(&pending_execution_key)
                                     .expect(
@@ -342,16 +333,8 @@ where
                 },
             };
 
-            match protocol::apply_tx(
-                tx_type,
-                tx_length,
-                &mut self.gas_meter,
-                &mut self.write_log,
-                &self.storage,
-                &mut self.vp_wasm_cache,
-                &mut self.tx_wasm_cache,
-            )
-            .map_err(Error::TxApply)
+            match protocol::apply_tx(tx_type, tx_length, self.into())
+                .map_err(Error::TxApply)
             {
                 Ok(result) => {
                     if result.is_accepted() {

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -116,8 +116,13 @@ where
                                     .expect(
                                         "Should be able to write to storage.",
                                     );
-                                let tx_result =
-                                    protocol::apply_tx(tx_type, 0, self.into());
+                                let tx_result = protocol::apply_tx(
+                                    tx_type,
+                                    0, /* this is used to compute the fee
+                                        * based on the code size. We dont
+                                        * need it here. */
+                                    self.into(),
+                                );
                                 self.storage
                                     .delete(&pending_execution_key)
                                     .expect(


### PR DESCRIPTION
Taken from the [`bat/eth-header-vp`](https://github.com/anoma/anoma/pull/1224) branch of the anoma repo.

This will allow us to load wasms inside `apply_tx`, and we can use such a struct to test `apply_tx` as well.