### PR TITLE
Update `eth-bridge-integration` with `main`

### DIFF
--- a/.changelog/unreleased/bug-fixes/419-fix-rustdoc.md
+++ b/.changelog/unreleased/bug-fixes/419-fix-rustdoc.md
@@ -1,0 +1,1 @@
+- Fix the rustdoc build. ([#419](https://github.com/anoma/namada/issues/419))

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! Any changes applied before [`Shell::finalize_block`] might have to be
 //! reverted, so any changes applied in the methods [`Shell::prepare_proposal`]
-//! must be also reverted (unless we can simply overwrite them in the next
-//! block). More info in <https://github.com/anoma/anoma/issues/362>.
+//! and [`Shell::process_proposal`] must be also reverted
+//! (unless we can simply overwrite them in the next block).
+//! More info in <https://github.com/anoma/anoma/issues/362>.
 mod finalize_block;
 mod init_chain;
 mod prepare_proposal;

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -1,4 +1,4 @@
-//! Implementation of the `PrepareProposal` ABCI++ method for the Shell
+//! Implementation of the [`RequestPrepareProposal`] ABCI++ method for the Shell
 
 use namada::ledger::storage::{DBIter, StorageHasher, DB};
 use namada::proto::Tx;


### PR DESCRIPTION
Resolves some conflicts where `cargo doc` had been fixed differently in `main`