### PR TITLE
Ensure Ethereum oracle starts up

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -87,11 +87,11 @@ pub mod oracle_process {
 
     /// Set up an Oracle and run the process where the Oracle
     /// processes and forwards Ethereum events to the ledger
-    pub async fn run_oracle(
+    pub fn run_oracle(
         url: impl AsRef<str>,
         sender: UnboundedSender<EthereumEvent>,
         abort_sender: Sender<()>,
-    ) {
+    ) -> tokio::task::JoinHandle<()> {
         let url = url.as_ref().to_owned();
         tokio::task::spawn_blocking(move || {
             let rt = tokio::runtime::Handle::current();
@@ -110,7 +110,7 @@ pub mod oracle_process {
                     })
                     .await
             });
-        });
+        })
     }
 
     /// Given an oracle, watch for new Ethereum events, processing

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
@@ -35,11 +35,12 @@ pub mod mock_oracle {
     pub fn run_oracle(
         _: impl AsRef<str>,
         _: UnboundedSender<EthereumEvent>,
-        mut abort: Sender<()>,
+        abort: Sender<()>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             tracing::info!("Mock Ethereum event oracle is starting");
 
+            let mut abort = abort;
             poll_fn(|cx| abort.poll_closed(cx)).await;
 
             tracing::info!("Mock Ethereum event oracle is no longer running");

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
@@ -33,7 +33,7 @@ pub mod mock_oracle {
     use tokio::task::LocalSet;
 
     pub fn run_oracle(
-        _: &str,
+        _: impl AsRef<str>,
         _: UnboundedSender<EthereumEvent>,
         abort: Sender<()>,
     ) -> tokio::task::JoinHandle<()> {

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
@@ -35,12 +35,11 @@ pub mod mock_oracle {
     pub fn run_oracle(
         _: impl AsRef<str>,
         _: UnboundedSender<EthereumEvent>,
-        abort: Sender<()>,
+        mut abort: Sender<()>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             tracing::info!("Mock Ethereum event oracle is starting");
 
-            let mut abort = abort;
             poll_fn(|cx| abort.poll_closed(cx)).await;
 
             tracing::info!("Mock Ethereum event oracle is no longer running");

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -355,12 +355,17 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
         let oracle = tokio::task::spawn_blocking(move || {
             let rt = tokio::runtime::Handle::current();
             rt.block_on(async move {
-                ethereum_node::run_oracle(
-                    &ethereum_url,
-                    eth_sender,
-                    abort_sender,
-                )
-                .await
+                let local = tokio::task::LocalSet::new();
+                local
+                    .run_until(async move {
+                        ethereum_node::run_oracle(
+                            &ethereum_url,
+                            eth_sender,
+                            abort_sender,
+                        )
+                        .await
+                    })
+                    .await
             });
         });
 

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -346,7 +346,7 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
         });
 
         let oracle =
-            ethereum_node::run_oracle(&ethereum_url, eth_sender, abort_sender);
+            ethereum_node::run_oracle(ethereum_url, eth_sender, abort_sender);
 
         // Shutdown ethereum_node via a message to ensure that the child process
         // is properly cleaned-up.

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -315,17 +315,19 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
         config.tendermint.tendermint_mode,
         TendermintMode::Validator
     ) {
-        let local = tokio::task::LocalSet::new();
         // boot up the ethereum node process and wait for it to finish syncing
         let (eth_sender, eth_receiver) = unbounded_channel();
         let url = ethereum_url.clone();
-        let (ethereum_node, abort_sender) = local
-            .run_until(async move {
-                EthereumNode::new(&url)
-                    .await
-                    .expect("Unable to start the Ethereum fullnode")
-            })
-            .await;
+        let (ethereum_node, abort_sender) = {
+            let local = tokio::task::LocalSet::new();
+            local
+                .run_until(async move {
+                    EthereumNode::new(&url)
+                        .await
+                        .expect("Unable to start the Ethereum fullnode")
+                })
+                .await
+        };
 
         // Start Ethereum fullnode
         // Channel for signalling shut down to Tendermint process
@@ -350,9 +352,16 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
             res
         });
 
-        let oracle = local.spawn_local(async move {
-            ethereum_node::run_oracle(&ethereum_url, eth_sender, abort_sender)
+        let oracle = tokio::task::spawn_blocking(move || {
+            let rt = tokio::runtime::Handle::current();
+            rt.block_on(async move {
+                ethereum_node::run_oracle(
+                    &ethereum_url,
+                    eth_sender,
+                    abort_sender,
+                )
                 .await
+            });
         });
 
         // Shutdown ethereum_node via a message to ensure that the child process
@@ -372,7 +381,7 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
                 eth_abort_resp_send,
                 eth_abort_resp_recv,
             )),
-            Some((local, oracle, eth_receiver)),
+            Some((oracle, eth_receiver)),
             Some((
                 tokio::spawn(async move {
                     // Construct a service for broadcasting protocol txs from
@@ -397,11 +406,11 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
         (None, None, None)
     };
 
-    let (rt, oracle_proc, eth_receiver) = match oracle {
-        Some((rt, oracle_proc, oracle_channel)) => {
-            (Some(rt), Some(oracle_proc), Some(oracle_channel))
+    let (oracle_proc, eth_receiver) = match oracle {
+        Some((oracle_proc, oracle_channel)) => {
+            (Some(oracle_proc), Some(oracle_channel))
         }
-        None => (None, None, None),
+        None => (None, None),
     };
 
     // Channel for signalling shut down to Tendermint process
@@ -501,10 +510,9 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
             eth_abort_resp_send,
             eth_abort_resp_recv,
         )),
-        Some(local),
         Some(oracle),
         Some((broadcaster, bc_abort_send)),
-    ) = (ethereum_node, rt, oracle_proc, broadcaster)
+    ) = (ethereum_node, oracle_proc, broadcaster)
     {
         // Ask to shutdown tendermint node cleanly. Ignore error, which can
         // happen if the tendermint_node task has already finished.
@@ -525,7 +533,7 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
         tokio::try_join!(
             tendermint_node,
             ethereum_node,
-            local.run_until(async move { oracle.await }),
+            oracle,
             abci,
             broadcaster
         )

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -318,16 +318,9 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
         // boot up the ethereum node process and wait for it to finish syncing
         let (eth_sender, eth_receiver) = unbounded_channel();
         let url = ethereum_url.clone();
-        let (ethereum_node, abort_sender) = {
-            let local = tokio::task::LocalSet::new();
-            local
-                .run_until(async move {
-                    EthereumNode::new(&url)
-                        .await
-                        .expect("Unable to start the Ethereum fullnode")
-                })
-                .await
-        };
+        let (ethereum_node, abort_sender) = EthereumNode::new(&url)
+            .await
+            .expect("Unable to start the Ethereum fullnode");
 
         // Start Ethereum fullnode
         // Channel for signalling shut down to Tendermint process

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -351,12 +351,16 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
                 let local = tokio::task::LocalSet::new();
                 local
                     .run_until(async move {
+                        tracing::info!("Ethereum event oracle is starting");
                         ethereum_node::run_oracle(
                             &ethereum_url,
                             eth_sender,
                             abort_sender,
                         )
-                        .await
+                        .await;
+                        tracing::info!(
+                            "Ethereum event oracle is no longer running"
+                        );
                     })
                     .await
             });

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -345,26 +345,8 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
             res
         });
 
-        let oracle = tokio::task::spawn_blocking(move || {
-            let rt = tokio::runtime::Handle::current();
-            rt.block_on(async move {
-                let local = tokio::task::LocalSet::new();
-                local
-                    .run_until(async move {
-                        tracing::info!("Ethereum event oracle is starting");
-                        ethereum_node::run_oracle(
-                            &ethereum_url,
-                            eth_sender,
-                            abort_sender,
-                        )
-                        .await;
-                        tracing::info!(
-                            "Ethereum event oracle is no longer running"
-                        );
-                    })
-                    .await
-            });
-        });
+        let oracle =
+            ethereum_node::run_oracle(&ethereum_url, eth_sender, abort_sender);
 
         // Shutdown ethereum_node via a message to ensure that the child process
         // is properly cleaned-up.


### PR DESCRIPTION
Relates to #269

Tested manually (for now), both with the `namada_apps/eth-fullnode` feature enabled and disabled. A log is emitted indicating the oracle is starting right after we've checked `geth` is reachable

```
...
namada_apps::node::ledger::ethereum_node::eth_fullnode: Finished syncing
2022-08-03T16:11:16.241376Z  INFO namada_apps::node::ledger::ethereum_node::oracle::oracle_process: Ethereum event oracle is starting
...
```

A log is emitted at shutdown indicating it stopped.

```
...
2022-08-03T15:48:13.114802Z  INFO namada_apps::node::ledger: Broadcaster is no longer running.
2022-08-03T15:48:13.114785Z  INFO namada_apps::node::ledger: Anoma ledger node has shut down.
2022-08-03T15:48:13.115287Z  INFO namada_apps::node::ledger::ethereum_node::oracle::oracle_process: Ethereum event oracle is no longer running
```