### PR TITLE
Fix ABCI++ compilation

### DIFF
--- a/apps/src/lib/node/ledger/protocol/transactions/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/mod.rs
@@ -4,4 +4,5 @@
 //! to update their blockchain state in a deterministic way. This can be done
 //! natively rather than via the wasm environment as happens with regular
 //! transactions.
+#[cfg(not(feature = "abcipp"))]
 pub(super) mod ethereum_events;

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -369,8 +369,8 @@ mod test_vote_extensions {
     /// Test that ethereum events are added to vote extensions.
     /// Check that vote extensions pass verification.
     #[cfg(feature = "abcipp")]
-    #[test]
-    fn test_eth_events_vote_extension() {
+    #[tokio::test]
+    async fn test_eth_events_vote_extension() {
         let (mut shell, _, oracle) = setup();
         let address = shell
             .mode
@@ -389,8 +389,8 @@ mod test_vote_extensions {
             name: "Test".to_string(),
             address: EthAddress([0; 20]),
         };
-        oracle.send(event_1.clone()).expect("Test failed");
-        oracle.send(event_2.clone()).expect("Test failed");
+        oracle.send(event_1.clone()).await.expect("Test failed");
+        oracle.send(event_2.clone()).await.expect("Test failed");
         let vote_extension =
             <VoteExtension as BorshDeserialize>::try_from_slice(
                 &shell.extend_vote(Default::default()).vote_extension[..],


### PR DESCRIPTION
Building `eth-bridge-integration` with the `abcipp` features enabled was failing, this PR updates the code to get it compiling again.

We no-op when applying protocol transactions for ABCI++ - the `ethereum_events` protocol tx logic is being further worked on for just ABCI for now.

Running `make test-unit-abcipp` and `make clippy-abcipp` passes locally (we can eventually set up a simple CI job to maintain the code we currently have - https://github.com/anoma/namada/issues/497 )