### PR TITLE
Record the block heights at which validators vote for Ethereum events

### DIFF
--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/eth_msgs.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/eth_msgs.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use namada::types::address::Address;
@@ -24,11 +24,11 @@ pub struct EthMsgUpdate {
     /// The event being seen
     pub body: EthereumEvent,
     /// Addresses of the validators who have just seen this event. We use
-    /// [`BTreeSet`] even though ordering is not important here, so that we
+    /// [`BTreeMap`] even though ordering is not important here, so that we
     /// can derive [`Hash`] for [`EthMsgUpdate`].
     // NOTE(feature = "abcipp"): This can just become BTreeSet<Address> because
     // BlockHeight will always be the previous block
-    pub seen_by: BTreeSet<(Address, BlockHeight)>,
+    pub seen_by: BTreeMap<Address, BlockHeight>,
 }
 
 impl From<MultiSignedEthEvent> for EthMsgUpdate {
@@ -80,8 +80,8 @@ mod tests {
         };
         let expected = EthMsgUpdate {
             body: event,
-            seen_by: BTreeSet::from_iter(vec![(
-                sole_validator,
+            seen_by: BTreeMap::from([(
+                sole_validator.clone(),
                 BlockHeight(100),
             )]),
         };

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/eth_msgs.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/eth_msgs.rs
@@ -1,12 +1,8 @@
-use std::collections::BTreeMap;
-
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use namada::types::address::Address;
 use namada::types::ethereum_events::EthereumEvent;
-use namada::types::storage::BlockHeight;
 use namada::types::vote_extensions::ethereum_events::MultiSignedEthEvent;
 
-use crate::node::ledger::protocol::transactions::votes::Tally;
+use crate::node::ledger::protocol::transactions::votes::{Tally, Votes};
 
 /// Represents an Ethereum event being seen by some validators
 #[derive(
@@ -21,14 +17,12 @@ use crate::node::ledger::protocol::transactions::votes::Tally;
     BorshDeserialize,
 )]
 pub struct EthMsgUpdate {
-    /// The event being seen
+    /// The event being seen.
     pub body: EthereumEvent,
-    /// Addresses of the validators who have just seen this event. We use
-    /// [`BTreeMap`] even though ordering is not important here, so that we
-    /// can derive [`Hash`] for [`EthMsgUpdate`].
+    /// New votes for this event.
     // NOTE(feature = "abcipp"): This can just become BTreeSet<Address> because
     // BlockHeight will always be the previous block
-    pub seen_by: BTreeMap<Address, BlockHeight>,
+    pub seen_by: Votes,
 }
 
 impl From<MultiSignedEthEvent> for EthMsgUpdate {
@@ -80,10 +74,7 @@ mod tests {
         };
         let expected = EthMsgUpdate {
             body: event,
-            seen_by: BTreeMap::from([(
-                sole_validator.clone(),
-                BlockHeight(100),
-            )]),
+            seen_by: Votes::from([(sole_validator.clone(), BlockHeight(100))]),
         };
 
         let update: EthMsgUpdate = with_signers.into();

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/eth_msgs.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/eth_msgs.rs
@@ -74,7 +74,7 @@ mod tests {
         };
         let expected = EthMsgUpdate {
             body: event,
-            seen_by: Votes::from([(sole_validator.clone(), BlockHeight(100))]),
+            seen_by: Votes::from([(sole_validator, BlockHeight(100))]),
         };
 
         let update: EthMsgUpdate = with_signers.into();

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -251,7 +251,7 @@ mod tests {
         };
         let update = EthMsgUpdate {
             body: body.clone(),
-            seen_by: BTreeSet::from_iter(vec![(
+            seen_by: BTreeMap::from([(
                 sole_validator.clone(),
                 BlockHeight(100),
             )]),
@@ -290,8 +290,8 @@ mod tests {
         let (seen_by_bytes, _) = storage.read(&eth_msg_keys.seen_by())?;
         let seen_by_bytes = seen_by_bytes.unwrap();
         assert_eq!(
-            Vec::<Address>::try_from_slice(&seen_by_bytes)?,
-            vec![sole_validator]
+            BTreeMap::<Address, BlockHeight>::try_from_slice(&seen_by_bytes)?,
+            BTreeMap::from([(sole_validator.clone(), BlockHeight(100))])
         );
 
         let (voting_power_bytes, _) =

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -288,7 +288,7 @@ mod tests {
         let seen_by_bytes = seen_by_bytes.unwrap();
         assert_eq!(
             Votes::try_from_slice(&seen_by_bytes)?,
-            Votes::from([(sole_validator.clone(), BlockHeight(100))])
+            Votes::from([(sole_validator, BlockHeight(100))])
         );
 
         let (voting_power_bytes, _) =

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -12,20 +12,18 @@ use namada::ledger::eth_bridge::storage::vote_tallies;
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::{DBIter, Storage, DB};
 use namada::types::address::Address;
-use namada::types::storage::{self, BlockHeight};
+use namada::types::storage::BlockHeight;
 use namada::types::transaction::TxResult;
 use namada::types::vote_extensions::ethereum_events::MultiSignedEthEvent;
 use namada::types::voting_power::FractionalVotingPower;
 
+use super::ChangedKeys;
 use crate::node::ledger::protocol::transactions::utils::{
     self, get_active_validators,
 };
 use crate::node::ledger::protocol::transactions::votes::{
     calculate_new, calculate_updated, write,
 };
-
-/// The keys changed while applying a protocol transaction
-type ChangedKeys = BTreeSet<storage::Key>;
 
 /// Applies derived state changes to storage, based on Ethereum `events` which
 /// were newly seen by some active validator(s) in the last epoch. For `events`
@@ -232,7 +230,6 @@ mod tests {
     };
     use namada::types::ethereum_events::{EthereumEvent, TransferToNamada};
     use namada::types::token::Amount;
-    use storage::BlockHeight;
 
     use super::*;
 

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -176,16 +176,16 @@ where
         );
         let mut votes = HashMap::default();
         seen_by.iter().for_each(|(address, block_height)| {
-            let fvp = voting_powers
+            let voting_power = voting_powers
                 .get(&(address.to_owned(), block_height.to_owned()))
                 .unwrap();
-            if let Some(already_present_fvp) =
-                votes.insert(address.to_owned(), fvp.to_owned())
+            if let Some(already_present_voting_power) =
+                votes.insert(address.to_owned(), voting_power.to_owned())
             {
                 tracing::warn!(
                     ?address,
-                    ?already_present_fvp,
-                    new_fvp = ?fvp,
+                    ?already_present_voting_power,
+                    new_voting_power = ?voting_power,
                     "Validator voted more than once, arbitrarily using later value",
                 )
             }

--- a/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -174,7 +174,6 @@ where
             %eth_msg_keys.prefix,
             "Ethereum event already exists in storage",
         );
-        // TODO: move construction of votes map up the call path
         let mut votes = HashMap::default();
         seen_by.iter().for_each(|(address, block_height)| {
             let fvp = voting_powers

--- a/apps/src/lib/node/ledger/protocol/transactions/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/mod.rs
@@ -4,6 +4,10 @@
 //! to update their blockchain state in a deterministic way. This can be done
 //! natively rather than via the wasm environment as happens with regular
 //! transactions.
+
+use std::collections::BTreeSet;
+
+use namada::types::storage;
 #[cfg(not(feature = "abcipp"))]
 pub(super) mod ethereum_events;
 #[cfg(not(feature = "abcipp"))]
@@ -17,3 +21,6 @@ mod update;
 
 #[cfg(not(feature = "abcipp"))]
 mod utils;
+
+/// The keys changed while applying a protocol transaction.
+pub type ChangedKeys = BTreeSet<storage::Key>;

--- a/apps/src/lib/node/ledger/protocol/transactions/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/mod.rs
@@ -8,8 +8,10 @@
 use std::collections::BTreeSet;
 
 use namada::types::storage;
+
 #[cfg(not(feature = "abcipp"))]
 pub(super) mod ethereum_events;
+
 #[cfg(not(feature = "abcipp"))]
 mod votes;
 

--- a/apps/src/lib/node/ledger/protocol/transactions/votes.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/votes.rs
@@ -1,7 +1,7 @@
 //! Logic and data types relating to tallying validators' votes for pieces of
 //! data stored in the ledger, where those pieces of data should only be acted
 //! on once they have received enough votes
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use eyre::{eyre, Result};
@@ -9,13 +9,11 @@ use namada::ledger::eth_bridge::storage::vote_tallies;
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::{DBIter, Storage, DB};
 use namada::types::address::Address;
-use namada::types::storage::{self, BlockHeight};
+use namada::types::storage::BlockHeight;
 use namada::types::voting_power::FractionalVotingPower;
 
+use super::ChangedKeys;
 use crate::node::ledger::protocol::transactions::read;
-
-/// The keys changed while applying a protocol transaction
-type ChangedKeys = BTreeSet<storage::Key>;
 
 #[derive(
     Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema,

--- a/apps/src/lib/node/ledger/protocol/transactions/votes.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/votes.rs
@@ -72,11 +72,11 @@ pub fn calculate_new(
 }
 
 /// Calculate an updated [`Tally`] based on one that is in storage under `keys`,
-/// and some new votes
+/// with some new `voters`.
 pub fn calculate_updated<D, H, T>(
     store: &mut Storage<D, H>,
     keys: &vote_tallies::Keys<T>,
-    _voting_powers: &HashMap<Address, FractionalVotingPower>,
+    _voters: &HashMap<Address, FractionalVotingPower>,
 ) -> Result<(Tally, ChangedKeys)>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,


### PR DESCRIPTION
This PR:
- changes the `seen_by` field that we store for every Ethereum event from `BTreeSet<Address>` to `BTreeMap<Address, BlockHeight>` (`Votes` type)
- propagates this change through the rest of the Ethereum event code that exists in `eth-bridge-integration`

This change to start recording the block heights will be necessary for tallying votes against validator set updates - when a validator set update has enough votes behind it, the relayer should look in the specified `BlockHeight`s for the protocol txs containing the signatures.