### PR TITLE
fix the height recorded for a new epoch

### DIFF
--- a/shared/src/ledger/storage/mod.rs
+++ b/shared/src/ledger/storage/mod.rs
@@ -631,7 +631,7 @@ where
             let evidence_max_age_num_blocks: u64 = 100000;
             self.block
                 .pred_epochs
-                .new_epoch(height + 1, evidence_max_age_num_blocks);
+                .new_epoch(height, evidence_max_age_num_blocks);
             tracing::info!("Began a new epoch {}", self.block.epoch);
         }
         self.update_epoch_in_merkle_tree()?;
@@ -992,12 +992,20 @@ mod tests {
                     block_height + epoch_duration.min_num_of_blocks);
                 assert_eq!(storage.next_epoch_min_start_time,
                     block_time + epoch_duration.min_duration);
-                assert_eq!(storage.block.pred_epochs.get_epoch(block_height), Some(epoch_before));
-                assert_eq!(storage.block.pred_epochs.get_epoch(block_height + 1), Some(epoch_before.next()));
+                assert_eq!(
+                    storage.block.pred_epochs.get_epoch(BlockHeight(block_height.0 - 1)),
+                    Some(epoch_before));
+                assert_eq!(
+                    storage.block.pred_epochs.get_epoch(block_height),
+                    Some(epoch_before.next()));
             } else {
                 assert_eq!(storage.block.epoch, epoch_before);
-                assert_eq!(storage.block.pred_epochs.get_epoch(block_height), Some(epoch_before));
-                assert_eq!(storage.block.pred_epochs.get_epoch(block_height + 1), Some(epoch_before));
+                assert_eq!(
+                    storage.block.pred_epochs.get_epoch(BlockHeight(block_height.0 - 1)),
+                    Some(epoch_before));
+                assert_eq!(
+                    storage.block.pred_epochs.get_epoch(block_height),
+                    Some(epoch_before));
             }
             // Last epoch should only change when the block is committed
             assert_eq!(storage.last_epoch, epoch_before);


### PR DESCRIPTION
This undoes the change from #384, which stemmed from my misunderstanding - we're *not* switching on the last block of an epoch, but rather on the beginning of a block in the new epoch