### PR TITLE
Add a new Makefile target to print stack traces after running failing unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,13 @@ test-unit:
 			--skip e2e \
 			-Z unstable-options --report-time
 
+test-unit-debug:
+	$(debug-cargo) test \
+			$(TEST_FILTER) -- \
+			--skip e2e \
+			--nocapture \
+			-Z unstable-options --report-time
+
 test-wasm:
 	make -C $(wasms) test
 


### PR DESCRIPTION
This is mostly added to stay on par with `eth-bridge-integration`, and smooth out future merges.