### PR TITLE
Handle vote extensions in ProcessProposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,6 +4261,7 @@ version = "0.7.0"
 dependencies = [
  "ark-serialize",
  "ark-std",
+ "assert_matches",
  "async-std",
  "async-trait",
  "base64 0.13.0",

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -152,6 +152,7 @@ websocket = "0.26.2"
 winapi = "0.3.9"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 namada = {path = "../shared", default-features = false, features = ["testing", "wasm-runtime"]}
 cargo-watch = "7.5.0"
 bit-set = "0.5.2"

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -134,7 +134,7 @@ pub enum ErrorCodes {
     InvalidOrder = 4,
     ExtraTxs = 5,
     Undecryptable = 6,
-    InvalidVoteExntension = 7,
+    InvalidVoteExtension = 7,
 }
 
 impl From<ErrorCodes> for u32 {

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -125,7 +125,7 @@ impl From<Error> for TxResult {
 /// The different error codes that the ledger may
 /// send back to a client indicating the status
 /// of their submitted tx
-#[derive(Debug, Clone, FromPrimitive, ToPrimitive, PartialEq)]
+#[derive(Debug, Copy, Clone, FromPrimitive, ToPrimitive, PartialEq)]
 pub enum ErrorCodes {
     Ok = 0,
     InvalidTx = 1,
@@ -135,6 +135,16 @@ pub enum ErrorCodes {
     ExtraTxs = 5,
     Undecryptable = 6,
     InvalidVoteExtension = 7,
+    // NOTE: keep these values in sync with
+    // [`ErrorCodes::is_recoverable`]
+}
+
+impl ErrorCodes {
+    /// Checks if the given [`ErrorCodes`] value is a protocol level error,
+    /// that can be recovered from at the finalize block stage.
+    pub const fn is_recoverable(self) -> bool {
+        (self as u32) <= 3
+    }
 }
 
 impl From<ErrorCodes> for u32 {
@@ -774,6 +784,19 @@ mod test_utils {
 
         let mut rng: ThreadRng = thread_rng();
         ed25519::SigScheme::generate(&mut rng).try_to_sk().unwrap()
+    }
+
+    /// Invalidate a valid signature `sig`.
+    pub(super) fn invalidate_signature(
+        sig: common::Signature,
+    ) -> common::Signature {
+        let mut sig_bytes = match sig {
+            common::Signature::Ed25519(ed25519::Signature(ref sig)) => {
+                sig.to_bytes()
+            }
+        };
+        sig_bytes[0] = sig_bytes[0].wrapping_add(1);
+        common::Signature::Ed25519(ed25519::Signature(sig_bytes.into()))
     }
 
     /// A wrapper around the shell that implements

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -195,7 +195,10 @@ mod prepare_block {
                     validator_voting_power,
                     total_voting_power,
                 )
-                .unwrap_or_default();
+                .expect(
+                    "The voting power we obtain from storage should always be \
+                     valid",
+                );
 
                 // register all ethereum events seen by `validator_addr`
                 for ev in vote_extension.data.ethereum_events {

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -355,21 +355,33 @@ mod prepare_block {
             // artificially change the block height
             shell.storage.last_height = LAST_HEIGHT;
 
-            let validator_addr = wallet::defaults::validator_address();
-
             let signed_vote_extension = {
-                // create a fake signature
-                let sig = common::Signature::Ed25519(ed25519::Signature(
-                    [0u8; 64].into(),
-                ));
+                let (protocol_key, _) = wallet::defaults::validator_keys();
+                let validator_addr = wallet::defaults::validator_address();
 
-                let data = VoteExtension {
+                // generate a valid signature
+                let mut ext = VoteExtension {
                     validator_addr,
                     block_height: LAST_HEIGHT,
                     ethereum_events: vec![],
+                }
+                .sign(&protocol_key);
+                assert!(ext.verify(&protocol_key.ref_to()).is_ok());
+
+                // modify this signature such that it becomes invalid
+                ext.sig = {
+                    let mut sig_bytes = match ext.sig {
+                        common::Signature::Ed25519(ed25519::Signature(
+                            ref sig,
+                        )) => sig.to_bytes(),
+                    };
+                    sig_bytes[0] = sig_bytes[0].wrapping_add(1);
+                    common::Signature::Ed25519(ed25519::Signature(
+                        sig_bytes.into(),
+                    ))
                 };
 
-                SignedExt { sig, data }
+                ext
             };
 
             check_vote_extension_filtering(&mut shell, signed_vote_extension);

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -283,7 +283,7 @@ mod prepare_block {
         use namada::types::address::xan;
         use namada::types::ethereum_events::vote_extensions::VoteExtension;
         use namada::types::ethereum_events::EthereumEvent;
-        use namada::types::key::{common, ed25519};
+        use namada::types::key::common;
         use namada::types::storage::{BlockHeight, Epoch};
         use namada::types::transaction::protocol::ProtocolTxType;
         use namada::types::transaction::{Fee, TxType};
@@ -369,18 +369,7 @@ mod prepare_block {
                 assert!(ext.verify(&protocol_key.ref_to()).is_ok());
 
                 // modify this signature such that it becomes invalid
-                ext.sig = {
-                    let mut sig_bytes = match ext.sig {
-                        common::Signature::Ed25519(ed25519::Signature(
-                            ref sig,
-                        )) => sig.to_bytes(),
-                    };
-                    sig_bytes[0] = sig_bytes[0].wrapping_add(1);
-                    common::Signature::Ed25519(ed25519::Signature(
-                        sig_bytes.into(),
-                    ))
-                };
-
+                ext.sig = test_utils::invalidate_signature(ext.sig);
                 ext
             };
 

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -88,13 +88,10 @@ mod prepare_block {
                     // handle genesis block
                     (None, BlockHeight(0)) => return vec![],
                     (Some(_), BlockHeight(0)) => {
-                        tracing::error!(
-                            "The genesis block should not contain vote \
-                             extensions"
-                        );
-                        // TODO: maybe slash validators who claim to have
-                        // seen vote extensions at H=0
-                        return vec![];
+                        unreachable!(
+                            "We already handle this scenario in \
+                             validate_vote_extension."
+                        )
                     }
                     // handle block heights > 0
                     (Some(digest), _) => digest,
@@ -652,7 +649,7 @@ mod prepare_block {
         /// Test if vote extension validation and inclusion in a block
         /// behaves as expected, considering <= 2/3 voting power.
         #[test]
-        #[should_panic(expected = "entered unreachable code")]
+        #[should_panic(expected = "Honest Namada validators")]
         fn test_prepare_proposal_vext_insufficient_voting_power() {
             const FIRST_HEIGHT: BlockHeight = BlockHeight(0);
             const LAST_HEIGHT: BlockHeight = BlockHeight(FIRST_HEIGHT.0 + 11);

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -15,7 +15,7 @@ mod prepare_block {
         ExtendedCommitInfo, ExtendedVoteInfo, TxRecord,
     };
 
-    use super::super::vote_extensions::SignedExt;
+    use super::super::vote_extensions::{SignedExt, VoteExtensionError};
     use super::super::*;
     use crate::node::ledger::shims::abcipp_shim_types::shim::TxBytes;
 
@@ -249,8 +249,12 @@ mod prepare_block {
         pub fn filter_invalid_vote_extensions_residuals(
             &self,
             vote_extensions: impl IntoIterator<Item = SignedExt> + 'static,
-        ) -> impl Iterator<Item = Option<(VotingPower, SignedExt)>> + '_
-        {
+        ) -> impl Iterator<
+            Item = core::result::Result<
+                (VotingPower, SignedExt),
+                VoteExtensionError,
+            >,
+        > + '_ {
             vote_extensions.into_iter().map(|vote_extension| {
                 self.validate_vote_ext_and_get_it_back(
                     vote_extension,
@@ -267,7 +271,7 @@ mod prepare_block {
             vote_extensions: impl IntoIterator<Item = SignedExt> + 'static,
         ) -> impl Iterator<Item = (VotingPower, SignedExt)> + '_ {
             self.filter_invalid_vote_extensions_residuals(vote_extensions)
-                .filter_map(|ext| ext)
+                .filter_map(|ext| ext.ok())
         }
     }
 

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -166,23 +166,14 @@ where
                                     .into(),
                             }
                         } else {
-                            // ```ignore
-                            // TxResult {
-                            //     code: ErrorCodes::InvalidVoteExntension. into(),
-                            //     info: " Process proposal rejected this \
-                            //            proposal because the backing stake of \
-                            //            the vote extensions published in the \
-                            //            proposal was insufficient"
-                            //         .into(),
-                            // }
-                            // ```
-                            //
-                            // TODO: is unreachable really fine?
-                            unreachable!(
-                                "We should never get an insufficient backing \
-                                 stake on vote extensions published in \
-                                 proposals."
-                            )
+                            TxResult {
+                                code: ErrorCodes::InvalidVoteExntension.into(),
+                                info: " Process proposal rejected this \
+                                       proposal because the backing stake of \
+                                       the vote extensions published in the \
+                                       proposal was insufficient"
+                                    .into(),
+                            }
                         }
                     } else {
                         // TODO: maybe return a summary of the reasons for

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -436,6 +436,32 @@ mod test_process_proposal {
         );
     }
 
+    fn check_rejected_digest(
+        shell: &mut TestShell,
+        vote_extension_digest: VoteExtensionDigest,
+        protocol_key: common::SecretKey,
+    ) {
+        let tx = ProtocolTxType::EthereumEvents(vote_extension_digest)
+            .sign(&protocol_key)
+            .to_bytes();
+        let request = ProcessProposal { txs: vec![tx] };
+        let response = if let Err(TestError::RejectProposal(resp)) =
+            shell.process_proposal(request)
+        {
+            if let [resp] = resp.as_slice() {
+                resp.clone()
+            } else {
+                panic!("Test failed")
+            }
+        } else {
+            panic!("Test failed")
+        };
+        assert_eq!(
+            response.result.code,
+            u32::from(ErrorCodes::InvalidVoteExntension)
+        );
+    }
+
     /// Test that if a proposal contains vote extensions with
     /// invalid validator signatures, we reject it.
     #[test]
@@ -480,25 +506,7 @@ mod test_process_proposal {
                 }],
             }
         };
-        let tx = ProtocolTxType::EthereumEvents(vote_extension_digest)
-            .sign(&protocol_key)
-            .to_bytes();
-        let request = ProcessProposal { txs: vec![tx] };
-        let response = if let Err(TestError::RejectProposal(resp)) =
-            shell.process_proposal(request)
-        {
-            if let [resp] = resp.as_slice() {
-                resp.clone()
-            } else {
-                panic!("Test failed")
-            }
-        } else {
-            panic!("Test failed")
-        };
-        assert_eq!(
-            response.result.code,
-            u32::from(ErrorCodes::InvalidVoteExntension)
-        );
+        check_rejected_digest(&mut shell, vote_extension_digest, protocol_key);
     }
 
     /// Test that if a proposal contains vote extensions with
@@ -542,25 +550,7 @@ mod test_process_proposal {
                 }],
             }
         };
-        let tx = ProtocolTxType::EthereumEvents(vote_extension_digest)
-            .sign(&protocol_key)
-            .to_bytes();
-        let request = ProcessProposal { txs: vec![tx] };
-        let response = if let Err(TestError::RejectProposal(resp)) =
-            shell.process_proposal(request)
-        {
-            if let [resp] = resp.as_slice() {
-                resp.clone()
-            } else {
-                panic!("Test failed")
-            }
-        } else {
-            panic!("Test failed")
-        };
-        assert_eq!(
-            response.result.code,
-            u32::from(ErrorCodes::InvalidVoteExntension)
-        );
+        check_rejected_digest(&mut shell, vote_extension_digest, protocol_key);
     }
 
     /// Test that if a proposal contains vote extensions with
@@ -606,25 +596,7 @@ mod test_process_proposal {
                 }],
             }
         };
-        let tx = ProtocolTxType::EthereumEvents(vote_extension_digest)
-            .sign(&protocol_key)
-            .to_bytes();
-        let request = ProcessProposal { txs: vec![tx] };
-        let response = if let Err(TestError::RejectProposal(resp)) =
-            shell.process_proposal(request)
-        {
-            if let [resp] = resp.as_slice() {
-                resp.clone()
-            } else {
-                panic!("Test failed")
-            }
-        } else {
-            panic!("Test failed")
-        };
-        assert_eq!(
-            response.result.code,
-            u32::from(ErrorCodes::InvalidVoteExntension)
-        );
+        check_rejected_digest(&mut shell, vote_extension_digest, protocol_key);
     }
 
     /// Test that if a wrapper tx is not signed, it is rejected

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -361,6 +361,7 @@ where
 mod test_process_proposal {
     use std::collections::{HashMap, HashSet};
 
+    use assert_matches::assert_matches;
     use borsh::BorshDeserialize;
     use namada::proto::SignedTxData;
     use namada::types::address::xan;
@@ -427,8 +428,8 @@ mod test_process_proposal {
             txs: vec![tx.clone(), tx],
         };
         let results = shell.process_proposal(request);
-        assert!(
-            matches!(results, Err(TestError::RejectProposal(s)) if s.len() == 2)
+        assert_matches!(
+            results, Err(TestError::RejectProposal(s)) if s.len() == 2
         );
     }
 

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -1,7 +1,7 @@
 //! Implementation of the ['VerifyHeader`], [`ProcessProposal`],
 //! and [`RevertProposal`] ABCI++ methods for the Shell
 use namada::types::ethereum_events::vote_extensions::FractionalVotingPower;
-use namada::types::transaction::protocol::{ProtocolTx, ProtocolTxType};
+use namada::types::transaction::protocol::ProtocolTxType;
 #[cfg(not(feature = "ABCI"))]
 use tendermint_proto::abci::response_process_proposal::ProposalStatus;
 #[cfg(not(feature = "ABCI"))]
@@ -48,8 +48,8 @@ where
             .collect();
 
         ResponseProcessProposal {
-            status: if vote_ext_digest_num <= 1
-                && tx_results.iter().any(|res| res.code > 3)
+            status: if vote_ext_digest_num > 1
+                || tx_results.iter().any(|res| res.code > 3)
             {
                 ProposalStatus::Reject as i32
             } else {
@@ -166,14 +166,23 @@ where
                                     .into(),
                             }
                         } else {
-                            TxResult {
-                                code: ErrorCodes::InvalidVoteExntension.into(),
-                                info: "Process proposal rejected this \
-                                       proposal because the backing stake of \
-                                       the vote extensions published in the \
-                                       proposal was insufficient"
-                                    .into(),
-                            }
+                            // ```ignore
+                            // TxResult {
+                            //     code: ErrorCodes::InvalidVoteExntension. into(),
+                            //     info: " Process proposal rejected this \
+                            //            proposal because the backing stake of \
+                            //            the vote extensions published in the \
+                            //            proposal was insufficient"
+                            //         .into(),
+                            // }
+                            // ```
+                            //
+                            // TODO: is unreachable really fine?
+                            unreachable!(
+                                "We should never get an insufficient backing \
+                                 stake on vote extensions published in \
+                                 proposals."
+                            )
                         }
                     } else {
                         TxResult {

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -95,7 +95,12 @@ where
         vote_ext_digest_num: &mut usize,
     ) -> TxResult {
         let maybe_tx = Tx::try_from(tx_bytes).map_or_else(
-            |_| {
+            |err| {
+                tracing::debug!(
+                    ?err,
+                    "couldn't deserialize transaction received during \
+                     PrepareProposal"
+                );
                 Err(TxResult {
                     code: ErrorCodes::InvalidTx.into(),
                     info: "The submitted transaction was not deserializable"

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -363,14 +363,15 @@ where
 /// are covered by the e2e tests.
 #[cfg(test)]
 mod test_process_proposal {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     use borsh::BorshDeserialize;
     use namada::proto::SignedTxData;
     use namada::types::address::xan;
     use namada::types::ethereum_events::vote_extensions::{
-        VoteExtension, VoteExtensionDigest,
+        MultiSignedEthEvent, VoteExtension, VoteExtensionDigest,
     };
+    use namada::types::ethereum_events::EthereumEvent;
     use namada::types::hash::Hash;
     use namada::types::key::*;
     use namada::types::storage::Epoch;
@@ -386,6 +387,7 @@ mod test_process_proposal {
     #[cfg(feature = "ABCI")]
     use tendermint_proto_abci::google::protobuf::Timestamp;
 
+    use super::super::vote_extensions::SignedExt;
     use super::*;
     #[cfg(not(feature = "ABCI"))]
     use crate::node::ledger::shell::test_utils::TestError;
@@ -431,6 +433,71 @@ mod test_process_proposal {
         let results = shell.process_proposal(request);
         assert!(
             matches!(results, Err(TestError::RejectProposal(s)) if s.len() == 2)
+        );
+    }
+
+    /// Test that if a proposal contains vote extensions with
+    /// invalid validator signatures, we reject it.
+    #[test]
+    fn test_drop_vext_digest_with_invalid_sigs() {
+        const LAST_HEIGHT: BlockHeight = BlockHeight(2);
+        let (mut shell, _, _) = test_utils::setup();
+        shell.storage.last_height = LAST_HEIGHT;
+        let (protocol_key, _) = wallet::defaults::validator_keys();
+        let vote_extension_digest = {
+            let addr = wallet::defaults::validator_address();
+            let ext = {
+                // create a fake signature
+                let sig = common::Signature::Ed25519(ed25519::Signature(
+                    [0u8; 64].into(),
+                ));
+
+                let data = VoteExtension {
+                    validator_addr: addr.clone(),
+                    block_height: LAST_HEIGHT,
+                    ethereum_events: vec![],
+                };
+
+                SignedExt { sig, data }
+            };
+            let event = EthereumEvent::TransfersToNamada {
+                nonce: 1u64.into(),
+                transfers: vec![],
+            };
+            VoteExtensionDigest {
+                signatures: {
+                    let mut s = HashMap::new();
+                    s.insert(addr.clone(), ext.sig);
+                    s
+                },
+                events: vec![MultiSignedEthEvent {
+                    event,
+                    signers: {
+                        let mut s = HashSet::new();
+                        s.insert(addr);
+                        s
+                    },
+                }],
+            }
+        };
+        let tx = ProtocolTxType::EthereumEvents(vote_extension_digest)
+            .sign(&protocol_key)
+            .to_bytes();
+        let request = ProcessProposal { txs: vec![tx] };
+        let response = if let Err(TestError::RejectProposal(resp)) =
+            shell.process_proposal(request)
+        {
+            if let [resp] = resp.as_slice() {
+                resp.clone()
+            } else {
+                panic!("Test failed")
+            }
+        } else {
+            panic!("Test failed")
+        };
+        assert_eq!(
+            response.result.code,
+            u32::from(ErrorCodes::InvalidVoteExntension)
         );
     }
 

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -446,6 +446,10 @@ mod test_process_proposal {
         let (protocol_key, _) = wallet::defaults::validator_keys();
         let vote_extension_digest = {
             let addr = wallet::defaults::validator_address();
+            let event = EthereumEvent::TransfersToNamada {
+                nonce: 1u64.into(),
+                transfers: vec![],
+            };
             let ext = {
                 // create a fake signature
                 let sig = common::Signature::Ed25519(ed25519::Signature(
@@ -455,14 +459,10 @@ mod test_process_proposal {
                 let data = VoteExtension {
                     validator_addr: addr.clone(),
                     block_height: LAST_HEIGHT,
-                    ethereum_events: vec![],
+                    ethereum_events: vec![event.clone()],
                 };
 
                 SignedExt { sig, data }
-            };
-            let event = EthereumEvent::TransfersToNamada {
-                nonce: 1u64.into(),
-                transfers: vec![],
             };
             VoteExtensionDigest {
                 signatures: {

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -83,7 +83,7 @@ where
     ///   3: Wasm runtime error
     ///   4: Invalid order of decrypted txs
     ///   5. More decrypted txs than expected
-    ///   6. A transaciton could not be decrypted
+    ///   6. A transaction could not be decrypted
     ///   7. An error in the vote extensions included in the proposal
     ///
     /// INVARIANT: Any changes applied in this method must be reverted if the

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -47,10 +47,19 @@ where
             })
             .collect();
 
+        // We should not have more than one `VoteExtensionDigest` in
+        // a proposal from some round's leader.
+        let too_many_vext_digests = vote_ext_digest_num > 1;
+
+        // Erroneous transactions were detected when processing
+        // the leader's proposal. We allow txs that do not
+        // deserialize properly, that have invalid signatures
+        // and that have invalid wasm code to reach FinalizeBlock.
+        // This is the reason behind that greater than three check.
+        let invalid_txs = tx_results.iter().any(|res| res.code > 3);
+
         ResponseProcessProposal {
-            status: if vote_ext_digest_num > 1
-                || tx_results.iter().any(|res| res.code > 3)
-            {
+            status: if too_many_vext_digests || invalid_txs {
                 ProposalStatus::Reject as i32
             } else {
                 ProposalStatus::Accept as i32

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -144,8 +144,8 @@ where
 
                     let extensions =
                         digest.decompress(self.storage.last_height);
-                    let filtered_extensions = self
-                        .filter_invalid_vote_extensions_residuals(extensions);
+                    let valid_extensions =
+                        self.validate_vote_extension_list(extensions);
 
                     let mut voting_power = FractionalVotingPower::default();
                     let total_power = {
@@ -156,7 +156,7 @@ where
                         u64::from(self.get_total_voting_power(epoch))
                     };
 
-                    if filtered_extensions.into_iter().all(|maybe_ext| {
+                    if valid_extensions.into_iter().all(|maybe_ext| {
                         maybe_ext
                             .map(|(power, _)| {
                                 voting_power += FractionalVotingPower::new(

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -128,13 +128,13 @@ where
                     let filtered_extensions = self
                         .filter_invalid_vote_extensions_residuals(extensions);
                     let mut voting_power = FractionalVotingPower::default();
-                    let epoch = self
-                        .storage
-                        .block
-                        .pred_epochs
-                        .get_epoch(BlockHeight(self.storage.last_height.0));
-                    let total_power =
-                        u64::from(self.get_total_voting_power(epoch));
+                    let total_power = {
+                        let epoch =
+                            self.storage.block.pred_epochs.get_epoch(
+                                BlockHeight(self.storage.last_height.0),
+                            );
+                        u64::from(self.get_total_voting_power(epoch))
+                    };
                     if filtered_extensions.into_iter().all(|maybe_ext| {
                         maybe_ext
                             .map(|(power, _)| {

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -391,8 +391,64 @@ mod test_process_proposal {
     #[cfg(not(feature = "ABCI"))]
     use crate::node::ledger::shell::test_utils::TestError;
     use crate::node::ledger::shell::test_utils::{
-        gen_keypair, ProcessProposal, TestShell,
+        self, gen_keypair, ProcessProposal, TestShell,
     };
+    use crate::wallet;
+
+    /// Test that if a proposal contains more than one `VoteExtensionDigest`,
+    /// we reject it.
+    #[test]
+    fn test_more_than_one_vext_digest_rejected() {
+        let (mut shell, _, _) = test_utils::setup();
+        let validator_addr = wallet::defaults::validator_address();
+        drop((shell, validator_addr));
+        /*
+        let tx = Tx::new(
+            "wasm_code".as_bytes().to_owned(),
+            Some("transaction data".as_bytes().to_owned()),
+        );
+        let wrapper = WrapperTx::new(
+            Fee {
+                amount: 0.into(),
+                token: xan(),
+            },
+            &keypair,
+            Epoch(0),
+            0.into(),
+            tx,
+            Default::default(),
+        );
+        let tx = Tx::new(
+            vec![],
+            Some(TxType::Wrapper(wrapper).try_to_vec().expect("Test failed")),
+        )
+        .to_bytes();
+        #[allow(clippy::redundant_clone)]
+        let request = ProcessProposal {
+            txs: vec![tx.clone()],
+        };
+
+        let response = if let [resp] = shell
+            .process_proposal(request)
+            .expect("Test failed")
+            .as_slice()
+        {
+            resp.clone()
+        } else {
+            panic!("Test failed")
+        };
+        assert_eq!(response.result.code, u32::from(ErrorCodes::InvalidSig));
+        assert_eq!(
+            response.result.info,
+            String::from("Wrapper transactions must be signed")
+        );
+        #[cfg(feature = "ABCI")]
+        {
+            assert_eq!(response.tx, tx);
+            assert!(shell.shell.storage.tx_queue.is_empty())
+        }
+        */
+    }
 
     /// Test that if a wrapper tx is not signed, it is rejected
     /// by [`process_proposal`].

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -165,7 +165,7 @@ where
                                 )
                                 .unwrap_or_default();
                             })
-                            .is_some()
+                            .is_ok()
                     }) {
                         if voting_power > FractionalVotingPower::TWO_THIRDS {
                             TxResult {
@@ -399,55 +399,53 @@ mod test_process_proposal {
     /// we reject it.
     #[test]
     fn test_more_than_one_vext_digest_rejected() {
-        let (mut shell, _, _) = test_utils::setup();
+        let (shell, _, _) = test_utils::setup();
         let validator_addr = wallet::defaults::validator_address();
         drop((shell, validator_addr));
-        /*
-        let tx = Tx::new(
-            "wasm_code".as_bytes().to_owned(),
-            Some("transaction data".as_bytes().to_owned()),
-        );
-        let wrapper = WrapperTx::new(
-            Fee {
-                amount: 0.into(),
-                token: xan(),
-            },
-            &keypair,
-            Epoch(0),
-            0.into(),
-            tx,
-            Default::default(),
-        );
-        let tx = Tx::new(
-            vec![],
-            Some(TxType::Wrapper(wrapper).try_to_vec().expect("Test failed")),
-        )
-        .to_bytes();
-        #[allow(clippy::redundant_clone)]
-        let request = ProcessProposal {
-            txs: vec![tx.clone()],
-        };
-
-        let response = if let [resp] = shell
-            .process_proposal(request)
-            .expect("Test failed")
-            .as_slice()
-        {
-            resp.clone()
-        } else {
-            panic!("Test failed")
-        };
-        assert_eq!(response.result.code, u32::from(ErrorCodes::InvalidSig));
-        assert_eq!(
-            response.result.info,
-            String::from("Wrapper transactions must be signed")
-        );
-        #[cfg(feature = "ABCI")]
-        {
-            assert_eq!(response.tx, tx);
-            assert!(shell.shell.storage.tx_queue.is_empty())
-        }
-        */
+        // let tx = Tx::new(
+        // "wasm_code".as_bytes().to_owned(),
+        // Some("transaction data".as_bytes().to_owned()),
+        // );
+        // let wrapper = WrapperTx::new(
+        // Fee {
+        // amount: 0.into(),
+        // token: xan(),
+        // },
+        // &keypair,
+        // Epoch(0),
+        // 0.into(),
+        // tx,
+        // Default::default(),
+        // );
+        // let tx = Tx::new(
+        // vec![],
+        // Some(TxType::Wrapper(wrapper).try_to_vec().expect("Test failed")),
+        // )
+        // .to_bytes();
+        // #[allow(clippy::redundant_clone)]
+        // let request = ProcessProposal {
+        // txs: vec![tx.clone()],
+        // };
+        //
+        // let response = if let [resp] = shell
+        // .process_proposal(request)
+        // .expect("Test failed")
+        // .as_slice()
+        // {
+        // resp.clone()
+        // } else {
+        // panic!("Test failed")
+        // };
+        // assert_eq!(response.result.code, u32::from(ErrorCodes::InvalidSig));
+        // assert_eq!(
+        // response.result.info,
+        // String::from("Wrapper transactions must be signed")
+        // );
+        // #[cfg(feature = "ABCI")]
+        // {
+        // assert_eq!(response.tx, tx);
+        // assert!(shell.shell.storage.tx_queue.is_empty())
+        // }
     }
 
     /// Test that if a wrapper tx is not signed, it is rejected

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -98,7 +98,7 @@ where
             |err| {
                 tracing::debug!(
                     ?err,
-                    "couldn't deserialize transaction received during \
+                    "Couldn't deserialize transaction received during \
                      PrepareProposal"
                 );
                 Err(TxResult {

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -133,15 +133,6 @@ where
                 ProtocolTxType::EthereumEvents(digest) => {
                     *vote_ext_digest_num += 1;
 
-                    if self.storage.last_height.0 == 0 {
-                        return TxResult {
-                            code: ErrorCodes::InvalidVoteExntension.into(),
-                            info: "No vote extensions should be included in \
-                                   block height 0"
-                                .into(),
-                        };
-                    }
-
                     let extensions =
                         digest.decompress(self.storage.last_height);
                     let filtered_extensions = self

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -165,9 +165,9 @@ where
                         }
                     } else {
                         TxResult {
-                            code: ErrorCodes::Ok.into(),
+                            code: ErrorCodes::InvalidVoteExntension.into(),
                             info: "Process proposal rejected this proposal \
-                                   because the at least on of the vote \
+                                   because at least one of the vote \
                                    extensions included was invalid."
                                 .into(),
                         }

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -173,7 +173,7 @@ where
                         } else {
                             TxResult {
                                 code: ErrorCodes::InvalidVoteExtension.into(),
-                                info: " Process proposal rejected this \
+                                info: "Process proposal rejected this \
                                        proposal because the backing stake of \
                                        the vote extensions published in the \
                                        proposal was insufficient"

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -501,6 +501,68 @@ mod test_process_proposal {
         );
     }
 
+    /// Test that if a proposal contains vote extensions with
+    /// invalid block heights, we reject it.
+    #[test]
+    fn test_drop_vext_digest_with_invalid_bheights() {
+        const LAST_HEIGHT: BlockHeight = BlockHeight(3);
+        const PRED_LAST_HEIGHT: BlockHeight = BlockHeight(LAST_HEIGHT.0 - 1);
+        let (mut shell, _, _) = test_utils::setup();
+        shell.storage.last_height = LAST_HEIGHT;
+        let (protocol_key, _) = wallet::defaults::validator_keys();
+        let vote_extension_digest = {
+            let addr = wallet::defaults::validator_address();
+            let event = EthereumEvent::TransfersToNamada {
+                nonce: 1u64.into(),
+                transfers: vec![],
+            };
+            let ext = {
+                let ext = VoteExtension {
+                    validator_addr: addr.clone(),
+                    block_height: PRED_LAST_HEIGHT,
+                    ethereum_events: vec![event.clone()],
+                }
+                .sign(&protocol_key);
+                assert!(ext.verify(&protocol_key.ref_to()).is_ok());
+                ext
+            };
+            VoteExtensionDigest {
+                signatures: {
+                    let mut s = HashMap::new();
+                    s.insert(addr.clone(), ext.sig);
+                    s
+                },
+                events: vec![MultiSignedEthEvent {
+                    event,
+                    signers: {
+                        let mut s = HashSet::new();
+                        s.insert(addr);
+                        s
+                    },
+                }],
+            }
+        };
+        let tx = ProtocolTxType::EthereumEvents(vote_extension_digest)
+            .sign(&protocol_key)
+            .to_bytes();
+        let request = ProcessProposal { txs: vec![tx] };
+        let response = if let Err(TestError::RejectProposal(resp)) =
+            shell.process_proposal(request)
+        {
+            if let [resp] = resp.as_slice() {
+                resp.clone()
+            } else {
+                panic!("Test failed")
+            }
+        } else {
+            panic!("Test failed")
+        };
+        assert_eq!(
+            response.result.code,
+            u32::from(ErrorCodes::InvalidVoteExntension)
+        );
+    }
+
     /// Test that if a wrapper tx is not signed, it is rejected
     /// by [`process_proposal`].
     #[test]

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -167,7 +167,7 @@ where
                             }
                         } else {
                             TxResult {
-                                code: ErrorCodes::InvalidVoteExntension.into(),
+                                code: ErrorCodes::InvalidVoteExtension.into(),
                                 info: " Process proposal rejected this \
                                        proposal because the backing stake of \
                                        the vote extensions published in the \
@@ -180,7 +180,7 @@ where
                         // dropping a vote extension. we have access to the
                         // motives in `filtered_extensions`
                         TxResult {
-                            code: ErrorCodes::InvalidVoteExntension.into(),
+                            code: ErrorCodes::InvalidVoteExtension.into(),
                             info: "Process proposal rejected this proposal \
                                    because at least one of the vote \
                                    extensions included was invalid."
@@ -449,7 +449,7 @@ mod test_process_proposal {
         };
         assert_eq!(
             response.result.code,
-            u32::from(ErrorCodes::InvalidVoteExntension)
+            u32::from(ErrorCodes::InvalidVoteExtension)
         );
     }
 

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -152,9 +152,7 @@ where
                             _ => false,
                         }
                     }) {
-                        if voting_power
-                            > FractionalVotingPower::new(2, 3).unwrap()
-                        {
+                        if voting_power > FractionalVotingPower::TWO_THIRDS {
                             TxResult {
                                 code: ErrorCodes::Ok.into(),
                                 info: "Process proposal accepted this \

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -163,7 +163,10 @@ where
                                     u64::from(power),
                                     total_power,
                                 )
-                                .unwrap_or_default();
+                                .expect(
+                                    "The voting power we obtain from storage \
+                                     should always be valid",
+                                );
                             })
                             .is_ok()
                     }) {

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -125,7 +125,7 @@ mod extend_votes {
             &self,
             ext: SignedExt,
             last_height: BlockHeight,
-        ) -> core::result::Result<(VotingPower, SignedExt), VoteExtensionError>
+        ) -> std::result::Result<(VotingPower, SignedExt), VoteExtensionError>
         {
             if ext.data.block_height != last_height {
                 let ext_height = ext.data.block_height;

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -11,16 +11,21 @@ mod extend_votes {
     pub type SignedExt = Signed<VoteExtension>;
 
     /// The error yielded from [`Shell::validate_vote_ext_and_get_it_back`].
+    #[derive(Error, Debug)]
     pub enum VoteExtensionError {
-        /// The vote extension has an unexpected block height.
+        #[error("The vote extension has an unexpected block height.")]
         UnexpectedBlockHeight,
-        /// The vote extension contains duplicate or non-sorted
-        /// Ethereum events.
+        #[error(
+            "The vote extension contains duplicate or non-sorted Ethereum \
+             events."
+        )]
         HaveDupesOrNonSorted,
-        /// The public key of the vote extension's associated validator
-        /// could not be found in storage.
+        #[error(
+            "The public key of the vote extension's associated validator \
+             could not be found in storage."
+        )]
         PubKeyNotInStorage,
-        /// The vote extension's signature is invalid.
+        #[error("The vote extension's signature is invalid.")]
         VerifySigFailed,
     }
 

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -13,6 +13,8 @@ mod extend_votes {
     /// The error yielded from [`Shell::validate_vote_ext_and_get_it_back`].
     #[derive(Error, Debug)]
     pub enum VoteExtensionError {
+        #[error("The vote extension was issued at block height 0.")]
+        IssuedAtGenesis,
         #[error("The vote extension has an unexpected block height.")]
         UnexpectedBlockHeight,
         #[error(
@@ -130,6 +132,10 @@ mod extend_votes {
                      different from the expected height {height}"
                 );
                 return Err(VoteExtensionError::UnexpectedBlockHeight);
+            }
+            if height.0 == 0 {
+                tracing::error!("Dropping vote extension issued at genesis");
+                return Err(VoteExtensionError::IssuedAtGenesis);
             }
             // verify if we have any duplicate Ethereum events,
             // and if these are sorted in ascending order

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -180,7 +180,7 @@ mod extend_votes {
         }
 
         /// Checks the channel from the Ethereum oracle monitoring
-        /// the fullnode and retrieves all VoteExtensionmessages sent.
+        /// the fullnode and retrieves all VoteExtension messages sent.
         pub fn new_ethereum_events(&mut self) -> Vec<EthereumEvent> {
             match &mut self.mode {
                 ShellMode::Validator {

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -231,7 +231,7 @@ mod extend_votes {
     }
 
     /// Given a `Vec` of [`ExtendedVoteInfo`], return an iterator over the
-    /// deserialized [`SignedExt`] instances.
+    /// ones we could deserialize to [`SignedExt`] instances.
     pub fn deserialize_vote_extensions(
         vote_extensions: Vec<ExtendedVoteInfo>,
     ) -> impl Iterator<Item = SignedExt> + 'static {

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -4,6 +4,7 @@ mod extend_votes {
     use namada::ledger::pos::namada_proof_of_stake::types::VotingPower;
     use namada::proto::Signed;
     use namada::types::ethereum_events::vote_extensions::VoteExtension;
+    use tendermint_proto::abci::ExtendedVoteInfo;
 
     use super::super::*;
 
@@ -194,6 +195,56 @@ mod extend_votes {
                 _ => vec![],
             }
         }
+
+        /// Takes a list of signed vote extensions,
+        /// and filters out invalid instances, returning
+        /// all residual values (including invalid vote
+        /// extensions).
+        #[inline]
+        pub fn filter_invalid_vote_extensions_residuals(
+            &self,
+            vote_extensions: impl IntoIterator<Item = SignedExt> + 'static,
+        ) -> impl Iterator<
+            Item = core::result::Result<
+                (VotingPower, SignedExt),
+                VoteExtensionError,
+            >,
+        > + '_ {
+            vote_extensions.into_iter().map(|vote_extension| {
+                self.validate_vote_ext_and_get_it_back(
+                    vote_extension,
+                    self.storage.last_height,
+                )
+            })
+        }
+
+        /// Takes a list of signed vote extensions,
+        /// and filters out invalid instances.
+        #[inline]
+        pub fn filter_invalid_vote_extensions(
+            &self,
+            vote_extensions: impl IntoIterator<Item = SignedExt> + 'static,
+        ) -> impl Iterator<Item = (VotingPower, SignedExt)> + '_ {
+            self.filter_invalid_vote_extensions_residuals(vote_extensions)
+                .filter_map(|ext| ext.ok())
+        }
+    }
+
+    /// Given a `Vec` of [`ExtendedVoteInfo`], return an iterator over the
+    /// deserialized [`SignedExt`] instances.
+    pub fn deserialize_vote_extensions(
+        vote_extensions: Vec<ExtendedVoteInfo>,
+    ) -> impl Iterator<Item = SignedExt> + 'static {
+        vote_extensions.into_iter().filter_map(|vote| {
+            SignedExt::try_from_slice(&vote.vote_extension[..])
+                .map_err(|err| {
+                    tracing::error!(
+                        ?err,
+                        "Failed to deserialize signed vote extension",
+                    );
+                })
+                .ok()
+        })
     }
 
     #[cfg(test)]

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -196,16 +196,16 @@ mod extend_votes {
             }
         }
 
-        /// Takes a list of signed vote extensions,
-        /// and filters out invalid instances, returning
-        /// all residual values (including invalid vote
-        /// extensions).
+        /// Takes an iterator over signed vote extensions,
+        /// and returns another iterator. The latter yields
+        /// valid vote extensions, or the reason why these
+        /// are invalid, in the form of a [`VoteExtensionError`].
         #[inline]
-        pub fn filter_invalid_vote_extensions_residuals(
+        pub fn validate_vote_extension_list(
             &self,
             vote_extensions: impl IntoIterator<Item = SignedExt> + 'static,
         ) -> impl Iterator<
-            Item = core::result::Result<
+            Item = std::result::Result<
                 (VotingPower, SignedExt),
                 VoteExtensionError,
             >,
@@ -225,7 +225,7 @@ mod extend_votes {
             &self,
             vote_extensions: impl IntoIterator<Item = SignedExt> + 'static,
         ) -> impl Iterator<Item = (VotingPower, SignedExt)> + '_ {
-            self.filter_invalid_vote_extensions_residuals(vote_extensions)
+            self.validate_vote_extension_list(vote_extensions)
                 .filter_map(|ext| ext.ok())
         }
     }

--- a/shared/src/types/ethereum_events/vote_extensions.rs
+++ b/shared/src/types/ethereum_events/vote_extensions.rs
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn test_fractional_voting_power_ord_eq() {
         assert!(
-            FractionalVotingPower::new(2, 3).unwrap()
+            FractionalVotingPower::TWO_THIRDS
                 > FractionalVotingPower::new(1, 4).unwrap()
         );
         assert!(

--- a/shared/src/types/ethereum_events/vote_extensions.rs
+++ b/shared/src/types/ethereum_events/vote_extensions.rs
@@ -323,10 +323,16 @@ mod tests {
 
         // finally, decompress the `VoteExtensionDigest` back into a
         // `Vec<Signed<VoteExtension>>`
-        let decompressed = digest
+        let mut decompressed = digest
             .decompress(last_block_height)
             .into_iter()
             .collect::<Vec<Signed<VoteExtension>>>();
+
+        // decompressing yields an arbitrary ordering of `VoteExtension`
+        // instances, which is fine
+        if decompressed[0].data.validator_addr != ext[0].data.validator_addr {
+            decompressed.swap(0, 1);
+        }
 
         assert_eq!(ext, decompressed);
         assert!(decompressed[0].verify(&sk_1.ref_to()).is_ok());


### PR DESCRIPTION
This PR implements handling vote extensions in ProcessProposal.

---

In ProcessProposal, each validator must check:

* All the signatures are valid
* All signatures came from an validator in the active validator set at the previous block height,
* The block height is correct,
* The sum of the stake of the validators in the contained vector is at least 2/3 of the total amount staked at the previous block height.