### PR TITLE
Derive BorshSchema on vote extension types

### DIFF
--- a/shared/src/types/vote_extensions/ethereum_events.rs
+++ b/shared/src/types/vote_extensions/ethereum_events.rs
@@ -11,14 +11,19 @@ use crate::types::ethereum_events::EthereumEvent;
 use crate::types::key::common::{self, Signature};
 use crate::types::storage::BlockHeight;
 
+/// Type alias for an [`EthereumEventsVext`].
+pub type Vext = EthereumEventsVext;
+
 /// Represents a set of [`EthereumEvent`] instances
 /// seen by some validator.
 ///
 /// This struct will be created and signed over by each
 /// active validator, to be included as a vote extension at the end of a
 /// Tendermint PreCommit phase.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-pub struct Vext {
+#[derive(
+    Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
+pub struct EthereumEventsVext {
     /// The block height for which this [`Vext`] was made.
     pub block_height: BlockHeight,
     /// TODO: the validator's address is temporarily being included
@@ -47,28 +52,6 @@ impl Vext {
     }
 }
 
-impl BorshSchema for Vext {
-    fn add_definitions_recursively(
-        definitions: &mut HashMap<
-            borsh::schema::Declaration,
-            borsh::schema::Definition,
-        >,
-    ) {
-        let fields =
-            borsh::schema::Fields::UnnamedFields(borsh::maybestd::vec![
-                BlockHeight::declaration(),
-                Address::declaration(),
-                Vec::<EthereumEvent>::declaration(),
-            ]);
-        let definition = borsh::schema::Definition::Struct { fields };
-        Self::add_definition(Self::declaration(), definition, definitions);
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        "ethereum_events::Vext".into()
-    }
-}
-
 /// Aggregates an Ethereum event with the corresponding
 /// validators who saw this event.
 #[derive(
@@ -86,10 +69,15 @@ pub struct MultiSignedEthEvent {
     pub signers: BTreeSet<(Address, BlockHeight)>,
 }
 
+/// Type alias for an [`EthereumEventsVextDigest`].
+pub type VextDigest = EthereumEventsVextDigest;
+
 /// Compresses a set of signed [`Vext`] instances, to save
 /// space on a block.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-pub struct VextDigest {
+#[derive(
+    Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
+pub struct EthereumEventsVextDigest {
     /// The signatures and signing address of each [`Vext`]
     #[cfg(feature = "abcipp")]
     pub signatures: HashMap<Address, Signature>,
@@ -99,27 +87,6 @@ pub struct VextDigest {
     pub signatures: HashMap<(Address, BlockHeight), Signature>,
     /// The events that were reported
     pub events: Vec<MultiSignedEthEvent>,
-}
-
-impl BorshSchema for VextDigest {
-    fn add_definitions_recursively(
-        definitions: &mut HashMap<
-            borsh::schema::Declaration,
-            borsh::schema::Definition,
-        >,
-    ) {
-        let fields =
-            borsh::schema::Fields::UnnamedFields(borsh::maybestd::vec![
-                HashMap::<Address, Signature>::declaration(),
-                Vec::<MultiSignedEthEvent>::declaration()
-            ]);
-        let definition = borsh::schema::Definition::Struct { fields };
-        Self::add_definition(Self::declaration(), definition, definitions);
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        "ethereum_events::VextDigest".into()
-    }
 }
 
 impl VextDigest {

--- a/shared/src/types/vote_extensions/validator_set_update.rs
+++ b/shared/src/types/vote_extensions/validator_set_update.rs
@@ -21,10 +21,15 @@ use crate::types::storage::Epoch;
 const BRIDGE_CONTRACT_NAMESPACE: &str = "bridge";
 const GOVERNANCE_CONTRACT_NAMESPACE: &str = "governance";
 
+/// Type alias for a [`ValidatorSetUpdateVextDigest`].
+pub type VextDigest = ValidatorSetUpdateVextDigest;
+
 /// Contains the digest of all signatures from a quorum of
 /// validators for a [`Vext`].
-#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-pub struct VextDigest {
+#[derive(
+    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
+pub struct ValidatorSetUpdateVextDigest {
     #[cfg(feature = "abcipp")]
     /// A mapping from a validator address to a [`Signature`].
     pub signatures: HashMap<Address, Signature>,
@@ -37,27 +42,6 @@ pub struct VextDigest {
     /// The addresses of the validators in the new [`Epoch`],
     /// and their respective voting power.
     pub voting_powers: VotingPowersMap,
-}
-
-impl BorshSchema for VextDigest {
-    fn add_definitions_recursively(
-        definitions: &mut HashMap<
-            borsh::schema::Declaration,
-            borsh::schema::Definition,
-        >,
-    ) {
-        let fields =
-            borsh::schema::Fields::UnnamedFields(borsh::maybestd::vec![
-                HashMap::<Address, Signature>::declaration(),
-                VotingPowersMap::declaration()
-            ]);
-        let definition = borsh::schema::Definition::Struct { fields };
-        Self::add_definition(Self::declaration(), definition, definitions);
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        "validator_set_update::VextDigest".into()
-    }
 }
 
 impl VextDigest {
@@ -101,9 +85,14 @@ impl VextDigest {
 /// an Ethereum key.
 pub type SignedVext = Signed<Vext, SerializeWithAbiEncode>;
 
+/// Type alias for a [`ValidatorSetUpdateVext`].
+pub type Vext = ValidatorSetUpdateVext;
+
 /// Represents a validator set update, for some new [`Epoch`].
-#[derive(Eq, PartialEq, Clone, Debug, BorshSerialize, BorshDeserialize)]
-pub struct Vext {
+#[derive(
+    Eq, PartialEq, Clone, Debug, BorshSerialize, BorshDeserialize, BorshSchema,
+)]
+pub struct ValidatorSetUpdateVext {
     /// The addresses of the validators in the new [`Epoch`],
     /// and their respective voting power.
     ///
@@ -139,28 +128,6 @@ impl Vext {
     #[inline]
     pub fn sign(&self, sk: &common::SecretKey) -> SignedVext {
         SignedVext::new(sk, self.clone())
-    }
-}
-
-impl BorshSchema for Vext {
-    fn add_definitions_recursively(
-        definitions: &mut HashMap<
-            borsh::schema::Declaration,
-            borsh::schema::Definition,
-        >,
-    ) {
-        let fields =
-            borsh::schema::Fields::UnnamedFields(borsh::maybestd::vec![
-                VotingPowersMap::declaration(),
-                Address::declaration(),
-                BlockHeight::declaration(),
-            ]);
-        let definition = borsh::schema::Definition::Struct { fields };
-        Self::add_definition(Self::declaration(), definition, definitions);
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        "validator_set_update::Vext".into()
     }
 }
 


### PR DESCRIPTION
Implementing `BorshSchema` ourselves is a recipe for disaster, when the underlying types are subject to change.

Before the changes in [this PR](https://github.com/anoma/namada/pull/461), vote extension schemas had the same identifier: `Vext` and `VextDigest`, for both ethereum events and validator set update vote extensions. This led to collisions, which were detected by `namada-encoding-spec`. The linked PR kept the same naming for these types, but manually implemented `BorshSchema` to disambiguate between the schemas.

[The shimming changes](https://github.com/anoma/namada/pull/437) to the representation of vote extensions introduced a fault in their schemas(*). To prevent further bugs of this kind, it is better to give different names to our vote extensions types, such that we can disambiguate between them and derive `BorshSchema`.

---

(*) Basically, vote extension schemas expect a `HashMap<Address, Signature>` , where the types themselves contain a `HashMap<(Address, BlockHeight), Signature>` instead.