### PR TITLE
CI: d/l masp params

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -102,7 +102,7 @@ jobs:
 
   anoma:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -215,6 +215,12 @@ jobs:
           chmod +x target/release/namadan
           chmod +x target/release/namadac
           chmod +x /usr/local/bin/tendermint
+      - name: Download masp parameters
+        run: |
+          mkdir /home/runner/work/masp
+          curl -o /home/runner/work/masp/masp-spend.params -sLO https://github.com/anoma/masp/blob/ef0ef75e81696ff4428db775c654fbec1b39c21f/masp-spend.params?raw=true
+          curl -o /home/runner/work/masp/masp-output.params -sLO https://github.com/anoma/masp/blob/ef0ef75e81696ff4428db775c654fbec1b39c21f/masp-output.params?raw=true
+          curl -o /home/runner/work/masp/masp-convert.params -sLO https://github.com/anoma/masp/blob/ef0ef75e81696ff4428db775c654fbec1b39c21f/masp-convert.params?raw=true
       - name: Run e2e test
         run: make test-e2e${{ matrix.make.suffix }}
         env:
@@ -223,6 +229,7 @@ jobs:
           ANOMA_E2E_KEEP_TEMP: "true"
           ENV_VAR_TM_STDOUT: "false"
           ANOMA_LOG_COLOR: "false"
+          ANOMA_MASP_PARAMS_DIR: "/home/runner/work/masp"
           ANOMA_LOG: "info"
       - name: Upload e2e logs
         if: success() || failure()


### PR DESCRIPTION
based on #351 

In preparation for #257 - we need to d/l MASP params in the CI before we run e2e tests, otherwise the ledger start-up times 
out while it's trying to download them. Because of the changes in https://github.com/anoma/namada/pull/346 (and its follow-ups), the CI doesn't use the .github/workflow files from the source branch, instead it uses the base, so we need to get the CI change merged before #257 can pass e2e tests. The commits in here are cherry-picked from #257 so we can remove them from there.