### PR TITLE
Allow the use of custom Ethereum JSON-RPC endpoint

### DIFF
--- a/apps/src/lib/config/ethereum.rs
+++ b/apps/src/lib/config/ethereum.rs
@@ -14,12 +14,15 @@ pub enum Mode {
     /// oracle is configured to listen for events from the Ethereum bridge
     /// smart contracts using this endpoint.
     Managed,
+    /// Do not run `geth`. The oracle will listen to the Ethereum JSON-RPC
+    /// endpoint as specified in the `oracle_rpc_endpoint` setting.
+    Remote,
     /// Do not start a managed `geth` subprocess. Instead of the oracle
     /// listening for events using a Ethereum JSON-RPC endpoint, an endpoint
     /// will be exposed by the ledger itself for submission of Borsh-
     /// serialized [`EthereumEvent`]s. Mostly useful for testing purposes.
     EventsEndpoint,
-    /// Do not run any components of the Ethereum bridge
+    /// Do not run any components of the Ethereum bridge.
     Off,
 }
 

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -132,11 +132,21 @@ async fn run_oracle_aux(oracle: Oracle) {
     // awaiting a certain number of confirmations
     let mut latest_block;
     let mut pending: Vec<PendingEvent> = Vec::new();
+    const SLEEP_DUR: std::time::Duration = std::time::Duration::from_secs(1);
     loop {
+        tokio::time::sleep(SLEEP_DUR).await;
         // update the latest block height
         latest_block = loop {
-            if let Ok(height) = oracle.eth_block_number().await {
-                break height;
+            match oracle.eth_block_number().await {
+                Ok(height) => break height,
+                Err(error) => {
+                    tracing::warn!(
+                        ?error,
+                        "Couldn't get the latest Ethereum block height, will \
+                         keep trying"
+                    );
+                    tokio::time::sleep(SLEEP_DUR).await;
+                }
             }
             if !oracle.connected() {
                 tracing::info!(
@@ -146,6 +156,7 @@ async fn run_oracle_aux(oracle: Oracle) {
                 return;
             }
         };
+        tracing::debug!(?latest_block, "Got latest Ethereum block height");
         // No blocks in existence yet with enough confirmations
         if Uint256::from(MIN_CONFIRMATIONS) > latest_block {
             if !oracle.connected() {

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -130,13 +130,12 @@ async fn run_oracle_aux(oracle: Oracle) {
     // Initialize our local state. This includes
     // the latest block height seen and a queue of events
     // awaiting a certain number of confirmations
-    let mut latest_block;
     let mut pending: Vec<PendingEvent> = Vec::new();
     const SLEEP_DUR: std::time::Duration = std::time::Duration::from_secs(1);
     loop {
         tokio::time::sleep(SLEEP_DUR).await;
         // update the latest block height
-        latest_block = loop {
+        let latest_block = loop {
             match oracle.eth_block_number().await {
                 Ok(height) => break height,
                 Err(error) => {

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -666,11 +666,13 @@ async fn start_ethereum_node(
     // Start the oracle for listening to Ethereum events
     let (eth_sender, eth_receiver) = mpsc::channel(ORACLE_CHANNEL_BUFFER_SIZE);
     let oracle = match config.ethereum.mode {
-        ethereum::Mode::Managed => ethereum_node::oracle::run_oracle(
-            ethereum_url,
-            eth_sender,
-            abort_sender,
-        ),
+        ethereum::Mode::Managed | ethereum::Mode::Remote => {
+            ethereum_node::oracle::run_oracle(
+                ethereum_url,
+                eth_sender,
+                abort_sender,
+            )
+        }
         ethereum::Mode::EventsEndpoint => {
             ethereum_node::test_tools::events_endpoint::serve(
                 eth_sender,


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/417 and https://github.com/anoma/namada/issues/464

This PR makes it so that the ledger will not start up `geth` if the `ledger.ethereum.mode = "Remote"`. The motivation for this PR is to be able to test the ledger more easily (with a separately managed `geth` process or some standin like `npx hardhat node`, or some remote Ethereum endpoint). I've manually tested using a separate `geth` process and passing envvars to override the appropriate config e.g.

```shell
# with npx hardhat node
export ANOMA_LEDGER__ETHEREUM__MODE='Remote'
target/debug/namadan ledger run
```