### PR TITLE
Fix failing `make test-wasm` in `eth-bridge-integration`

### DIFF
--- a/shared/src/ledger/storage/merkle_tree.rs
+++ b/shared/src/ledger/storage/merkle_tree.rs
@@ -45,8 +45,10 @@ pub enum Error {
     StoreType(String),
     #[error("Non-existence proofs not supported for store type: {0}")]
     NonExistenceProof(String),
-    #[error("Invalid value given to sub-tree storage")]
-    InvalidValue,
+    #[error("Expected a bytes value")]
+    ExpectedBytesValue,
+    #[error("Expected a bridge pool transfer value")]
+    ExpectedBridgePoolTransferValue,
     #[error("ICS23 commitment proofs do not support multiple leaves")]
     Ics23MultiLeaf,
     #[error("A Tendermint proof can only be constructed from an ICS23 proof.")]

--- a/shared/src/ledger/storage/traits.rs
+++ b/shared/src/ledger/storage/traits.rs
@@ -62,7 +62,7 @@ impl<'a, H: StorageHasher + Default> SubTreeRead for &'a Smt<H> {
         let key: &Key = &keys[0];
         let value = match values.remove(0) {
             MerkleValue::Bytes(b) => b,
-            _ => return Err(Error::InvalidValue),
+            _ => return Err(Error::ExpectedBytesValue),
         };
         let cp = self.membership_proof(&H::hash(key.to_string()).into())?;
         // Replace the values and the leaf op for the verification
@@ -90,7 +90,7 @@ impl<'a, H: StorageHasher + Default> SubTreeWrite for &'a mut Smt<H> {
     ) -> Result<Hash, Error> {
         let value = match value {
             MerkleValue::Bytes(bytes) => H::hash(bytes.as_slice()),
-            _ => return Err(Error::InvalidValue),
+            _ => return Err(Error::ExpectedBytesValue),
         };
         self.update(H::hash(key.to_string()).into(), value.into())
             .map(Hash::from)
@@ -149,7 +149,7 @@ impl<'a, H: StorageHasher + Default> SubTreeWrite for &'a mut Amt<H> {
         let key = StringKey::try_from_bytes(key.to_string().as_bytes())?;
         let value = match value {
             MerkleValue::Bytes(bytes) => TreeBytes::from(bytes),
-            _ => return Err(Error::InvalidValue),
+            _ => return Err(Error::ExpectedBytesValue),
         };
         self.update(key, value)
             .map(Into::into)
@@ -199,7 +199,7 @@ impl<'a> SubTreeWrite for &'a mut BridgePoolTree {
             self.insert_key(key)
                 .map_err(|err| Error::MerkleTree(err.to_string()))
         } else {
-            Err(Error::InvalidValue)
+            Err(Error::ExpectedBridgePoolTransferValue)
         }
     }
 

--- a/tests/src/vm_host_env/tx.rs
+++ b/tests/src/vm_host_env/tx.rs
@@ -115,7 +115,6 @@ impl TestTxEnv {
                 address.borrow(),
                 Address::Internal(_) | Address::Implicit(_)
             ) {
-                // don't write a VP for internal addresses
                 continue;
             }
             let key = Key::validity_predicate(address.borrow());


### PR DESCRIPTION
Backporting PR https://github.com/anoma/namada/pull/694 but for `eth-bridge-integration`

Also splits up an error type into two different error types