### PR TITLE
Accommodate natively updating blockchain state based on protocol transactions

### DIFF
--- a/apps/src/lib/node/ledger/protocol/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/mod.rs
@@ -69,7 +69,7 @@ where
 {
     pub block_gas_meter: &'a mut BlockGasMeter,
     pub write_log: &'a mut WriteLog,
-    pub storage: &'a mut Storage<D, H>,
+    pub storage: &'a Storage<D, H>,
     pub vp_wasm_cache: &'a mut VpCache<CA>,
     pub tx_wasm_cache: &'a mut TxCache<CA>,
 }
@@ -84,7 +84,7 @@ where
         Self {
             block_gas_meter: &mut shell.gas_meter,
             write_log: &mut shell.write_log,
-            storage: &mut shell.storage,
+            storage: &shell.storage,
             vp_wasm_cache: &mut shell.vp_wasm_cache,
             tx_wasm_cache: &mut shell.tx_wasm_cache,
         }
@@ -103,13 +103,11 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub(crate) fn dispatch_tx<'a, D, H, CA>(
     tx_type: TxType,
     tx_length: usize,
-    ShellParams {
-        block_gas_meter,
-        write_log,
-        storage,
-        vp_wasm_cache,
-        tx_wasm_cache,
-    }: ShellParams<'a, D, H, CA>,
+    block_gas_meter: &'a mut BlockGasMeter,
+    write_log: &'a mut WriteLog,
+    storage: &'a mut Storage<D, H>,
+    vp_wasm_cache: &'a mut VpCache<CA>,
+    tx_wasm_cache: &'a mut TxCache<CA>,
 ) -> Result<TxResult>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -344,7 +344,11 @@ where
             match protocol::dispatch_tx(
                 tx_type,
                 tx_length,
-                self.into(),
+                &mut self.gas_meter,
+                &mut self.write_log,
+                &mut self.storage,
+                &mut self.vp_wasm_cache,
+                &mut self.tx_wasm_cache,
             )
             .map_err(Error::TxApply)
             {

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -119,11 +119,7 @@ where
                                     0, /* this is used to compute the fee
                                         * based on the code size. We dont
                                         * need it here. */
-                                    &mut BlockGasMeter::default(),
-                                    &mut self.write_log,
-                                    &self.storage,
-                                    &mut self.vp_wasm_cache,
-                                    &mut self.tx_wasm_cache,
+                                    self.into(),
                                 );
                                 self.storage
                                     .delete(&pending_execution_key)
@@ -348,11 +344,7 @@ where
             match protocol::dispatch_tx(
                 tx_type,
                 tx_length,
-                &mut self.gas_meter,
-                &mut self.write_log,
-                &mut self.storage,
-                &mut self.vp_wasm_cache,
-                &mut self.tx_wasm_cache,
+                self.into(),
             )
             .map_err(Error::TxApply)
             {

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -662,7 +662,7 @@ where
     }
 
     /// Simulate validation and application of a transaction.
-    fn dry_run_tx(&self, tx_bytes: &[u8]) -> response::Query {
+    fn dry_run_tx(&mut self, tx_bytes: &[u8]) -> response::Query {
         let mut response = response::Query::default();
         let mut gas_meter = BlockGasMeter::default();
         let mut write_log = WriteLog::default();
@@ -670,16 +670,8 @@ where
         let mut tx_wasm_cache = self.tx_wasm_cache.read_only();
         match Tx::try_from(tx_bytes) {
             Ok(tx) => {
-                match protocol::apply_wasm_tx(
-                    tx,
-                    tx_bytes.len(),
-                    &mut gas_meter,
-                    &mut write_log,
-                    &self.storage,
-                    &mut vp_wasm_cache,
-                    &mut tx_wasm_cache,
-                )
-                .map_err(Error::TxApply)
+                match protocol::apply_wasm_tx(tx, tx_bytes.len(), self.into())
+                    .map_err(Error::TxApply)
                 {
                     Ok(result) => response.info = result.to_string(),
                     Err(error) => {

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -74,7 +74,6 @@ use tower_abci_old::{request, response};
 use super::rpc;
 use crate::config::{genesis, TendermintMode};
 use crate::node::ledger::events::Event;
-use crate::node::ledger::protocol::ShellParams;
 use crate::node::ledger::shims::abcipp_shim_types::shim;
 use crate::node::ledger::shims::abcipp_shim_types::shim::response::TxResult;
 use crate::node::ledger::{protocol, storage, tendermint_node};
@@ -671,18 +670,14 @@ where
         let mut tx_wasm_cache = self.tx_wasm_cache.read_only();
         match Tx::try_from(tx_bytes) {
             Ok(tx) => {
-                let tx = TxType::Decrypted(DecryptedTx::Decrypted(tx));
-                match protocol::apply_tx(
+                match protocol::apply_wasm_tx(
                     tx,
                     tx_bytes.len(),
-                    ShellParams {
-                        block_gas_meter: &mut gas_meter,
-                        write_log: &mut write_log,
-                        storage: &self.storage,
-                        wasm_dir: self.wasm_dir.as_path(),
-                        vp_wasm_cache: &mut vp_wasm_cache,
-                        tx_wasm_cache: &mut tx_wasm_cache,
-                    },
+                    &mut gas_meter,
+                    &mut write_log,
+                    &self.storage,
+                    &mut vp_wasm_cache,
+                    &mut tx_wasm_cache,
                 )
                 .map_err(Error::TxApply)
                 {

--- a/apps/src/lib/node/ledger/shell/queries.rs
+++ b/apps/src/lib/node/ledger/shell/queries.rs
@@ -60,7 +60,7 @@ where
     /// right query method and returns the result (which may be
     /// the default if `path` is not a supported string.
     /// INVARIANT: This method must be stateless.
-    pub fn query(&mut self, query: request::Query) -> response::Query {
+    pub fn query(&self, query: request::Query) -> response::Query {
         use rpc::Path;
         let height = match query.height {
             0 => self.storage.get_block_height().0,

--- a/apps/src/lib/node/ledger/shell/queries.rs
+++ b/apps/src/lib/node/ledger/shell/queries.rs
@@ -60,7 +60,7 @@ where
     /// right query method and returns the result (which may be
     /// the default if `path` is not a supported string.
     /// INVARIANT: This method must be stateless.
-    pub fn query(&self, query: request::Query) -> response::Query {
+    pub fn query(&mut self, query: request::Query) -> response::Query {
         use rpc::Path;
         let height = match query.height {
             0 => self.storage.get_block_height().0,


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/309 , functionality like in this PR will be needed for https://github.com/anoma/namada/pull/284

This PR isn't a pure refactor but changes how transactions are dispatched slightly during `FinalizeBlock`. `apply_tx` becomes `dispatch_tx` which may call either `apply_wasm_tx` or `apply_protocol_tx`. `apply_wasm_tx` meters gas and can update storage via the wasm environment, updates are checked by validity predicates. `apply_protocol_tx` lets us update storage directly without going via wasm. Gas doesn't apply and validity predicates aren't checked.

`dry_run_tx` and the application of governance proposal transactions now go directly via `apply_wasm_tx`. When iterating over transactions in `finalize_block.rs`, we do `dispatch_tx` and pass a `&'a mut Storage<D, H>` in case it is a protocol transaction being applied. Before we were passing `&Storage<D,H>` everywhere. We can also now get rid of `ShellParams`.
