### PR TITLE
make: use build-doc to only check rustdoc build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,6 @@ clean:
 
 build-doc:
 	$(cargo) doc --no-deps
-	$(cargo) run --bin namada_encoding_spec
-	make -C docs build
 
 doc:
 	# build and opens the docs in browser


### PR DESCRIPTION
this is follow-up to https://github.com/anoma/namada/pull/405