### PR TITLE
Don't check `checksums.json` when initializing a chain during tests

### DIFF
--- a/.changelog/unreleased/improvements/652-wasm-checksums-unit-tests.md
+++ b/.changelog/unreleased/improvements/652-wasm-checksums-unit-tests.md
@@ -1,0 +1,2 @@
+- Add a WasmLoader component for reading wasms
+  ([#652](https://github.com/anoma/namada/pull/652))

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -31,6 +31,7 @@ use crate::node::ledger::config::genesis;
 use crate::node::ledger::shell::{Error, MempoolTxType, Shell};
 use crate::node::ledger::shims::abcipp_shim::AbcippShim;
 use crate::node::ledger::shims::abcipp_shim_types::shim::{Request, Response};
+use crate::wasm_loader::WasmLoader;
 use crate::{config, wasm_loader};
 
 /// Env. var to set a number of Tokio RT worker threads
@@ -430,7 +431,7 @@ fn start_abci_broadcaster_shell(
     let genesis = genesis::genesis();
     let (shell, abci_service) = AbcippShim::new(
         config,
-        wasm_dir,
+        WasmLoader::new(wasm_dir),
         broadcaster_sender,
         &db_cache,
         vp_wasm_compilation_cache,

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -78,8 +78,7 @@ where
         // borrow necessary for release build, annoys clippy on dev build
         #[allow(clippy::needless_borrow)]
         let implicit_vp =
-            wasm_loader::read_wasm(&self.wasm_dir, &implicit_vp_code_path)
-                .map_err(Error::ReadingWasm)?;
+            self.wasm_loader.read_from_disk(&implicit_vp_code_path).map_err(Error::ReadingWasm)?;
         // In dev, we don't check the hash
         #[cfg(feature = "dev")]
         let _ = implicit_vp_sha256;

--- a/apps/src/lib/node/ledger/shims/abcipp_shim.rs
+++ b/apps/src/lib/node/ledger/shims/abcipp_shim.rs
@@ -1,6 +1,5 @@
 use std::convert::TryFrom;
 use std::future::Future;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -24,6 +23,7 @@ use crate::config;
 #[cfg(not(feature = "abcipp"))]
 use crate::facade::tendermint_proto::abci::RequestBeginBlock;
 use crate::facade::tower_abci::{BoxError, Request as Req, Response as Resp};
+use crate::wasm_loader::WasmLoader;
 
 /// The shim wraps the shell, which implements ABCI++.
 /// The shim makes a crude translation between the ABCI interface currently used
@@ -46,7 +46,7 @@ impl AbcippShim {
     /// shell.
     pub fn new(
         config: config::Ledger,
-        wasm_dir: PathBuf,
+        wasm_loader: WasmLoader,
         broadcast_sender: UnboundedSender<Vec<u8>>,
         db_cache: &rocksdb::Cache,
         vp_wasm_compilation_cache: u64,
@@ -60,7 +60,7 @@ impl AbcippShim {
             Self {
                 service: Shell::new(
                     config,
-                    wasm_dir,
+                    wasm_loader,
                     broadcast_sender,
                     Some(db_cache),
                     vp_wasm_compilation_cache,

--- a/apps/src/lib/wasm_loader/mod.rs
+++ b/apps/src/lib/wasm_loader/mod.rs
@@ -382,7 +382,7 @@ impl WasmLoader {
         };
 
         let path = &self.directory.join(filename);
-        fs::read(&path).wrap_err_with(|| {
+        fs::read(path).wrap_err_with(|| {
             format!("Failed to read wasm from {}", &path.to_string_lossy())
         })
     }
@@ -408,10 +408,10 @@ mod tests {
         let wasm_path = tmp_dir.path().join(&wasm_filename_with_hash);
         const WASM_CONTENTS: &str =
             "specific contents of the wasm file not relevant to tests";
-        fs::write(&wasm_path, WASM_CONTENTS).unwrap();
+        fs::write(wasm_path, WASM_CONTENTS).unwrap();
         let checksums_path = tmp_dir.path().join("checksums.json");
         fs::write(
-            &checksums_path,
+            checksums_path,
             json!({
                 wasm_filename_without_hash: wasm_filename_with_hash,
             })
@@ -431,10 +431,10 @@ mod tests {
             .expect("Couldn't run test - couldn't set up test directory");
         const WASM_NAME: &str = "tx_foo";
         let wasm_filename_without_hash = format!("{WASM_NAME}.wasm");
-        let wasm_path = tmp_dir.path().join(&wasm_filename_without_hash);
+        let wasm_path = tmp_dir.path().join(wasm_filename_without_hash);
         const WASM_CONTENTS: &str =
             "specific contents of the wasm file not relevant to tests";
-        fs::write(&wasm_path, WASM_CONTENTS).unwrap();
+        fs::write(wasm_path, WASM_CONTENTS).unwrap();
 
         let wasm_loader =
             WasmLoader::new_without_checksums(tmp_dir.path().to_owned());

--- a/apps/src/lib/wasm_loader/mod.rs
+++ b/apps/src/lib/wasm_loader/mod.rs
@@ -2,7 +2,7 @@
 use core::borrow::Borrow;
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use data_encoding::HEXLOWER;
 use eyre::{eyre, WrapErr};
@@ -324,5 +324,38 @@ async fn download_wasm(url: String) -> Result<Vec<u8>, Error> {
             }
         }
         Err(e) => Err(Error::Download(url, e)),
+    }
+}
+
+/// Handle for reading *.wasm files from a directory
+#[derive(Debug)]
+pub struct WasmLoader {
+    /// The directory on disk where the *.wasm files are to be found
+    directory: PathBuf,
+    /// If `checksums` is true, then there must be a valid `checksums.json`
+    /// file in `directory` in order to load any *.wasm files.
+    checksums: bool,
+}
+
+impl WasmLoader {
+    pub fn new(directory: PathBuf) -> Self {
+        Self {
+            directory,
+            checksums: true,
+        }
+    }
+
+    pub fn new_without_checksums(directory: PathBuf) -> Self {
+        Self {
+            directory,
+            checksums: false,
+        }
+    }
+
+    pub fn read_from_disk(
+        &self,
+        name: impl AsRef<str>,
+    ) -> eyre::Result<Vec<u8>> {
+        Ok(vec![])
     }
 }


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/104

This PR adds a `WasmLoader` type that is used by the `Shell` to read *.wasm files during ABCI `InitChain`, in place of the raw `wasm_dir` path field that was being used previously. The `WasmLoader` type can be set to optionally not check `checksums.json`, so `make test-unit` can run so long as the necessary `*.wasm` files are present on disk (e.g. `vp_user.wasm`) but without needing `checksums.json` to have been updated.
