### PR TITLE
Fix up cargo doc / cargo check

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/events.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/events.rs
@@ -1,4 +1,4 @@
-#[cfg(any(test, feature = "eth-fullnode"))]
+#[cfg(feature = "eth-fullnode")]
 pub mod signatures {
     pub const TRANSFER_TO_NAMADA_SIG: &str =
         "TransferToNamada(uint256,address[],string[],uint256[],uint32)";

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools.rs
@@ -47,7 +47,7 @@ pub mod mock_oracle {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "eth-fullnode"))]
 pub mod mock_web3_client {
     use std::cell::RefCell;
     use std::fmt::Debug;

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1,10 +1,9 @@
 //! The ledger shell connects the ABCI++ interface with the Anoma ledger app.
 //!
 //! Any changes applied before [`Shell::finalize_block`] might have to be
-//! reverted, so any changes applied in the methods `Shell::prepare_proposal`
-//! (ABCI++), [`Shell::process_and_decode_proposal`] must be also reverted
-//! (unless we can simply overwrite them in the next block).
-//! More info in <https://github.com/anoma/anoma/issues/362>.
+//! reverted, so any changes applied in the methods [`Shell::prepare_proposal`]
+//! must be also reverted (unless we can simply overwrite them in the next
+//! block). More info in <https://github.com/anoma/anoma/issues/362>.
 mod finalize_block;
 mod init_chain;
 #[cfg(not(feature = "ABCI"))]

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -1,4 +1,4 @@
-//! Implementation of the [`PrepareProposal`] ABCI++ method for the Shell
+//! Implementation of the `PrepareProposal` ABCI++ method for the Shell
 
 #[cfg(not(feature = "ABCI"))]
 mod prepare_block {

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -172,7 +172,8 @@ mod prepare_block {
 
         /// Compresses a set of signed Ethereum events into a single
         /// [`ethereum_events::VextDigest`], whilst filtering invalid
-        /// [`Signed<ethereum_events::Vext>`] instances in the process
+        /// [`namada::proto::Signed<ethereum_events::Vext>`] instances in the
+        /// process
         // TODO: rename this as `compress_vote_extensions`, and return
         // a `VoteExtensionDigest`, which will contain both digests of
         // ethereum events and validator set update vote extensions

--- a/apps/src/lib/wallet/pre_genesis.rs
+++ b/apps/src/lib/wallet/pre_genesis.rs
@@ -138,8 +138,8 @@ impl ValidatorWallet {
         }
     }
 
-    /// Generate a new [`Validator`] with required pre-genesis keys. Will prompt
-    /// for password when `!unsafe_dont_encrypt`.
+    /// Generate a new [`ValidatorWallet`] with required pre-genesis keys. Will
+    /// prompt for password when `!unsafe_dont_encrypt`.
     fn gen(unsafe_dont_encrypt: bool) -> Self {
         let password = wallet::read_and_confirm_pwd(unsafe_dont_encrypt);
         let (account_key, account_sk) = gen_key_to_store(&password);

--- a/shared/src/types/vote_extensions/ethereum_events.rs
+++ b/shared/src/types/vote_extensions/ethereum_events.rs
@@ -23,7 +23,7 @@ pub struct Vext {
     pub block_height: BlockHeight,
     /// TODO: the validator's address is temporarily being included
     /// until we're able to map a Tendermint address to a validator
-    /// address (see https://github.com/anoma/namada/issues/200)
+    /// address (see <https://github.com/anoma/namada/issues/200>)
     pub validator_addr: Address,
     /// The new ethereum events seen. These should be
     /// deterministically ordered.

--- a/shared/src/types/vote_extensions/validator_set_update.rs
+++ b/shared/src/types/vote_extensions/validator_set_update.rs
@@ -79,7 +79,7 @@ pub struct Vext {
     pub voting_powers: VotingPowersMap,
     /// TODO: the validator's address is temporarily being included
     /// until we're able to map a Tendermint address to a validator
-    /// address (see https://github.com/anoma/namada/issues/200)
+    /// address (see <https://github.com/anoma/namada/issues/200>)
     pub validator_addr: Address,
     /// The new [`Epoch`].
     ///


### PR DESCRIPTION
Small changes to make it so that
- `cargo doc` can compile for ABCI++ on our branch
- `cargo check` does not show dead code warnings when the `eth-fullnode` feature is not enabled