### PR TITLE
Avoid starving other Tokio tasks while waiting for geth to exit

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/mod.rs
@@ -99,7 +99,6 @@ pub mod eth_fullnode {
 
     use async_trait::async_trait;
     use tokio::process::{Child, Command};
-    use tokio::sync::oneshot::error::TryRecvError;
     use tokio::sync::oneshot::{channel, Receiver, Sender};
     use tokio::task::LocalSet;
     use web30::client::Web3;
@@ -209,22 +208,19 @@ pub mod eth_fullnode {
         /// received from the Oracle process. If either, return the
         /// status.
         async fn wait(&mut self) -> Result<()> {
-            loop {
-                match self.process.try_wait() {
-                    Ok(Some(status)) => {
-                        return if status.success() {
-                            Ok(())
-                        } else {
-                            Err(Error::Runtime(status.to_string()))
-                        };
-                    }
-                    Ok(None) => {}
-                    Err(err) => return Err(Error::Runtime(err.to_string())),
+            use futures::future::{self, Either};
+
+            let child_proc = self.process.wait();
+            futures::pin_mut!(child_proc);
+
+            match future::select(&mut self.abort_recv, child_proc).await {
+                Either::Left((_abort_received, _)) => Err(Error::Oracle),
+                Either::Right((Ok(status), _)) if status.success() => Ok(()),
+                Either::Right((Ok(status), _)) => {
+                    Err(Error::Runtime(format!("{status}")))
                 }
-                match self.abort_recv.try_recv() {
-                    Ok(()) => return Ok(()),
-                    Err(TryRecvError::Empty) => {}
-                    Err(TryRecvError::Closed) => return Err(Error::Oracle),
+                Either::Right((Err(err), _)) => {
+                    Err(Error::Runtime(format!("{err}")))
                 }
             }
         }

--- a/apps/src/lib/node/ledger/ethereum_node/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/mod.rs
@@ -214,7 +214,7 @@ pub mod eth_fullnode {
             futures::pin_mut!(child_proc);
 
             match future::select(&mut self.abort_recv, child_proc).await {
-                Either::Left((_abort_received, _)) => Err(Error::Oracle),
+                Either::Left(_) => Err(Error::Oracle),
                 Either::Right((Ok(status), _)) if status.success() => Ok(()),
                 Either::Right((Ok(status), _)) => {
                     Err(Error::Runtime(format!("{status}")))


### PR DESCRIPTION
Waiting for `geth` to finish had no `.await` points in an infinite loop. This meant waiting for it to finish starved other tasks from making progress on one of the runtime's threads. This PR fixes that.