### PR TITLE
Update the Ethereum bridge oracle to process blocks in sequence from zero

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -729,7 +729,7 @@ mod test_oracle {
 
     /// Test that if the Ethereum RPC endpoint returns a latest block that is
     /// more than one block later than the previous latest block we received, we
-    /// still check all the blocks inbetween
+    /// still check all the blocks in between
     #[tokio::test]
     async fn test_all_blocks_checked() {
         let TestPackage {

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -318,7 +318,7 @@ async fn process(
                 pending = pending.len(),
                 confirmed = confirmed.len(),
                 ?MIN_CONFIRMATIONS,
-                "Some events that have reached the minimum number of \
+                "Some events have reached the minimum number of \
                  confirmations and will be sent onwards"
             );
         }

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -177,7 +177,11 @@ async fn run_oracle_aux(oracle: Oracle) {
                         }
                         next_block_to_process += 1u8.into()
                     },
-                    Err(error) => tracing::warn!(?error, block = ?next_block_to_process, "Error while trying to process Ethereum block"),
+                    Err(error) => tracing::warn!(
+                        ?error,
+                        block = ?next_block_to_process,
+                        "Error while trying to process Ethereum block"
+                    ),
                 }
             },
             _ = oracle.sender.closed() => {

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -210,8 +210,7 @@ async fn process(
             Err(error) => {
                 return Err(eyre!(
                     "Couldn't get the latest synced Ethereum block height \
-                     from the RPC endpoint: {:?}",
-                    error
+                     from the RPC endpoint: {error:?}",
                 ));
             }
         };
@@ -264,8 +263,7 @@ async fn process(
                 Err(error) => {
                     return Err(eyre!(
                         "Couldn't check for events ({sig} from {addr}) with \
-                         the RPC endpoint: {:?}",
-                        error
+                         the RPC endpoint: {error:?}",
                     ));
                 }
             };

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -47,7 +47,14 @@ impl Drop for Oracle {
         // send an abort signal to shut down the
         // rest of the ledger gracefully
         let abort = self.abort.take().unwrap();
-        let _ = abort.send(());
+        match abort.send(()) {
+            Ok(()) => tracing::debug!("Oracle sent abort signal"),
+            Err(()) => {
+                // this isn't necessarily an issue as the ledger may have shut
+                // down first
+                tracing::debug!("Oracle was unable to send an abort signal")
+            }
+        };
     }
 }
 

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -39,10 +39,6 @@ pub struct Oracle {
     abort: Option<Sender<()>>,
     /// How long the oracle should wait between checking blocks
     backoff: Duration,
-    /// If provided, the oracle will attempt to send block heights that it has
-    /// processed to this channel, but won't pause if this channel is full
-    /// or disconnected.
-    blocks_processed: Option<BoundedSender<Uint256>>,
 }
 
 impl Deref for Oracle {
@@ -84,7 +80,6 @@ impl Oracle {
             sender,
             abort: Some(abort),
             backoff,
-            blocks_processed: None,
         }
     }
 
@@ -169,14 +164,7 @@ async fn run_oracle_aux(oracle: Oracle) {
         tokio::select! {
             result = process(&oracle, &mut pending, next_block_to_process.clone()) => {
                 match result {
-                    Ok(()) => {
-                        if let Some(blocks_processed) = &oracle.blocks_processed {
-                            if let Err(error) = blocks_processed.try_send(next_block_to_process.clone()) {
-                                tracing::warn!(?error, block = ?next_block_to_process, "Failed to send processed block height to `blocks_processed` channel");
-                            };
-                        }
-                        next_block_to_process += 1u8.into()
-                    },
+                    Ok(()) => next_block_to_process += 1u8.into(),
                     Err(error) => tracing::warn!(
                         ?error,
                         block = ?next_block_to_process,
@@ -318,8 +306,8 @@ async fn process(
                 pending = pending.len(),
                 confirmed = confirmed.len(),
                 ?MIN_CONFIRMATIONS,
-                "Some events have reached the minimum number of confirmations \
-                 and will be sent onwards"
+                "Some events that have reached the minimum number of \
+                 confirmations and will be sent onwards"
             );
         }
         if !oracle.send(confirmed).await {
@@ -371,16 +359,14 @@ mod test_oracle {
         oracle: Oracle,
         admin_channel: tokio::sync::mpsc::UnboundedSender<TestCmd>,
         eth_recv: tokio::sync::mpsc::Receiver<EthereumEvent>,
-        blocks_processed_recv: tokio::sync::mpsc::Receiver<Uint256>,
+        blocks_processed_recv: tokio::sync::mpsc::UnboundedReceiver<Uint256>,
         abort_recv: Receiver<()>,
     }
 
     /// Set up an oracle with a mock web3 client that we can control
     fn setup() -> TestPackage {
-        let (admin_channel, client) = Web3::setup();
+        let (admin_channel, blocks_processed_recv, client) = Web3::setup();
         let (eth_sender, eth_receiver) = tokio::sync::mpsc::channel(1000);
-        let (blocks_processed, blocks_processed_recv) =
-            tokio::sync::mpsc::channel(1000);
         let (abort, abort_recv) = channel();
         TestPackage {
             oracle: Oracle {
@@ -389,7 +375,6 @@ mod test_oracle {
                 abort: Some(abort),
                 // backoff should be short for tests so that they run faster
                 backoff: Duration::from_millis(5),
-                blocks_processed: Some(blocks_processed),
             },
             admin_channel,
             eth_recv: eth_receiver,
@@ -439,6 +424,7 @@ mod test_oracle {
             oracle,
             mut eth_recv,
             admin_channel,
+            blocks_processed_recv: _processed,
             ..
         } = setup();
         let oracle = std::thread::spawn(move || {
@@ -466,6 +452,7 @@ mod test_oracle {
             oracle,
             mut eth_recv,
             admin_channel,
+            blocks_processed_recv: _processed,
             ..
         } = setup();
         let oracle = std::thread::spawn(move || {
@@ -508,6 +495,7 @@ mod test_oracle {
             oracle,
             eth_recv,
             admin_channel,
+            blocks_processed_recv: _processed,
             ..
         } = setup();
         let oracle = std::thread::spawn(move || {
@@ -564,6 +552,7 @@ mod test_oracle {
             oracle,
             mut eth_recv,
             admin_channel,
+            blocks_processed_recv: _processed,
             ..
         } = setup();
         let oracle = std::thread::spawn(move || {

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -245,7 +245,7 @@ async fn process(
             "Checking for bridge events"
         );
         // fetch the events for matching the given signature
-        let mut events = loop {
+        let mut events = {
             let logs = match oracle
                 .check_for_events(
                     block_to_check.clone(),
@@ -273,8 +273,7 @@ async fn process(
                     "Found bridge events in Ethereum block"
                 )
             }
-            break logs
-                .into_iter()
+            logs.into_iter()
                 .filter_map(|log| {
                     match PendingEvent::decode(
                         sig,

--- a/apps/src/lib/node/ledger/ethereum_node/oracle.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle.rs
@@ -318,8 +318,8 @@ async fn process(
                 pending = pending.len(),
                 confirmed = confirmed.len(),
                 ?MIN_CONFIRMATIONS,
-                "Some events have reached the minimum number of \
-                 confirmations and will be sent onwards"
+                "Some events have reached the minimum number of confirmations \
+                 and will be sent onwards"
             );
         }
         if !oracle.send(confirmed).await {

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools/mod.rs
@@ -105,6 +105,8 @@ pub mod mock_web3_client {
         active: bool,
         latest_block_height: Uint256,
         events: Vec<(MockEventType, Vec<u8>, u32, Sender<()>)>,
+        blocks_processed: UnboundedSender<Uint256>,
+        last_block_processed: Option<Uint256>,
     }
 
     impl Web3 {
@@ -120,16 +122,23 @@ pub mod mock_web3_client {
 
         /// Return a new client and a separate sender
         /// to send in admin commands
-        pub fn setup() -> (UnboundedSender<TestCmd>, Self) {
+        pub fn setup()
+        -> (UnboundedSender<TestCmd>, UnboundedReceiver<Uint256>, Self)
+        {
             // we can only send one command at a time.
             let (cmd_sender, cmd_channel) = unbounded_channel();
+            let (block_processed_send, block_processed_recv) =
+                unbounded_channel();
             (
                 cmd_sender,
+                block_processed_recv,
                 Self(RefCell::new(Web3Client {
                     cmd_channel,
                     active: true,
                     latest_block_height: Default::default(),
                     events: vec![],
+                    blocks_processed: block_processed_send,
+                    last_block_processed: None,
                 })),
             )
         }
@@ -205,6 +214,14 @@ pub mod mock_web3_client {
                     } else {
                         client.events.push((event_ty, data, height, seen));
                     }
+                }
+                if client.last_block_processed.as_ref() < Some(&block_to_check)
+                {
+                    client
+                        .blocks_processed
+                        .send(block_to_check.clone())
+                        .unwrap();
+                    client.last_block_processed = Some(block_to_check);
                 }
                 Ok(logs)
             } else {


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/560

This PR makes some changes to the Ethereum oracle
- add more logging
- when the oracle starts up, process all Ethereum blocks in sequence starting from block #0, rather than the latest confirmed block
- make the oracle sleep time configurable (it is currently hardcoded to be 1s between blocks in production, but in tests we want it much shorter)
- make the oracle emit the block heights it processes for observability (in tests)

Processing blocks from 0 every time the ledger starts up is not the final behaviour - validators should process Ethereum blocks only from when they become an active validator, and should stop processing Ethereum blocks once they are no longer an active validator.