### PR TITLE
Update bridge pool vp to use merkle tree

### DIFF
--- a/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
@@ -23,8 +23,7 @@ use crate::ledger::storage::{DBIter, DB};
 use crate::proto::SignedTxData;
 use crate::types::address::{xan, Address, InternalAddress};
 use crate::types::eth_bridge_pool::PendingTransfer;
-use crate::types::keccak::encode::Encode;
-use crate::types::storage::{Key, KeySeg};
+use crate::types::storage::Key;
 use crate::types::token::{balance_key, Amount};
 use crate::vm::WasmCacheAccess;
 
@@ -117,11 +116,11 @@ where
         };
 
         let pending_key = get_pending_key(&transfer);
-        for key in keys_changed.iter().filter(is_bridge_pool_key) {
-            if key != pending_key {
+        for key in keys_changed.iter().filter(|k| is_bridge_pool_key(k)) {
+            if *key != pending_key {
                 tracing::debug!(
-                    "Rejecting transaction as it is attempting to change an incorrect \
-                    key in the pending transaction pool."
+                    "Rejecting transaction as it is attempting to change an \
+                     incorrect key in the pending transaction pool."
                 );
                 return Ok(false);
             }
@@ -132,9 +131,7 @@ where
                  pending transfers"
             ))?;
         if pending != transfer {
-            tracing::debug!(
-                    "An incorrect transfer was added to the pool."
-            );
+            tracing::debug!("An incorrect transfer was added to the pool.");
             return Ok(false);
         }
 

--- a/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
@@ -23,8 +23,7 @@ use crate::ledger::storage::{DBIter, DB};
 use crate::proto::SignedTxData;
 use crate::types::address::{xan, Address, InternalAddress};
 use crate::types::eth_bridge_pool::PendingTransfer;
-use crate::types::keccak::encode::Encode;
-use crate::types::storage::{Key, KeySeg};
+use crate::types::storage::Key;
 use crate::types::token::{balance_key, Amount};
 use crate::vm::WasmCacheAccess;
 
@@ -457,6 +456,15 @@ mod test_bridge_pool_vp {
         assert_bridge_pool(
             SignedAmount::Negative(GAS_FEE.into()),
             SignedAmount::Negative(GAS_FEE.into()),
+            |transfer, log| {
+                log.write(
+                    &get_pending_key(&transfer),
+                    transfer.try_to_vec().unwrap(),
+                )
+                .unwrap();
+                BTreeSet::from([get_pending_key(&transfer)])
+            },
+            Expect::False,
             |transfer, log| {
                 log.write(
                     &get_pending_key(&transfer),

--- a/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
@@ -23,7 +23,8 @@ use crate::ledger::storage::{DBIter, DB};
 use crate::proto::SignedTxData;
 use crate::types::address::{xan, Address, InternalAddress};
 use crate::types::eth_bridge_pool::PendingTransfer;
-use crate::types::storage::Key;
+use crate::types::keccak::encode::Encode;
+use crate::types::storage::{Key, KeySeg};
 use crate::types::token::{balance_key, Amount};
 use crate::vm::WasmCacheAccess;
 

--- a/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
@@ -466,15 +466,6 @@ mod test_bridge_pool_vp {
                 BTreeSet::from([get_pending_key(&transfer)])
             },
             Expect::False,
-            |transfer, log| {
-                log.write(
-                    &get_pending_key(&transfer),
-                    transfer.try_to_vec().unwrap(),
-                )
-                .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
-            },
-            Expect::False,
         );
     }
 

--- a/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
@@ -23,7 +23,8 @@ use crate::ledger::storage::{DBIter, DB};
 use crate::proto::SignedTxData;
 use crate::types::address::{xan, Address, InternalAddress};
 use crate::types::eth_bridge_pool::PendingTransfer;
-use crate::types::storage::Key;
+use crate::types::keccak::encode::Encode;
+use crate::types::storage::{Key, KeySeg};
 use crate::types::token::{balance_key, Amount};
 use crate::vm::WasmCacheAccess;
 
@@ -116,11 +117,11 @@ where
         };
 
         let pending_key = get_pending_key(&transfer);
-        for key in keys_changed.iter().filter(|k| is_bridge_pool_key(k)) {
-            if *key != pending_key {
+        for key in keys_changed.iter().filter(is_bridge_pool_key) {
+            if key != pending_key {
                 tracing::debug!(
-                    "Rejecting transaction as it is attempting to change an \
-                     incorrect key in the pending transaction pool."
+                    "Rejecting transaction as it is attempting to change an incorrect \
+                    key in the pending transaction pool."
                 );
                 return Ok(false);
             }
@@ -131,7 +132,9 @@ where
                  pending transfers"
             ))?;
         if pending != transfer {
-            tracing::debug!("An incorrect transfer was added to the pool.");
+            tracing::debug!(
+                    "An incorrect transfer was added to the pool."
+            );
             return Ok(false);
         }
 

--- a/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
@@ -14,16 +14,15 @@ use std::collections::{BTreeSet, HashSet};
 use borsh::BorshDeserialize;
 use eyre::eyre;
 
-use crate::ledger::eth_bridge::storage::bridge_pool::{
-    get_pending_key, is_protected_storage, BRIDGE_POOL_ADDRESS,
-};
+use crate::ledger::eth_bridge::storage::bridge_pool::{get_pending_key, is_protected_storage, BRIDGE_POOL_ADDRESS, is_bridge_pool_key};
 use crate::ledger::native_vp::{Ctx, NativeVp, StorageReader};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, DB};
 use crate::proto::SignedTxData;
 use crate::types::address::{xan, Address, InternalAddress};
 use crate::types::eth_bridge_pool::PendingTransfer;
-use crate::types::storage::Key;
+use crate::types::keccak::encode::Encode;
+use crate::types::storage::{Key, KeySeg};
 use crate::types::token::{balance_key, Amount};
 use crate::vm::WasmCacheAccess;
 
@@ -115,42 +114,26 @@ where
             }
         };
 
-        // check that only the pending_key value is changed
-        if keys_changed.iter().any(is_protected_storage) {
-            tracing::debug!(
-                "Rejecting transaction as it is attempting to change the \
-                 bridge pool storage other than the pending transaction pool"
-            );
-            return Ok(false);
-        }
-        // check that the pending transfer (and only that) was added to the pool
-        // TODO: This will change slightly when we merkelize the pool,
-        // but that will be a separate PR.
-        let pending_key = get_pending_key();
-        let pending_pre: HashSet<PendingTransfer> =
-            (&self.ctx).read_pre_value(&pending_key)?.ok_or(eyre!(
-                "The bridge pool transfers are missing from storage"
-            ))?;
-        let pending_post: HashSet<PendingTransfer> =
-            (&self.ctx).read_post_value(&pending_key)?.ok_or(eyre!(
-                "The bridge pool transfers are missing from storage"
-            ))?;
-        if !pending_post.contains(&transfer) {
-            tracing::debug!(
-                "Rejecting transaction as the transfer wasn't added to the \
-                 pending transfers"
-            );
-            return Ok(false);
-        }
-        for item in pending_pre.symmetric_difference(&pending_post) {
-            if item != &transfer {
+        let pending_key = get_pending_key(&transfer);
+        for key in keys_changed.iter().filter(is_bridge_pool_key) {
+            if key != pending_key {
                 tracing::debug!(
-                    ?item,
-                    "Rejecting transaction as an unrecognized item was added \
-                     to the pending transfers"
+                    "Rejecting transaction as it is attempting to change an incorrect \
+                    key in the pending transaction pool."
                 );
                 return Ok(false);
             }
+        }
+        let pending: PendingTransfer =
+            (&self.ctx).read_post_value(&pending_key)?.ok_or(eyre!(
+                "Rejecting transaction as the transfer wasn't added to the \
+                 pending transfers"
+            ))?;
+        if pending != transfer {
+            tracing::debug!(
+                    "An incorrect transfer was added to the pool."
+            );
+            return Ok(false);
         }
 
         // check that gas fees were put into escrow
@@ -232,8 +215,8 @@ mod test_bridge_pool_vp {
     }
 
     /// The bridge pool at the beginning of all tests
-    fn initial_pool() -> HashSet<PendingTransfer> {
-        let transfer = PendingTransfer {
+    fn initial_pool() -> PendingTransfer {
+        PendingTransfer {
             transfer: TransferToEthereum {
                 asset: EthAddress([0; 20]),
                 recipient: EthAddress([0; 20]),
@@ -244,9 +227,7 @@ mod test_bridge_pool_vp {
                 amount: 0.into(),
                 payer: bertha_address(),
             },
-        };
-
-        HashSet::<PendingTransfer>::from([transfer])
+        }
     }
 
     /// Create a new storage
@@ -256,9 +237,9 @@ mod test_bridge_pool_vp {
         writelog
             .write(&get_signed_root_key(), Hash([0; 32]).try_to_vec().unwrap())
             .unwrap();
-
+        let transfer = initial_pool();
         writelog
-            .write(&get_pending_key(), initial_pool().try_to_vec().unwrap())
+            .write(&get_pending_key(&transfer), transfer.try_to_vec().unwrap())
             .unwrap();
         let escrow_key = balance_key(&xan(), &BRIDGE_POOL_ADDRESS);
         let amount: Amount = ESCROWED_AMOUNT.into();

--- a/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
@@ -23,6 +23,7 @@ use crate::ledger::storage::{DBIter, DB};
 use crate::proto::SignedTxData;
 use crate::types::address::{xan, Address, InternalAddress};
 use crate::types::eth_bridge_pool::PendingTransfer;
+use crate::types::keccak::encode::Encode;
 use crate::types::storage::Key;
 use crate::types::token::{balance_key, Amount};
 use crate::vm::WasmCacheAccess;

--- a/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
@@ -23,7 +23,6 @@ use crate::ledger::storage::{DBIter, DB};
 use crate::proto::SignedTxData;
 use crate::types::address::{xan, Address, InternalAddress};
 use crate::types::eth_bridge_pool::PendingTransfer;
-use crate::types::keccak::encode::Encode;
 use crate::types::storage::Key;
 use crate::types::token::{balance_key, Amount};
 use crate::vm::WasmCacheAccess;

--- a/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool_vp.rs
@@ -120,7 +120,10 @@ where
             if *key != pending_key {
                 tracing::debug!(
                     "Rejecting transaction as it is attempting to change an \
-                     incorrect key in the pending transaction pool."
+                     incorrect key in the pending transaction pool: {}.\n \
+                     Expected key: {}",
+                    key,
+                    pending_key
                 );
                 return Ok(false);
             }
@@ -131,7 +134,12 @@ where
                  pending transfers"
             ))?;
         if pending != transfer {
-            tracing::debug!("An incorrect transfer was added to the pool.");
+            tracing::debug!(
+                "An incorrect transfer was added to the pool: {:?}.\n \
+                 Expected: {:?}",
+                transfer,
+                pending
+            );
             return Ok(false);
         }
 

--- a/shared/src/ledger/eth_bridge/storage/bridge_pool.rs
+++ b/shared/src/ledger/eth_bridge/storage/bridge_pool.rs
@@ -16,8 +16,6 @@ use crate::types::storage::{DbKeySeg, Key, KeySeg};
 /// The main address of the Ethereum bridge pool
 pub const BRIDGE_POOL_ADDRESS: Address =
     Address::Internal(InternalAddress::EthBridgePool);
-/// Sub-segmnet for getting the contents of the pool
-const PENDING_TRANSFERS_SEG: &str = "pending_transfers";
 /// Sub-segment for getting the latest signed
 const SIGNED_ROOT_SEG: &str = "signed_root";
 

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -656,6 +656,22 @@ impl KeySeg for KeccakHash {
     }
 }
 
+impl KeySeg for KeccakHash {
+    fn parse(seg: String) -> Result<Self> {
+        seg.clone()
+            .try_into()
+            .map_err(|_| Error::ParseError(seg, "Hash".into()))
+    }
+
+    fn raw(&self) -> String {
+        self.to_string()
+    }
+
+    fn to_db_key(&self) -> DbKeySeg {
+        DbKeySeg::StringSeg(self.raw())
+    }
+}
+
 /// Epoch identifier. Epochs are identified by consecutive numbers.
 #[derive(
     Clone,

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -20,6 +20,7 @@ use crate::ledger::storage::IBC_KEY_LIMIT;
 use crate::types::address::{self, Address};
 use crate::types::eth_bridge_pool::PendingTransfer;
 use crate::types::hash::Hash;
+use crate::types::keccak::KeccakHash;
 use crate::types::time::DateTimeUtc;
 
 #[allow(missing_docs)]
@@ -629,6 +630,22 @@ impl KeySeg for Hash {
         seg.try_into().map_err(|e: crate::types::hash::Error| {
             Error::ParseError(e.to_string())
         })
+    }
+
+    fn raw(&self) -> String {
+        self.to_string()
+    }
+
+    fn to_db_key(&self) -> DbKeySeg {
+        DbKeySeg::StringSeg(self.raw())
+    }
+}
+
+impl KeySeg for KeccakHash {
+    fn parse(seg: String) -> Result<Self> {
+        seg.clone()
+            .try_into()
+            .map_err(|_| Error::ParseError(seg, "Hash".into()))
     }
 
     fn raw(&self) -> String {

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -20,7 +20,7 @@ use crate::ledger::storage::IBC_KEY_LIMIT;
 use crate::types::address::{self, Address};
 use crate::types::eth_bridge_pool::PendingTransfer;
 use crate::types::hash::Hash;
-use crate::types::keccak::KeccakHash;
+use crate::types::keccak::{KeccakHash, TryFromError};
 use crate::types::time::DateTimeUtc;
 
 #[allow(missing_docs)]
@@ -643,41 +643,8 @@ impl KeySeg for Hash {
 
 impl KeySeg for KeccakHash {
     fn parse(seg: String) -> Result<Self> {
-        seg.clone()
-            .try_into()
-            .map_err(|_| Error::ParseError(seg, "Hash".into()))
-    }
-
-    fn raw(&self) -> String {
-        self.to_string()
-    }
-
-    fn to_db_key(&self) -> DbKeySeg {
-        DbKeySeg::StringSeg(self.raw())
-    }
-}
-
-impl KeySeg for KeccakHash {
-    fn parse(seg: String) -> Result<Self> {
-        seg.clone()
-            .try_into()
-            .map_err(|_| Error::ParseError(seg, "Hash".into()))
-    }
-
-    fn raw(&self) -> String {
-        self.to_string()
-    }
-
-    fn to_db_key(&self) -> DbKeySeg {
-        DbKeySeg::StringSeg(self.raw())
-    }
-}
-
-impl KeySeg for KeccakHash {
-    fn parse(seg: String) -> Result<Self> {
-        seg.clone()
-            .try_into()
-            .map_err(|_| Error::ParseError(seg, "Hash".into()))
+        seg.try_into()
+            .map_err(|e: TryFromError| Error::ParseError(e.to_string()))
     }
 
     fn raw(&self) -> String {

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -673,6 +673,22 @@ impl KeySeg for KeccakHash {
     }
 }
 
+impl KeySeg for KeccakHash {
+    fn parse(seg: String) -> Result<Self> {
+        seg.clone()
+            .try_into()
+            .map_err(|_| Error::ParseError(seg, "Hash".into()))
+    }
+
+    fn raw(&self) -> String {
+        self.to_string()
+    }
+
+    fn to_db_key(&self) -> DbKeySeg {
+        DbKeySeg::StringSeg(self.raw())
+    }
+}
+
 /// Epoch identifier. Epochs are identified by consecutive numbers.
 #[derive(
     Clone,

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -657,6 +657,22 @@ impl KeySeg for KeccakHash {
     }
 }
 
+impl KeySeg for KeccakHash {
+    fn parse(seg: String) -> Result<Self> {
+        seg.clone()
+            .try_into()
+            .map_err(|_| Error::ParseError(seg, "Hash".into()))
+    }
+
+    fn raw(&self) -> String {
+        self.to_string()
+    }
+
+    fn to_db_key(&self) -> DbKeySeg {
+        DbKeySeg::StringSeg(self.raw())
+    }
+}
+
 /// Epoch identifier. Epochs are identified by consecutive numbers.
 #[derive(
     Clone,

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -656,22 +656,6 @@ impl KeySeg for KeccakHash {
     }
 }
 
-impl KeySeg for KeccakHash {
-    fn parse(seg: String) -> Result<Self> {
-        seg.clone()
-            .try_into()
-            .map_err(|_| Error::ParseError(seg, "Hash".into()))
-    }
-
-    fn raw(&self) -> String {
-        self.to_string()
-    }
-
-    fn to_db_key(&self) -> DbKeySeg {
-        DbKeySeg::StringSeg(self.raw())
-    }
-}
-
 /// Epoch identifier. Epochs are identified by consecutive numbers.
 #[derive(
     Clone,

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -689,6 +689,22 @@ impl KeySeg for KeccakHash {
     }
 }
 
+impl KeySeg for KeccakHash {
+    fn parse(seg: String) -> Result<Self> {
+        seg.clone()
+            .try_into()
+            .map_err(|_| Error::ParseError(seg, "Hash".into()))
+    }
+
+    fn raw(&self) -> String {
+        self.to_string()
+    }
+
+    fn to_db_key(&self) -> DbKeySeg {
+        DbKeySeg::StringSeg(self.raw())
+    }
+}
+
 /// Epoch identifier. Epochs are identified by consecutive numbers.
 #[derive(
     Clone,

--- a/wasm/wasm_source/src/tx_bridge_pool.rs
+++ b/wasm/wasm_source/src/tx_bridge_pool.rs
@@ -20,8 +20,6 @@ fn apply_tx(tx_data: Vec<u8>) {
     } = transfer.gas_fees;
     token::transfer(payer, &BRIDGE_POOL_ADDRESS, &address::xan(), amount);
     // add transfer into the pool
-    let pending_key = bridge_pool::get_pending_key();
-    let mut pending: HashSet<PendingTransfer> = read(&pending_key).unwrap();
-    pending.insert(transfer);
-    write(pending_key, pending.try_to_vec().unwrap());
+    let pending_key = bridge_pool::get_pending_key(&transfer);
+    write(pending_key, transfer.try_to_vec().unwrap());
 }


### PR DESCRIPTION
This PR closes #422 

This PR depends on #579 which added a merkle tree to our storage for the bridge pool. This PR actually switches to using this tree and the necessary updates to the VP and wasm have been made.