### PR TITLE
Re-enable `run_ledger` e2e test for `eth-bridge-integration`

### DIFF
--- a/.github/workflows/build-tendermint.yml
+++ b/.github/workflows/build-tendermint.yml
@@ -24,9 +24,6 @@ jobs:
           - name: tendermint-unreleased
             repository: heliaxdev/tendermint
             tendermint_version: 559fb33ff9b27503ce7ac1c7d8589fe1d8b3e900
-          - name: tendermint-unreleased
-            repository: heliaxdev/tendermint
-            tendermint_version: ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
 
     steps:
       - name: Build ${{ matrix.make.name }}

--- a/.github/workflows/build-tendermint.yml
+++ b/.github/workflows/build-tendermint.yml
@@ -12,6 +12,7 @@ permissions:
 env:
   GIT_LFS_SKIP_SMUDGE: 1
 
+
 jobs:
   tendermint:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-tendermint.yml
+++ b/.github/workflows/build-tendermint.yml
@@ -12,7 +12,6 @@ permissions:
 env:
   GIT_LFS_SKIP_SMUDGE: 1
 
-
 jobs:
   tendermint:
     runs-on: ${{ matrix.os }}
@@ -24,6 +23,9 @@ jobs:
           - name: tendermint-unreleased
             repository: heliaxdev/tendermint
             tendermint_version: 559fb33ff9b27503ce7ac1c7d8589fe1d8b3e900
+          - name: tendermint-unreleased
+            repository: heliaxdev/tendermint
+            tendermint_version: ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
 
     steps:
       - name: Build ${{ matrix.make.name }}

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -133,6 +133,8 @@ fn test_node_connectivity() -> Result<()> {
 /// 3. Check that the node detects this
 /// 4. Check that the node shuts down
 #[test]
+#[ignore]
+// TODO(namada#418): re-enable once working again
 fn test_anoma_shuts_down_if_tendermint_dies() -> Result<()> {
     let test = setup::single_node_net()?;
 
@@ -169,6 +171,8 @@ fn test_anoma_shuts_down_if_tendermint_dies() -> Result<()> {
 /// 5. Reset the ledger's state
 /// 6. Run the ledger again, it should start from fresh state
 #[test]
+#[ignore]
+// TODO(namada#418): re-enable once working again
 fn run_ledger_load_state_and_reset() -> Result<()> {
     let test = setup::single_node_net()?;
 

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -35,8 +35,6 @@ use crate::{run, run_as};
 /// combinations from fresh state, the node starts-up successfully for both a
 /// validator and non-validator user.
 #[test]
-#[ignore]
-// TODO(namada#418): re-enable once working again
 fn run_ledger() -> Result<()> {
     let test = setup::single_node_net()?;
     let cmd_combinations = vec![vec!["ledger"], vec!["ledger", "run"]];
@@ -135,8 +133,6 @@ fn test_node_connectivity() -> Result<()> {
 /// 3. Check that the node detects this
 /// 4. Check that the node shuts down
 #[test]
-#[ignore]
-// TODO(namada#418): re-enable once working again
 fn test_anoma_shuts_down_if_tendermint_dies() -> Result<()> {
     let test = setup::single_node_net()?;
 

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -169,8 +169,6 @@ fn test_anoma_shuts_down_if_tendermint_dies() -> Result<()> {
 /// 5. Reset the ledger's state
 /// 6. Run the ledger again, it should start from fresh state
 #[test]
-#[ignore]
-// TODO(namada#418): re-enable once working again
 fn run_ledger_load_state_and_reset() -> Result<()> {
     let test = setup::single_node_net()?;
 

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -58,55 +58,6 @@ fn run_ledger() -> Result<()> {
     Ok(())
 }
 
-#[test]
-/// In this test we:
-/// 1. Run a single genesis validator node
-/// 2. Submit a valid token transfer tx
-/// 3. Check that the transfer was processed
-fn test_simple_transfer() -> Result<()> {
-    let test =
-        setup::network(|genesis| setup::add_validators(0, genesis), None)?;
-
-    let args = ["ledger"];
-    let mut validator =
-        run_as!(test, Who::Validator(0), Bin::Node, args, Some(40))?;
-    validator.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
-
-    let bg_validator = validator.background();
-
-    // 2. Submit a valid token transfer tx
-    let tendermint_rpc_addr = get_actor_rpc(&test, &Who::Validator(0));
-    let tx_args = [
-        "transfer",
-        "--source",
-        BERTHA,
-        "--target",
-        ALBERT,
-        "--token",
-        XAN,
-        "--amount",
-        "10.1",
-        "--fee-amount",
-        "0",
-        "--gas-limit",
-        "0",
-        "--fee-token",
-        XAN,
-        "--ledger-address",
-        &tendermint_rpc_addr,
-    ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
-    client.exp_string("Transaction is valid.")?;
-    client.assert_success();
-
-    // // 3. Check that the transfer was processed
-    let mut validator = bg_validator.foreground();
-    let expected_result = "all VPs accepted transaction";
-    validator.exp_string(expected_result)?;
-
-    Ok(())
-}
-
 /// In this test we:
 /// 1. Run 2 genesis validator ledger nodes and 1 non-validator node
 /// 2. Submit a valid token transfer tx

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -666,6 +666,7 @@ where
     run_cmd
         .env("ANOMA_LOG", "info")
         .env("TM_LOG_LEVEL", "info")
+        .env("ANOMA_LEDGER__ETHEREUM__MODE", "Off")
         .env("ANOMA_LOG_COLOR", "false")
         .current_dir(working_dir)
         .args(&[

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -664,9 +664,9 @@ where
     );
 
     run_cmd
-        .env("ANOMA_LOG", "debug")
+        .env("ANOMA_LOG", "info")
         .env("ANOMA_TM_STDOUT", "true")
-        .env("TM_LOG_LEVEL", "debug")
+        .env("TM_LOG_LEVEL", "info")
         .env("ANOMA_LEDGER__ETHEREUM__MODE", "Off")
         .env("ANOMA_LOG_COLOR", "false")
         .current_dir(working_dir)

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -664,8 +664,9 @@ where
     );
 
     run_cmd
-        .env("ANOMA_LOG", "info")
-        .env("TM_LOG_LEVEL", "info")
+        .env("ANOMA_LOG", "debug")
+        .env("ANOMA_TM_STDOUT", "true")
+        .env("TM_LOG_LEVEL", "debug")
         .env("ANOMA_LEDGER__ETHEREUM__MODE", "Off")
         .env("ANOMA_LOG_COLOR", "false")
         .current_dir(working_dir)


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/418

- turn off Ethereum bridge componentry in e2e tests for the time being
- re-enable the `run_ledger` test which seems to pass in CI again (even with old Tendermint)
- Tendermint CI changes are being cherry picked in a separate PR, https://github.com/anoma/namada/pull/593

```
 running 19 tests
test e2e::eth_bridge_tests::everything ... ignored
test e2e::gossip_tests::match_intents ... ignored
test e2e::gossip_tests::run_gossip ... ignored
test e2e::ledger_tests::invalid_transactions ... ignored
test e2e::ledger_tests::ledger_many_txs_in_a_block ... ignored
test e2e::ledger_tests::ledger_txs_and_queries ... ignored
test e2e::ledger_tests::pos_bonds ... ignored
test e2e::ledger_tests::pos_init_validator ... ignored
test e2e::ledger_tests::proposal_offline ... ignored
test e2e::ledger_tests::proposal_submission ... ignored
test e2e::ledger_tests::run_ledger ... ok <4.399s>
test e2e::ledger_tests::run_ledger_load_state_and_reset ... ignored
test e2e::ledger_tests::test_anoma_shuts_down_if_tendermint_dies ... ignored
test e2e::ledger_tests::test_genesis_validators ... ignored
test e2e::ledger_tests::test_node_connectivity ... ignored
test e2e::wallet_tests::wallet_address_cmds ... ok <0.422s>
test e2e::wallet_tests::wallet_encrypted_key_cmds ... ok <0.878s>
test e2e::wallet_tests::wallet_encrypted_key_cmds_env_var ... ok <0.854s>
test e2e::wallet_tests::wallet_unencrypted_key_cmds ... ok <0.294s>
```
https://github.com/anoma/namada/actions/runs/3243948741/jobs/5319410827