### PR TITLE
Shutdown oracle when the receiver of it's channel is dropped

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/events.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/events.rs
@@ -202,7 +202,7 @@ pub mod eth_events {
         /// Check if the minimum number of confirmations has been
         /// reached at the input block height.
         pub fn is_confirmed(&self, height: &Uint256) -> bool {
-            self.confirmations >= height.clone() - self.block_height.clone()
+            self.confirmations <= height.clone() - self.block_height.clone()
         }
     }
 

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -73,6 +73,9 @@ impl Oracle {
     /// N.B. this will block if the internal channel buffer
     /// is full.
     async fn send(&self, events: Vec<EthereumEvent>) -> bool {
+        if self.sender.is_closed() {
+            return false;
+        }
         for event in events.into_iter() {
             if self.sender.send(event).await.is_err() {
                 return false;


### PR DESCRIPTION
This is a bug fix. When sending an message over a bounded channel, if the receiver is dropped, the send method will still block indefinitely. This is despite the  documentation stating that it should error. So we need to add a check that the channel is still open.