### PR TITLE
Temporarily add validator address to vote extensions

### DIFF
--- a/apps/src/lib/node/ledger/shell/queries.rs
+++ b/apps/src/lib/node/ledger/shell/queries.rs
@@ -428,6 +428,7 @@ where
     /// address from storage using this hash.
     /// TODO: We may change how this lookup is done, see
     /// https://github.com/anoma/namada/issues/200
+    #[allow(dead_code)]
     pub fn get_validator_from_tm_address(
         &self,
         tm_address: &[u8],

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -18,16 +18,11 @@ mod extend_votes {
             &mut self,
             _req: request::ExtendVote,
         ) -> response::ExtendVote {
-            let validator_addr = match self.mode.get_validator_address() {
-                Some(validator_addr) => validator_addr.to_owned(),
-                None => {
-                    tracing::warn!(
-                        "couldn't get validator address, returning empty vote \
-                         extension"
-                    );
-                    return response::ExtendVote::default();
-                }
-            };
+            let validator_addr = self
+                .mode
+                .get_validator_address()
+                .expect("only validators should receive this method call")
+                .to_owned();
             let ext = VoteExtension {
                 block_height: self.storage.last_height + 1,
                 ethereum_events: self.new_ethereum_events(),

--- a/shared/src/types/ethereum_events/vote_extensions.rs
+++ b/shared/src/types/ethereum_events/vote_extensions.rs
@@ -19,6 +19,10 @@ use crate::types::storage::BlockHeight;
 pub struct VoteExtension {
     /// The block height for which this [`VoteExtension`] was made.
     pub block_height: BlockHeight,
+    /// The validator's address is temporarily being included
+    /// until we're able to map a Tendermint address to a validator
+    /// address (see https://github.com/anoma/namada/issues/200)
+    pub validator_addr: Address,
     /// The new ethereum events seen. These should be
     /// deterministically ordered.
     pub ethereum_events: Vec<EthereumEvent>,
@@ -26,10 +30,11 @@ pub struct VoteExtension {
 
 impl VoteExtension {
     /// Creates a [`VoteExtension`] without any Ethereum events.
-    pub fn empty(block_height: BlockHeight) -> Self {
+    pub fn empty(block_height: BlockHeight, validator_addr: Address) -> Self {
         Self {
             block_height,
             ethereum_events: Vec::new(),
+            validator_addr,
         }
     }
 
@@ -136,7 +141,7 @@ impl VoteExtensionDigest {
         let mut extensions = vec![];
 
         for (sig, addr) in signatures.into_iter() {
-            let mut ext = VoteExtension::empty(last_height);
+            let mut ext = VoteExtension::empty(last_height, addr.clone());
 
             for event in events.iter() {
                 if event.signers.contains(&addr) {
@@ -164,7 +169,7 @@ mod tests {
     use super::super::EthereumEvent;
     use super::*;
     use crate::proto::Signed;
-    use crate::types::address::Address;
+    use crate::types::address::{self, Address};
     use crate::types::ethereum_events::Uint;
     use crate::types::hash::Hash;
     use crate::types::key;
@@ -240,8 +245,11 @@ mod tests {
             transfers: vec![],
         };
 
-        let ext = {
-            let mut ext = VoteExtension::empty(last_block_height);
+        let validator_1 = address::testing::established_address_2();
+        let validator_2 = address::testing::established_address_2();
+
+        let ext = |validator: Address| -> VoteExtension {
+            let mut ext = VoteExtension::empty(last_block_height, validator);
 
             ext.ethereum_events.push(ev_1.clone());
             ext.ethereum_events.push(ev_2.clone());
@@ -252,16 +260,16 @@ mod tests {
 
         // assume both v1 and v2 saw the same events,
         // so each of them signs `ext` with their respective sk
-        let ext_1 = Signed::new(&sk_1, ext.clone());
-        let ext_2 = Signed::new(&sk_2, ext);
+        let ext_1 = Signed::new(&sk_1, ext(validator_1.clone()));
+        let ext_2 = Signed::new(&sk_2, ext(validator_2.clone()));
 
         let ext = vec![ext_1, ext_2];
 
         // we have the `Signed<VoteExtension>` instances we need,
         // let us now compress them into a single `VoteExtensionDigest`
         let signatures: Vec<(_, Address)> = vec![
-            (ext[0].sig.clone(), (&sk_1.ref_to()).into()),
-            (ext[1].sig.clone(), (&sk_2.ref_to()).into()),
+            (ext[0].sig.clone(), validator_1),
+            (ext[1].sig.clone(), validator_2),
         ];
         let signers = {
             let mut s = HashSet::new();

--- a/shared/src/types/ethereum_events/vote_extensions.rs
+++ b/shared/src/types/ethereum_events/vote_extensions.rs
@@ -267,7 +267,7 @@ mod tests {
 
         // we have the `Signed<VoteExtension>` instances we need,
         // let us now compress them into a single `VoteExtensionDigest`
-        let signatures: Vec<(_, Address)> = vec![
+        let signatures = vec![
             (ext[0].sig.clone(), validator_1),
             (ext[1].sig.clone(), validator_2),
         ];

--- a/shared/src/types/ethereum_events/vote_extensions.rs
+++ b/shared/src/types/ethereum_events/vote_extensions.rs
@@ -19,7 +19,7 @@ use crate::types::storage::BlockHeight;
 pub struct VoteExtension {
     /// The block height for which this [`VoteExtension`] was made.
     pub block_height: BlockHeight,
-    /// The validator's address is temporarily being included
+    /// TODO: the validator's address is temporarily being included
     /// until we're able to map a Tendermint address to a validator
     /// address (see https://github.com/anoma/namada/issues/200)
     pub validator_addr: Address,


### PR DESCRIPTION
Resolves https://github.com/anoma/namada/issues/208

`make test-unit-abci-plus-plus` passes, and I manually verified running a chain with `namadan` doesn't encounter the error from https://github.com/anoma/namada/pull/206 anymore