### PR TITLE
Ensure Ethereum events endpoint shuts down correctly

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/events.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/events.rs
@@ -202,7 +202,7 @@ pub mod eth_events {
         /// Check if the minimum number of confirmations has been
         /// reached at the input block height.
         pub fn is_confirmed(&self, height: &Uint256) -> bool {
-            self.confirmations >= height.clone() - self.block_height.clone()
+            self.confirmations <= height.clone() - self.block_height.clone()
         }
     }
 

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -73,6 +73,9 @@ impl Oracle {
     /// N.B. this will block if the internal channel buffer
     /// is full.
     async fn send(&self, events: Vec<EthereumEvent>) -> bool {
+        if self.sender.is_closed() {
+            return false;
+        }
         for event in events.into_iter() {
             if self.sender.send(event).await.is_err() {
                 return false;

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
@@ -2,7 +2,7 @@ use borsh::BorshDeserialize;
 use namada::types::ethereum_events::EthereumEvent;
 use tokio::sync::mpsc::UnboundedSender;
 
-const DEFAULT_ENDPOINT: ([u8; 4], u16) = ([127, 0, 0, 1], 3030);
+const DEFAULT_ENDPOINT: ([u8; 4], u16) = ([0, 0, 0, 0], 3030);
 
 /// The path to which Borsh-serialized Ethereum events should be submitted
 const PATH: &str = "eth_events";

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
@@ -1,7 +1,8 @@
 use borsh::BorshDeserialize;
 use namada::types::ethereum_events::EthereumEvent;
 use tokio::macros::support::poll_fn;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender as BoundedSender;
+use warp::reply::WithStatus;
 use warp::Filter;
 
 /// The default IP address and port on which the events endpoint will listen.
@@ -15,38 +16,14 @@ const EVENTS_POST_ENDPOINT: &str = "eth_events";
 /// and then forwards them to `sender`. It shuts down if `abort_sender` is
 /// closed.
 pub fn serve(
-    sender: UnboundedSender<EthereumEvent>,
+    sender: BoundedSender<EthereumEvent>,
     mut abort_sender: tokio::sync::oneshot::Sender<()>,
 ) -> tokio::task::JoinHandle<()> {
+    tracing::info!(?DEFAULT_LISTEN_ADDR, "Ethereum event endpoint is starting");
     let eth_events = warp::post()
         .and(warp::path(EVENTS_POST_ENDPOINT))
         .and(warp::body::bytes())
-        .map(move |bytes: bytes::Bytes| {
-            tracing::info!(len = bytes.len(), "Received request");
-            let event = match EthereumEvent::try_from_slice(&bytes) {
-                Ok(event) => event,
-                Err(error) => {
-                    tracing::warn!(?error, "Couldn't handle request");
-                    return warp::reply::with_status(
-                        "Bad request",
-                        warp::http::StatusCode::BAD_REQUEST,
-                    );
-                }
-            };
-            tracing::debug!("Serialized event - {:#?}", event);
-            match sender.send(event) {
-                Ok(()) => {
-                    warp::reply::with_status("OK", warp::http::StatusCode::OK)
-                }
-                Err(error) => {
-                    tracing::warn!(?error, "Couldn't send event");
-                    warp::reply::with_status(
-                        "Internal server error",
-                        warp::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    )
-                }
-            }
-        });
+        .then(move |bytes: bytes::Bytes| send(bytes, sender.clone()));
 
     let (_, server) = warp::serve(eth_events).bind_with_graceful_shutdown(
         DEFAULT_LISTEN_ADDR,
@@ -64,4 +41,33 @@ pub fn serve(
     );
 
     tokio::task::spawn(server)
+}
+
+/// Callback to send out events from the oracle
+async fn send(
+    bytes: bytes::Bytes,
+    sender: BoundedSender<EthereumEvent>,
+) -> WithStatus<&'static str> {
+    tracing::info!(len = bytes.len(), "Received request");
+    let event = match EthereumEvent::try_from_slice(&bytes) {
+        Ok(event) => event,
+        Err(error) => {
+            tracing::warn!(?error, "Couldn't handle request");
+            return warp::reply::with_status(
+                "Bad request",
+                warp::http::StatusCode::BAD_REQUEST,
+            );
+        }
+    };
+    tracing::debug!("Serialized event - {:#?}", event);
+    match sender.send(event).await {
+        Ok(()) => warp::reply::with_status("OK", warp::http::StatusCode::OK),
+        Err(error) => {
+            tracing::warn!(?error, "Couldn't send event");
+            warp::reply::with_status(
+                "Internal server error",
+                warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+            )
+        }
+    }
 }

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
@@ -1,0 +1,59 @@
+use borsh::BorshDeserialize;
+use namada::types::ethereum_events::EthereumEvent;
+use tokio::sync::mpsc::UnboundedSender;
+
+const DEFAULT_ENDPOINT: ([u8; 4], u16) = ([127, 0, 0, 1], 3030);
+
+/// The path to which Borsh-serialized Ethereum events should be submitted
+const PATH: &str = "eth_events";
+
+pub fn serve(
+    sender: UnboundedSender<EthereumEvent>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        use warp::Filter;
+
+        tracing::info!(
+            ?DEFAULT_ENDPOINT,
+            "Ethereum event endpoint is starting"
+        );
+
+        let eth_events = warp::post()
+            .and(warp::path(PATH))
+            .and(warp::body::bytes())
+            .map(move |bytes: bytes::Bytes| {
+                tracing::info!(len = bytes.len(), "Received request");
+                let event = match EthereumEvent::try_from_slice(&bytes) {
+                    Ok(event) => event,
+                    Err(error) => {
+                        tracing::warn!(?error, "Couldn't handle request");
+                        return warp::reply::with_status(
+                            "Bad request",
+                            warp::http::StatusCode::BAD_REQUEST,
+                        );
+                    }
+                };
+                tracing::debug!("Serialized event - {:#?}", event);
+                match sender.send(event) {
+                    Ok(()) => warp::reply::with_status(
+                        "OK",
+                        warp::http::StatusCode::OK,
+                    ),
+                    Err(error) => {
+                        tracing::warn!(?error, "Couldn't send event");
+                        warp::reply::with_status(
+                            "Internal server error",
+                            warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        )
+                    }
+                }
+            });
+
+        warp::serve(eth_events).run(DEFAULT_ENDPOINT).await;
+
+        tracing::info!(
+            ?DEFAULT_ENDPOINT,
+            "Ethereum event endpoint is no longer running"
+        );
+    })
+}

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
@@ -1,6 +1,8 @@
 use borsh::BorshDeserialize;
 use namada::types::ethereum_events::EthereumEvent;
+use tokio::macros::support::poll_fn;
 use tokio::sync::mpsc::UnboundedSender;
+use warp::Filter;
 
 const DEFAULT_ENDPOINT: ([u8; 4], u16) = ([0, 0, 0, 0], 3030);
 
@@ -9,51 +11,52 @@ const PATH: &str = "eth_events";
 
 pub fn serve(
     sender: UnboundedSender<EthereumEvent>,
+    mut abort_sender: tokio::sync::oneshot::Sender<()>,
 ) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        use warp::Filter;
-
-        tracing::info!(
-            ?DEFAULT_ENDPOINT,
-            "Ethereum event endpoint is starting"
-        );
-
-        let eth_events = warp::post()
-            .and(warp::path(PATH))
-            .and(warp::body::bytes())
-            .map(move |bytes: bytes::Bytes| {
-                tracing::info!(len = bytes.len(), "Received request");
-                let event = match EthereumEvent::try_from_slice(&bytes) {
-                    Ok(event) => event,
-                    Err(error) => {
-                        tracing::warn!(?error, "Couldn't handle request");
-                        return warp::reply::with_status(
-                            "Bad request",
-                            warp::http::StatusCode::BAD_REQUEST,
-                        );
-                    }
-                };
-                tracing::debug!("Serialized event - {:#?}", event);
-                match sender.send(event) {
-                    Ok(()) => warp::reply::with_status(
-                        "OK",
-                        warp::http::StatusCode::OK,
-                    ),
-                    Err(error) => {
-                        tracing::warn!(?error, "Couldn't send event");
-                        warp::reply::with_status(
-                            "Internal server error",
-                            warp::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        )
-                    }
+    let eth_events = warp::post()
+        .and(warp::path(PATH))
+        .and(warp::body::bytes())
+        .map(move |bytes: bytes::Bytes| {
+            tracing::info!(len = bytes.len(), "Received request");
+            let event = match EthereumEvent::try_from_slice(&bytes) {
+                Ok(event) => event,
+                Err(error) => {
+                    tracing::warn!(?error, "Couldn't handle request");
+                    return warp::reply::with_status(
+                        "Bad request",
+                        warp::http::StatusCode::BAD_REQUEST,
+                    );
                 }
-            });
+            };
+            tracing::debug!("Serialized event - {:#?}", event);
+            match sender.send(event) {
+                Ok(()) => {
+                    warp::reply::with_status("OK", warp::http::StatusCode::OK)
+                }
+                Err(error) => {
+                    tracing::warn!(?error, "Couldn't send event");
+                    warp::reply::with_status(
+                        "Internal server error",
+                        warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    )
+                }
+            }
+        });
 
-        warp::serve(eth_events).run(DEFAULT_ENDPOINT).await;
+    let (_, server) = warp::serve(eth_events).bind_with_graceful_shutdown(
+        DEFAULT_ENDPOINT,
+        async move {
+            tracing::info!(
+                ?DEFAULT_ENDPOINT,
+                "Starting to listen for Borsh-serialized Ethereum events"
+            );
+            poll_fn(|cx| abort_sender.poll_closed(cx)).await;
+            tracing::info!(
+                ?DEFAULT_ENDPOINT,
+                "Stopping listening for Borsh-serialized Ethereum events"
+            );
+        },
+    );
 
-        tracing::info!(
-            ?DEFAULT_ENDPOINT,
-            "Ethereum event endpoint is no longer running"
-        );
-    })
+    tokio::task::spawn(server)
 }

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools/events_endpoint.rs
@@ -4,11 +4,15 @@ use tokio::macros::support::poll_fn;
 use tokio::sync::mpsc::UnboundedSender;
 use warp::Filter;
 
+/// The default IP address and port on which the events endpoint will listen
 const DEFAULT_ENDPOINT: ([u8; 4], u16) = ([0, 0, 0, 0], 3030);
 
-/// The path to which Borsh-serialized Ethereum events should be submitted
+/// The path to which Borsh-serialized Ethereum events should be POSTed
 const PATH: &str = "eth_events";
 
+/// Starts a [`warp::Server`] that listens for Borsh-serialized Ethereum events
+/// and then forwards them to `sender`. It shuts down if `abort_sender` is
+/// closed.
 pub fn serve(
     sender: UnboundedSender<EthereumEvent>,
     mut abort_sender: tokio::sync::oneshot::Sender<()>,

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -672,7 +672,10 @@ async fn start_ethereum_node(
             abort_sender,
         ),
         ethereum::Mode::EventsEndpoint => {
-            ethereum_node::test_tools::events_endpoint::serve(eth_sender)
+            ethereum_node::test_tools::events_endpoint::serve(
+                eth_sender,
+                abort_sender,
+            )
         }
         ethereum::Mode::Off => {
             ethereum_node::test_tools::mock_oracle::run_oracle(

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -672,7 +672,7 @@ async fn start_ethereum_node(
             abort_sender,
         ),
         ethereum::Mode::EventsEndpoint => {
-            ethereum_node::test_tools::event_endpoint::start_oracle(eth_sender)
+            ethereum_node::test_tools::events_endpoint::serve(eth_sender)
         }
         ethereum::Mode::Off => {
             ethereum_node::test_tools::mock_oracle::run_oracle(


### PR DESCRIPTION
This is a quick PR to improve the fake Ethereum events endpoint
- refactor and add some docstrings
- make it so that it shuts down correctly (fixes https://github.com/anoma/namada/issues/507)
- listen on `0.0.0.0:3030` rather than `127.0.0.1:3030` so that the endpoint can be more easily exposed from within Docker containers (as will be used in [anoma/ethereum-bridge-e2e-tests](https://github.com/anoma/ethereum-bridge-e2e-tests))