### PR TITLE
Add rate limiting to the Ethereum event oracle

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -123,13 +123,12 @@ async fn run_oracle_aux(oracle: Oracle) {
     // Initialize our local state. This includes
     // the latest block height seen and a queue of events
     // awaiting a certain number of confirmations
-    let mut latest_block;
     let mut pending: Vec<PendingEvent> = Vec::new();
     const SLEEP_DUR: std::time::Duration = std::time::Duration::from_secs(1);
     loop {
         tokio::time::sleep(SLEEP_DUR).await;
         // update the latest block height
-        latest_block = loop {
+        let latest_block = loop {
             match oracle.eth_block_number().await {
                 Ok(height) => break height,
                 Err(error) => {

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -125,11 +125,21 @@ async fn run_oracle_aux(oracle: Oracle) {
     // awaiting a certain number of confirmations
     let mut latest_block;
     let mut pending: Vec<PendingEvent> = Vec::new();
+    const SLEEP_DUR: std::time::Duration = std::time::Duration::from_secs(1);
     loop {
+        tokio::time::sleep(SLEEP_DUR).await;
         // update the latest block height
         latest_block = loop {
-            if let Ok(height) = oracle.eth_block_number().await {
-                break height;
+            match oracle.eth_block_number().await {
+                Ok(height) => break height,
+                Err(error) => {
+                    tracing::warn!(
+                        ?error,
+                        "Couldn't get the latest Ethereum block height, will \
+                         keep trying"
+                    );
+                    tokio::time::sleep(SLEEP_DUR).await;
+                }
             }
             if !oracle.connected() {
                 tracing::info!(
@@ -139,6 +149,7 @@ async fn run_oracle_aux(oracle: Oracle) {
                 return;
             }
         };
+        tracing::debug!(?latest_block, "Got latest Ethereum block height");
         // No blocks in existence yet with enough confirmations
         if Uint256::from(MIN_CONFIRMATIONS) > latest_block {
             if !oracle.connected() {


### PR DESCRIPTION
(this PR was split out from https://github.com/anoma/namada/pull/253)

Closes https://github.com/anoma/namada/issues/464

This PR has the oracle back off a bit after having gotten the latest block from the Ethereum JSON-RPC endpoint being used, otherwise we call the Ethereum RPC endpoint very fast over and over. Also adding some extra logging, so we can see what the latest block height is.

```
2022-08-04T12:56:01.158995Z  WARN namada_apps::node::ledger::ethereum_node::oracle::oracle_process: 
Couldn't get the latest Ethereum block height, will keep trying
error=FailedToSend(Connect(Io(Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })))
```

```
2022-08-04T12:53:54.587542Z DEBUG namada_apps::node::ledger::ethereum_node::oracle::oracle_process:
Got latest Ethereum block height latest_block=Uint256(7345457)
```

(we could expand the backoff strategy in later PRs but adding these small 1-second sleeps solves the immediate issue)