### PR TITLE
Add a configuration section for the Ethereum bridge

### DIFF
--- a/apps/src/lib/config/ethereum.rs
+++ b/apps/src/lib/config/ethereum.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+/// Default [Ethereum JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/) endpoint used by the oracle
+pub const DEFAULT_ORACLE_RPC_ENDPOINT: &str = "http://127.0.0.1:8545";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Config {
+    /// The Ethereum JSON-RPC endpoint that the Ethereum event oracle will use
+    /// to listen for events from the Ethereum bridge smart contracts
+    pub oracle_rpc_endpoint: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            oracle_rpc_endpoint: DEFAULT_ORACLE_RPC_ENDPOINT.to_owned(),
+        }
+    }
+}

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -1,5 +1,6 @@
 //! Node and client configuration
 
+pub mod ethereum;
 pub mod genesis;
 pub mod global;
 pub mod utils;
@@ -38,8 +39,6 @@ pub const FILENAME: &str = "config.toml";
 pub const TENDERMINT_DIR: &str = "tendermint";
 /// Chain-specific Anoma DB. Nested in chain dirs.
 pub const DB_DIR: &str = "db";
-/// Websocket address for Ethereum fullnode RPC
-pub const ETHEREUM_URL: &str = "http://127.0.0.1:8545";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
@@ -84,6 +83,7 @@ pub struct Ledger {
     pub chain_id: ChainId,
     pub shell: Shell,
     pub tendermint: Tendermint,
+    pub ethereum: ethereum::Config,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -103,8 +103,6 @@ pub struct Shell {
     db_dir: PathBuf,
     /// Use the [`Ledger::tendermint_dir()`] method to read the value.
     tendermint_dir: PathBuf,
-    /// Use the [`Ledger::ethereum_url()`] method to read the value.
-    ethereum_url: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -176,7 +174,6 @@ impl Ledger {
                 tx_wasm_compilation_cache_bytes: None,
                 db_dir: DB_DIR.into(),
                 tendermint_dir: TENDERMINT_DIR.into(),
-                ethereum_url: ETHEREUM_URL.into(),
             },
             tendermint: Tendermint {
                 rpc_address: SocketAddr::new(
@@ -200,6 +197,7 @@ impl Ledger {
                 ),
                 instrumentation_namespace: "anoman_tm".to_string(),
             },
+            ethereum: ethereum::Config::default(),
         }
     }
 
@@ -216,11 +214,6 @@ impl Ledger {
     /// Get the directory path to Tendermint
     pub fn tendermint_dir(&self) -> PathBuf {
         self.shell.tendermint_dir(&self.chain_id)
-    }
-
-    /// Get the websocket url for the Ethereum fullnode
-    pub fn ethereum_url(&self) -> String {
-        self.shell.ethereum_url.clone()
     }
 }
 

--- a/apps/src/lib/node/ledger/ethereum_node/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/mod.rs
@@ -141,15 +141,17 @@ pub mod eth_fullnode {
                     let client = Web3::new(url, CLIENT_TIMEOUT);
 
                     const SLEEP_DUR: Duration = Duration::from_secs(1);
+                    tracing::info!(?url, "Checking Geth status");
                     loop {
                         if let Ok(false) = client.eth_syncing().await {
-                            tracing::info!("Finished syncing");
+                            tracing::info!(?url, "Finished syncing");
                             break;
                         }
                         if let Err(error) = client.eth_syncing().await {
                             // This is very noisy and usually not interesting.
                             // Still can be very useful
                             tracing::debug!(
+                                ?url,
                                 ?error,
                                 "Couldn't check Geth sync status"
                             );

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -101,12 +101,16 @@ pub mod oracle_process {
             rt.block_on(async move {
                 LocalSet::new()
                     .run_until(async move {
-                        tracing::info!("Ethereum event oracle is starting");
+                        tracing::info!(
+                            ?url,
+                            "Ethereum event oracle is starting"
+                        );
 
                         let oracle = Oracle::new(&url, sender, abort_sender);
                         run_oracle_aux(oracle).await;
 
                         tracing::info!(
+                            ?url,
                             "Ethereum event oracle is no longer running"
                         );
                     })

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -305,7 +305,7 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
     let (broadcaster_sender, broadcaster_receiver) =
         tokio::sync::mpsc::unbounded_channel();
 
-    let ethereum_url = config.ethereum_url();
+    let ethereum_url = config.ethereum.oracle_rpc_endpoint.clone();
     let (ethereum_node, oracle, broadcaster) = if matches!(
         config.tendermint.tendermint_mode,
         TendermintMode::Validator


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/416

Moves the current `ledger.ethereum_url` config var to `ledger.ethereum.oracle_rpc_endpoint`

Can be overridden like so:

```shell
ANOMA_LEDGER__ETHEREUM__ORACLE_RPC_ENDPOINT='blah' target/debug/namadan ledger run
```

Also added a couple of log changes to log out the Ethereum endpoint so that overriding it can be verified.

More settings to be added as part of other PRs (e.g. https://github.com/anoma/namada/pull/294)