### PR TITLE
Allow testing wasm with Native VPs

### DIFF
--- a/wasm/wasm_source/src/tx_bond.rs
+++ b/wasm/wasm_source/src/tx_bond.rs
@@ -89,7 +89,12 @@ mod tests {
 
             // Ensure that the bond's source has enough tokens for the bond
             let target = bond.source.as_ref().unwrap_or(&bond.validator);
-            tx_env.credit_tokens(target, &staking_token_address(), bond.amount);
+            tx_env.credit_tokens(
+                target,
+                &staking_token_address(),
+                None,
+                bond.amount,
+            );
         });
 
         let tx_code = vec![];

--- a/wasm/wasm_source/src/tx_unbond.rs
+++ b/wasm/wasm_source/src/tx_unbond.rs
@@ -99,6 +99,7 @@ mod tests {
                 tx_env.credit_tokens(
                     source,
                     &staking_token_address(),
+                    None,
                     initial_stake,
                 );
             }

--- a/wasm/wasm_source/src/tx_withdraw.rs
+++ b/wasm/wasm_source/src/tx_withdraw.rs
@@ -106,6 +106,7 @@ mod tests {
                 tx_env.credit_tokens(
                     source,
                     &staking_token_address(),
+                    None,
                     initial_stake,
                 );
             }

--- a/wasm/wasm_source/src/vp_testnet_faucet.rs
+++ b/wasm/wasm_source/src/vp_testnet_faucet.rs
@@ -139,7 +139,7 @@ mod tests {
 
         // Credit the tokens to the source before running the transaction to be
         // able to transfer from it
-        tx_env.credit_tokens(&source, &token, amount);
+        tx_env.credit_tokens(&source, &token, None, amount);
 
         // Initialize VP environment from a transaction
         vp_host_env::init_from_tx(vp_owner.clone(), tx_env, |address| {
@@ -275,7 +275,7 @@ mod tests {
 
         // Credit the tokens to the VP owner before running the transaction to
         // be able to transfer from it
-        tx_env.credit_tokens(&vp_owner, &token, amount);
+        tx_env.credit_tokens(&vp_owner, &token, None, amount);
 
         // Initialize VP environment from a transaction
         vp_host_env::init_from_tx(vp_owner.clone(), tx_env, |address| {
@@ -308,7 +308,7 @@ mod tests {
 
         // Credit the tokens to the VP owner before running the transaction to
         // be able to transfer from it
-        tx_env.credit_tokens(&vp_owner, &token, amount);
+        tx_env.credit_tokens(&vp_owner, &token, None, amount);
 
         // Initialize VP environment from a transaction
         vp_host_env::init_from_tx(vp_owner.clone(), tx_env, |address| {

--- a/wasm/wasm_source/src/vp_user.rs
+++ b/wasm/wasm_source/src/vp_user.rs
@@ -229,7 +229,7 @@ mod tests {
 
         // Credit the tokens to the source before running the transaction to be
         // able to transfer from it
-        tx_env.credit_tokens(&source, &token, amount);
+        tx_env.credit_tokens(&source, &token, None, amount);
 
         // Initialize VP environment from a transaction
         vp_host_env::init_from_tx(vp_owner.clone(), tx_env, |address| {
@@ -273,7 +273,7 @@ mod tests {
 
         // Credit the tokens to the VP owner before running the transaction to
         // be able to transfer from it
-        tx_env.credit_tokens(&vp_owner, &token, amount);
+        tx_env.credit_tokens(&vp_owner, &token, None, amount);
 
         // Initialize VP environment from a transaction
         vp_host_env::init_from_tx(vp_owner.clone(), tx_env, |address| {
@@ -319,7 +319,7 @@ mod tests {
 
         // Credit the tokens to the VP owner before running the transaction to
         // be able to transfer from it
-        tx_env.credit_tokens(&vp_owner, &token, amount);
+        tx_env.credit_tokens(&vp_owner, &token, None, amount);
 
         tx_env.write_public_key(&vp_owner, &public_key);
 
@@ -369,7 +369,7 @@ mod tests {
 
         // Credit the tokens to the VP owner before running the transaction to
         // be able to transfer from it
-        tx_env.credit_tokens(&source, &token, amount);
+        tx_env.credit_tokens(&source, &token, None, amount);
 
         // Initialize VP environment from a transaction
         vp_host_env::init_from_tx(vp_owner.clone(), tx_env, |address| {


### PR DESCRIPTION
This makes some small changes to the `TestTxEnv`. 
 * It enables crediting multitokens
 * It allows use to execute wasm on it. This is useful for making sure wasm works with native vps.