### PR TITLE
e2e tests: switch dep expectrl from fork to release

### DIFF
--- a/.changelog/unreleased/testing/1142-expectrl-switch-from-fork.md
+++ b/.changelog/unreleased/testing/1142-expectrl-switch-from-fork.md
@@ -1,0 +1,2 @@
+- Switch back from a fork to a newly released version of expectrl
+  ([#1142](https://github.com/anoma/anoma/pull/1142))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,8 +2028,9 @@ checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "expectrl"
-version = "0.4.0"
-source = "git+https://github.com/heliaxdev/expectrl.git?branch=tomas/expect-eager-2#9982bb2fd32560b359619dafe92964656406d36e"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2795e11f4ee3124984d454f25ac899515a5fa6d956562ef2b147fef6050b02f8"
 dependencies = [
  "conpty",
  "nix 0.23.1",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -49,7 +49,7 @@ borsh = "0.9.1"
 color-eyre = "0.5.11"
 # NOTE: enable "print" feature to see output from builds ran by e2e tests
 escargot = {version = "0.5.7"} # , features = ["print"]}
-expectrl = {git = "https://github.com/heliaxdev/expectrl.git", branch = "tomas/expect-eager-2"}
+expectrl = {version = "=0.5.2"}
 eyre = "0.6.5"
 file-serve = "0.2.0"
 fs_extra = "1.2.0"

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -467,7 +467,7 @@ impl AnomaCmd {
     pub fn exp_string(&mut self, needle: &str) -> Result<String> {
         let found = self
             .session
-            .expect_eager(needle)
+            .expect(needle)
             .map_err(|e| eyre!(format!("{}\n Needle: {}", e, needle)))?;
         if found.is_empty() {
             Err(eyre!(format!("Expected needle not found: {}", needle)))
@@ -487,7 +487,7 @@ impl AnomaCmd {
     pub fn exp_regex(&mut self, regex: &str) -> Result<(String, String)> {
         let found = self
             .session
-            .expect_eager(expectrl::Regex(regex))
+            .expect(expectrl::Regex(regex))
             .map_err(|e| eyre!(format!("{}", e)))?;
         if found.is_empty() {
             Err(eyre!(format!("Expected regex not found: {}", regex)))
@@ -508,8 +508,7 @@ impl AnomaCmd {
     /// reporting.
     #[allow(dead_code)]
     pub fn exp_eof(&mut self) -> Result<String> {
-        let found =
-            self.session.expect_eager(Eof).map_err(|e| eyre!("{}", e))?;
+        let found = self.session.expect(Eof).map_err(|e| eyre!("{}", e))?;
         if found.is_empty() {
             Err(eyre!("Expected EOF"))
         } else {


### PR DESCRIPTION
moved from https://github.com/anoma/anoma/pull/1142

follow-up to https://github.com/anoma/anoma/pull/1095, based on it