### PR TITLE
Update the config crate dependency to v0.13.2

### DIFF
--- a/.changelog/unreleased/bug-fixes/398-update-config.md
+++ b/.changelog/unreleased/bug-fixes/398-update-config.md
@@ -1,0 +1,2 @@
+- Update the config crate to fix passing config values by environment variable
+  ([#398](https://github.com/anoma/namada/pull/398))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "num-traits 0.2.15",
+ "num-traits",
  "zeroize",
 ]
 
@@ -136,7 +136,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits",
  "paste",
  "rustc_version 0.3.3",
  "zeroize",
@@ -159,7 +159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.15",
+ "num-traits",
  "quote",
  "syn",
 ]
@@ -205,7 +205,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "num-traits 0.2.15",
+ "num-traits",
  "rand 0.8.5",
 ]
 
@@ -568,7 +568,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.137",
+ "serde",
 ]
 
 [[package]]
@@ -899,7 +899,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.1",
+ "nom",
 ]
 
 [[package]]
@@ -958,7 +958,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits",
  "time 0.1.44",
  "winapi 0.3.9",
 ]
@@ -1084,15 +1084,18 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.11.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+checksum = "11f1667b8320afa80d69d8bbe40830df2c8a06003d86f73d8e003b2c48df416d"
 dependencies = [
+ "async-trait",
+ "json5",
  "lazy_static 1.4.0",
- "nom 5.1.2",
+ "nom",
+ "pathdiff",
+ "ron",
  "rust-ini",
- "serde 1.0.137",
- "serde-hjson",
+ "serde",
  "serde_json",
  "toml",
  "yaml-rust",
@@ -1642,6 +1645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
 name = "dns-parser"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,7 +1716,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
- "serde 1.0.137",
+ "serde",
  "signature",
 ]
 
@@ -1720,7 +1729,7 @@ dependencies = [
  "curve25519-dalek-ng",
  "hex",
  "rand_core 0.6.3",
- "serde 1.0.137",
+ "serde",
  "sha2 0.9.9",
  "thiserror",
  "zeroize",
@@ -1736,7 +1745,7 @@ dependencies = [
  "ed25519",
  "merlin",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -1858,7 +1867,7 @@ checksum = "f5584ba17d7ab26a8a7284f13e5bd196294dd2f2d79773cff29b9e9edef601a6"
 dependencies = [
  "log 0.4.17",
  "once_cell",
- "serde 1.0.137",
+ "serde",
  "serde_json",
 ]
 
@@ -1940,7 +1949,7 @@ dependencies = [
  "num",
  "rand 0.7.3",
  "rand 0.8.5",
- "serde 1.0.137",
+ "serde",
  "serde_bytes",
  "serde_json",
  "subproductdomain",
@@ -1957,7 +1966,7 @@ dependencies = [
  "ark-ec",
  "ark-serialize",
  "ark-std",
- "serde 1.0.137",
+ "serde",
  "serde_bytes",
 ]
 
@@ -2461,8 +2470,8 @@ dependencies = [
  "byteorder",
  "crossbeam-channel",
  "flate2",
- "nom 7.1.1",
- "num-traits 0.2.15",
+ "nom",
+ "num-traits",
 ]
 
 [[package]]
@@ -2738,11 +2747,11 @@ dependencies = [
  "flex-error",
  "ibc-proto",
  "ics23",
- "num-traits 0.2.15",
+ "num-traits",
  "prost 0.9.0",
  "prost-types 0.9.0",
  "safe-regex",
- "serde 1.0.137",
+ "serde",
  "serde_derive",
  "serde_json",
  "sha2 0.10.2",
@@ -2763,7 +2772,7 @@ dependencies = [
  "bytes 1.1.0",
  "prost 0.9.0",
  "prost-types 0.9.0",
- "serde 1.0.137",
+ "serde",
  "tendermint-proto",
  "tonic",
 ]
@@ -2863,7 +2872,7 @@ checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.11.2",
- "serde 1.0.137",
+ "serde",
 ]
 
 [[package]]
@@ -2983,13 +2992,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonpath_lib"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
 dependencies = [
  "log 0.4.17",
- "serde 1.0.137",
+ "serde",
  "serde_json",
 ]
 
@@ -3060,19 +3080,6 @@ name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -3559,7 +3566,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.137",
+ "serde",
  "sha2 0.9.9",
  "typenum",
 ]
@@ -3622,7 +3629,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 dependencies = [
- "serde 1.0.137",
+ "serde",
  "serde_test",
 ]
 
@@ -3721,10 +3728,16 @@ dependencies = [
  "indexmap",
  "linked-hash-map",
  "regex",
- "serde 1.0.137",
+ "serde",
  "serde_derive",
  "serde_yaml",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "match_cfg"
@@ -3811,7 +3824,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "log 0.4.17",
  "mio 0.7.14",
- "serde 1.0.137",
+ "serde",
  "strum",
  "tungstenite 0.16.0",
  "url 2.2.2",
@@ -4056,7 +4069,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.3",
  "rust_decimal",
- "serde 1.0.137",
+ "serde",
  "serde_json",
  "sha2 0.9.9",
  "sparse-merkle-tree",
@@ -4117,7 +4130,7 @@ dependencies = [
  "message-io",
  "namada",
  "num-derive",
- "num-traits 0.2.15",
+ "num-traits",
  "num_cpus",
  "once_cell",
  "orion",
@@ -4133,7 +4146,7 @@ dependencies = [
  "rlimit",
  "rocksdb",
  "rpassword",
- "serde 1.0.137",
+ "serde",
  "serde_bytes",
  "serde_json",
  "serde_regex",
@@ -4338,17 +4351,6 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check 0.9.4",
-]
-
-[[package]]
-name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
@@ -4395,7 +4397,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.15",
+ "num-traits",
 ]
 
 [[package]]
@@ -4406,7 +4408,7 @@ checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits",
 ]
 
 [[package]]
@@ -4415,7 +4417,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
 dependencies = [
- "num-traits 0.2.15",
+ "num-traits",
 ]
 
 [[package]]
@@ -4436,7 +4438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg 1.1.0",
- "num-traits 0.2.15",
+ "num-traits",
 ]
 
 [[package]]
@@ -4447,7 +4449,7 @@ checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits",
 ]
 
 [[package]]
@@ -4459,16 +4461,7 @@ dependencies = [
  "autocfg 1.1.0",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.15",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.15",
+ "num-traits",
 ]
 
 [[package]]
@@ -4581,6 +4574,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.12.1",
+]
+
+[[package]]
 name = "orion"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,7 +4627,7 @@ dependencies = [
  "data-encoding",
  "multihash",
  "percent-encoding 2.1.0",
- "serde 1.0.137",
+ "serde",
  "static_assertions",
  "unsigned-varint 0.7.1",
  "url 2.2.2",
@@ -4786,6 +4789,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1 0.8.2",
 ]
 
 [[package]]
@@ -5014,7 +5051,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "lazy_static 1.4.0",
- "num-traits 0.2.15",
+ "num-traits",
  "quick-error 2.0.1",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5545,7 +5582,7 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.2.9",
- "serde 1.0.137",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -5649,6 +5686,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
 name = "rpassword"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5660,9 +5708,13 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.13.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
+]
 
 [[package]]
 name = "rust_decimal"
@@ -5671,8 +5723,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2ee7337df68898256ad0d4af4aad178210d9e44d2ff900ce44064a97cd86530"
 dependencies = [
  "arrayvec 0.7.2",
- "num-traits 0.2.15",
- "serde 1.0.137",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -5953,12 +6005,6 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-
-[[package]]
-name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
@@ -5967,24 +6013,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-hjson"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
-dependencies = [
- "lazy_static 1.4.0",
- "num-traits 0.1.43",
- "regex",
- "serde 0.8.23",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
 dependencies = [
- "serde 1.0.137",
+ "serde",
 ]
 
 [[package]]
@@ -6007,7 +6041,7 @@ dependencies = [
  "indexmap",
  "itoa",
  "ryu",
- "serde 1.0.137",
+ "serde",
 ]
 
 [[package]]
@@ -6017,7 +6051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
- "serde 1.0.137",
+ "serde",
 ]
 
 [[package]]
@@ -6037,7 +6071,7 @@ version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe196827aea34242c314d2f0dd49ed00a129225e80dda71b0dbf65d54d25628d"
 dependencies = [
- "serde 1.0.137",
+ "serde",
 ]
 
 [[package]]
@@ -6049,7 +6083,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.137",
+ "serde",
 ]
 
 [[package]]
@@ -6060,7 +6094,7 @@ checksum = "ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051"
 dependencies = [
  "dtoa",
  "linked-hash-map",
- "serde 1.0.137",
+ "serde",
  "yaml-rust",
 ]
 
@@ -6483,12 +6517,12 @@ dependencies = [
  "flex-error",
  "futures 0.3.21",
  "k256",
- "num-traits 0.2.15",
+ "num-traits",
  "once_cell",
  "prost 0.9.0",
  "prost-types 0.9.0",
  "ripemd160",
- "serde 1.0.137",
+ "serde",
  "serde_bytes",
  "serde_json",
  "serde_repr",
@@ -6507,7 +6541,7 @@ version = "0.23.5"
 source = "git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc37927218374f94ac8e2a19bd35bec9#95c52476bc37927218374f94ac8e2a19bd35bec9"
 dependencies = [
  "flex-error",
- "serde 1.0.137",
+ "serde",
  "serde_json",
  "tendermint",
  "toml",
@@ -6521,7 +6555,7 @@ source = "git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc379272183
 dependencies = [
  "derive_more",
  "flex-error",
- "serde 1.0.137",
+ "serde",
  "tendermint",
  "tendermint-rpc",
  "time 0.3.9",
@@ -6535,10 +6569,10 @@ dependencies = [
  "bytes 1.1.0",
  "flex-error",
  "num-derive",
- "num-traits 0.2.15",
+ "num-traits",
  "prost 0.9.0",
  "prost-types 0.9.0",
- "serde 1.0.137",
+ "serde",
  "serde_bytes",
  "subtle-encoding",
  "time 0.3.9",
@@ -6561,7 +6595,7 @@ dependencies = [
  "hyper-rustls",
  "peg",
  "pin-project 1.0.10",
- "serde 1.0.137",
+ "serde",
  "serde_bytes",
  "serde_json",
  "subtle-encoding",
@@ -6584,7 +6618,7 @@ source = "git+https://github.com/heliaxdev/tendermint-rs?rev=95c52476bc379272183
 dependencies = [
  "ed25519-dalek",
  "gumdrop",
- "serde 1.0.137",
+ "serde",
  "serde_json",
  "simple-error",
  "tempfile",
@@ -6961,7 +6995,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
- "serde 1.0.137",
+ "serde",
 ]
 
 [[package]]
@@ -7737,7 +7771,7 @@ dependencies = [
  "enumset",
  "loupe",
  "rkyv",
- "serde 1.0.137",
+ "serde",
  "serde_bytes",
  "smallvec 1.8.0",
  "target-lexicon",
@@ -7812,7 +7846,7 @@ dependencies = [
  "memmap2",
  "more-asserts",
  "rustc-demangle",
- "serde 1.0.137",
+ "serde",
  "serde_bytes",
  "target-lexicon",
  "thiserror",
@@ -7835,7 +7869,7 @@ dependencies = [
  "loupe",
  "object",
  "rkyv",
- "serde 1.0.137",
+ "serde",
  "tempfile",
  "tracing 0.1.35",
  "wasmer-compiler",
@@ -7887,7 +7921,7 @@ dependencies = [
  "indexmap",
  "loupe",
  "rkyv",
- "serde 1.0.137",
+ "serde",
  "thiserror",
 ]
 
@@ -7908,7 +7942,7 @@ dependencies = [
  "more-asserts",
  "region",
  "rkyv",
- "serde 1.0.137",
+ "serde",
  "thiserror",
  "wasmer-types",
  "winapi 0.3.9",

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -60,7 +60,7 @@ byteorder = "1.4.2"
 # https://github.com/clap-rs/clap/issues/1037
 clap = {git = "https://github.com/clap-rs/clap/", tag = "v3.0.0-beta.2", default-features = false, features = ["std", "suggestions", "color", "cargo"]}
 color-eyre = "0.5.10"
-config = "0.11.0"
+config = "0.13.2"
 curl = "0.4.43"
 derivative = "2.2.0"
 directories = "4.0.1"

--- a/apps/src/lib/config/global.rs
+++ b/apps/src/lib/config/global.rs
@@ -45,11 +45,13 @@ impl GlobalConfig {
         if !file_path.exists() {
             return Err(Error::FileNotFound(file_name.to_string()));
         };
-        let mut config = config::Config::new();
+        let mut config = config::Config::default();
         config
             .merge(config::File::with_name(file_name))
             .map_err(Error::ReadError)?;
-        config.try_into().map_err(Error::DeserializationError)
+        config
+            .try_deserialize()
+            .map_err(Error::DeserializationError)
     }
 
     /// Write configuration to a file.

--- a/apps/src/lib/config/global.rs
+++ b/apps/src/lib/config/global.rs
@@ -45,9 +45,10 @@ impl GlobalConfig {
         if !file_path.exists() {
             return Err(Error::FileNotFound(file_name.to_string()));
         };
-        let mut config = config::Config::default();
-        config
-            .merge(config::File::with_name(file_name))
+
+        let config = config::Config::builder()
+            .add_source(config::File::with_name(file_name))
+            .build()
             .map_err(Error::ReadError)?;
         config
             .try_deserialize()

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -352,7 +352,7 @@ impl Config {
             mode,
         ))
         .map_err(Error::ReadError)?;
-        let mut config = config::Config::new();
+        let mut config = config::Config::default();
         config
             .merge(defaults)
             .and_then(|c| c.merge(config::File::with_name(file_name)))
@@ -362,7 +362,9 @@ impl Config {
                 )
             })
             .map_err(Error::ReadError)?;
-        config.try_into().map_err(Error::DeserializationError)
+        config
+            .try_deserialize()
+            .map_err(Error::DeserializationError)
     }
 
     /// Generate configuration and write it to a file.

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -352,15 +352,13 @@ impl Config {
             mode,
         ))
         .map_err(Error::ReadError)?;
-        let mut config = config::Config::default();
-        config
-            .merge(defaults)
-            .and_then(|c| c.merge(config::File::with_name(file_name)))
-            .and_then(|c| {
-                c.merge(
-                    config::Environment::with_prefix("anoma").separator("__"),
-                )
-            })
+        let config = config::Config::builder()
+            .add_source(defaults)
+            .add_source(config::File::with_name(file_name))
+            .add_source(
+                config::Environment::with_prefix("anoma").separator("__"),
+            )
+            .build()
             .map_err(Error::ReadError)?;
         config
             .try_deserialize()


### PR DESCRIPTION
Closes #399

In the version of `config` we were using, it looks like overriding config variables via environment variables wasn't using our custom separator (`__`). This is "fixed" in later versions of `config` so that we could use `ANOMA__` rather than `ANOMA_`.

After this PR lands, we should be able to override config vars via the environment like e.g.
```shell
ANOMA__LEDGER__SHELL__DB_DIR="abc" target/debug/namadan ledger run
```
to override
```toml
# .anoma/<chain-id>/config.toml
[ledger.shell]
db_dir = "..."
```
