### PR TITLE
Events voted on by validators are not voted on again

### DIFF
--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -521,7 +521,7 @@ mod test_finalize_block {
     use namada::types::storage::Epoch;
     use namada::types::transaction::{EncryptionKey, Fee};
     use namada::types::vote_extensions::ethereum_events::{
-        MultiSignedEthEvent, Vext, VextDigest,
+        self, MultiSignedEthEvent,
     };
 
     use super::*;
@@ -1019,7 +1019,7 @@ mod test_finalize_block {
         assert_eq!(queued_event, event);
 
         // ---- The protocol tx that includes this event on-chain
-        let signature = Vext {
+        let signature = ethereum_events::Vext {
             block_height: shell.storage.last_height,
             ethereum_events: vec![event.clone()],
             validator_addr: address.clone(),
@@ -1031,7 +1031,7 @@ mod test_finalize_block {
             signers: HashSet::from([address.clone()]),
         };
 
-        let digest = VextDigest {
+        let digest = ethereum_events::VextDigest {
             signatures: vec![(address, signature)].into_iter().collect(),
             events: vec![signed],
         };

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -243,6 +243,18 @@ impl ShellMode {
         }
     }
 
+    /// Remove an Ethereum event from the internal queue
+    pub fn deque_eth_event(&mut self, event: &EthereumEvent) {
+        if let ShellMode::Validator {
+            ethereum_recv: EthereumReceiver { ref mut queue, .. },
+            ..
+        } = self
+        {
+            queue.remove(event);
+        }
+    }
+
+    /// Get the protocol keypair for this validator
     pub fn get_protocol_key(&self) -> Option<&common::SecretKey> {
         match &self {
             ShellMode::Validator {


### PR DESCRIPTION
Closes #308 

When a new ethereum event is seen, it is put in a queue to be included in a vote extension. Once that event is included on chain, it should be removed from the queue so that the validator that saw it stops including it in vote extensions.