### PR TITLE
Reduce logging and transactions in eth-bridge-integration

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/mod.rs
@@ -139,10 +139,7 @@ pub mod eth_fullnode {
                 if let Err(error) = client.eth_syncing().await {
                     // This is very noisy and usually not interesting.
                     // Still can be very useful
-                    tracing::debug!(
-                        ?error,
-                        "Couldn't connect to Geth, will retry"
-                    );
+                    tracing::debug!(?error, "Couldn't check Geth sync status");
                 }
                 tokio::time::sleep(SLEEP_DUR).await;
             }

--- a/apps/src/lib/node/ledger/ethereum_node/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/mod.rs
@@ -132,11 +132,15 @@ pub mod eth_fullnode {
                     tracing::info!("Finished syncing");
                     break;
                 }
-                if let Err(e) = client.eth_syncing().await {
+                if let Err(error) = client.eth_syncing().await {
                     // This is very noisy and usually not interesting.
                     // Still can be very useful
-                    tracing::debug!("Error trying to connect to Geth: {:?}", e);
+                    tracing::debug!(
+                        ?error,
+                        "Couldn't connect to Geth, will retry"
+                    );
                 }
+                std::thread::sleep(std::time::Duration::from_secs(1));
             }
 
             let (abort_sender, receiver) = channel();

--- a/apps/src/lib/node/ledger/protocol/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/mod.rs
@@ -14,6 +14,7 @@ use namada::ledger::storage::{DBIter, Storage, StorageHasher, DB};
 use namada::ledger::treasury::TreasuryVp;
 use namada::proto::{self, Tx};
 use namada::types::address::{Address, InternalAddress};
+use namada::types::ethereum_events::vote_extensions::VoteExtensionDigest;
 use namada::types::storage;
 use namada::types::transaction::protocol::{ProtocolTx, ProtocolTxType};
 use namada::types::transaction::{DecryptedTx, TxResult, TxType, VpsResult};
@@ -157,9 +158,12 @@ where
             })
         }
         TxType::Protocol(ProtocolTx {
-            tx: ProtocolTxType::EthereumEvents(_),
+            tx:
+                ProtocolTxType::EthereumEvents(VoteExtensionDigest {
+                    events, ..
+                }),
             ..
-        }) => {
+        }) if !events.is_empty() => {
             tracing::debug!("Ethereum events received");
             let gas_used = block_gas_meter
                 .finalize_transaction()

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -203,7 +203,9 @@ impl EthereumReceiver {
                 new_events += 1;
             };
         }
-        tracing::debug!(n = new_events, "received Ethereum events");
+        if new_events > 0 {
+            tracing::info!(n = new_events, "received Ethereum events");
+        }
     }
 
     /// Get a copy of the queue


### PR DESCRIPTION
Some noise I've seen while testing eth bridge branches
- sleep between logging attempts to connect to `geth`
- don't log if no Ethereum events were received in vote extensions in the previous round (we also won't derive/apply a state update transaction either)
- make validators log only if they receive >=1 Ethereum events from their Ethereum node