### PR TITLE
Return the VoteExtension protocol txs from PrepareProposal

### DIFF
--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -120,7 +120,12 @@ where
                 .votes,
         );
         #[cfg(not(feature = "abcipp"))]
-        let (eth_events, valset_upds) = split_vote_extensions(txs);
+        let (protocol_txs, eth_events, valset_upds) =
+            split_vote_extensions(txs);
+
+        // TODO: remove this later, when we get rid of `abciplus`
+        #[cfg(feature = "abcipp")]
+        let protocol_txs = vec![];
 
         let ethereum_events = self
             .compress_ethereum_events(eth_events)
@@ -148,6 +153,8 @@ where
             validator_set_update,
         })
         .map(|tx| tx.sign(protocol_key).to_bytes())
+        // TODO: remove this later, when we get rid of `abciplus`
+        .chain(protocol_txs.into_iter())
         .collect()
     }
 

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -728,14 +728,8 @@ mod test_prepare_proposal {
                 txs: vec![tx],
                 ..Default::default()
             });
-            #[cfg(feature = "abcipp")]
-            assert_eq!(rsp.txs.len(), 1);
-            #[cfg(not(feature = "abcipp"))]
-            assert_eq!(rsp.txs.len(), 2);
+            assert_eq!(rsp.txs.len(), 3);
 
-            #[cfg(feature = "abcipp")]
-            let tx_bytes = rsp.txs.pop().unwrap();
-            #[cfg(not(feature = "abcipp"))]
             // NOTE: we remove the first pos, bc the ethereum events
             // vote extension protocol tx will always precede the
             // valset upd vext protocol tx
@@ -868,7 +862,7 @@ mod test_prepare_proposal {
                 txs: vec![vote],
                 ..Default::default()
             });
-            assert_eq!(rsp.txs.len(), 2);
+            assert_eq!(rsp.txs.len(), 3);
 
             let tx_bytes = rsp.txs.remove(0);
             let got = Tx::try_from(&tx_bytes[..]).unwrap();

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -273,11 +273,11 @@ pub fn deserialize_vote_extensions(
 #[cfg(not(feature = "abcipp"))]
 pub fn deserialize_vote_extensions(
     txs: &[TxBytes],
-) -> impl Iterator<Item = VoteExtension> + '_ {
+) -> impl Iterator<Item = (TxBytes, VoteExtension)> + '_ {
     use namada::types::transaction::protocol::ProtocolTx;
 
-    txs.iter().filter_map(|tx| {
-        let tx = match Tx::try_from(tx.as_slice()) {
+    txs.iter().filter_map(|tx_bytes| {
+        let tx = match Tx::try_from(tx_bytes.as_slice()) {
             Ok(tx) => tx,
             Err(err) => {
                 tracing::warn!(
@@ -291,7 +291,7 @@ pub fn deserialize_vote_extensions(
             TxType::Protocol(ProtocolTx {
                 tx: ProtocolTxType::VoteExtension(ext),
                 ..
-            }) => Some(ext),
+            }) => Some((tx_bytes.clone(), ext)),
             _ => None,
         }
     })
@@ -315,9 +315,9 @@ pub fn iter_protocol_txs(
 /// Deserializes `vote_extensions` as [`VoteExtension`] instances, filtering
 /// out invalid data, and splits these into [`ethereum_events::Vext`]
 /// and [`validator_set_update::Vext`] instances.
+#[cfg(feature = "abcipp")]
 pub fn split_vote_extensions(
-    #[cfg(feature = "abcipp")] vote_extensions: Vec<ExtendedVoteInfo>,
-    #[cfg(not(feature = "abcipp"))] vote_extensions: &[TxBytes],
+    vote_extensions: Vec<ExtendedVoteInfo>,
 ) -> (
     Vec<Signed<ethereum_events::Vext>>,
     Vec<validator_set_update::SignedVext>,
@@ -333,4 +333,33 @@ pub fn split_vote_extensions(
     }
 
     (eth_evs, valset_upds)
+}
+
+/// Deserializes [`VoteExtension`] instances from mempool protocol txs,
+/// filtering out non-protocol txs, and splits these into
+/// [`ethereum_events::Vext`] and [`validator_set_update::Vext`] instances.
+///
+/// The original [`TxBytes`] are also returned, such that we can remove
+/// them from Tendermint's mempool.
+#[cfg(not(feature = "abcipp"))]
+pub fn split_vote_extensions(
+    mempool_txs: &[TxBytes],
+) -> (
+    Vec<TxBytes>,
+    Vec<Signed<ethereum_events::Vext>>,
+    Vec<validator_set_update::SignedVext>,
+) {
+    let mut txs = vec![];
+    let mut eth_evs = vec![];
+    let mut valset_upds = vec![];
+
+    for (tx, ext) in deserialize_vote_extensions(mempool_txs) {
+        if let Some(validator_set_update) = ext.validator_set_update {
+            valset_upds.push(validator_set_update);
+        }
+        eth_evs.push(ext.ethereum_events);
+        txs.push(tx);
+    }
+
+    (txs, eth_evs, valset_upds)
 }


### PR DESCRIPTION
This PR changes the following: during PrepareProposal, we return `ProtocolTxType::VoteExtension` instances in the tx arguments back to the replication engine. We do this so Tendermint can remove these protocol txs from its mempool.