### PR TITLE
Fixed error message for overspending. Added missing RPC endpoints: re…

### DIFF
--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -129,7 +129,6 @@ pub async fn query_tx_deltas(
     query_token: &Option<Address>,
 ) -> BTreeMap<(BlockHeight, TxIndex), (Epoch, TransferDelta, TransactionDelta)>
 {
-    use masp_primitives::transaction::components::Amount;
     const TXS_PER_PAGE: u8 = 100;
     // Connect to the Tendermint server holding the transactions
     let client = HttpClient::new(ledger_address.clone()).unwrap();

--- a/shared/src/ledger/storage/mockdb.rs
+++ b/shared/src/ledger/storage/mockdb.rs
@@ -469,6 +469,17 @@ impl<'iter> DBIter<'iter> for MockDB {
             db_prefix,
         )
     }
+
+    fn iter_results(&'iter self) -> MockPrefixIterator {
+        let db_prefix = "results/".to_owned();
+        let prefix = "results".to_owned();
+        let iter = self.0.borrow().clone().into_iter();
+        MockPrefixIterator::new(MockIterator {
+            prefix,
+            iter,
+            reverse_order: false,
+        }, db_prefix)
+    }
 }
 
 /// A prefix iterator base for the [`MockPrefixIterator`].

--- a/shared/src/ledger/storage/mod.rs
+++ b/shared/src/ledger/storage/mod.rs
@@ -296,6 +296,9 @@ pub trait DBIter<'iter> {
     /// Read account subspace key value pairs with the given prefix from the DB,
     /// reverse ordered by the storage keys.
     fn rev_iter_prefix(&'iter self, prefix: &Key) -> Self::PrefixIter;
+
+    /// Read results subspace key value pairs from the DB
+    fn iter_results(&'iter self) -> Self::PrefixIter;
 }
 
 /// Atomic batch write.
@@ -505,6 +508,11 @@ where
         prefix: &Key,
     ) -> (<D as DBIter<'_>>::PrefixIter, u64) {
         (self.db.rev_iter_prefix(prefix), prefix.len() as _)
+    }
+
+    /// Returns a prefix iterator and the gas cost
+    pub fn iter_results(&self) -> (<D as DBIter<'_>>::PrefixIter, u64) {
+        (self.db.iter_results(), 0)
     }
 
     /// Write a value to the specified subspace and returns the gas cost and the

--- a/shared/src/types/masp.rs
+++ b/shared/src/types/masp.rs
@@ -368,6 +368,15 @@ impl TransferSource {
     }
 }
 
+impl Display for TransferSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Address(x) => x.fmt(f),
+            Self::ExtendedSpendingKey(x) => x.fmt(f),
+        }
+    }
+}
+
 /// Represents a target for the funds of a transfer
 #[derive(Debug, Clone)]
 pub enum TransferTarget {
@@ -401,6 +410,15 @@ impl TransferTarget {
         match self {
             Self::Address(x) => Some(x.clone()),
             _ => None,
+        }
+    }
+}
+
+impl Display for TransferTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Address(x) => x.fmt(f),
+            Self::PaymentAddress(x) => x.fmt(f),
         }
     }
 }

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -474,7 +474,7 @@ fn masp_txs_and_queries() -> Result<()> {
     let test = setup::network(
         |genesis| {
             let parameters = ParametersConfig {
-                min_duration: 60,
+                min_duration: 3600,
                 ..genesis.parameters
             };
             GenesisConfig {
@@ -613,7 +613,7 @@ fn masp_txs_and_queries() -> Result<()> {
                 "--ledger-address",
                 &validator_one_rpc,
             ],
-            "ChangeIsNegative",
+            "is lower than the amount to be transferred and fees",
         ),
         // 9. Spend 6 BTC at SK(A) to PA(B)
         (


### PR DESCRIPTION
Fixing failing MASP E2E tests. More specifically made the following changes:
* Lengthened the epoch duration for the masp_txs_and_queries test
* Added missing RPC endpoints: results (to obtain accepted txs) and conv (to obtain conversions)
* Improved the error message produced when user overspends (from a stacktrace)
