### PR TITLE
fix: use `crate::facade` for importing tendermint crates

### DIFF
--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -36,16 +36,16 @@ use namada::types::key::*;
 use namada::types::storage::{Epoch, Key, KeySeg, PrefixValue};
 use namada::types::token::{balance_key, Amount};
 use namada::types::{address, storage, token};
-use tendermint_config::net::Address as TendermintAddress;
-use tendermint_rpc::error::Error as TError;
-use tendermint_rpc::query::Query;
-use tendermint_rpc::{
-    Client, HttpClient, Order, SubscriptionClient, WebSocketClient,
-};
 use tokio::time::{Duration, Instant};
 
 use crate::cli::{self, args, Context};
 use crate::client::tendermint_rpc_types::TxResponse;
+use crate::facade::tendermint_config::net::Address as TendermintAddress;
+use crate::facade::tendermint_rpc::error::Error as TError;
+use crate::facade::tendermint_rpc::query::Query;
+use crate::facade::tendermint_rpc::{
+    Client, HttpClient, Order, SubscriptionClient, WebSocketClient,
+};
 
 /// Query the status of a given transaction.
 ///


### PR DESCRIPTION
Use `crate::facade` for tendermint imports in `rpc.rs` (this happened during https://github.com/anoma/namada/pull/723 so this is already the case in `main`)