### PR TITLE
Add endpoint for direct submission of Ethereum events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4333,6 +4343,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "multipart"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log 0.4.17",
+ "mime 0.3.16",
+ "mime_guess",
+ "quick-error 1.2.3",
+ "rand 0.8.5",
+ "safemem",
+ "tempfile",
+ "twoway",
+]
+
+[[package]]
 name = "multistream-select"
 version = "0.10.3"
 source = "git+https://github.com/heliaxdev/rust-libp2p.git?rev=1abe349c231eb307d3dbe03f3ffffc6cf5e9084d#1abe349c231eb307d3dbe03f3ffffc6cf5e9084d"
@@ -4422,6 +4450,7 @@ dependencies = [
  "borsh",
  "byte-unit",
  "byteorder",
+ "bytes 1.1.0",
  "cargo-watch",
  "clap 3.0.0-beta.2",
  "clarity",
@@ -4491,6 +4520,7 @@ dependencies = [
  "tracing 0.1.35",
  "tracing-log",
  "tracing-subscriber 0.3.11",
+ "warp",
  "web30",
  "websocket",
  "winapi 0.3.9",
@@ -6312,6 +6342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7451,6 +7487,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+dependencies = [
+ "futures-util",
+ "log 0.4.17",
+ "pin-project 1.0.10",
+ "tokio",
+ "tungstenite 0.14.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7812,6 +7861,25 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes 1.1.0",
+ "http",
+ "httparse",
+ "log 0.4.17",
+ "rand 0.8.5",
+ "sha-1 0.9.8",
+ "thiserror",
+ "url 2.2.2",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1"
@@ -7827,6 +7895,15 @@ dependencies = [
  "thiserror",
  "url 2.2.2",
  "utf-8",
+]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -8103,6 +8180,36 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log 0.4.17",
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper 0.14.19",
+ "log 0.4.17",
+ "mime 0.3.16",
+ "mime_guess",
+ "multipart",
+ "percent-encoding 2.1.0",
+ "pin-project 1.0.10",
+ "scoped-tls",
+ "serde 1.0.137",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util 0.6.10",
+ "tower-service",
+ "tracing 0.1.35",
 ]
 
 [[package]]

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -128,6 +128,9 @@ web30 = "0.19.1"
 websocket = "0.26.2"
 winapi = "0.3.9"
 
+warp = "0.3.2"
+bytes = "1.1.0"
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 namada = {path = "../shared", features = ["testing", "wasm-runtime"]}

--- a/apps/src/lib/config/ethereum.rs
+++ b/apps/src/lib/config/ethereum.rs
@@ -1,3 +1,4 @@
+//! Configuration settings to do with the Ethereum bridge.
 use serde::{Deserialize, Serialize};
 
 /// Default [Ethereum JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/) endpoint used by the oracle

--- a/apps/src/lib/config/ethereum.rs
+++ b/apps/src/lib/config/ethereum.rs
@@ -1,4 +1,6 @@
 //! Configuration settings to do with the Ethereum bridge.
+#[allow(unused_imports)]
+use namada::types::ethereum_events::EthereumEvent;
 use serde::{Deserialize, Serialize};
 
 /// Default [Ethereum JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/) endpoint used by the oracle
@@ -12,7 +14,7 @@ pub struct Config {
     /// If this is set to `true`, then instead of the oracle listening for
     /// events at a Ethereum JSON-RPC endpoint, an endpoint will be exposed by
     /// the ledger for submission of Borsh-serialized
-    /// [`namada::types::ethereum_events::EthereumEvent`]s
+    /// [`EthereumEvent`]s
     #[cfg(not(feature = "eth-fullnode"))]
     pub oracle_event_endpoint: bool,
 }

--- a/apps/src/lib/config/ethereum.rs
+++ b/apps/src/lib/config/ethereum.rs
@@ -8,12 +8,20 @@ pub struct Config {
     /// The Ethereum JSON-RPC endpoint that the Ethereum event oracle will use
     /// to listen for events from the Ethereum bridge smart contracts
     pub oracle_rpc_endpoint: String,
+    /// If this is set to `true`, then instead of the oracle listening for
+    /// events at a Ethereum JSON-RPC endpoint, an endpoint will be exposed by
+    /// the ledger for submission of Borsh-serialized
+    /// [`namada::types::ethereum_events::EthereumEvent`]s
+    #[cfg(not(feature = "eth-fullnode"))]
+    pub oracle_event_endpoint: bool,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             oracle_rpc_endpoint: DEFAULT_ORACLE_RPC_ENDPOINT.to_owned(),
+            #[cfg(not(feature = "eth-fullnode"))]
+            oracle_event_endpoint: false,
         }
     }
 }

--- a/apps/src/lib/node/ledger/ethereum_node/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/mod.rs
@@ -1,12 +1,8 @@
 pub mod events;
 pub mod oracle;
-#[cfg(feature = "eth-fullnode")]
-pub use oracle::{run_oracle, Oracle};
 pub mod test_tools;
 use std::ffi::OsString;
 
-#[cfg(not(feature = "eth-fullnode"))]
-pub use test_tools::mock_oracle::run_oracle;
 use thiserror::Error;
 use tokio::sync::oneshot::{Receiver, Sender};
 

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
@@ -47,6 +47,69 @@ pub mod mock_oracle {
     }
 }
 
+#[cfg(not(feature = "eth-fullnode"))]
+pub mod event_endpoint {
+    use borsh::BorshDeserialize;
+    use namada::types::ethereum_events::EthereumEvent;
+    use tokio::sync::mpsc::UnboundedSender;
+
+    const ETHEREUM_EVENTS_ENDPOINT: ([u8; 4], u16) = ([127, 0, 0, 1], 3030);
+
+    /// The path to which Borsh-serialized Ethereum events should be submitted
+    const PATH: &str = "eth_events";
+
+    pub fn start_oracle(
+        sender: UnboundedSender<EthereumEvent>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            use warp::Filter;
+
+            tracing::info!(
+                ?ETHEREUM_EVENTS_ENDPOINT,
+                "Ethereum event endpoint is starting"
+            );
+
+            let eth_events = warp::post()
+                .and(warp::path(PATH))
+                .and(warp::body::bytes())
+                .map(move |bytes: bytes::Bytes| {
+                    tracing::info!(len = bytes.len(), "Received request");
+                    let event = match EthereumEvent::try_from_slice(&bytes) {
+                        Ok(event) => event,
+                        Err(error) => {
+                            tracing::warn!(?error, "Couldn't handle request");
+                            return warp::reply::with_status(
+                                "Bad request",
+                                warp::http::StatusCode::BAD_REQUEST,
+                            );
+                        }
+                    };
+                    tracing::debug!("Serialized event - {:#?}", event);
+                    match sender.send(event) {
+                        Ok(()) => warp::reply::with_status(
+                            "OK",
+                            warp::http::StatusCode::OK,
+                        ),
+                        Err(error) => {
+                            tracing::warn!(?error, "Couldn't send event");
+                            warp::reply::with_status(
+                                "Internal server error",
+                                warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            )
+                        }
+                    }
+                });
+
+            warp::serve(eth_events).run(ETHEREUM_EVENTS_ENDPOINT).await;
+
+            tracing::info!(
+                ?ETHEREUM_EVENTS_ENDPOINT,
+                "Ethereum event endpoint is no longer running"
+            );
+        })
+    }
+}
+
 #[cfg(all(test, feature = "eth-fullnode"))]
 pub mod mock_web3_client {
     use std::cell::RefCell;

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -340,8 +340,26 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
             res
         });
 
-        let oracle =
-            ethereum_node::run_oracle(ethereum_url, eth_sender, abort_sender);
+        let oracle = {
+            #[cfg(not(feature = "eth-fullnode"))]
+            if config.ethereum.oracle_event_endpoint {
+                ethereum_node::test_tools::event_endpoint::start_oracle(
+                    eth_sender,
+                )
+            } else {
+                ethereum_node::test_tools::mock_oracle::run_oracle(
+                    ethereum_url,
+                    eth_sender,
+                    abort_sender,
+                )
+            }
+            #[cfg(feature = "eth-fullnode")]
+            ethereum_node::oracle::run_oracle(
+                ethereum_url,
+                eth_sender,
+                abort_sender,
+            )
+        };
 
         // Shutdown ethereum_node via a message to ensure that the child process
         // is properly cleaned-up.


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/227

When the `namada_apps/eth-fullnode` feature is not enabled, there is a config option - `ledger.ethereum.oracle_event_endpoint` - which if set to true, makes it so that a server is started by the oracle exposing an endpoint at `http://127.0.0.1:3030` for submission of Borsh-serialized `EthereumEvent`s. Any events submitted there will be included in validator's vote extensions.

Enabling this functionality at runtime can be done like so:

```shell
ANOMA_LEDGER__ETHEREUM__ORACLE_EVENT_ENDPOINT=true target/debug/namadan ledger run
```

This functionality can be tested out using a devtool built from https://github.com/anoma/devtool/pull/2

```shell
devtool submit-fake-transfer-to-namada \
	--nonce 1 \
	--receiver atest1v4ehgw36x5myzdfcg5myg3feg4p5vvzyxfrrgdpnxccnvvp5gdrrqse3gdz5zv2yxsenqs3ntgy89n
```