### PR TITLE
scripts: revert change to package `git describe`

### DIFF
--- a/scripts/make-package.sh
+++ b/scripts/make-package.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION="$(git describe --tags)"
+VERSION="$(git describe --dirty --broken)"
 PLATFORM="$(uname -s)-$(uname -m)"
 PACKAGE_NAME="namada-${VERSION}-${PLATFORM}"
 BIN="namada namadac namadan namadaw"


### PR DESCRIPTION
This was mistakenly not rebased out of c8994d2 ('ci: move to github
actions'). There should never be lightweight tags on the CI-bearing
remote, so --tags is either a no-op or an error in CI, and it is
always an error locally if the local user uses a lightweight tag.

--broken is a useful safeguard for weird or inconsistent repository
states, and --dirty distinguishes things which are not exactly the
commit in question.