### PR TITLE
Deduplicate votes during FinalizeBlock

### DIFF
--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -57,7 +57,7 @@ where
         .map(|MultiSignedEthEvent { event, signers }| {
             let voters: HashSet<Address> =
                 signers.iter().map(|(addr, _)| addr.to_owned()).collect();
-            let mut votes = BTreeSet::default();
+            let mut earliest_votes = BTreeSet::default();
             for voter in voters {
                 let earliest_vote_height = signers
                     .iter()
@@ -66,11 +66,11 @@ where
                     .min()
                     .expect("every voter must have at least one vote");
                 // TODO: remove the above expect!
-                _ = votes.insert((voter, earliest_vote_height));
+                _ = earliest_votes.insert((voter, earliest_vote_height));
             }
             MultiSignedEthEvent {
                 event,
-                signers: votes,
+                signers: earliest_votes,
             }
         })
         .collect();

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -348,7 +348,7 @@ mod tests {
     fn test_get_voting_powers_empty() {
         let storage = TestStorage::default();
 
-        let result = get_voting_powers(&storage, &vec![]);
+        let result = get_voting_powers(&storage, &[]);
 
         assert!(result.unwrap().is_empty())
     }
@@ -402,7 +402,7 @@ mod tests {
                 equal_voting_power,
             ),
         ];
-        let storage = set_up_test_storage(HashMap::from_iter(voters.clone()));
+        let storage = set_up_test_storage(HashMap::from_iter(voters));
         let event = EthereumEvent::TransfersToNamada {
             nonce: 1.into(),
             transfers: vec![TransferToNamada {

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -318,6 +318,38 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_get_voting_powers_one_validator() {
+        let voter = address::testing::established_address_1();
+        let voting_height = BlockHeight(100);
+        let storage = set_up_test_storage(HashMap::from_iter(vec![(
+            voter.clone(),
+            VotingPower::from(100),
+        )]));
+
+        let event = EthereumEvent::TransfersToNamada {
+            nonce: 1.into(),
+            transfers: vec![TransferToNamada {
+                amount: Amount::from(100),
+                asset: DAI_ERC20_ETH_ADDRESS,
+                receiver: address::testing::established_address_1(),
+            }],
+        };
+        let signers = HashSet::from_iter(vec![(voter.clone(), voting_height)]);
+
+        let events = vec![MultiSignedEthEvent { event, signers }];
+
+        let result = get_voting_powers(&storage, &events);
+
+        assert_eq!(
+            result.unwrap(),
+            HashMap::from_iter(vec![(
+                (voter, voting_height),
+                FractionalVotingPower::new(1, 1).unwrap()
+            )])
+        );
+    }
+
+    #[test]
     /// Test applying a `TransfersToNamada` batch containing a single transfer
     fn test_apply_single_transfer() -> Result<()> {
         let sole_validator = address::testing::gen_established_address();

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -36,7 +36,7 @@ type ChangedKeys = BTreeSet<storage::Key>;
 /// the passed `events`.
 pub(crate) fn apply_derived_tx<D, H>(
     storage: &mut Storage<D, H>,
-    events: Vec<MultiSignedEthEvent>,
+    events: Vec<MultiSignedEthEvent>, /* TODO: should this be a BTreeMap<EthereumEvent, BTreeSet<(Address, BlockHeight)>> */
 ) -> Result<TxResult>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -57,7 +57,7 @@ where
         .map(|MultiSignedEthEvent { event, signers }| {
             let voters: HashSet<Address> =
                 signers.iter().map(|(addr, _)| addr.to_owned()).collect();
-            let mut votes = HashSet::with_capacity(voters.len());
+            let mut votes = BTreeSet::default();
             for voter in voters {
                 let earliest_vote_height = signers
                     .iter()
@@ -370,7 +370,7 @@ mod tests {
                 receiver: address::testing::established_address_1(),
             }],
         };
-        let signers = HashSet::from_iter(vec![(voter.clone(), voting_height)]);
+        let signers = BTreeSet::from_iter(vec![(voter.clone(), voting_height)]);
 
         let events = vec![MultiSignedEthEvent { event, signers }];
 
@@ -411,7 +411,7 @@ mod tests {
                 receiver: address::testing::established_address_1(),
             }],
         };
-        let signers = HashSet::from_iter(vec![
+        let signers = BTreeSet::from_iter(vec![
             (address::testing::established_address_1(), BlockHeight(100)),
             (address::testing::established_address_1(), BlockHeight(101)),
             (address::testing::established_address_1(), BlockHeight(102)),

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -74,6 +74,10 @@ where
             }
         })
         .collect();
+    // from a type perspective we ultimately want something like a
+    // `BTreeMap<EthereumEvent, BTreeMap<Address, BlockHeight>>` where each seen
+    // event has an associated map of validators who saw it mapped to the
+    // earliest block height at which they saw it
 
     let voting_powers = get_voting_powers(storage, &deduped)?;
 

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -318,6 +318,15 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_get_voting_powers_empty() {
+        let storage = TestStorage::default();
+
+        let result = get_voting_powers(&storage, &vec![]);
+
+        assert!(result.unwrap().is_empty())
+    }
+
+    #[test]
     fn test_get_voting_powers_one_validator() {
         let voter = address::testing::established_address_1();
         let voting_height = BlockHeight(100);


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/515

It is possible for multiple votes from the same validator for the same event but at different block heights to be included in a vext digest. We arbitrarily take the earliest one by block height and use that when adding voting power for an event. 