### PR TITLE
CI: add workaround for release build missing git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - run: git fetch --tags --force origin # WA: https://github.com/actions/checkout/issues/882
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
using workaround from https://github.com/actions/checkout/issues/882#issuecomment-1231911465

closes #627 