### PR TITLE
Refactor `get_voting_powers` when applying protocol tx state changes

### DIFF
--- a/apps/src/lib/node/ledger/protocol/transactions/utils.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/utils.rs
@@ -39,7 +39,7 @@ where
     tracing::debug!(
         n = active_validators.len(),
         ?active_validators,
-        "Got active validators in valset upd vote aggregation"
+        "Got active validators"
     );
 
     let voting_powers =

--- a/apps/src/lib/node/ledger/protocol/transactions/utils.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/utils.rs
@@ -18,8 +18,9 @@ pub(super) trait GetVoters {
     fn get_voters(&self) -> HashSet<(Address, BlockHeight)>;
 }
 
-/// Constructs a map of validators and the block height at which they signed
-/// a validator set update to their respective voting power at the given height.
+/// Returns a map whose keys are addresses of validators and the block height at
+/// which they signed some arbitrary object, and whose values are the voting
+/// powers of these validators at the key's given block height.
 pub(super) fn get_voting_powers<D, H, P>(
     storage: &Storage<D, H>,
     proof: &P,

--- a/apps/src/lib/node/ledger/protocol/transactions/utils.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/utils.rs
@@ -8,6 +8,7 @@ use namada::ledger::storage::{DBIter, Storage, DB};
 use namada::types::address::Address;
 use namada::types::storage::BlockHeight;
 use namada::types::vote_extensions::ethereum_events::MultiSignedEthEvent;
+use namada::types::vote_extensions::validator_set_update;
 use namada::types::voting_power::FractionalVotingPower;
 
 use crate::node::ledger::shell::queries::QueriesExt;
@@ -40,6 +41,15 @@ pub(super) fn get_votes_for_events<'a>(
         validators.extend(event.signers.iter().cloned());
         validators
     })
+}
+
+/// Extract all the voters and the block heights at which they voted from the
+/// given validator set update.
+#[inline]
+pub(super) fn get_votes_for_valset_upd(
+    ext: &validator_set_update::VextDigest,
+) -> HashSet<(Address, BlockHeight)> {
+    ext.signatures.keys().cloned().collect()
 }
 
 /// Gets the voting power of `selected` from `all_active`. Errors if a

--- a/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -8,14 +8,29 @@ use namada::ledger::storage::{DBIter, Storage, DB};
 use namada::types::transaction::TxResult;
 use namada::types::vote_extensions::validator_set_update;
 
+use super::ChangedKeys;
+use crate::node::ledger::protocol::transactions::utils;
+
+impl utils::GetVoters for validator_set_update::VextDigest {
+    #[inline]
+    fn get_voters(&self) -> HashSet<(Address, BlockHeight)> {
+        self.signatures.keys().cloned().collect()
+    }
+}
+
 pub(crate) fn aggregate_votes<D, H>(
-    _storage: &mut Storage<D, H>,
-    _ext: validator_set_update::VextDigest,
+    storage: &mut Storage<D, H>,
+    ext: validator_set_update::VextDigest,
 ) -> Result<TxResult>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
-    tracing::warn!("Called aggregate_votes() with no side effects");
-    Ok(TxResult::default())
+    tracing::info!(
+        num_votes = ext.signatures.len(),
+        "Aggregating new votes for validator set update"
+    );
+
+    let voting_powers = utils::get_voting_powers(storage, &ext)?;
+    let changed_keys = apply_updates(storage, updates, voting_powers)?;
 }

--- a/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -54,5 +54,6 @@ where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
-    todo!()
+    tracing::warn!("Called apply_updates() with no side effects");
+    Ok(ChangedKeys::new())
 }

--- a/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -2,11 +2,16 @@
 //! [`namada::types::transaction::protocol::ProtocolTxType::ValidatorSetUpdate`]
 //! transactions.
 
+use std::collections::{HashMap, HashSet};
+
 use eyre::Result;
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::{DBIter, Storage, DB};
+use namada::types::address::Address;
+use namada::types::storage::BlockHeight;
 use namada::types::transaction::TxResult;
 use namada::types::vote_extensions::validator_set_update;
+use namada::types::voting_power::FractionalVotingPower;
 
 use super::ChangedKeys;
 use crate::node::ledger::protocol::transactions::utils;
@@ -32,5 +37,22 @@ where
     );
 
     let voting_powers = utils::get_voting_powers(storage, &ext)?;
-    let changed_keys = apply_updates(storage, updates, voting_powers)?;
+    let changed_keys = apply_updates(storage, ext, voting_powers)?;
+
+    Ok(TxResult {
+        changed_keys,
+        ..Default::default()
+    })
+}
+
+fn apply_updates<D, H>(
+    _storage: &mut Storage<D, H>,
+    _ext: validator_set_update::VextDigest,
+    _voting_powers: HashMap<(Address, BlockHeight), FractionalVotingPower>,
+) -> Result<ChangedKeys>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    todo!()
 }


### PR DESCRIPTION
Based on #684

This PR refactors `get_voting_powers` to accept different kinds of items that have been voted on (e.g. ethereum events and validator set updates). 