### PR TITLE
fix flakey e2e tests

### DIFF
--- a/.changelog/unreleased/features/658-add-client-block-query.md
+++ b/.changelog/unreleased/features/658-add-client-block-query.md
@@ -1,0 +1,2 @@
+- Client: Add a command to query the last committed block's hash, height and
+  timestamp. ([#658](https://github.com/anoma/namada/issues/658))

--- a/apps/src/bin/anoma-client/cli.rs
+++ b/apps/src/bin/anoma-client/cli.rs
@@ -52,6 +52,9 @@ pub async fn main() -> Result<()> {
                 Sub::QueryEpoch(QueryEpoch(args)) => {
                     rpc::query_epoch(args).await;
                 }
+                Sub::QueryBlock(QueryBlock(args)) => {
+                    rpc::query_block(args).await;
+                }
                 Sub::QueryBalance(QueryBalance(args)) => {
                     rpc::query_balance(ctx, args).await;
                 }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -167,6 +167,7 @@ pub mod cmds {
                 .subcommand(Withdraw::def().display_order(2))
                 // Queries
                 .subcommand(QueryEpoch::def().display_order(3))
+                .subcommand(QueryBlock::def().display_order(3))
                 .subcommand(QueryBalance::def().display_order(3))
                 .subcommand(QueryBonds::def().display_order(3))
                 .subcommand(QueryVotingPower::def().display_order(3))
@@ -198,6 +199,7 @@ pub mod cmds {
             let unbond = Self::parse_with_ctx(matches, Unbond);
             let withdraw = Self::parse_with_ctx(matches, Withdraw);
             let query_epoch = Self::parse_with_ctx(matches, QueryEpoch);
+            let query_block = Self::parse_with_ctx(matches, QueryBlock);
             let query_balance = Self::parse_with_ctx(matches, QueryBalance);
             let query_bonds = Self::parse_with_ctx(matches, QueryBonds);
             let query_voting_power =
@@ -224,6 +226,7 @@ pub mod cmds {
                 .or(unbond)
                 .or(withdraw)
                 .or(query_epoch)
+                .or(query_block)
                 .or(query_balance)
                 .or(query_bonds)
                 .or(query_voting_power)
@@ -283,6 +286,7 @@ pub mod cmds {
         Unbond(Unbond),
         Withdraw(Withdraw),
         QueryEpoch(QueryEpoch),
+        QueryBlock(QueryBlock),
         QueryBalance(QueryBalance),
         QueryBonds(QueryBonds),
         QueryVotingPower(QueryVotingPower),
@@ -932,6 +936,25 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about("Query the epoch of the last committed block.")
+                .add_args::<args::Query>()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct QueryBlock(pub args::Query);
+
+    impl SubCmd for QueryBlock {
+        const CMD: &'static str = "block";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches
+                .subcommand_matches(Self::CMD)
+                .map(|matches| QueryBlock(args::Query::parse(matches)))
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about("Query the last committed block.")
                 .add_args::<args::Query>()
         }
     }

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -72,6 +72,21 @@ pub async fn query_epoch(args: args::Query) -> Epoch {
     cli::safe_exit(1)
 }
 
+/// Query the last committed block
+pub async fn query_block(
+    args: args::Query,
+) -> tendermint_rpc::endpoint::block::Response {
+    let client = HttpClient::new(args.ledger_address).unwrap();
+    let response = client.latest_block().await.unwrap();
+    println!(
+        "Last committed block ID: {}, height: {}, time: {}",
+        response.block_id,
+        response.block.header.height,
+        response.block.header.time
+    );
+    response
+}
+
 /// Query the raw bytes of given storage key
 pub async fn query_raw_bytes(_ctx: Context, args: args::QueryRawBytes) {
     let client = HttpClient::new(args.query.ledger_address).unwrap();


### PR DESCRIPTION
depends on #659 

With the new version of tendermint from #510, a non-validator sometimes syncs without applying txs. This can make e2e tests where we're checking txs result in the node's log fail. 

To deal with this in a more reliable way, we first check the block height after the tx is applied in a validator node and wait for the non-validator node to be synced to the same height (#659), before checking the state via another client query.
