### PR TITLE
Aggregate votes for validator set updates in storage

### DIFF
--- a/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -1,6 +1,4 @@
-//! Code for handling
-//! [`namada::types::transaction::protocol::ProtocolTxType::ValidatorSetUpdate`]
-//! transactions.
+//! Code for handling [`ProtocolTxType::ValidatorSetUpdate`] protocol txs.
 
 use std::collections::{HashMap, HashSet};
 
@@ -10,6 +8,8 @@ use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::{DBIter, Storage, DB};
 use namada::types::address::Address;
 use namada::types::storage::BlockHeight;
+#[allow(unused_imports)]
+use namada::types::transaction::protocol::ProtocolTxType;
 use namada::types::transaction::TxResult;
 use namada::types::vote_extensions::validator_set_update;
 use namada::types::voting_power::FractionalVotingPower;
@@ -110,9 +110,8 @@ where
         );
         let mut votes = HashMap::default();
         seen_by.into_iter().for_each(|(address, block_height)| {
-            let fract_voting_power = voting_powers
-                .get(&(address.clone(), block_height))
-                .unwrap();
+            let fract_voting_power =
+                voting_powers.get(&(address.clone(), block_height)).unwrap();
             if let Some(already_present_fract_voting_power) =
                 votes.insert(address.clone(), fract_voting_power.to_owned())
             {
@@ -120,7 +119,8 @@ where
                     ?address,
                     ?already_present_fract_voting_power,
                     new_fract_voting_power = ?fract_voting_power,
-                    "Validator voted more than once, arbitrarily using later value",
+                    "Validator voted more than once on validator set update, \
+                     arbitrarily using later value"
                 )
             }
         });

--- a/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/apps/src/lib/node/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -5,6 +5,7 @@
 use std::collections::{HashMap, HashSet};
 
 use eyre::Result;
+use namada::ledger::eth_bridge::storage::vote_tallies;
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::{DBIter, Storage, DB};
 use namada::types::address::Address;
@@ -15,6 +16,7 @@ use namada::types::voting_power::FractionalVotingPower;
 
 use super::ChangedKeys;
 use crate::node::ledger::protocol::transactions::utils;
+use crate::node::ledger::shell::queries::QueriesExt;
 
 impl utils::GetVoters for validator_set_update::VextDigest {
     #[inline]
@@ -31,13 +33,18 @@ where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
+    if ext.signatures.is_empty() {
+        tracing::debug!("Ignoring empty validator set update");
+        return Ok(Default::default());
+    }
+
     tracing::info!(
         num_votes = ext.signatures.len(),
         "Aggregating new votes for validator set update"
     );
 
     let voting_powers = utils::get_voting_powers(storage, &ext)?;
-    let changed_keys = apply_updates(storage, ext, voting_powers)?;
+    let changed_keys = apply_update(storage, ext, voting_powers)?;
 
     Ok(TxResult {
         changed_keys,
@@ -45,15 +52,39 @@ where
     })
 }
 
-fn apply_updates<D, H>(
-    _storage: &mut Storage<D, H>,
-    _ext: validator_set_update::VextDigest,
+fn apply_update<D, H>(
+    storage: &mut Storage<D, H>,
+    ext: validator_set_update::VextDigest,
     _voting_powers: HashMap<(Address, BlockHeight), FractionalVotingPower>,
 ) -> Result<ChangedKeys>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
-    tracing::warn!("Called apply_updates() with no side effects");
+    let epoch = {
+        // all votes we gathered are for the same epoch, so
+        // we can just fetch the block height from the first
+        // signature we iterate over, and calculate its cor-
+        // responding epoch
+        let height = ext
+            .signatures
+            .keys()
+            .map(|(_, height)| *height)
+            .by_ref()
+            .next()
+            .expect(
+                "We have at least one signature present in this validator set \
+                 update vote extension digest",
+            );
+
+        storage
+            .get_epoch(height)
+            .expect("The epoch of the given block height should be known")
+    };
+
+    let valset_upd_keys = vote_tallies::Keys::from(&epoch);
+    let _ = valset_upd_keys;
+
+    tracing::warn!("Called apply_update() with no side effects");
     Ok(ChangedKeys::new())
 }


### PR DESCRIPTION
Based on #683

Count votes on validator set updates signed off for some epoch. Currently, nothing happens when we reach a complete proof (i.e. more than 2/3 of the voting power) on some set of validators, but we could, e.g. emit some kind of event which would be consumed by a relayer.