### PR TITLE
Add chain parameters for the Ethereum bridge

### DIFF
--- a/apps/src/lib/config/ethereum_bridge/ledger.rs
+++ b/apps/src/lib/config/ethereum_bridge/ledger.rs
@@ -1,4 +1,4 @@
-//! Configuration settings to do with the Ethereum bridge.
+//! Runtime configuration for a validator node
 #[allow(unused_imports)]
 use namada::types::ethereum_events::EthereumEvent;
 use serde::{Deserialize, Serialize};
@@ -28,7 +28,8 @@ pub enum Mode {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
-    /// The mode in which to run the Ethereum bridge
+    /// The mode in which to run the Ethereum node and oracle setup of this
+    /// validator
     pub mode: Mode,
     /// The Ethereum JSON-RPC endpoint that the Ethereum event oracle will use
     /// to listen for events from the Ethereum bridge smart contracts

--- a/apps/src/lib/config/ethereum_bridge/ledger.rs
+++ b/apps/src/lib/config/ethereum_bridge/ledger.rs
@@ -29,7 +29,7 @@ pub enum Mode {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
     /// The mode in which to run the Ethereum node and oracle setup of this
-    /// validator
+    /// validator.
     pub mode: Mode,
     /// The Ethereum JSON-RPC endpoint that the Ethereum event oracle will use
     /// to listen for events from the Ethereum bridge smart contracts

--- a/apps/src/lib/config/ethereum_bridge/ledger.rs
+++ b/apps/src/lib/config/ethereum_bridge/ledger.rs
@@ -1,4 +1,4 @@
-//! Runtime configuration for a validator node
+//! Runtime configuration for a validator node.
 #[allow(unused_imports)]
 use namada::types::ethereum_events::EthereumEvent;
 use serde::{Deserialize, Serialize};

--- a/apps/src/lib/config/ethereum_bridge/mod.rs
+++ b/apps/src/lib/config/ethereum_bridge/mod.rs
@@ -1,0 +1,2 @@
+pub mod ledger;
+pub mod params;

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -1,6 +1,14 @@
 //! Blockchain-level parameters for the configuration of the Ethereum bridge.
 use serde::{Deserialize, Serialize};
 
+/// Represents a configuration value for an Ethereum address e.g.
+/// 0x6B175474E89094C44Da98b954EedeAC495271d0F
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
+#[repr(transparent)]
+pub struct Address(String);
+
+/// Represents a configuration value for the minimum number of
+/// confirmations an Ethereum event must reach before it can be acted on.
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Deserialize, Serialize)]
 #[repr(transparent)]
 pub struct MinimumConfirmations(u64);
@@ -11,29 +19,32 @@ impl Default for MinimumConfirmations {
     }
 }
 
+/// Represents chain parameters for the Ethereum bridge.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Config {
     /// Minimum number of confirmations needed to trust an Ethereum branch.
     /// This must be at least one.
     pub min_confirmations: MinimumConfirmations,
     /// The addresses of the Ethereum contracts that need to be directly known
-    /// by validators
-    pub contract_addresses: Addresses,
+    /// by validators.
+    pub contracts: Contracts,
 }
 
+/// Represents all the Ethereum contracts that need to be directly know about by
+/// validators.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct Addresses {
+pub struct Contracts {
     /// The Ethereum address of the ERC20 contract that represents this chain's
-    /// native token e.g. 0x6B175474E89094C44Da98b954EedeAC495271d0F
-    pub native_erc20: String,
-    /// The Ethereum address of the bridge contract e.g.
-    /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
-    pub bridge: EthereumContract,
-    /// The Ethereum address of the governance contract e.g.
-    /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
-    pub governance: EthereumContract,
+    /// native token.
+    pub native_erc20: Address,
+    /// The Ethereum address of the bridge contract.
+    pub bridge: UpgradeableContract,
+    /// The Ethereum address of the governance contract.
+    pub governance: UpgradeableContract,
 }
 
+/// Represents a configuration value for the version of a contract that can be
+/// upgraded. Starts from 1.
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Deserialize, Serialize)]
 #[repr(transparent)]
 pub struct ContractVersion(u64);
@@ -44,12 +55,12 @@ impl Default for ContractVersion {
     }
 }
 
+/// Represents an Ethereum contract that may be upgraded.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct EthereumContract {
-    /// The Ethereum address of the contract e.g.
-    /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
-    pub address: String,
-    /// The version of the contract e.g. 1
+pub struct UpgradeableContract {
+    /// The Ethereum address of the contract.
+    pub address: Address,
+    /// The version of the contract. Starts from 1.
     pub version: ContractVersion,
 }
 
@@ -66,17 +77,22 @@ mod tests {
     fn test_round_trip_toml_serde() -> Result<()> {
         let config = Config {
             min_confirmations: MinimumConfirmations::default(),
-            contract_addresses: Addresses {
-                native_erc20: "0x1721b337BBdd2b11f9Eef736d9192a8E9Cba5872"
-                    .to_string(),
-                bridge: EthereumContract {
-                    address: "0x237d915037A1ba79365E84e2b8574301B6D25Ea0"
-                        .to_string(),
+            contracts: Contracts {
+                native_erc20: Address(
+                    "0x1721b337BBdd2b11f9Eef736d9192a8E9Cba5872".to_string(),
+                ),
+                bridge: UpgradeableContract {
+                    address: Address(
+                        "0x237d915037A1ba79365E84e2b8574301B6D25Ea0"
+                            .to_string(),
+                    ),
                     version: ContractVersion::default(),
                 },
-                governance: EthereumContract {
-                    address: "0x308728EEa73538d0edEfd95EF148Eb678F71c71D"
-                        .to_string(),
+                governance: UpgradeableContract {
+                    address: Address(
+                        "0x308728EEa73538d0edEfd95EF148Eb678F71c71D"
+                            .to_string(),
+                    ),
                     version: ContractVersion::default(),
                 },
             },

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -1,0 +1,22 @@
+//! Blockchain-level parameters for the configuration of the Ethereum bridge.
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Config {
+    /// Minimum number of confirmations needed to trust an Ethereum branch.
+    /// This must be at least one.
+    pub min_confirmations: u64,
+    /// The addresses of the Ethereum contracts that need to be directly known
+    /// by validators
+    pub contract_addresses: Addresses,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Addresses {
+    /// The Ethereum address of the proxy contract e.g.
+    /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
+    pub proxy: String,
+    /// The Ethereum address of the ERC20 contract that represents this chain's
+    /// native token e.g. 0x6B175474E89094C44Da98b954EedeAC495271d0F
+    pub native_erc20: String,
+}

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -2,6 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[repr(transparent)]
 pub struct MinimumConfirmations(u64);
 
 impl Default for MinimumConfirmations {
@@ -22,18 +23,19 @@ pub struct Config {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Addresses {
+    /// The Ethereum address of the ERC20 contract that represents this chain's
+    /// native token e.g. 0x6B175474E89094C44Da98b954EedeAC495271d0F
+    pub native_erc20: String,
     /// The Ethereum address of the bridge contract e.g.
     /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
     pub bridge: EthereumContract,
     /// The Ethereum address of the governance contract e.g.
     /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
     pub governance: EthereumContract,
-    /// The Ethereum address of the ERC20 contract that represents this chain's
-    /// native token e.g. 0x6B175474E89094C44Da98b954EedeAC495271d0F
-    pub native_erc20: String,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[repr(transparent)]
 pub struct ContractVersion(u64);
 
 impl Default for ContractVersion {

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -19,6 +19,8 @@ pub struct MinimumConfirmations(NonZeroU64);
 
 impl Default for MinimumConfirmations {
     fn default() -> Self {
+        // SAFETY: The only way the API contract of `NonZeroU64`can be violated
+        // is if we construct values of this type using 0 as argument.
         Self(unsafe { NonZeroU64::new_unchecked(100) })
     }
 }
@@ -55,6 +57,8 @@ pub struct ContractVersion(NonZeroU64);
 
 impl Default for ContractVersion {
     fn default() -> Self {
+        // SAFETY: The only way the API contract of `NonZeroU64`can be violated
+        // is if we construct values of this type using 0 as argument.
         Self(unsafe { NonZeroU64::new_unchecked(1) })
     }
 }

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -3,8 +3,10 @@ use std::num::NonZeroU64;
 
 use serde::{Deserialize, Serialize};
 
-/// Represents a configuration value for an Ethereum address e.g.
-/// 0x6B175474E89094C44Da98b954EedeAC495271d0F
+/// Represents a configuration value for an Ethereum address.
+///
+/// For instance:
+/// `0x6B175474E89094C44Da98b954EedeAC495271d0F`
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 #[repr(transparent)]
 pub struct Address(String);

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -1,11 +1,20 @@
 //! Blockchain-level parameters for the configuration of the Ethereum bridge.
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct MinimumConfirmations(u64);
+
+impl Default for MinimumConfirmations {
+    fn default() -> Self {
+        Self(1)
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Config {
     /// Minimum number of confirmations needed to trust an Ethereum branch.
     /// This must be at least one.
-    pub min_confirmations: u64,
+    pub min_confirmations: MinimumConfirmations,
     /// The addresses of the Ethereum contracts that need to be directly known
     /// by validators
     pub contract_addresses: Addresses,
@@ -13,10 +22,31 @@ pub struct Config {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Addresses {
-    /// The Ethereum address of the proxy contract e.g.
+    /// The Ethereum address of the bridge contract e.g.
     /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
-    pub proxy: String,
+    pub bridge: EthereumContract,
+    /// The Ethereum address of the governance contract e.g.
+    /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
+    pub governance: EthereumContract,
     /// The Ethereum address of the ERC20 contract that represents this chain's
     /// native token e.g. 0x6B175474E89094C44Da98b954EedeAC495271d0F
     pub native_erc20: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct ContractVersion(u64);
+
+impl Default for ContractVersion {
+    fn default() -> Self {
+        Self(1)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EthereumContract {
+    /// The Ethereum address of the contract e.g.
+    /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
+    pub address: String,
+    /// The version of the contract e.g. 1
+    pub version: ContractVersion,
 }

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -1,17 +1,17 @@
 //! Blockchain-level parameters for the configuration of the Ethereum bridge.
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Deserialize, Serialize)]
 #[repr(transparent)]
 pub struct MinimumConfirmations(u64);
 
 impl Default for MinimumConfirmations {
     fn default() -> Self {
-        Self(1)
+        Self(100)
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Config {
     /// Minimum number of confirmations needed to trust an Ethereum branch.
     /// This must be at least one.
@@ -21,7 +21,7 @@ pub struct Config {
     pub contract_addresses: Addresses,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Addresses {
     /// The Ethereum address of the ERC20 contract that represents this chain's
     /// native token e.g. 0x6B175474E89094C44Da98b954EedeAC495271d0F
@@ -34,7 +34,7 @@ pub struct Addresses {
     pub governance: EthereumContract,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Deserialize, Serialize)]
 #[repr(transparent)]
 pub struct ContractVersion(u64);
 
@@ -44,11 +44,47 @@ impl Default for ContractVersion {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct EthereumContract {
     /// The Ethereum address of the contract e.g.
     /// 0x6B175474E89094C44Da98b954EedeAC495271d0F
     pub address: String,
     /// The version of the contract e.g. 1
     pub version: ContractVersion,
+}
+
+#[cfg(test)]
+mod tests {
+    use eyre::Result;
+
+    use super::*;
+
+    /// Ensure we can serialize and deserialize a [`Config`] struct to and from
+    /// TOML. This can fail if complex fields are ordered before simple fields
+    /// in any of the config structs.
+    #[test]
+    fn test_round_trip_toml_serde() -> Result<()> {
+        let config = Config {
+            min_confirmations: MinimumConfirmations::default(),
+            contract_addresses: Addresses {
+                native_erc20: "0x1721b337BBdd2b11f9Eef736d9192a8E9Cba5872"
+                    .to_string(),
+                bridge: EthereumContract {
+                    address: "0x237d915037A1ba79365E84e2b8574301B6D25Ea0"
+                        .to_string(),
+                    version: ContractVersion::default(),
+                },
+                governance: EthereumContract {
+                    address: "0x308728EEa73538d0edEfd95EF148Eb678F71c71D"
+                        .to_string(),
+                    version: ContractVersion::default(),
+                },
+            },
+        };
+        let serialized = toml::to_string(&config)?;
+        let deserialized: Config = toml::from_str(&serialized)?;
+
+        assert_eq!(config, deserialized);
+        Ok(())
+    }
 }

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -19,7 +19,7 @@ pub struct MinimumConfirmations(NonZeroU64);
 
 impl Default for MinimumConfirmations {
     fn default() -> Self {
-        // SAFETY: The only way the API contract of `NonZeroU64`can be violated
+        // SAFETY: The only way the API contract of `NonZeroU64` can be violated
         // is if we construct values of this type using 0 as argument.
         Self(unsafe { NonZeroU64::new_unchecked(100) })
     }
@@ -57,8 +57,9 @@ pub struct ContractVersion(NonZeroU64);
 
 impl Default for ContractVersion {
     fn default() -> Self {
-        // SAFETY: The only way the API contract of `NonZeroU64`can be violated
-        // is if we construct values of this type using 0 as argument.
+        // SAFETY: The only way the API contract of `NonZeroU64` can be
+        // violated is if we construct values of this type using 0 as
+        // argument.
         Self(unsafe { NonZeroU64::new_unchecked(1) })
     }
 }

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -27,7 +27,7 @@ impl Default for MinimumConfirmations {
 
 /// Represents chain parameters for the Ethereum bridge.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct Config {
+pub struct GenesisConfig {
     /// Minimum number of confirmations needed to trust an Ethereum branch.
     /// This must be at least one.
     pub min_confirmations: MinimumConfirmations,
@@ -84,7 +84,7 @@ mod tests {
     /// in any of the config structs.
     #[test]
     fn test_round_trip_toml_serde() -> Result<()> {
-        let config = Config {
+        let config = GenesisConfig {
             min_confirmations: MinimumConfirmations::default(),
             contracts: Contracts {
                 native_erc20: Address(
@@ -107,7 +107,7 @@ mod tests {
             },
         };
         let serialized = toml::to_string(&config)?;
-        let deserialized: Config = toml::from_str(&serialized)?;
+        let deserialized: GenesisConfig = toml::from_str(&serialized)?;
 
         assert_eq!(config, deserialized);
         Ok(())

--- a/apps/src/lib/config/ethereum_bridge/params.rs
+++ b/apps/src/lib/config/ethereum_bridge/params.rs
@@ -1,4 +1,6 @@
 //! Blockchain-level parameters for the configuration of the Ethereum bridge.
+use std::num::NonZeroU64;
+
 use serde::{Deserialize, Serialize};
 
 /// Represents a configuration value for an Ethereum address e.g.
@@ -11,11 +13,11 @@ pub struct Address(String);
 /// confirmations an Ethereum event must reach before it can be acted on.
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Deserialize, Serialize)]
 #[repr(transparent)]
-pub struct MinimumConfirmations(u64);
+pub struct MinimumConfirmations(NonZeroU64);
 
 impl Default for MinimumConfirmations {
     fn default() -> Self {
-        Self(100)
+        Self(unsafe { NonZeroU64::new_unchecked(100) })
     }
 }
 
@@ -47,11 +49,11 @@ pub struct Contracts {
 /// upgraded. Starts from 1.
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Deserialize, Serialize)]
 #[repr(transparent)]
-pub struct ContractVersion(u64);
+pub struct ContractVersion(NonZeroU64);
 
 impl Default for ContractVersion {
     fn default() -> Self {
-        Self(1)
+        Self(unsafe { NonZeroU64::new_unchecked(1) })
     }
 }
 

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -123,7 +123,8 @@ pub mod genesis_config {
         // Treasury parameters
         pub treasury_params: TreasuryParamasConfig,
         // Ethereum bridge config
-        pub ethereum_bridge_params: Option<ethereum_bridge::params::Config>,
+        pub ethereum_bridge_params:
+            Option<ethereum_bridge::params::GenesisConfig>,
         // Wasm definitions
         pub wasm: HashMap<String, WasmConfig>,
     }

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -44,6 +44,7 @@ pub mod genesis_config {
         EstablishedAccount, Genesis, ImplicitAccount, TokenAccount, Validator,
     };
     use crate::cli;
+    use crate::config::ethereum_bridge;
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct HexString(pub String);
@@ -121,6 +122,8 @@ pub mod genesis_config {
         pub gov_params: GovernanceParamsConfig,
         // Treasury parameters
         pub treasury_params: TreasuryParamasConfig,
+        // Ethereum bridge config
+        pub ethereum_bridge_params: Option<ethereum_bridge::params::Config>,
         // Wasm definitions
         pub wasm: HashMap<String, WasmConfig>,
     }

--- a/apps/src/lib/config/mod.rs
+++ b/apps/src/lib/config/mod.rs
@@ -1,6 +1,6 @@
 //! Node and client configuration
 
-pub mod ethereum;
+pub mod ethereum_bridge;
 pub mod genesis;
 pub mod global;
 pub mod utils;
@@ -83,7 +83,7 @@ pub struct Ledger {
     pub chain_id: ChainId,
     pub shell: Shell,
     pub tendermint: Tendermint,
-    pub ethereum: ethereum::Config,
+    pub ethereum_bridge: ethereum_bridge::ledger::Config,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -197,7 +197,7 @@ impl Ledger {
                 ),
                 instrumentation_namespace: "anoman_tm".to_string(),
             },
-            ethereum: ethereum::Config::default(),
+            ethereum_bridge: ethereum_bridge::ledger::Config::default(),
         }
     }
 

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 use borsh::BorshSerialize;
 use color_eyre::eyre::Result;
 use namada::types::token;
-use namada_apps::config::ethereum;
+use namada_apps::config::ethereum_bridge;
 use namada_apps::config::genesis::genesis_config::{
     GenesisConfig, ParametersConfig, PosParamsConfig,
 };
@@ -1814,7 +1814,7 @@ fn test_genesis_validators() -> Result<()> {
             .set_port(first_port + 1);
         config.ledger.shell.ledger_address.set_port(first_port + 2);
         // disable eth full node
-        config.ledger.ethereum.mode = ethereum::Mode::Off;
+        config.ledger.ethereum_bridge.mode = ethereum_bridge::ledger::Mode::Off;
         config
     };
 

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -21,7 +21,7 @@ use itertools::{Either, Itertools};
 use namada::types::chain::ChainId;
 use namada_apps::client::utils;
 use namada_apps::config::genesis::genesis_config::{self, GenesisConfig};
-use namada_apps::config::{ethereum, Config};
+use namada_apps::config::{ethereum_bridge, Config};
 use namada_apps::{config, wallet};
 use rand::Rng;
 use tempfile::{tempdir, TempDir};
@@ -77,7 +77,7 @@ pub fn update_actor_config<F>(
 /// Disable the Ethereum fullnode of `who`.
 pub fn disable_eth_fullnode(test: &Test, chain_id: &ChainId, who: &Who) {
     update_actor_config(test, chain_id, who, |config| {
-        config.ledger.ethereum.mode = ethereum::Mode::Off;
+        config.ledger.ethereum_bridge.mode = ethereum_bridge::ledger::Mode::Off;
     });
 }
 


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/365 and https://github.com/anoma/namada/issues/562

This PR adds *preliminary* chain parameters for the Ethereum bridge, and also renames ledger runtime configuration to be under `[ledger.ethereum_bridge]` rather than just `[ledger.ethereum]`. We can change/add extra validation for these configuration parameters in other PRs.

In a network config file, Ethereum bridge parameters will be able to be specified like so:

```toml
[ethereum_bridge_params]
min_confirmations = 100

[ethereum_bridge_params.contracts]
native_erc20 = "0x1721b337BBdd2b11f9Eef736d9192a8E9Cba5872"

[ethereum_bridge_params.contracts.bridge]
address = "0x237d915037A1ba79365E84e2b8574301B6D25Ea0"
version = 1

[ethereum_bridge_params.contracts.governance]
address = "0x308728EEa73538d0edEfd95EF148Eb678F71c71D"
version = 1
```

These parameters as a whole are optional but if any are set, then all must be set. i.e. a Namada chain can either start without any Ethereum bridge parameters set, or with all Ethereum bridge parameters set.

This PR only adds the parameter fields, but they aren't used yet by the oracle. When validator nodes start up, they will need to check blockchain storage for the appropriate parameter values for whatever epoch they have synced to, and configure their events oracle accordingly. If no Ethereum bridge parameters have been set for a chain yet, then validator nodes don't need to start any Ethereum bridge componentry (i.e. the events oracle or `geth`).

Specs need to be updated for no more proxy contract (have added an item to https://github.com/anoma/namada/issues/448)

I've tested this manually and have been able to `namadac utils init-network` etc. with this network config file which has Ethereum bridge parameters: [network-config.toml.txt](https://github.com/anoma/namada/files/9832307/network-config.toml.txt)