### PR TITLE
Make ABCI compile again

### DIFF
--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -1003,6 +1003,7 @@ mod test_finalize_block {
     /// Test that once a validator's vote for an Ethereum event lands
     /// on-chain, it dequeues from the list of events to vote on.
     #[test]
+    #[cfg(not(feature = "ABCI"))]
     fn test_eth_events_dequeued() {
         let (mut shell, _, oracle) = setup();
         let protocol_key =

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -190,6 +190,7 @@ pub(super) enum ShellMode {
 /// and queueing them up for inclusion in vote extensions
 #[derive(Debug)]
 pub(super) struct EthereumReceiver {
+    #[cfg_attr(feature = "ABCI", allow(dead_code))]
     channel: UnboundedReceiver<EthereumEvent>,
     queue: BTreeSet<EthereumEvent>,
 }
@@ -207,6 +208,7 @@ impl EthereumReceiver {
     /// Pull messages from the channel and add to queue
     /// Since vote extensions require ordering of ethereum
     /// events, we do that here. We also de-duplicate events
+    #[cfg_attr(feature = "ABCI", allow(dead_code))]
     pub fn fill_queue(&mut self) {
         let mut new_events = 0;
         while let Ok(eth_event) = self.channel.try_recv() {
@@ -220,6 +222,7 @@ impl EthereumReceiver {
     }
 
     /// Get a copy of the queue
+    #[cfg_attr(feature = "ABCI", allow(dead_code))]
     pub fn get_events(&self) -> Vec<EthereumEvent> {
         self.queue.iter().cloned().collect()
     }

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -435,6 +435,7 @@ mod test_process_proposal {
     /// Test that if a proposal contains more than one
     /// `ethereum_events::VextDigest`, we reject it.
     #[test]
+    #[cfg(not(feature = "ABCI"))]
     fn test_more_than_one_vext_digest_rejected() {
         const LAST_HEIGHT: BlockHeight = BlockHeight(2);
         let (mut shell, _, _) = test_utils::setup();
@@ -503,6 +504,7 @@ mod test_process_proposal {
     /// Test that if a proposal contains Ethereum events with
     /// invalid validator signatures, we reject it.
     #[test]
+    #[cfg(not(feature = "ABCI"))]
     fn test_drop_vext_digest_with_invalid_sigs() {
         const LAST_HEIGHT: BlockHeight = BlockHeight(2);
         let (mut shell, _, _) = test_utils::setup();
@@ -550,6 +552,7 @@ mod test_process_proposal {
     /// Test that if a proposal contains Ethereum events with
     /// invalid block heights, we reject it.
     #[test]
+    #[cfg(not(feature = "ABCI"))]
     fn test_drop_vext_digest_with_invalid_bheights() {
         const LAST_HEIGHT: BlockHeight = BlockHeight(3);
         const PRED_LAST_HEIGHT: BlockHeight = BlockHeight(LAST_HEIGHT.0 - 1);
@@ -594,6 +597,7 @@ mod test_process_proposal {
     /// Test that if a proposal contains Ethereum events with
     /// invalid validators, we reject it.
     #[test]
+    #[cfg(not(feature = "ABCI"))]
     fn test_drop_vext_digest_with_invalid_validators() {
         const LAST_HEIGHT: BlockHeight = BlockHeight(2);
         let (mut shell, _, _) = test_utils::setup();

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -427,10 +427,8 @@ mod test_process_proposal {
     use tendermint_proto_abci::google::protobuf::Timestamp;
 
     use super::*;
-    #[cfg(not(feature = "ABCI"))]
-    use crate::node::ledger::shell::test_utils::TestError;
     use crate::node::ledger::shell::test_utils::{
-        self, gen_keypair, ProcessProposal, TestShell,
+        self, gen_keypair, ProcessProposal, TestError, TestShell,
     };
     use crate::wallet;
 

--- a/apps/src/lib/node/ledger/shell/queries.rs
+++ b/apps/src/lib/node/ledger/shell/queries.rs
@@ -4,7 +4,6 @@ use std::cmp::max;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ferveo_common::TendermintValidator;
 use namada::ledger::parameters::EpochDuration;
-#[cfg(not(feature = "ABCI"))]
 use namada::ledger::pos::namada_proof_of_stake::types::VotingPower;
 use namada::ledger::pos::types::WeightedValidator;
 use namada::ledger::pos::PosParams;
@@ -341,7 +340,6 @@ where
             .clone()
     }
 
-    #[cfg(not(feature = "ABCI"))]
     fn get_total_voting_power(&self, epoch: Option<Epoch>) -> VotingPower {
         self.get_active_validators(epoch)
             .iter()
@@ -447,7 +445,6 @@ where
             .ok_or_else(|| Error::NotValidatorKey(pk.to_string(), epoch))
     }
 
-    #[cfg(not(feature = "ABCI"))]
     fn get_validator_from_address(
         &self,
         address: &Address,

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -545,3 +545,48 @@ mod extend_votes {
 
 #[cfg(not(feature = "ABCI"))]
 pub use extend_votes::*;
+
+#[cfg(feature = "ABCI")]
+#[allow(dead_code)]
+/// ABCI is soon being removed - this is solely so that we can still compile
+/// with the default features
+mod extend_votes_stub {
+    use namada::ledger::pos::namada_proof_of_stake::types::VotingPower;
+    use namada::proto::Signed;
+    use namada::types::vote_extensions::ethereum_events;
+
+    use super::super::*;
+
+    #[derive(Error, Debug)]
+    pub enum VoteExtensionError {
+        #[error("This is a stub error")]
+        StubError,
+    }
+
+    impl<D, H> Shell<D, H>
+    where
+        D: DB + for<'iter> DBIter<'iter> + Sync + 'static,
+        H: StorageHasher + Sync + 'static,
+    {
+        pub fn validate_vote_extension_list(
+            &self,
+            _vote_extensions: impl IntoIterator<
+                Item = Signed<ethereum_events::Vext>,
+            > + 'static,
+        ) -> impl Iterator<
+            Item = std::result::Result<
+                (VotingPower, Signed<ethereum_events::Vext>),
+                VoteExtensionError,
+            >,
+        > + '_ {
+            unimplemented!(
+                "validate_vote_extension_list is not implemented for ABCI"
+            );
+            #[allow(unreachable_code)]
+            vec![].into_iter()
+        }
+    }
+}
+
+#[cfg(feature = "ABCI")]
+pub use extend_votes_stub::*;

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -547,7 +547,6 @@ mod extend_votes {
 pub use extend_votes::*;
 
 #[cfg(feature = "ABCI")]
-#[allow(dead_code)]
 /// ABCI is soon being removed - this is solely so that we can still compile
 /// with the default features
 mod extend_votes_stub {
@@ -559,6 +558,7 @@ mod extend_votes_stub {
 
     #[derive(Error, Debug)]
     pub enum VoteExtensionError {
+        #[allow(dead_code)]
         #[error("This is a stub error")]
         StubError,
     }


### PR DESCRIPTION
Adapted from https://github.com/anoma/namada/pull/281

Although we are not using the default feature flag set in developing `eth-bridge-integration`, these are used in CI in `main` at the moment which we'll eventually merge in. This PR is the minimal changes to make it so that running "default" commands like `make check`, `make test-unit`, etc. will still compile and pass.