### PR TITLE
fix pred epoch height

### DIFF
--- a/.changelog/unreleased/bug-fixes/1249-fix-shell-last-epoch.md
+++ b/.changelog/unreleased/bug-fixes/1249-fix-shell-last-epoch.md
@@ -1,0 +1,2 @@
+- Fix the `last_epoch` field in the shell to only be updated when the block is
+  committed. ([#1249](https://github.com/anoma/anoma/pull/1249))

--- a/shared/src/ledger/storage/mod.rs
+++ b/shared/src/ledger/storage/mod.rs
@@ -358,6 +358,7 @@ where
         };
         self.db.write_block(state)?;
         self.last_height = self.block.height;
+        self.last_epoch = self.block.epoch;
         self.header = None;
         Ok(())
     }
@@ -597,8 +598,6 @@ where
         if new_epoch {
             // Begin a new epoch
             self.block.epoch = self.block.epoch.next();
-            self.last_epoch = self.last_epoch.next();
-            debug_assert_eq!(self.block.epoch, self.last_epoch);
             let EpochDuration {
                 min_num_of_blocks,
                 min_duration,

--- a/shared/src/ledger/storage/mod.rs
+++ b/shared/src/ledger/storage/mod.rs
@@ -609,7 +609,7 @@ where
             let evidence_max_age_num_blocks: u64 = 100000;
             self.block
                 .pred_epochs
-                .new_epoch(height, evidence_max_age_num_blocks);
+                .new_epoch(height + 1, evidence_max_age_num_blocks);
             tracing::info!("Began a new epoch {}", self.block.epoch);
         }
         self.update_epoch_in_merkle_tree()?;
@@ -828,10 +828,12 @@ mod tests {
                     block_height + epoch_duration.min_num_of_blocks);
                 assert_eq!(storage.next_epoch_min_start_time,
                     block_time + epoch_duration.min_duration);
-                assert_eq!(storage.block.pred_epochs.get_epoch(block_height), Some(epoch_before.next()));
+                assert_eq!(storage.block.pred_epochs.get_epoch(block_height), Some(epoch_before));
+                assert_eq!(storage.block.pred_epochs.get_epoch(block_height + 1), Some(epoch_before.next()));
             } else {
                 assert_eq!(storage.block.epoch, epoch_before);
                 assert_eq!(storage.block.pred_epochs.get_epoch(block_height), Some(epoch_before));
+                assert_eq!(storage.block.pred_epochs.get_epoch(block_height + 1), Some(epoch_before));
             }
             // Last epoch should only change when the block is committed
             assert_eq!(storage.last_epoch, epoch_before);

--- a/shared/src/ledger/storage/mod.rs
+++ b/shared/src/ledger/storage/mod.rs
@@ -824,7 +824,6 @@ mod tests {
                 )
             {
                 assert_eq!(storage.block.epoch, epoch_before.next());
-                assert_eq!(storage.last_epoch, epoch_before.next());
                 assert_eq!(storage.next_epoch_min_start_height,
                     block_height + epoch_duration.min_num_of_blocks);
                 assert_eq!(storage.next_epoch_min_start_time,
@@ -832,9 +831,10 @@ mod tests {
                 assert_eq!(storage.block.pred_epochs.get_epoch(block_height), Some(epoch_before.next()));
             } else {
                 assert_eq!(storage.block.epoch, epoch_before);
-                assert_eq!(storage.last_epoch, epoch_before);
                 assert_eq!(storage.block.pred_epochs.get_epoch(block_height), Some(epoch_before));
             }
+            // Last epoch should only change when the block is committed
+            assert_eq!(storage.last_epoch, epoch_before);
 
             // Update the epoch duration parameters
             parameters.epoch_duration.min_num_of_blocks =
@@ -848,7 +848,7 @@ mod tests {
             parameters::update_epoch_parameter(&mut storage, &parameters.epoch_duration).unwrap();
 
             // Test for 2.
-            let epoch_before = storage.last_epoch;
+            let epoch_before = storage.block.epoch;
             let height_of_update = storage.next_epoch_min_start_height.0 ;
             let time_of_update = storage.next_epoch_min_start_time;
             let height_before_update = BlockHeight(height_of_update - 1);
@@ -859,18 +859,14 @@ mod tests {
             // satisfied
             storage.update_epoch(height_before_update, time_before_update).unwrap();
             assert_eq!(storage.block.epoch, epoch_before);
-            assert_eq!(storage.last_epoch, epoch_before);
             storage.update_epoch(height_of_update, time_before_update).unwrap();
             assert_eq!(storage.block.epoch, epoch_before);
-            assert_eq!(storage.last_epoch, epoch_before);
             storage.update_epoch(height_before_update, time_of_update).unwrap();
             assert_eq!(storage.block.epoch, epoch_before);
-            assert_eq!(storage.last_epoch, epoch_before);
 
             // Update should happen at this or after this height and time
             storage.update_epoch(height_of_update, time_of_update).unwrap();
             assert_eq!(storage.block.epoch, epoch_before.next());
-            assert_eq!(storage.last_epoch, epoch_before.next());
             // The next epoch's minimum duration should change
             assert_eq!(storage.next_epoch_min_start_height,
                 height_of_update + parameters.epoch_duration.min_num_of_blocks);


### PR DESCRIPTION
based on #327 

The value written to pred_epoch.height was off by one - we're switching on the last block of an epoch, so the start height that should be recorded for the new epoch is `current + 1`