### PR TITLE
Fix valset upd verification

### DIFF
--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -95,7 +95,7 @@ where
             }
         };
         // verify if the new epoch validators' voting powers in storage match
-        // the voting powers in the vote extensions
+        // the voting powers in the vote extension
         for (eth_addr_book, namada_addr, namada_power) in self
             .storage
             .get_active_eth_addresses(Some(ext_height_epoch.next()))

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -94,11 +94,11 @@ where
                 return Err(VoteExtensionError::UnexpectedEpoch);
             }
         };
-        // verify if the voting powers in storage match the voting powers in the
-        // vote extensions
+        // verify if the new epoch validators' voting powers in storage match
+        // the voting powers in the vote extensions
         for (eth_addr_book, namada_addr, namada_power) in self
             .storage
-            .get_active_eth_addresses(Some(ext_height_epoch))
+            .get_active_eth_addresses(Some(ext_height_epoch.next()))
         {
             let &ext_power = match ext.data.voting_powers.get(&eth_addr_book) {
                 Some(voting_power) => voting_power,


### PR DESCRIPTION
When verifying voting powers of validators, for validator set update vote extensions, we should fetch data from the new epoch, not from the epoch of the block height at which the extension was signed.