### PR TITLE
Save new Ethereum events to storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4430,6 +4430,7 @@ dependencies = [
  "namada",
  "namada_macros",
  "namada_tests",
+ "num-rational 0.4.1",
 ]
 
 [[package]]

--- a/shared/src/ledger/eth_bridge/storage.rs
+++ b/shared/src/ledger/eth_bridge/storage.rs
@@ -1,7 +1,6 @@
 //! storage helpers
 use super::vp::ADDRESS;
-use crate::types::hash::Hash;
-use crate::types::storage::{DbKeySeg, Key, KeySeg};
+use crate::types::storage::{Key, KeySeg};
 
 const QUEUE_STORAGE_KEY: &str = "queue";
 
@@ -12,60 +11,69 @@ pub fn queue_key() -> Key {
         .expect("Cannot obtain a storage key")
 }
 
-const ETH_MSGS_STORAGE_KEY: &str = "eth_msgs";
+// TODO: This module should live with the EthSentinel VP rather than
+// the EthBridge VP, as it is the EthSentinel VP which guards it
+/// Keys to do with the /eth_msgs storage subspace
+pub mod eth_msgs {
+    use crate::types::hash::Hash;
+    use crate::types::storage::{DbKeySeg, Key};
 
-/// Get the key corresponding to the /eth_msgs storage subspace
-pub fn eth_msgs_key() -> Key {
-    Key::from(DbKeySeg::StringSeg(ETH_MSGS_STORAGE_KEY.to_owned()))
-}
+    const ETH_MSGS_STORAGE_KEY: &str = "eth_msgs";
 
-/// Convenient way to generate /eth_msgs keys
-pub struct EthMsgKeys {
-    /// The prefix under which the keys for the EthMsg are stored
-    pub prefix: Key,
-}
-
-impl EthMsgKeys {
-    /// Create a new [`EthMsgKeys`] based on the hash
-    pub fn new(msg_hash: Hash) -> Self {
-        let hex = format!("{}", msg_hash);
-        let prefix = eth_msgs_key().push(&hex).expect(
-            "should always be able to construct prefix, given hex-encoded hash",
-        );
-        Self { prefix }
+    /// Get the key corresponding to the /eth_msgs storage subspace
+    pub fn eth_msgs_key() -> Key {
+        Key::from(DbKeySeg::StringSeg(ETH_MSGS_STORAGE_KEY.to_owned()))
     }
 
-    /// Get the `body` key for the given EthMsg
-    pub fn body(&self) -> Key {
-        self.prefix.push(&"body".to_owned()).unwrap()
+    /// Convenient way to generate /eth_msgs keys
+    pub struct EthMsgKeys {
+        /// The prefix under which the keys for the EthMsg are stored
+        pub prefix: Key,
     }
 
-    /// Get the `seen` key for the given EthMsg
-    pub fn seen(&self) -> Key {
-        self.prefix.push(&"seen".to_owned()).unwrap()
+    impl EthMsgKeys {
+        /// Create a new [`EthMsgKeys`] based on the hash
+        pub fn new(msg_hash: Hash) -> Self {
+            let hex = format!("{}", msg_hash);
+            let prefix = eth_msgs_key().push(&hex).expect(
+                "should always be able to construct prefix, given hex-encoded \
+                 hash",
+            );
+            Self { prefix }
+        }
+
+        /// Get the `body` key for the given EthMsg
+        pub fn body(&self) -> Key {
+            self.prefix.push(&"body".to_owned()).unwrap()
+        }
+
+        /// Get the `seen` key for the given EthMsg
+        pub fn seen(&self) -> Key {
+            self.prefix.push(&"seen".to_owned()).unwrap()
+        }
+
+        /// Get the `seen_by` key for the given EthMsg
+        pub fn seen_by(&self) -> Key {
+            self.prefix.push(&"seen_by".to_owned()).unwrap()
+        }
+
+        /// Get the `voting_power` key for the given EthMsg
+        pub fn voting_power(&self) -> Key {
+            self.prefix.push(&"voting_power".to_owned()).unwrap()
+        }
     }
 
-    /// Get the `seen_by` key for the given EthMsg
-    pub fn seen_by(&self) -> Key {
-        self.prefix.push(&"seen_by".to_owned()).unwrap()
-    }
+    // TODO: tests for EthMsgKeys
 
-    /// Get the `voting_power` key for the given EthMsg
-    pub fn voting_power(&self) -> Key {
-        self.prefix.push(&"voting_power".to_owned()).unwrap()
-    }
-}
+    #[cfg(test)]
+    mod test {
+        use super::*;
 
-// TODO: tests for EthMsgKeys
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_eth_msgs_key() {
-        assert!(
-            matches!(&eth_msgs_key().segments[..], [DbKeySeg::StringSeg(s)] if s == ETH_MSGS_STORAGE_KEY)
-        )
+        #[test]
+        fn test_eth_msgs_key() {
+            assert!(
+                matches!(&eth_msgs_key().segments[..], [DbKeySeg::StringSeg(s)] if s == ETH_MSGS_STORAGE_KEY)
+            )
+        }
     }
 }

--- a/shared/src/ledger/eth_bridge/storage.rs
+++ b/shared/src/ledger/eth_bridge/storage.rs
@@ -1,6 +1,7 @@
 //! storage helpers
 use super::vp::ADDRESS;
-use crate::types::storage::{Key, KeySeg};
+use crate::types::hash::Hash;
+use crate::types::storage::{DbKeySeg, Key, KeySeg};
 
 const QUEUE_STORAGE_KEY: &str = "queue";
 
@@ -9,4 +10,62 @@ pub fn queue_key() -> Key {
     Key::from(ADDRESS.to_db_key())
         .push(&QUEUE_STORAGE_KEY.to_owned())
         .expect("Cannot obtain a storage key")
+}
+
+const ETH_MSGS_STORAGE_KEY: &str = "eth_msgs";
+
+/// Get the key corresponding to the /eth_msgs storage subspace
+pub fn eth_msgs_key() -> Key {
+    Key::from(DbKeySeg::StringSeg(ETH_MSGS_STORAGE_KEY.to_owned()))
+}
+
+/// Convenient way to generate /eth_msgs keys
+pub struct EthMsgKeys {
+    /// The prefix under which the keys for the EthMsg are stored
+    pub prefix: Key,
+}
+
+impl EthMsgKeys {
+    /// Create a new [`EthMsgKeys`] based on the hash
+    pub fn new(msg_hash: Hash) -> Self {
+        let hex = format!("{}", msg_hash);
+        let prefix = eth_msgs_key().push(&hex).expect(
+            "should always be able to construct prefix, given hex-encoded hash",
+        );
+        Self { prefix }
+    }
+
+    /// Get the `body` key for the given EthMsg
+    pub fn body(&self) -> Key {
+        self.prefix.push(&"body".to_owned()).unwrap()
+    }
+
+    /// Get the `seen` key for the given EthMsg
+    pub fn seen(&self) -> Key {
+        self.prefix.push(&"seen".to_owned()).unwrap()
+    }
+
+    /// Get the `seen_by` key for the given EthMsg
+    pub fn seen_by(&self) -> Key {
+        self.prefix.push(&"seen_by".to_owned()).unwrap()
+    }
+
+    /// Get the `voting_power` key for the given EthMsg
+    pub fn voting_power(&self) -> Key {
+        self.prefix.push(&"voting_power".to_owned()).unwrap()
+    }
+}
+
+// TODO: tests for EthMsgKeys
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_eth_msgs_key() {
+        assert!(
+            matches!(&eth_msgs_key().segments[..], [DbKeySeg::StringSeg(s)] if s == ETH_MSGS_STORAGE_KEY)
+        )
+    }
 }

--- a/shared/src/ledger/eth_bridge/storage.rs
+++ b/shared/src/ledger/eth_bridge/storage.rs
@@ -77,7 +77,7 @@ pub mod eth_msgs {
         }
 
         #[test]
-        fn test_eth_msgs_keys() {
+        fn test_top_level_key() {
             assert!(
                 matches!(&top_level_key().segments[..], [DbKeySeg::StringSeg(s)] if s == TOP_LEVEL_KEY)
             )

--- a/shared/src/ledger/eth_bridge/storage.rs
+++ b/shared/src/ledger/eth_bridge/storage.rs
@@ -68,17 +68,71 @@ pub mod eth_msgs {
         }
     }
 
-    // TODO: tests for EthMsgKeys
-
     #[cfg(test)]
     mod test {
         use super::*;
 
+        fn arbitrary_hash_with_hex() -> (Hash, String) {
+            (Hash::sha256(b"arbitrary"), "87288D68ED71BF8FA35E531A1E56F3B3705FA0EEA54A2AA689B41694A8F83F5B".to_owned())
+        }
+
         #[test]
-        fn test_eth_msgs_key() {
+        fn test_eth_msgs_keys() {
             assert!(
                 matches!(&top_level_key().segments[..], [DbKeySeg::StringSeg(s)] if s == TOP_LEVEL_KEY)
             )
+        }
+
+        #[test]
+        fn test_eth_msgs_key_body() {
+            let (msg_hash, hex) = arbitrary_hash_with_hex();
+            let keys = EthMsgKeys::new(msg_hash);
+            let body_key = keys.body();
+            assert_eq!(
+                body_key.segments,
+                vec![
+                    DbKeySeg::StringSeg(TOP_LEVEL_KEY.to_owned()),
+                    DbKeySeg::StringSeg(hex),
+                    DbKeySeg::StringSeg(BODY_KEY.to_owned()),
+                ]
+            );
+        }
+
+        #[test]
+        fn test_eth_msgs_keys_all_keys() {
+            let (msg_hash, hex) = arbitrary_hash_with_hex();
+            let keys = EthMsgKeys::new(msg_hash);
+            let prefix = vec![
+                DbKeySeg::StringSeg(TOP_LEVEL_KEY.to_owned()),
+                DbKeySeg::StringSeg(hex),
+            ];
+            let body_key = keys.body();
+            assert_eq!(body_key.segments[..2], prefix[..]);
+            assert_eq!(
+                body_key.segments[2],
+                DbKeySeg::StringSeg(BODY_KEY.to_owned())
+            );
+
+            let seen_key = keys.seen();
+            assert_eq!(seen_key.segments[..2], prefix[..]);
+            assert_eq!(
+                seen_key.segments[2],
+                DbKeySeg::StringSeg(SEEN_KEY.to_owned())
+            );
+
+            let seen_by_key = keys.seen_by();
+            assert_eq!(seen_by_key.segments[..2], prefix[..]);
+            assert_eq!(
+                seen_by_key.segments[2],
+                DbKeySeg::StringSeg(SEEN_BY_KEY.to_owned())
+            );
+
+            let voting_power_key = keys.voting_power();
+            assert_eq!(voting_power_key.segments[..2], prefix[..]);
+            assert_eq!(
+                voting_power_key.segments[2],
+                DbKeySeg::StringSeg(VOTING_POWER_KEY.to_owned())
+            );
         }
     }
 }

--- a/shared/src/ledger/eth_bridge/storage.rs
+++ b/shared/src/ledger/eth_bridge/storage.rs
@@ -84,21 +84,6 @@ pub mod eth_msgs {
         }
 
         #[test]
-        fn test_eth_msgs_key_body() {
-            let (msg_hash, hex) = arbitrary_hash_with_hex();
-            let keys = EthMsgKeys::new(msg_hash);
-            let body_key = keys.body();
-            assert_eq!(
-                body_key.segments,
-                vec![
-                    DbKeySeg::StringSeg(TOP_LEVEL_KEY.to_owned()),
-                    DbKeySeg::StringSeg(hex),
-                    DbKeySeg::StringSeg(BODY_KEY.to_owned()),
-                ]
-            );
-        }
-
-        #[test]
         fn test_eth_msgs_keys_all_keys() {
             let (msg_hash, hex) = arbitrary_hash_with_hex();
             let keys = EthMsgKeys::new(msg_hash);

--- a/shared/src/ledger/eth_bridge/storage.rs
+++ b/shared/src/ledger/eth_bridge/storage.rs
@@ -18,14 +18,19 @@ pub mod eth_msgs {
     use crate::types::hash::Hash;
     use crate::types::storage::{DbKeySeg, Key};
 
-    const ETH_MSGS_STORAGE_KEY: &str = "eth_msgs";
+    const TOP_LEVEL_KEY: &str = "eth_msgs";
 
     /// Get the key corresponding to the /eth_msgs storage subspace
-    pub fn eth_msgs_key() -> Key {
-        Key::from(DbKeySeg::StringSeg(ETH_MSGS_STORAGE_KEY.to_owned()))
+    pub fn top_level_key() -> Key {
+        Key::from(DbKeySeg::StringSeg(TOP_LEVEL_KEY.to_owned()))
     }
 
-    /// Convenient way to generate /eth_msgs keys
+    const BODY_KEY: &str = "body";
+    const SEEN_KEY: &str = "seen";
+    const SEEN_BY_KEY: &str = "seen_by";
+    const VOTING_POWER_KEY: &str = "voting_power";
+
+    /// Handle for the storage space for a specific [`EthMsg`]
     pub struct EthMsgKeys {
         /// The prefix under which the keys for the EthMsg are stored
         pub prefix: Key,
@@ -35,7 +40,7 @@ pub mod eth_msgs {
         /// Create a new [`EthMsgKeys`] based on the hash
         pub fn new(msg_hash: Hash) -> Self {
             let hex = format!("{}", msg_hash);
-            let prefix = eth_msgs_key().push(&hex).expect(
+            let prefix = top_level_key().push(&hex).expect(
                 "should always be able to construct prefix, given hex-encoded \
                  hash",
             );
@@ -44,22 +49,22 @@ pub mod eth_msgs {
 
         /// Get the `body` key for the given EthMsg
         pub fn body(&self) -> Key {
-            self.prefix.push(&"body".to_owned()).unwrap()
+            self.prefix.push(&BODY_KEY.to_owned()).unwrap()
         }
 
         /// Get the `seen` key for the given EthMsg
         pub fn seen(&self) -> Key {
-            self.prefix.push(&"seen".to_owned()).unwrap()
+            self.prefix.push(&SEEN_KEY.to_owned()).unwrap()
         }
 
         /// Get the `seen_by` key for the given EthMsg
         pub fn seen_by(&self) -> Key {
-            self.prefix.push(&"seen_by".to_owned()).unwrap()
+            self.prefix.push(&SEEN_BY_KEY.to_owned()).unwrap()
         }
 
         /// Get the `voting_power` key for the given EthMsg
         pub fn voting_power(&self) -> Key {
-            self.prefix.push(&"voting_power".to_owned()).unwrap()
+            self.prefix.push(&VOTING_POWER_KEY.to_owned()).unwrap()
         }
     }
 
@@ -72,7 +77,7 @@ pub mod eth_msgs {
         #[test]
         fn test_eth_msgs_key() {
             assert!(
-                matches!(&eth_msgs_key().segments[..], [DbKeySeg::StringSeg(s)] if s == ETH_MSGS_STORAGE_KEY)
+                matches!(&top_level_key().segments[..], [DbKeySeg::StringSeg(s)] if s == TOP_LEVEL_KEY)
             )
         }
     }

--- a/shared/src/types/ethereum_events.rs
+++ b/shared/src/types/ethereum_events.rs
@@ -179,8 +179,7 @@ pub enum EthereumEvent {
 
 impl EthereumEvent {
     /// SHA256 of the Borsh serialization of the [`EthereumEvent`].
-    #[allow(dead_code)]
-    fn hash(&self) -> Result<Hash, std::io::Error> {
+    pub fn hash(&self) -> Result<Hash, std::io::Error> {
         let bytes = self.try_to_vec()?;
         Ok(Hash::sha256(&bytes))
     }

--- a/vm_env/Cargo.toml
+++ b/vm_env/Cargo.toml
@@ -24,6 +24,7 @@ namada = {path = "../shared", default-features = false}
 namada_macros = {path = "../macros"}
 borsh = "0.9.0"
 hex = "0.4.3"
+num-rational = "0.4.1"
 
 [dev-dependencies]
 namada_tests = {path = "../tests", default-features = false}

--- a/vm_env/src/eth_bridge_tx.rs
+++ b/vm_env/src/eth_bridge_tx.rs
@@ -93,7 +93,7 @@ pub fn apply_aux(tx_data: Vec<u8>) -> Result<(), Box<dyn Error>> {
             EthMsg {
                 body: update.body,
                 voting_power: fvp.into(),
-                seen_by: update.seen_by,
+                seen_by: update.seen_by.into_iter().collect(), /* this should result in a sorted vector as update.seen_by is a [`BTreeSet`] */
                 seen,
             }
         } else {

--- a/vm_env/src/eth_bridge_tx.rs
+++ b/vm_env/src/eth_bridge_tx.rs
@@ -1,15 +1,45 @@
 //! code that should be executed within a transaction
 use std::error::Error;
 
-use borsh::BorshDeserialize;
-use namada::types::ethereum_events::TxEthBridgeData;
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use namada::ledger::eth_bridge::storage::{self, EthMsgKeys};
+use namada::ledger::pos::types::VotingPower;
+use namada::types::address::Address;
+use namada::types::ethereum_events::{EthereumEvent, TxEthBridgeData};
+use num_rational::Ratio;
 
-use crate::imports::tx::log_string;
+use crate::imports::tx::{self, log_string};
+use crate::tx_prelude::{has_key, read};
 
 const TX_NAME: &str = "tx_eth_bridge";
 
 fn log(msg: impl AsRef<str>) {
     log_string(format!("[{}] {}", TX_NAME, msg.as_ref()))
+}
+
+fn threshold() -> Ratio<u64> {
+    Ratio::new(2, 3)
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
+pub struct EthMsg {
+    pub body: EthereumEvent,
+    pub voting_power: (u64, u64),
+    pub seen_by: Vec<Address>,
+    pub seen: bool,
+}
+
+fn write_eth_msg(eth_msg_keys: &EthMsgKeys, eth_msg: &EthMsg) {
+    log(format!("writing EthMsg - {:#?}", eth_msg));
+    tx::write(&eth_msg_keys.body().to_string(), &eth_msg.body);
+    tx::write(&eth_msg_keys.seen().to_string(), &eth_msg.seen);
+    tx::write(&eth_msg_keys.seen_by().to_string(), &eth_msg.seen_by);
+    tx::write(
+        &eth_msg_keys.voting_power().to_string(),
+        &eth_msg.voting_power,
+    );
 }
 
 pub fn apply(tx_data: Vec<u8>) {
@@ -31,6 +61,86 @@ pub fn apply_aux(tx_data: Vec<u8>) -> Result<(), Box<dyn Error>> {
         data.voting_powers,
     ));
 
+    let mut confirmed = vec![];
+    for update in data.updates {
+        let hash = update.body.hash()?;
+        let eth_msg_keys = storage::EthMsgKeys::new(hash);
+
+        // TODO: we arbitrarily look at whether the seen key is present to
+        // determine if the /eth_msg already exists in storage, but maybe there
+        // is a less arbitrary way to do this
+        let exists_in_storage = has_key(&eth_msg_keys.seen().to_string());
+
+        let eth_msg = if !exists_in_storage {
+            log(format!("New Ethereum event - {}", &eth_msg_keys.prefix));
+
+            // TODO: be careful for overflows
+            let seen_by_voting_power: VotingPower = update
+                .seen_by
+                .iter()
+                .map(|validator| data.voting_powers.get(validator).unwrap())
+                .fold(VotingPower::from(0), |acc, elem| acc + *elem);
+
+            let seen_by_voting_power: u64 = seen_by_voting_power.into();
+            let total_voting_power: u64 = data.total_voting_power.into();
+            let fvp: Ratio<u64> =
+                Ratio::new(seen_by_voting_power, total_voting_power);
+            let seen = fvp > threshold();
+            if seen {
+                confirmed.push(update.body.clone())
+            }
+            EthMsg {
+                body: update.body,
+                voting_power: fvp.into(),
+                seen_by: update.seen_by,
+                seen,
+            }
+        } else {
+            log(format!(
+                "Existing Ethereum event - {}",
+                &eth_msg_keys.prefix
+            ));
+            let body: Option<EthereumEvent> =
+                read(&eth_msg_keys.body().to_string());
+            if body.is_none() {
+                return Err("couldn't read body")?;
+            }
+            let seen: Option<bool> = read(&eth_msg_keys.seen().to_string());
+            if seen.is_none() {
+                return Err("couldn't read seen")?;
+            }
+            let seen_by: Option<Vec<Address>> =
+                read(&eth_msg_keys.seen_by().to_string());
+            if seen_by.is_none() {
+                return Err("couldn't read seen_by")?;
+            }
+            let voting_power: Option<(u64, u64)> =
+                read(&eth_msg_keys.voting_power().to_string());
+            if voting_power.is_none() {
+                return Err("couldn't read voting_power")?;
+            }
+            let eth_msg = EthMsg {
+                body: body.unwrap(),
+                voting_power: voting_power.unwrap(),
+                seen_by: seen_by.unwrap(),
+                seen: seen.unwrap(),
+            };
+            log(format!("read EthMsg - {:#?}", &eth_msg));
+            // TODO: apply the diff to eth_msg and return an updated eth_msg
+            // TODO: add to the confirmed vec if seen is going false -> true
+            eth_msg
+        };
+        write_eth_msg(&eth_msg_keys, &eth_msg);
+        if confirmed.is_empty() {
+            log("no events were newly confirmed");
+            return Ok(());
+        }
+        log(format!(
+            "events were newly confirmed - n = {}",
+            confirmed.len()
+        ));
+        // TODO: act on confirmed events
+    }
     Ok(())
 }
 
@@ -50,7 +160,6 @@ mod tests {
     use namada_tests::tx::tx_host_env;
 
     use super::*;
-
     #[test]
     fn test_apply_tx() {
         let sole_validator = address::testing::gen_established_address();
@@ -86,7 +195,9 @@ mod tests {
             panic!("apply_aux error: {:?}", err);
         }
         let env = tx_host_env::take();
+        // TODO: we should touch 4 keys for storage update
         assert_eq!(env.all_touched_storage_keys().len(), 0);
+        // TODO: check specific keys e.g. /eth_msg/$msg_hash/body
     }
 
     #[test]

--- a/vm_env/src/eth_bridge_tx.rs
+++ b/vm_env/src/eth_bridge_tx.rs
@@ -2,7 +2,8 @@
 use std::error::Error;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use namada::ledger::eth_bridge::storage::{self, EthMsgKeys};
+use namada::ledger::eth_bridge::storage::eth_msgs::EthMsgKeys;
+use namada::ledger::eth_bridge::storage::{self};
 use namada::ledger::pos::types::VotingPower;
 use namada::types::address::Address;
 use namada::types::ethereum_events::{EthereumEvent, TxEthBridgeData};
@@ -64,7 +65,7 @@ pub fn apply_aux(tx_data: Vec<u8>) -> Result<(), Box<dyn Error>> {
     let mut confirmed = vec![];
     for update in data.updates {
         let hash = update.body.hash()?;
-        let eth_msg_keys = storage::EthMsgKeys::new(hash);
+        let eth_msg_keys = storage::eth_msgs::EthMsgKeys::new(hash);
 
         // TODO: we arbitrarily look at whether the seen key is present to
         // determine if the /eth_msg already exists in storage, but maybe there

--- a/wasm/tx_template/Cargo.lock
+++ b/wasm/tx_template/Cargo.lock
@@ -1574,6 +1574,7 @@ dependencies = [
  "hex",
  "namada",
  "namada_macros",
+ "num-rational",
 ]
 
 [[package]]

--- a/wasm/vp_template/Cargo.lock
+++ b/wasm/vp_template/Cargo.lock
@@ -1566,6 +1566,7 @@ dependencies = [
  "hex",
  "namada",
  "namada_macros",
+ "num-rational",
 ]
 
 [[package]]

--- a/wasm/wasm_source/Cargo.lock
+++ b/wasm/wasm_source/Cargo.lock
@@ -1574,6 +1574,7 @@ dependencies = [
  "hex",
  "namada",
  "namada_macros",
+ "num-rational",
 ]
 
 [[package]]

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "hex",
  "namada",
  "namada_macros",
+ "num-rational",
 ]
 
 [[package]]


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/144

This PR adds logic to `tx_eth_bridge` such that the `/eth_msgs` storage subspace is updated appropriately when a new Ethereum event is seen. No actions are taken for confirmed events yet.