### PR TITLE
Add stub call to handle validator set update protocol txs

### DIFF
--- a/apps/src/lib/node/ledger/protocol/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/mod.rs
@@ -227,9 +227,17 @@ where
         }
         ProtocolTxType::ValidatorSetUpdate(ext) => {
             // NOTE(feature = "abcipp"): we will not need to apply any
-            // storage changes when we rollback to ABCI++; we could emit
-            // some kind of event, notifying a relayer process of a newly
-            // available validator set update, though
+            // storage changes when we rollback to ABCI++; this is because
+            // the decided vote extension digest should have >2/3 of the
+            // voting power already, which is the whole reason why we
+            // have to apply state updates with `abciplus` - we need
+            // to aggregate votes consisting of >2/3 of the voting power
+            // on a validator set update.
+            //
+            // we could, however, emit some kind of event, notifying a
+            // relayer process of a newly available validator set update;
+            // for this, we need to receive a mutable reference to the
+            // event log, in `apply_protocol_tx()`
             self::transactions::validator_set_update::aggregate_votes(
                 storage, ext,
             )

--- a/apps/src/lib/node/ledger/protocol/transactions/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/mod.rs
@@ -13,6 +13,9 @@ use namada::types::storage;
 pub(super) mod ethereum_events;
 
 #[cfg(not(feature = "abcipp"))]
+pub(super) mod validator_set_update;
+
+#[cfg(not(feature = "abcipp"))]
 mod votes;
 
 #[cfg(not(feature = "abcipp"))]

--- a/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -2,8 +2,11 @@
 //! [`namada::types::transaction::protocol::ProtocolTxType::ValidatorSetUpdate`]
 //! transactions.
 
+use eyre::Result;
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::{DBIter, Storage, DB};
+use namada::types::transaction::TxResult;
+use namada::types::vote_extensions::validator_set_update;
 
 pub(crate) fn aggregate_votes<D, H>(
     _storage: &mut Storage<D, H>,

--- a/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -1,3 +1,17 @@
 //! Code for handling
 //! [`namada::types::transaction::protocol::ProtocolTxType::ValidatorSetUpdate`]
 //! transactions.
+
+use namada::ledger::storage::traits::StorageHasher;
+use namada::ledger::storage::{DBIter, Storage, DB};
+
+pub(crate) fn aggregate_votes<D, H>(
+    _storage: &mut Storage<D, H>,
+    _ext: validator_set_update::VextDigest,
+) -> Result<TxResult>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    todo!()
+}

--- a/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -1,0 +1,3 @@
+//! Code for handling
+//! [`namada::types::transaction::protocol::ProtocolTxType::ValidatorSetUpdate`]
+//! transactions.

--- a/shared/src/ledger/eth_bridge/storage/vote_tallies.rs
+++ b/shared/src/ledger/eth_bridge/storage/vote_tallies.rs
@@ -1,10 +1,17 @@
 //! Functionality for accessing keys to do with tallying votes
+
 use crate::types::ethereum_events::EthereumEvent;
 use crate::types::hash::Hash;
-use crate::types::storage::Key;
+use crate::types::storage::{Epoch, Key};
+use crate::types::vote_extensions::validator_set_update;
 
-#[allow(missing_docs)]
+/// Storage sub-key space reserved to keeping track of the
+/// voting power assigned to Ethereum events.
 pub const ETH_MSGS_PREFIX_KEY_SEGMENT: &str = "eth_msgs";
+
+/// Storage sub-key space reserved to keeping track of the
+/// voting power assigned to validator set updates.
+pub const VALSET_UPDS_PREFIX_KEY_SEGMENT: &str = "validator_set_updates";
 
 const BODY_KEY_SEGMENT: &str = "body";
 const SEEN_KEY_SEGMENT: &str = "seen";
@@ -68,8 +75,8 @@ impl<T> IntoIterator for &Keys<T> {
     }
 }
 
-/// Get the key prefix corresponding to where details of seen [`EthereumEvent`]s
-/// are stored
+/// Get the key prefix corresponding to the storage location of
+/// [`EthereumEvent`]s whose "seen" state is being tracked.
 pub fn eth_msgs_prefix() -> Key {
     super::prefix()
         .push(&ETH_MSGS_PREFIX_KEY_SEGMENT.to_owned())
@@ -90,6 +97,26 @@ impl From<&Hash> for Keys<EthereumEvent> {
         let hex = format!("{}", hash);
         let prefix = eth_msgs_prefix()
             .push(&hex)
+            .expect("should always be able to construct this key");
+        Keys {
+            prefix,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+/// Get the key prefix corresponding to the storage location of validator set
+/// updates whose "seen" state is being tracked.
+pub fn valset_upds_prefix() -> Key {
+    super::prefix()
+        .push(&VALSET_UPDS_PREFIX_KEY_SEGMENT.to_owned())
+        .expect("should always be able to construct this key")
+}
+
+impl From<&Epoch> for Keys<validator_set_update::VextDigest> {
+    fn from(epoch: &Epoch) -> Self {
+        let prefix = valset_upds_prefix()
+            .push(epoch)
             .expect("should always be able to construct this key");
         Keys {
             prefix,


### PR DESCRIPTION
Based on #676

This PR adds a stub call to `apply_protocol_tx()` to handle validator set update protocol txs. Further, it adds some new sub-key types to handle the storage of validator set update tallies.