### PR TITLE
Changed hash-map to BiHashMap

### DIFF
--- a/.changelog/unreleased/improvements/1138-change-wallet-bihashmap.md
+++ b/.changelog/unreleased/improvements/1138-change-wallet-bihashmap.md
@@ -1,0 +1,4 @@
+- Allows simple retrival of aliases from addresses in the wallet without
+  the need for multiple hashmaps. This is the first step to improving the
+  UI if one wants to show aliases when fetching addresses from anoma wallet
+  ([#1138](https://github.com/anoma/anoma/pull/1138))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bech32",
+ "bimap",
  "bit-set",
  "blake2b-rs",
  "borsh",
@@ -795,6 +796,15 @@ name = "bech32"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+
+[[package]]
+name = "bimap"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
+dependencies = [
+ "serde 1.0.137",
+]
 
 [[package]]
 name = "bincode"

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -145,6 +145,7 @@ tracing-log = "0.1.2"
 tracing-subscriber = {version = "0.3.7", features = ["env-filter"]}
 websocket = "0.26.2"
 winapi = "0.3.9"
+bimap = {version = "0.6.2", features = ["serde"]}
 
 [dev-dependencies]
 anoma = {path = "../shared", default-features = false, features = ["testing", "wasm-runtime"]}

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -188,6 +188,10 @@ pub async fn query_balance(ctx: Context, args: args::QueryBalance) {
                         for (key, balance) in balances {
                             let owner =
                                 token::is_any_token_balance_key(&key).unwrap();
+                            let owner = match ctx.wallet.find_alias(owner) {
+                                Some(alias) => format!("{}", alias),
+                                None => format!("{}", owner),
+                            };
                             writeln!(w, "  {}, owned by {}", balance, owner)
                                 .unwrap();
                         }

--- a/apps/src/lib/wallet/mod.rs
+++ b/apps/src/lib/wallet/mod.rs
@@ -285,6 +285,11 @@ impl Wallet {
         self.store.find_address(alias)
     }
 
+    /// Find an alias by the address if it's in the wallet.
+    pub fn find_alias(&self, address: &Address) -> Option<&Alias> {
+        self.store.find_alias(address)
+    }
+
     /// Get all known addresses by their alias, paired with PKH, if known.
     pub fn get_addresses(&self) -> HashMap<String, Address> {
         self.store

--- a/apps/src/lib/wallet/store.rs
+++ b/apps/src/lib/wallet/store.rs
@@ -12,6 +12,7 @@ use anoma::types::key::*;
 use anoma::types::transaction::EllipticCurve;
 use ark_std::rand::prelude::*;
 use ark_std::rand::SeedableRng;
+use bimap::BiHashMap;
 use file_lock::{FileLock, FileOptions};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -53,7 +54,7 @@ pub struct Store {
     /// Cryptographic keypairs
     keys: HashMap<Alias, StoredKeypair>,
     /// Anoma address book
-    addresses: HashMap<Alias, Address>,
+    addresses: BiHashMap<Alias, Address>,
     /// Known mappings of public key hashes to their aliases in the `keys`
     /// field. Used for look-up by a public key.
     pkhs: HashMap<PublicKeyHash, Alias>,
@@ -224,7 +225,7 @@ impl Store {
 
     /// Find the stored address by an alias.
     pub fn find_address(&self, alias: impl AsRef<str>) -> Option<&Address> {
-        self.addresses.get(&alias.into())
+        self.addresses.get_by_left(&alias.into())
     }
 
     /// Get all known keys by their alias, paired with PKH, if known.
@@ -248,7 +249,7 @@ impl Store {
     }
 
     /// Get all known addresses by their alias, paired with PKH, if known.
-    pub fn get_addresses(&self) -> &HashMap<Alias, Address> {
+    pub fn get_addresses(&self) -> &BiHashMap<Alias, Address> {
         &self.addresses
     }
 
@@ -362,7 +363,7 @@ impl Store {
                 alias = address.encode()
             );
         }
-        if self.addresses.contains_key(&alias) {
+        if self.addresses.contains_left(&alias) {
             match show_overwrite_confirmation(&alias, "an address") {
                 ConfirmationResponse::Replace => {}
                 ConfirmationResponse::Reselect(new_alias) => {

--- a/apps/src/lib/wallet/store.rs
+++ b/apps/src/lib/wallet/store.rs
@@ -228,6 +228,11 @@ impl Store {
         self.addresses.get_by_left(&alias.into())
     }
 
+    /// Find an alias by the address if it's in the wallet.
+    pub fn find_alias(&self, address: &Address) -> Option<&Alias> {
+        self.addresses.get_by_right(address)
+    }
+
     /// Get all known keys by their alias, paired with PKH, if known.
     pub fn get_keys(
         &self,


### PR DESCRIPTION
moved from https://github.com/anoma/anoma/pull/1138

In the wallet in order to be able to retrieve alias from address.

I think this is a good idea for UI, since atm we are spitting out hashed addresses that we don't know correspond to any account
