### PR TITLE
More logging during PrepareProposal, ProcessProposal, FinalizeBlock

### DIFF
--- a/apps/src/lib/node/ledger/protocol/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/mod.rs
@@ -174,7 +174,11 @@ where
                 ..Default::default()
             })
         }
-        _ => {
+        tx_type @ _ => {
+            tracing::error!(
+                "Attempt made to apply an unsupported transaction! - {:#?}",
+                tx_type
+            );
             let gas_used = block_gas_meter
                 .finalize_transaction()
                 .map_err(Error::GasError)?;

--- a/apps/src/lib/node/ledger/protocol/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/mod.rs
@@ -164,8 +164,10 @@ where
                     ..
                 }),
             ..
-        }) if !events.is_empty() => {
-            tracing::debug!("Ethereum events received");
+        }) => {
+            if !events.is_empty() {
+                tracing::debug!("Ethereum events received");
+            }
             let gas_used = block_gas_meter
                 .finalize_transaction()
                 .map_err(Error::GasError)?;

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -36,6 +36,7 @@ mod prepare_block {
             &mut self,
             req: RequestPrepareProposal,
         ) -> response::PrepareProposal {
+            tracing::info!("Preparing block proposal");
             // We can safely reset meter, because if the block is rejected,
             // we'll reset again on the next proposal, until the
             // proposal is accepted
@@ -66,6 +67,7 @@ mod prepare_block {
                 vec![]
             };
 
+            tracing::info!(n_transactions = txs.len(), "Proposing block");
             response::PrepareProposal {
                 tx_records: txs,
                 ..Default::default()

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -48,8 +48,14 @@ mod prepare_block {
                     self.build_vote_extensions_txs(req.local_last_commit);
 
                 // add mempool txs
-                let mut mempool_txs = self.build_mempool_txs(req.txs);
-                txs.append(&mut mempool_txs);
+                if !req.txs.is_empty() {
+                    tracing::info!(
+                        n = req.txs.len(),
+                        "Received transactions from mempool"
+                    );
+                    let mut mempool_txs = self.build_mempool_txs(req.txs);
+                    txs.append(&mut mempool_txs);
+                }
 
                 // decrypt the wrapper txs included in the previous block
                 let mut decrypted_txs = self.build_decrypted_txs();

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -36,7 +36,11 @@ mod prepare_block {
             &mut self,
             req: RequestPrepareProposal,
         ) -> response::PrepareProposal {
-            tracing::info!("Preparing block proposal");
+            tracing::info!(
+                height = req.height,
+                req.txs.len = req.txs.len(),
+                "Preparing block proposal"
+            );
             // We can safely reset meter, because if the block is rejected,
             // we'll reset again on the next proposal, until the
             // proposal is accepted
@@ -49,14 +53,8 @@ mod prepare_block {
                     self.build_vote_extensions_txs(req.local_last_commit);
 
                 // add mempool txs
-                if !req.txs.is_empty() {
-                    tracing::info!(
-                        n = req.txs.len(),
-                        "Received transactions from mempool"
-                    );
-                    let mut mempool_txs = self.build_mempool_txs(req.txs);
-                    txs.append(&mut mempool_txs);
-                }
+                let mut mempool_txs = self.build_mempool_txs(req.txs);
+                txs.append(&mut mempool_txs);
 
                 // decrypt the wrapper txs included in the previous block
                 let mut decrypted_txs = self.build_decrypted_txs();
@@ -67,7 +65,11 @@ mod prepare_block {
                 vec![]
             };
 
-            tracing::info!(n_transactions = txs.len(), "Proposing block");
+            tracing::info!(
+                height = req.height,
+                tx_records = txs.len(),
+                "Proposing block"
+            );
             response::PrepareProposal {
                 tx_records: txs,
                 ..Default::default()

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -36,11 +36,6 @@ mod prepare_block {
             &mut self,
             req: RequestPrepareProposal,
         ) -> response::PrepareProposal {
-            tracing::info!(
-                height = req.height,
-                txs_from_tendermint.len = req.txs.len(),
-                "Preparing block proposal"
-            );
             // We can safely reset meter, because if the block is rejected,
             // we'll reset again on the next proposal, until the
             // proposal is accepted

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -38,7 +38,7 @@ mod prepare_block {
         ) -> response::PrepareProposal {
             tracing::info!(
                 height = req.height,
-                req.txs.len = req.txs.len(),
+                txs_from_tendermint.len = req.txs.len(),
                 "Preparing block proposal"
             );
             // We can safely reset meter, because if the block is rejected,

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -37,9 +37,9 @@ where
         req: RequestProcessProposal,
     ) -> ResponseProcessProposal {
         tracing::info!(
-            proposer = ?req.proposer_address,
+            proposer = ?hex::encode(&req.proposer_address),
             height = req.height,
-            hash = ?req.hash,
+            hash = ?hex::encode(&req.hash),
             n_txs = req.txs.len(),
             "Received block proposal",
         );
@@ -60,9 +60,9 @@ where
         let too_many_vext_digests = vote_ext_digest_num > 1;
         if too_many_vext_digests {
             tracing::warn!(
-                proposer = ?req.proposer_address,
+                proposer = ?hex::encode(&req.proposer_address),
                 height = req.height,
-                hash = ?req.hash,
+                hash = ?hex::encode(&req.hash),
                 vote_ext_digest_num,
                 "found too many vote extension transactions, proposed block \
                  will be rejected"
@@ -81,27 +81,27 @@ where
         });
         if invalid_txs {
             tracing::warn!(
-                proposer = ?req.proposer_address,
+                proposer = ?hex::encode(&req.proposer_address),
                 height = req.height,
-                hash = ?req.hash,
+                hash = ?hex::encode(&req.hash),
                 "found invalid transactions, proposed block will be rejected"
             );
         }
 
         let status = if too_many_vext_digests || invalid_txs {
-            ProposalStatus::Reject as i32
+            ProposalStatus::Reject
         } else {
-            ProposalStatus::Accept as i32
+            ProposalStatus::Accept
         };
         tracing::info!(
-            proposer = ?req.proposer_address,
+            proposer = ?hex::encode(&req.proposer_address),
             height = req.height,
-            hash = ?req.hash,
-            %status,
+            hash = ?hex::encode(&req.hash),
+            ?status,
             "Processed block proposal",
         );
         ResponseProcessProposal {
-            status,
+            status: status as i32,
             tx_results,
             ..Default::default()
         }

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -51,6 +51,13 @@ where
         // We should not have more than one `ethereum_events::VextDigest` in
         // a proposal from some round's leader.
         let too_many_vext_digests = vote_ext_digest_num > 1;
+        if too_many_vext_digests {
+            tracing::warn!(
+                vote_ext_digest_num,
+                "found too many vote extension transactions, proposed block \
+                 will be rejected"
+            );
+        }
 
         // Erroneous transactions were detected when processing
         // the leader's proposal. We allow txs that do not
@@ -62,6 +69,11 @@ where
             );
             !error.is_recoverable()
         });
+        if invalid_txs {
+            tracing::warn!(
+                "found invalid transactions, proposed block will be rejected"
+            );
+        }
 
         ResponseProcessProposal {
             status: if too_many_vext_digests || invalid_txs {

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -36,6 +36,13 @@ where
         &mut self,
         req: RequestProcessProposal,
     ) -> ResponseProcessProposal {
+        tracing::info!(
+            ?req.proposer_address,
+            req.height,
+            ?req.hash,
+            n_transactions = req.txs.len(),
+            "Received block proposal",
+        );
         // the number of vote extension digests included in the block proposal
         let mut vote_ext_digest_num = 0;
         let tx_results: Vec<ExecTxResult> = req
@@ -47,16 +54,15 @@ where
                 )
             })
             .collect();
-        tracing::info!(
-            n = req.txs.len(),
-            "Processed transactions in proposed block",
-        );
 
         // We should not have more than one `ethereum_events::VextDigest` in
         // a proposal from some round's leader.
         let too_many_vext_digests = vote_ext_digest_num > 1;
         if too_many_vext_digests {
             tracing::warn!(
+                ?req.proposer_address,
+                req.height,
+                ?req.hash,
                 vote_ext_digest_num,
                 "found too many vote extension transactions, proposed block \
                  will be rejected"
@@ -75,16 +81,27 @@ where
         });
         if invalid_txs {
             tracing::warn!(
+                ?req.proposer_address,
+                req.height,
+                ?req.hash,
                 "found invalid transactions, proposed block will be rejected"
             );
         }
 
+        let status = if too_many_vext_digests || invalid_txs {
+            ProposalStatus::Reject as i32
+        } else {
+            ProposalStatus::Accept as i32
+        };
+        tracing::info!(
+            ?req.proposer_address,
+            req.height,
+            ?req.hash,
+            %status,
+            "Processed block proposal",
+        );
         ResponseProcessProposal {
-            status: if too_many_vext_digests || invalid_txs {
-                ProposalStatus::Reject as i32
-            } else {
-                ProposalStatus::Accept as i32
-            },
+            status,
             tx_results,
             ..Default::default()
         }

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -37,10 +37,10 @@ where
         req: RequestProcessProposal,
     ) -> ResponseProcessProposal {
         tracing::info!(
-            ?req.proposer_address,
-            req.height,
-            ?req.hash,
-            n_transactions = req.txs.len(),
+            proposer = ?req.proposer_address,
+            height = req.height,
+            hash = ?req.hash,
+            n_txs = req.txs.len(),
             "Received block proposal",
         );
         // the number of vote extension digests included in the block proposal
@@ -60,9 +60,9 @@ where
         let too_many_vext_digests = vote_ext_digest_num > 1;
         if too_many_vext_digests {
             tracing::warn!(
-                ?req.proposer_address,
-                req.height,
-                ?req.hash,
+                proposer = ?req.proposer_address,
+                height = req.height,
+                hash = ?req.hash,
                 vote_ext_digest_num,
                 "found too many vote extension transactions, proposed block \
                  will be rejected"
@@ -81,9 +81,9 @@ where
         });
         if invalid_txs {
             tracing::warn!(
-                ?req.proposer_address,
-                req.height,
-                ?req.hash,
+                proposer = ?req.proposer_address,
+                height = req.height,
+                hash = ?req.hash,
                 "found invalid transactions, proposed block will be rejected"
             );
         }
@@ -94,9 +94,9 @@ where
             ProposalStatus::Accept as i32
         };
         tracing::info!(
-            ?req.proposer_address,
-            req.height,
-            ?req.hash,
+            proposer = ?req.proposer_address,
+            height = req.height,
+            hash = ?req.hash,
             %status,
             "Processed block proposal",
         );

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -64,7 +64,7 @@ where
                 height = req.height,
                 hash = ?hex::encode(&req.hash),
                 vote_ext_digest_num,
-                "found too many vote extension transactions, proposed block \
+                "Found too many vote extension transactions, proposed block \
                  will be rejected"
             );
         }
@@ -84,7 +84,7 @@ where
                 proposer = ?hex::encode(&req.proposer_address),
                 height = req.height,
                 hash = ?hex::encode(&req.hash),
-                "found invalid transactions, proposed block will be rejected"
+                "Found invalid transactions, proposed block will be rejected"
             );
         }
 

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -47,6 +47,10 @@ where
                 )
             })
             .collect();
+        tracing::info!(
+            n = req.txs.len(),
+            "Processed transactions in proposed block",
+        );
 
         // We should not have more than one `ethereum_events::VextDigest` in
         // a proposal from some round's leader.


### PR DESCRIPTION
This is a quick PR to add some more visibility around what is happening during block proposal and finalization. Especially:
- logging when we reject a block proposal as a validator
- logging when we receive an unsupported transaction in `apply_tx`