### PR TITLE
Handle acting on tallied pieces of data that take longer than one round to confirm

### DIFF
--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -144,7 +144,7 @@ where
             %eth_msg_keys.prefix,
             "Ethereum event already exists in storage",
         );
-        let vote_info = VoteInfo::new(update.seen_by.clone(), voting_powers);
+        let vote_info = VoteInfo::new(update.seen_by.clone(), voting_powers)?;
         let (vote_tracking, changed) =
             calculate_updated(storage, &eth_msg_keys, &vote_info)?;
         let confirmed =

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -11,7 +11,7 @@ use eyre::Result;
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::utils::{self};
-use crate::ledger::protocol::transactions::votes::update::VoteInfo;
+use crate::ledger::protocol::transactions::votes::update::NewVotes;
 use crate::ledger::protocol::transactions::votes::{self, calculate_new};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
@@ -142,9 +142,9 @@ where
             %eth_msg_keys.prefix,
             "Ethereum event already exists in storage",
         );
-        let vote_info = VoteInfo::new(update.seen_by.clone(), voting_powers)?;
+        let new_votes = NewVotes::new(update.seen_by.clone(), voting_powers)?;
         let (vote_tracking, changed) =
-            votes::update::calculate(storage, &eth_msg_keys, vote_info)?;
+            votes::update::calculate(storage, &eth_msg_keys, new_votes)?;
         if changed.is_empty() {
             return Ok((changed, false));
         }

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -10,9 +10,7 @@ use eyre::Result;
 
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
-use crate::ledger::protocol::transactions::utils::{
-    self, filter_fractional_voting_powers_by_address,
-};
+use crate::ledger::protocol::transactions::utils::{self, construct_vote_info};
 use crate::ledger::protocol::transactions::votes::{
     self, calculate_new, calculate_updated,
 };
@@ -145,17 +143,9 @@ where
             %eth_msg_keys.prefix,
             "Ethereum event already exists in storage",
         );
-        let fractional_voting_powers =
-            filter_fractional_voting_powers_by_address(
-                update.seen_by.clone(),
-                voting_powers,
-            );
-        let (vote_tracking, changed) = calculate_updated(
-            storage,
-            &eth_msg_keys,
-            &fractional_voting_powers,
-            &update.seen_by,
-        )?;
+        let voters = construct_vote_info(update.seen_by.clone(), voting_powers);
+        let (vote_tracking, changed) =
+            calculate_updated(storage, &eth_msg_keys, &voters)?;
         let confirmed =
             vote_tracking.seen && changed.contains(&eth_msg_keys.seen());
         (vote_tracking, changed, confirmed)

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -10,9 +10,9 @@ use eyre::Result;
 
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
-use crate::ledger::protocol::transactions::utils::{self, construct_vote_info};
+use crate::ledger::protocol::transactions::utils::{self};
 use crate::ledger::protocol::transactions::votes::{
-    self, calculate_new, calculate_updated,
+    calculate_new, calculate_updated, write, VoteInfo,
 };
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
@@ -143,7 +143,7 @@ where
             %eth_msg_keys.prefix,
             "Ethereum event already exists in storage",
         );
-        let voters = construct_vote_info(update.seen_by.clone(), voting_powers);
+        let voters = VoteInfo::new(update.seen_by.clone(), voting_powers);
         let (vote_tracking, changed) =
             calculate_updated(storage, &eth_msg_keys, &voters)?;
         let confirmed =

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -116,7 +116,8 @@ where
 }
 
 /// Apply an [`EthMsgUpdate`] to storage. Returns any keys changed and whether
-/// the event was newly seen.
+/// the event was newly seen. The `voting_powers` map must contain a voting
+/// power for all `(Address, BlockHeight)`s that occur in `update`.
 fn apply_update<D, H>(
     storage: &mut Storage<D, H>,
     update: EthMsgUpdate,

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -11,9 +11,7 @@ use eyre::Result;
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::utils::{self};
-use crate::ledger::protocol::transactions::votes::update::{
-    calculate_updated, VoteInfo,
-};
+use crate::ledger::protocol::transactions::votes::update::VoteInfo;
 use crate::ledger::protocol::transactions::votes::{self, calculate_new};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
@@ -146,7 +144,7 @@ where
         );
         let vote_info = VoteInfo::new(update.seen_by.clone(), voting_powers)?;
         let (vote_tracking, changed) =
-            calculate_updated(storage, &eth_msg_keys, vote_info)?;
+            votes::update::calculate(storage, &eth_msg_keys, vote_info)?;
         let confirmed =
             vote_tracking.seen && changed.contains(&eth_msg_keys.seen());
         (vote_tracking, changed, confirmed)

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -146,7 +146,7 @@ where
         );
         let vote_info = VoteInfo::new(update.seen_by.clone(), voting_powers)?;
         let (vote_tracking, changed) =
-            calculate_updated(storage, &eth_msg_keys, &vote_info)?;
+            calculate_updated(storage, &eth_msg_keys, vote_info)?;
         let confirmed =
             vote_tracking.seen && changed.contains(&eth_msg_keys.seen());
         (vote_tracking, changed, confirmed)

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -68,7 +68,9 @@ where
 }
 
 /// Apply votes to Ethereum events in storage and act on any events which are
-/// confirmed. The `voting_powers` map must contain a voting power for all
+/// confirmed.
+///
+/// The `voting_powers` map must contain a voting power for all
 /// `(Address, BlockHeight)`s that occur in any of the `updates`.
 pub(super) fn apply_updates<D, H>(
     storage: &mut Storage<D, H>,
@@ -113,8 +115,10 @@ where
 }
 
 /// Apply an [`EthMsgUpdate`] to storage. Returns any keys changed and whether
-/// the event was newly seen. The `voting_powers` map must contain a voting
-/// power for all `(Address, BlockHeight)`s that occur in `update`.
+/// the event was newly seen.
+///
+/// The `voting_powers` map must contain a voting power for all
+/// `(Address, BlockHeight)`s that occur in `update`.
 fn apply_update<D, H>(
     storage: &mut Storage<D, H>,
     update: EthMsgUpdate,

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -12,7 +12,7 @@ use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::utils::{self};
 use crate::ledger::protocol::transactions::votes::{
-    calculate_new, calculate_updated, write, VoteInfo,
+    self, calculate_new, calculate_updated, VoteInfo,
 };
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
@@ -151,7 +151,12 @@ where
         (vote_tracking, changed, confirmed)
     };
 
-    write(storage, &eth_msg_keys, &update.body, &vote_tracking)?;
+    votes::storage::write(
+        storage,
+        &eth_msg_keys,
+        &update.body,
+        &vote_tracking,
+    )?;
 
     Ok((changed, confirmed))
 }

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -145,6 +145,9 @@ where
         let vote_info = VoteInfo::new(update.seen_by.clone(), voting_powers)?;
         let (vote_tracking, changed) =
             votes::update::calculate(storage, &eth_msg_keys, vote_info)?;
+        if changed.is_empty() {
+            return Ok((changed, false));
+        }
         let confirmed =
             vote_tracking.seen && changed.contains(&eth_msg_keys.seen());
         (vote_tracking, changed, confirmed)

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -11,7 +11,7 @@ use eyre::Result;
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::utils::{
-    self, construct_fractional_voting_powers_by_address,
+    self, filter_fractional_voting_powers_by_address,
 };
 use crate::ledger::protocol::transactions::votes::{
     self, calculate_new, calculate_updated,
@@ -146,8 +146,8 @@ where
             "Ethereum event already exists in storage",
         );
         let fractional_voting_powers =
-            construct_fractional_voting_powers_by_address(
-                &update.seen_by,
+            filter_fractional_voting_powers_by_address(
+                update.seen_by.clone(),
                 voting_powers,
             );
         let (vote_tracking, changed) = calculate_updated(

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -70,7 +70,9 @@ where
     })
 }
 
-/// Apply an Ethereum state update + act on any events which are confirmed
+/// Apply votes to Ethereum events in storage and act on any events which are
+/// confirmed. The `voting_powers` map must contain a voting power for all
+/// `(Address, BlockHeight)`s that occur in any of the `updates`.
 pub(super) fn apply_updates<D, H>(
     storage: &mut Storage<D, H>,
     updates: HashSet<EthMsgUpdate>,

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -143,9 +143,9 @@ where
             %eth_msg_keys.prefix,
             "Ethereum event already exists in storage",
         );
-        let voters = VoteInfo::new(update.seen_by.clone(), voting_powers);
+        let vote_info = VoteInfo::new(update.seen_by.clone(), voting_powers);
         let (vote_tracking, changed) =
-            calculate_updated(storage, &eth_msg_keys, &voters)?;
+            calculate_updated(storage, &eth_msg_keys, &vote_info)?;
         let confirmed =
             vote_tracking.seen && changed.contains(&eth_msg_keys.seen());
         (vote_tracking, changed, confirmed)

--- a/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
+++ b/shared/src/ledger/protocol/transactions/ethereum_events/mod.rs
@@ -11,9 +11,10 @@ use eyre::Result;
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::utils::{self};
-use crate::ledger::protocol::transactions::votes::{
-    self, calculate_new, calculate_updated, VoteInfo,
+use crate::ledger::protocol::transactions::votes::update::{
+    calculate_updated, VoteInfo,
 };
+use crate::ledger::protocol::transactions::votes::{self, calculate_new};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
 use crate::types::address::Address;

--- a/shared/src/ledger/protocol/transactions/utils.rs
+++ b/shared/src/ledger/protocol/transactions/utils.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use eyre::eyre;
 use itertools::Itertools;
 
+use super::votes::Votes;
 use crate::ledger::pos::types::{VotingPower, WeightedValidator};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
@@ -18,15 +19,16 @@ pub(super) trait GetVoters {
     fn get_voters(&self) -> HashSet<(Address, BlockHeight)>;
 }
 
+/// Constructs a map of validator [`Address`]es from `votes` to the relevant
+/// [`FractionalVotingPower`] from `voting_powers`
 pub(super) fn filter_fractional_voting_powers_by_address(
-    vote_heights: BTreeMap<Address, BlockHeight>,
+    votes: Votes,
     voting_powers: &HashMap<(Address, BlockHeight), FractionalVotingPower>,
 ) -> HashMap<Address, FractionalVotingPower> {
     let mut fractional_voting_powers = HashMap::default();
-    vote_heights.into_iter().for_each(|(address, block_height)| {
-        let fract_voting_power = voting_powers
-            .get(&(address.clone(), block_height))
-            .unwrap();
+    votes.into_iter().for_each(|(address, block_height)| {
+        let fract_voting_power =
+            voting_powers.get(&(address.clone(), block_height)).unwrap();
         if let Some(already_present_fract_voting_power) =
             fractional_voting_powers
                 .insert(address.clone(), fract_voting_power.to_owned())

--- a/shared/src/ledger/protocol/transactions/utils.rs
+++ b/shared/src/ledger/protocol/transactions/utils.rs
@@ -18,14 +18,14 @@ pub(super) trait GetVoters {
     fn get_voters(&self) -> HashSet<(Address, BlockHeight)>;
 }
 
-pub(super) fn construct_fractional_voting_powers_by_address(
-    vote_heights: &BTreeMap<Address, BlockHeight>,
+pub(super) fn filter_fractional_voting_powers_by_address(
+    vote_heights: BTreeMap<Address, BlockHeight>,
     voting_powers: &HashMap<(Address, BlockHeight), FractionalVotingPower>,
 ) -> HashMap<Address, FractionalVotingPower> {
     let mut fractional_voting_powers = HashMap::default();
-    vote_heights.iter().for_each(|(address, block_height)| {
+    vote_heights.into_iter().for_each(|(address, block_height)| {
         let fract_voting_power = voting_powers
-            .get(&(address.clone(), block_height.to_owned()))
+            .get(&(address.clone(), block_height))
             .unwrap();
         if let Some(already_present_fract_voting_power) =
             fractional_voting_powers

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -7,7 +7,7 @@ use eyre::Result;
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::utils::{
-    self, construct_fractional_voting_powers_by_address,
+    self, filter_fractional_voting_powers_by_address,
 };
 use crate::ledger::protocol::transactions::votes::{self, Votes};
 use crate::ledger::storage::traits::StorageHasher;
@@ -113,8 +113,8 @@ where
             "Validator set update votes already in storage",
         );
         let fractional_voting_powers =
-            construct_fractional_voting_powers_by_address(
-                &seen_by,
+            filter_fractional_voting_powers_by_address(
+                seen_by.clone(),
                 &voting_powers,
             );
         let (tally, changed) = votes::calculate_updated(

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -111,7 +111,7 @@ where
             %valset_upd_keys.prefix,
             "Validator set update votes already in storage",
         );
-        let new_votes = NewVotes::new(seen_by.clone(), &voting_powers)?;
+        let new_votes = NewVotes::new(seen_by, &voting_powers)?;
         let (tally, changed) =
             votes::update::calculate(storage, &valset_upd_keys, new_votes)?;
         if changed.is_empty() {

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -7,7 +7,7 @@ use eyre::Result;
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::utils;
-use crate::ledger::protocol::transactions::votes::update::VoteInfo;
+use crate::ledger::protocol::transactions::votes::update::NewVotes;
 use crate::ledger::protocol::transactions::votes::{self, Votes};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
@@ -111,9 +111,9 @@ where
             %valset_upd_keys.prefix,
             "Validator set update votes already in storage",
         );
-        let vote_info = VoteInfo::new(seen_by.clone(), &voting_powers)?;
+        let new_votes = NewVotes::new(seen_by.clone(), &voting_powers)?;
         let (tally, changed) =
-            votes::update::calculate(storage, &valset_upd_keys, vote_info)?;
+            votes::update::calculate(storage, &valset_upd_keys, new_votes)?;
         if changed.is_empty() {
             return Ok(changed);
         }

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -110,9 +110,9 @@ where
             %valset_upd_keys.prefix,
             "Validator set update votes already in storage",
         );
-        let voters = VoteInfo::new(seen_by.clone(), &voting_powers);
+        let vote_info = VoteInfo::new(seen_by.clone(), &voting_powers);
         let (tally, changed) =
-            votes::calculate_updated(storage, &valset_upd_keys, &voters)?;
+            votes::calculate_updated(storage, &valset_upd_keys, &vote_info)?;
         let confirmed = tally.seen && changed.contains(&valset_upd_keys.seen());
         (tally, changed, confirmed)
     };

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -113,7 +113,7 @@ where
             %valset_upd_keys.prefix,
             "Validator set update votes already in storage",
         );
-        let vote_info = VoteInfo::new(seen_by.clone(), &voting_powers);
+        let vote_info = VoteInfo::new(seen_by.clone(), &voting_powers)?;
         let (tally, changed) =
             calculate_updated(storage, &valset_upd_keys, &vote_info)?;
         let confirmed = tally.seen && changed.contains(&valset_upd_keys.seen());

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -7,9 +7,7 @@ use eyre::Result;
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::utils;
-use crate::ledger::protocol::transactions::votes::update::{
-    calculate_updated, VoteInfo,
-};
+use crate::ledger::protocol::transactions::votes::update::VoteInfo;
 use crate::ledger::protocol::transactions::votes::{self, Votes};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
@@ -115,7 +113,7 @@ where
         );
         let vote_info = VoteInfo::new(seen_by.clone(), &voting_powers)?;
         let (tally, changed) =
-            calculate_updated(storage, &valset_upd_keys, vote_info)?;
+            votes::update::calculate(storage, &valset_upd_keys, vote_info)?;
         let confirmed = tally.seen && changed.contains(&valset_upd_keys.seen());
         (tally, changed, confirmed)
     };

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -7,7 +7,10 @@ use eyre::Result;
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::utils;
-use crate::ledger::protocol::transactions::votes::{self, VoteInfo, Votes};
+use crate::ledger::protocol::transactions::votes::update::{
+    calculate_updated, VoteInfo,
+};
+use crate::ledger::protocol::transactions::votes::{self, Votes};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
 use crate::ledger::storage_api::queries::QueriesExt;
@@ -112,7 +115,7 @@ where
         );
         let vote_info = VoteInfo::new(seen_by.clone(), &voting_powers);
         let (tally, changed) =
-            votes::calculate_updated(storage, &valset_upd_keys, &vote_info)?;
+            calculate_updated(storage, &valset_upd_keys, &vote_info)?;
         let confirmed = tally.seen && changed.contains(&valset_upd_keys.seen());
         (tally, changed, confirmed)
     };

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -115,7 +115,7 @@ where
         );
         let vote_info = VoteInfo::new(seen_by.clone(), &voting_powers)?;
         let (tally, changed) =
-            calculate_updated(storage, &valset_upd_keys, &vote_info)?;
+            calculate_updated(storage, &valset_upd_keys, vote_info)?;
         let confirmed = tally.seen && changed.contains(&valset_upd_keys.seen());
         (tally, changed, confirmed)
     };

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -114,6 +114,9 @@ where
         let vote_info = VoteInfo::new(seen_by.clone(), &voting_powers)?;
         let (tally, changed) =
             votes::update::calculate(storage, &valset_upd_keys, vote_info)?;
+        if changed.is_empty() {
+            return Ok(changed);
+        }
         let confirmed = tally.seen && changed.contains(&valset_upd_keys.seen());
         (tally, changed, confirmed)
     };

--- a/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
+++ b/shared/src/ledger/protocol/transactions/validator_set_update/mod.rs
@@ -6,8 +6,8 @@ use eyre::Result;
 
 use super::ChangedKeys;
 use crate::ledger::eth_bridge::storage::vote_tallies;
-use crate::ledger::protocol::transactions::utils::{self, construct_vote_info};
-use crate::ledger::protocol::transactions::votes::{self, Votes};
+use crate::ledger::protocol::transactions::utils;
+use crate::ledger::protocol::transactions::votes::{self, VoteInfo, Votes};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, Storage, DB};
 use crate::ledger::storage_api::queries::QueriesExt;
@@ -110,7 +110,7 @@ where
             %valset_upd_keys.prefix,
             "Validator set update votes already in storage",
         );
-        let voters = construct_vote_info(seen_by.clone(), &voting_powers);
+        let voters = VoteInfo::new(seen_by.clone(), &voting_powers);
         let (tally, changed) =
             votes::calculate_updated(storage, &valset_upd_keys, &voters)?;
         let confirmed = tally.seen && changed.contains(&valset_upd_keys.seen());

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -160,6 +160,7 @@ fn calculate_update<T>(
     pre: &Tally,
     vote_info: &VoteInfo,
 ) -> Tally {
+    // TODO: no need to accept `keys` - it is just accepted for logging, is there a better way?
     let new_voters: BTreeSet<Address> = vote_info.voters();
 
     // For any event and validator, only the first vote by that validator for

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -154,9 +154,7 @@ where
 }
 
 /// Takes an existing [`Tally`] and calculates the new [`Tally`] based on new
-/// validators which have seen it. `voting_powers` should map validators who
-/// have newly seen the event to their fractional voting power at a block height
-/// at which they saw the event.
+/// validators which have seen it.
 fn calculate_update<T>(
     keys: &vote_tallies::Keys<T>,
     pre: &Tally,

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -165,13 +165,14 @@ fn calculate_update<T>(
 
     let previous_voters: BTreeSet<_> = pre.seen_by.keys().cloned().collect();
     let new_voters: BTreeSet<_> = previous_voters.difference(&vote_info.voters()).cloned().collect();
+    let duplicate_voters: BTreeSet<_> = previous_voters.intersection(&vote_info.voters()).cloned().collect();
 
     // For any event and validator, only the first vote by that validator for
     // that event counts, later votes we encounter here can just be ignored. We
     // can warn here when we encounter duplicate votes but these are
     // reasonably likely to occur so this perhaps shouldn't be a warning unless
     // it is happening a lot.
-    for validator in previous_voters.intersection(&new_voters) {
+    for validator in duplicate_voters {
         tracing::warn!(
             ?keys.prefix,
             ?validator,

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -103,7 +103,7 @@ impl VoteInfo {
     }
 
     pub fn get_vote_power(&self, validator: &Address) -> Option<FractionalVotingPower> {
-        self.inner.get(validator).map(|(_, voting_power)| *voting_power)
+        self.inner.get(validator).map(|(_, voting_power)| voting_power.clone())
     }
 }
 
@@ -121,7 +121,7 @@ where
 {
     tracing::info!(
         ?keys.prefix,
-        ?vote_info.voters(),
+        validators = ?vote_info.voters(),
         "Recording validators as having voted for this event"
     );
     let tally_pre = read(store, keys)?;
@@ -150,7 +150,7 @@ where
 
 /// Takes an existing [`Tally`] and calculates the new [`Tally`] based on new
 /// voters from `vote_info`. Returns an error if any new voters have already voted previously.
-fn calculate_update<T>(
+fn calculate_update(
     pre: &Tally,
     vote_info: &VoteInfo,
 ) -> Result<Tally> {
@@ -159,7 +159,7 @@ fn calculate_update<T>(
     let duplicate_voters: BTreeSet<_> = previous_voters.intersection(&new_voters).collect();
     if !duplicate_voters.is_empty() {
         // TODO: this is a programmer error and should never happen
-        return Err(eyre!("Duplicate voters found - {}", duplicate_voters));
+        return Err(eyre!("Duplicate voters found - {:?}", duplicate_voters));
     }
 
     let mut voting_power_post = pre.voting_power.clone();

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -128,7 +128,7 @@ where
         "Recording validators as having voted for this event"
     );
     let tally_pre = read(store, keys)?;
-    let tally_post = calculate_update(&tally_pre, vote_info)?;
+    let tally_post = calculate_tally_post(&tally_pre, vote_info)?;
     let changed_keys = validate_update(keys, &tally_pre, &tally_post)?;
 
     if tally_post.seen {
@@ -154,7 +154,7 @@ where
 /// Takes an existing [`Tally`] and calculates the new [`Tally`] based on new
 /// voters from `vote_info`. Returns an error if any new voters have already
 /// voted previously.
-fn calculate_update(pre: &Tally, vote_info: &VoteInfo) -> Result<Tally> {
+fn calculate_tally_post(pre: &Tally, vote_info: &VoteInfo) -> Result<Tally> {
     let previous_voters: BTreeSet<_> = pre.seen_by.keys().cloned().collect();
     let new_voters = vote_info.voters();
     let duplicate_voters: BTreeSet<_> =

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -121,21 +121,12 @@ where
     H: 'static + StorageHasher + Sync,
     T: BorshDeserialize,
 {
-    let seen: bool = read::value(store, &keys.seen())?;
-    let seen_by: Votes = read::value(store, &keys.seen_by())?;
-    let voting_power: FractionalVotingPower =
-        read::value(store, &keys.voting_power())?;
-
-    let tally_pre = Tally {
-        voting_power,
-        seen_by,
-        seen,
-    };
     tracing::info!(
         ?keys.prefix,
         ?vote_info.voters(),
         "Recording validators as having voted for this event"
     );
+    let tally_pre = read(store, keys)?;
     let tally_post = calculate_update(&tally_pre, vote_info)?;
     let changed_keys = validate_update(keys, &tally_pre, &tally_post)?;
 

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -7,15 +7,13 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use eyre::{eyre, Result};
 
 use super::ChangedKeys;
-use crate::ledger::eth_bridge::storage::vote_tallies;
 use crate::ledger::protocol::transactions::read;
-use crate::ledger::storage::traits::StorageHasher;
-use crate::ledger::storage::{DBIter, Storage, DB};
 use crate::types::address::Address;
 use crate::types::storage::BlockHeight;
 use crate::types::voting_power::FractionalVotingPower;
 
 pub(super) mod storage;
+pub(super) mod update;
 
 /// The addresses of validators that voted for something, and the block
 /// heights at which they voted. We use a [`BTreeMap`] to enforce that a
@@ -71,175 +69,6 @@ pub fn calculate_new(
         seen_by,
         seen: newly_confirmed,
     })
-}
-
-pub(super) struct VoteInfo {
-    inner: HashMap<Address, (BlockHeight, FractionalVotingPower)>,
-}
-
-impl VoteInfo {
-    pub fn new(
-        votes: Votes,
-        voting_powers: &HashMap<(Address, BlockHeight), FractionalVotingPower>,
-    ) -> Self {
-        let mut inner = HashMap::default();
-        votes.into_iter().for_each(|(address, block_height)| {
-            let fract_voting_power =
-                voting_powers.get(&(address.clone(), block_height)).unwrap();
-            _ = inner
-                .insert(address, (block_height, fract_voting_power.to_owned()));
-        });
-        Self { inner }
-    }
-
-    pub fn voters(&self) -> BTreeSet<Address> {
-        self.inner.keys().cloned().collect()
-    }
-
-    pub fn iter(
-        &self,
-    ) -> BTreeSet<(Address, BlockHeight, FractionalVotingPower)> {
-        self.inner
-            .iter()
-            .map(|(address, (block_height, fract_voting_power))| {
-                (address.clone(), *block_height, fract_voting_power.clone())
-            })
-            .collect()
-    }
-}
-
-/// Calculate an updated [`Tally`] based on one that is in storage under `keys`,
-/// with some new `voters`.
-pub(super) fn calculate_updated<D, H, T>(
-    store: &mut Storage<D, H>,
-    keys: &vote_tallies::Keys<T>,
-    vote_info: &VoteInfo,
-) -> Result<(Tally, ChangedKeys)>
-where
-    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
-    H: 'static + StorageHasher + Sync,
-    T: BorshDeserialize,
-{
-    tracing::info!(
-        ?keys.prefix,
-        validators = ?vote_info.voters(),
-        "Recording validators as having voted for this event"
-    );
-    let tally_pre = storage::read(store, keys)?;
-    let tally_post = calculate_tally_post(&tally_pre, vote_info)?;
-    let changed_keys = validate_update(keys, &tally_pre, &tally_post)?;
-
-    if tally_post.seen {
-        tracing::info!(
-            ?keys.prefix,
-            "Event has been seen by a quorum of validators",
-        );
-    } else {
-        tracing::debug!(
-            ?keys.prefix,
-            "Event is not yet seen by a quorum of validators",
-        );
-    };
-
-    tracing::debug!(
-        ?tally_pre,
-        ?tally_post,
-        "Calculated and validated vote tracking updates",
-    );
-    Ok((tally_post, changed_keys))
-}
-
-/// Takes an existing [`Tally`] and calculates the new [`Tally`] based on new
-/// voters from `vote_info`. Returns an error if any new voters have already
-/// voted previously.
-fn calculate_tally_post(pre: &Tally, vote_info: &VoteInfo) -> Result<Tally> {
-    let previous_voters: BTreeSet<_> = pre.seen_by.keys().cloned().collect();
-    let new_voters = vote_info.voters();
-    let duplicate_voters: BTreeSet<_> =
-        previous_voters.intersection(&new_voters).collect();
-    if !duplicate_voters.is_empty() {
-        // TODO: this is a programmer error and should never happen
-        return Err(eyre!("Duplicate voters found - {:?}", duplicate_voters));
-    }
-
-    let mut voting_power_post = pre.voting_power.clone();
-    let mut seen_by_post = pre.seen_by.clone();
-    for (validator, vote_height, voting_power) in vote_info.iter() {
-        _ = seen_by_post.insert(validator, vote_height);
-        voting_power_post += voting_power;
-    }
-
-    let seen_post = voting_power_post > FractionalVotingPower::TWO_THIRDS;
-
-    Ok(Tally {
-        voting_power: voting_power_post,
-        seen_by: seen_by_post,
-        seen: seen_post,
-    })
-}
-
-/// Validates that `post` is an updated version of `pre`, and returns keys which
-/// changed. This function serves as a sort of validity predicate for this
-/// native transaction, which is otherwise not checked by anything else.
-fn validate_update<T>(
-    keys: &vote_tallies::Keys<T>,
-    pre: &Tally,
-    post: &Tally,
-) -> Result<ChangedKeys> {
-    let mut keys_changed = ChangedKeys::default();
-
-    let mut seen = false;
-    if pre.seen != post.seen {
-        // the only valid transition for `seen` is from `false` to `true`
-        if pre.seen || !post.seen {
-            return Err(eyre!(
-                "Tally seen changed from {:#?} to {:#?}",
-                &pre.seen,
-                &post.seen,
-            ));
-        }
-        keys_changed.insert(keys.seen());
-        seen = true;
-    }
-    let pre_seen_by: BTreeSet<_> = pre.seen_by.keys().cloned().collect();
-    let post_seen_by: BTreeSet<_> = post.seen_by.keys().cloned().collect();
-
-    if pre_seen_by != post_seen_by {
-        // if seen_by changes, it must be a strict superset of the previous
-        // seen_by
-        if !post_seen_by.is_superset(&pre_seen_by) {
-            return Err(eyre!(
-                "Tally seen changed from {:#?} to {:#?}",
-                &pre_seen_by,
-                &post_seen_by,
-            ));
-        }
-        keys_changed.insert(keys.seen_by());
-    }
-
-    if pre.voting_power != post.voting_power {
-        // if voting_power changes, it must have increased
-        if pre.voting_power >= post.voting_power {
-            return Err(eyre!(
-                "Tally voting_power changed from {:#?} to {:#?}",
-                &pre.voting_power,
-                &post.voting_power,
-            ));
-        }
-        keys_changed.insert(keys.voting_power());
-    }
-
-    if post.voting_power > FractionalVotingPower::TWO_THIRDS
-        && !seen
-        && pre.voting_power >= post.voting_power
-    {
-        return Err(eyre!(
-            "Tally is not seen even though new voting_power is enough: {:#?}",
-            &post.voting_power,
-        ));
-    }
-
-    Ok(keys_changed)
 }
 
 /// Deterministically constructs a [`Votes`] map from a set of validator

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -86,10 +86,8 @@ impl VoteInfo {
         votes.into_iter().for_each(|(address, block_height)| {
             let fract_voting_power =
                 voting_powers.get(&(address.clone(), block_height)).unwrap();
-            _ = inner.insert(
-                address.clone(),
-                (block_height, fract_voting_power.to_owned()),
-            );
+            _ = inner
+                .insert(address, (block_height, fract_voting_power.to_owned()));
         });
         Self { inner }
     }
@@ -127,7 +125,7 @@ where
         validators = ?vote_info.voters(),
         "Recording validators as having voted for this event"
     );
-    let tally_pre = read(store, keys)?;
+    let tally_pre = storage::read(store, keys)?;
     let tally_post = calculate_tally_post(&tally_pre, vote_info)?;
     let changed_keys = validate_update(keys, &tally_pre, &tally_post)?;
 

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -97,7 +97,7 @@ where
         seen_by,
         seen,
     };
-    let tally_post = calculate_update(keys, &tally_pre, &vote_info);
+    let tally_post = calculate_update(keys, &tally_pre, vote_info);
     let changed_keys = validate_update(keys, &tally_pre, &tally_post)?;
 
     tracing::warn!(

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -98,14 +98,12 @@ impl VoteInfo {
         self.inner.keys().cloned().collect()
     }
 
-    pub fn get_vote_height(&self, validator: &Address) -> BlockHeight {
-        // TODO: don't unwrap
-        self.inner.get(validator).unwrap().0
+    pub fn get_vote_height(&self, validator: &Address) -> Option<BlockHeight> {
+        self.inner.get(validator).map(|(height, _)| *height)
     }
 
-    pub fn get_vote_power(&self, validator: &Address) -> FractionalVotingPower {
-        // TODO: don't unwrap
-        self.inner.get(validator).unwrap().1.clone()
+    pub fn get_vote_power(&self, validator: &Address) -> Option<FractionalVotingPower> {
+        self.inner.get(validator).map(|(_, voting_power)| *voting_power)
     }
 }
 
@@ -168,8 +166,8 @@ fn calculate_update<T>(
     let mut seen_by_post = pre.seen_by.clone();
     for validator in new_voters {
         _ = seen_by_post
-            .insert(validator.to_owned(), vote_info.get_vote_height(&validator));
-        voting_power_post += vote_info.get_vote_power(&validator);
+            .insert(validator.to_owned(), vote_info.get_vote_height(&validator).expect("We can always get the vote height for a voter"));
+        voting_power_post += vote_info.get_vote_power(&validator).expect("We can always get the voting power for a voter");
     }
 
     let seen_post = voting_power_post > FractionalVotingPower::TWO_THIRDS;

--- a/shared/src/ledger/protocol/transactions/votes.rs
+++ b/shared/src/ledger/protocol/transactions/votes.rs
@@ -86,21 +86,10 @@ impl VoteInfo {
         votes.into_iter().for_each(|(address, block_height)| {
             let fract_voting_power =
                 voting_powers.get(&(address.clone(), block_height)).unwrap();
-            if let Some((
-                already_present_block_height,
-                already_present_fract_voting_power,
-            )) = inner.insert(
+            _ = inner.insert(
                 address.clone(),
                 (block_height, fract_voting_power.to_owned()),
-            ) {
-                tracing::warn!(
-                    ?address,
-                    ?already_present_block_height,
-                    ?already_present_fract_voting_power,
-                    new_fract_voting_power = ?fract_voting_power,
-                    "Validator voted more than once, arbitrarily using later value"
-                )
-            }
+            );
         });
         Self { inner }
     }

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -152,9 +152,8 @@ fn apply(tally: &Tally, vote_info: NewVotes) -> Result<Tally> {
             seen_by_post.insert(validator.clone(), vote_height)
         {
             return Err(eyre!(
-                "Validator {} had already voted at height {}",
-                validator,
-                already_voted_height,
+                "Validator {validator} had already voted at height \
+                 {already_voted_height}",
             ));
         };
         voting_power_post += voting_power;
@@ -202,7 +201,8 @@ mod tests {
     mod helpers {
         use super::*;
 
-        /// Returns an arbitrary piece of data that can have votes tallied against it.
+        /// Returns an arbitrary piece of data that can have votes tallied
+        /// against it.
         pub(super) fn arbitrary_event() -> EthereumEvent {
             EthereumEvent::TransfersToNamada {
                 nonce: 0.into(),

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -28,18 +28,18 @@ impl NewVotes {
         voting_powers: &HashMap<(Address, BlockHeight), FractionalVotingPower>,
     ) -> Result<Self> {
         let mut inner = HashMap::default();
-        for (address, block_height) in votes {
-            let fract_voting_power = match voting_powers
-                .get(&(address.clone(), block_height))
-            {
+        for vote in votes {
+            let fract_voting_power = match voting_powers.get(&vote) {
                 Some(fract_voting_power) => fract_voting_power,
                 None => {
+                    let (address, block_height) = vote;
                     return Err(eyre!(
                         "No fractional voting power provided for vote by \
                          validator {address} at block height {block_height}"
                     ));
                 }
             };
+            let (address, block_height) = vote;
             _ = inner
                 .insert(address, (block_height, fract_voting_power.to_owned()));
         }

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -276,6 +276,21 @@ mod tests {
     }
 
     #[test]
+    fn test_vote_info_new_error() -> Result<()> {
+        let validator = address::testing::established_address_1;
+        let vote_height = || BlockHeight(100);
+        let vote = || (validator(), vote_height());
+        let votes = Votes::from([vote()]);
+        // voting powers map is missing vote
+        let voting_powers = HashMap::default();
+
+        let result = VoteInfo::new(votes, &voting_powers);
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
     fn test_calculate_updated_empty() -> Result<()> {
         let mut storage = TestStorage::default();
         let (event, keys) = arbitrary_event();

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -173,7 +173,7 @@ fn validate<T>(
 ) -> Result<ChangedKeys> {
     let mut keys_changed = ChangedKeys::default();
 
-    let mut seen = false;
+    let mut newly_seen = false;
     if pre.seen != post.seen {
         // the only valid transition for `seen` is from `false` to `true`
         if pre.seen || !post.seen {
@@ -184,7 +184,7 @@ fn validate<T>(
             ));
         }
         keys_changed.insert(keys.seen());
-        seen = true;
+        newly_seen = true;
     }
     let pre_seen_by: BTreeSet<_> = pre.seen_by.keys().cloned().collect();
     let post_seen_by: BTreeSet<_> = post.seen_by.keys().cloned().collect();
@@ -215,7 +215,7 @@ fn validate<T>(
     }
 
     if post.voting_power > FractionalVotingPower::TWO_THIRDS
-        && !seen
+        && !newly_seen
         && pre.voting_power >= post.voting_power
     {
         return Err(eyre!(

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -48,15 +48,15 @@ impl VoteInfo {
         self.inner.keys().cloned().collect()
     }
 
-    pub fn iter(
+    pub fn iterate(
         &self,
-    ) -> BTreeSet<(Address, BlockHeight, FractionalVotingPower)> {
-        self.inner
-            .iter()
-            .map(|(address, (block_height, fract_voting_power))| {
+    ) -> impl Iterator<Item = (Address, BlockHeight, FractionalVotingPower)> + '_
+    {
+        self.inner.iter().map(
+            |(address, (block_height, fract_voting_power))| {
                 (address.clone(), *block_height, fract_voting_power.clone())
-            })
-            .collect()
+            },
+        )
     }
 }
 
@@ -116,7 +116,7 @@ fn calculate_tally_post(pre: &Tally, vote_info: &VoteInfo) -> Result<Tally> {
 
     let mut voting_power_post = pre.voting_power.clone();
     let mut seen_by_post = pre.seen_by.clone();
-    for (validator, vote_height, voting_power) in vote_info.iter() {
+    for (validator, vote_height, voting_power) in vote_info.iterate() {
         _ = seen_by_post.insert(validator, vote_height);
         voting_power_post += voting_power;
     }

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -1,0 +1,181 @@
+use std::collections::{BTreeSet, HashMap};
+
+use borsh::BorshDeserialize;
+use eyre::{eyre, Result};
+
+use super::{ChangedKeys, Tally, Votes};
+use crate::ledger::eth_bridge::storage::vote_tallies;
+use crate::ledger::storage::traits::StorageHasher;
+use crate::ledger::storage::{DBIter, Storage, DB};
+use crate::types::address::Address;
+use crate::types::storage::BlockHeight;
+use crate::types::voting_power::FractionalVotingPower;
+
+pub(in super::super) struct VoteInfo {
+    inner: HashMap<Address, (BlockHeight, FractionalVotingPower)>,
+}
+
+impl VoteInfo {
+    pub fn new(
+        votes: Votes,
+        voting_powers: &HashMap<(Address, BlockHeight), FractionalVotingPower>,
+    ) -> Self {
+        let mut inner = HashMap::default();
+        votes.into_iter().for_each(|(address, block_height)| {
+            let fract_voting_power =
+                voting_powers.get(&(address.clone(), block_height)).unwrap();
+            _ = inner
+                .insert(address, (block_height, fract_voting_power.to_owned()));
+        });
+        Self { inner }
+    }
+
+    pub fn voters(&self) -> BTreeSet<Address> {
+        self.inner.keys().cloned().collect()
+    }
+
+    pub fn iter(
+        &self,
+    ) -> BTreeSet<(Address, BlockHeight, FractionalVotingPower)> {
+        self.inner
+            .iter()
+            .map(|(address, (block_height, fract_voting_power))| {
+                (address.clone(), *block_height, fract_voting_power.clone())
+            })
+            .collect()
+    }
+}
+
+/// Calculate an updated [`Tally`] based on one that is in storage under `keys`,
+/// with some new `voters`.
+pub(in super::super) fn calculate_updated<D, H, T>(
+    store: &mut Storage<D, H>,
+    keys: &vote_tallies::Keys<T>,
+    vote_info: &VoteInfo,
+) -> Result<(Tally, ChangedKeys)>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+    T: BorshDeserialize,
+{
+    tracing::info!(
+        ?keys.prefix,
+        validators = ?vote_info.voters(),
+        "Recording validators as having voted for this event"
+    );
+    let tally_pre = super::storage::read(store, keys)?;
+    let tally_post = calculate_tally_post(&tally_pre, vote_info)?;
+    let changed_keys = validate_update(keys, &tally_pre, &tally_post)?;
+
+    if tally_post.seen {
+        tracing::info!(
+            ?keys.prefix,
+            "Event has been seen by a quorum of validators",
+        );
+    } else {
+        tracing::debug!(
+            ?keys.prefix,
+            "Event is not yet seen by a quorum of validators",
+        );
+    };
+
+    tracing::debug!(
+        ?tally_pre,
+        ?tally_post,
+        "Calculated and validated vote tracking updates",
+    );
+    Ok((tally_post, changed_keys))
+}
+
+/// Takes an existing [`Tally`] and calculates the new [`Tally`] based on new
+/// voters from `vote_info`. Returns an error if any new voters have already
+/// voted previously.
+fn calculate_tally_post(pre: &Tally, vote_info: &VoteInfo) -> Result<Tally> {
+    let previous_voters: BTreeSet<_> = pre.seen_by.keys().cloned().collect();
+    let new_voters = vote_info.voters();
+    let duplicate_voters: BTreeSet<_> =
+        previous_voters.intersection(&new_voters).collect();
+    if !duplicate_voters.is_empty() {
+        // TODO: this is a programmer error and should never happen
+        return Err(eyre!("Duplicate voters found - {:?}", duplicate_voters));
+    }
+
+    let mut voting_power_post = pre.voting_power.clone();
+    let mut seen_by_post = pre.seen_by.clone();
+    for (validator, vote_height, voting_power) in vote_info.iter() {
+        _ = seen_by_post.insert(validator, vote_height);
+        voting_power_post += voting_power;
+    }
+
+    let seen_post = voting_power_post > FractionalVotingPower::TWO_THIRDS;
+
+    Ok(Tally {
+        voting_power: voting_power_post,
+        seen_by: seen_by_post,
+        seen: seen_post,
+    })
+}
+
+/// Validates that `post` is an updated version of `pre`, and returns keys which
+/// changed. This function serves as a sort of validity predicate for this
+/// native transaction, which is otherwise not checked by anything else.
+fn validate_update<T>(
+    keys: &vote_tallies::Keys<T>,
+    pre: &Tally,
+    post: &Tally,
+) -> Result<ChangedKeys> {
+    let mut keys_changed = ChangedKeys::default();
+
+    let mut seen = false;
+    if pre.seen != post.seen {
+        // the only valid transition for `seen` is from `false` to `true`
+        if pre.seen || !post.seen {
+            return Err(eyre!(
+                "Tally seen changed from {:#?} to {:#?}",
+                &pre.seen,
+                &post.seen,
+            ));
+        }
+        keys_changed.insert(keys.seen());
+        seen = true;
+    }
+    let pre_seen_by: BTreeSet<_> = pre.seen_by.keys().cloned().collect();
+    let post_seen_by: BTreeSet<_> = post.seen_by.keys().cloned().collect();
+
+    if pre_seen_by != post_seen_by {
+        // if seen_by changes, it must be a strict superset of the previous
+        // seen_by
+        if !post_seen_by.is_superset(&pre_seen_by) {
+            return Err(eyre!(
+                "Tally seen changed from {:#?} to {:#?}",
+                &pre_seen_by,
+                &post_seen_by,
+            ));
+        }
+        keys_changed.insert(keys.seen_by());
+    }
+
+    if pre.voting_power != post.voting_power {
+        // if voting_power changes, it must have increased
+        if pre.voting_power >= post.voting_power {
+            return Err(eyre!(
+                "Tally voting_power changed from {:#?} to {:#?}",
+                &pre.voting_power,
+                &post.voting_power,
+            ));
+        }
+        keys_changed.insert(keys.voting_power());
+    }
+
+    if post.voting_power > FractionalVotingPower::TWO_THIRDS
+        && !seen
+        && pre.voting_power >= post.voting_power
+    {
+        return Err(eyre!(
+            "Tally is not seen even though new voting_power is enough: {:#?}",
+            &post.voting_power,
+        ));
+    }
+
+    Ok(keys_changed)
+}

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -18,7 +18,7 @@ pub(in super::super) struct NewVotes {
 }
 
 impl NewVotes {
-    /// Constructs a new [`VoteInfo`]. For all `votes` provided, a corresponding
+    /// Constructs a new [`NewVotes`]. For all `votes` provided, a corresponding
     /// [`FractionalVotingPower`] must be provided in `voting_powers` also,
     /// otherwise an error will be returned.
     pub fn new(
@@ -48,7 +48,7 @@ impl NewVotes {
         self.inner.keys().cloned().collect()
     }
 
-    /// Consumes `self` and returns a `VoteInfo` with any addresses from
+    /// Consumes `self` and returns a [`NewVotes`] with any addresses from
     /// `voters` removed, as well as the set of addresses that were actually
     /// removed. Useful for removing voters who have already voted for
     /// something.

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -243,31 +243,30 @@ mod tests {
 
     #[test]
     fn test_vote_info_new_single_voter() -> Result<()> {
-        let validator = address::testing::established_address_1;
-        let vote_height = || BlockHeight(100);
-        let voting_power = || FractionalVotingPower::new(1, 3).unwrap();
-        let vote = || (validator(), vote_height());
-        let votes = Votes::from([vote()]);
-        let voting_powers = HashMap::from([(vote(), voting_power())]);
+        let validator = address::testing::established_address_1();
+        let vote_height = BlockHeight(100);
+        let voting_power = FractionalVotingPower::new(1, 3)?;
+        let vote = (validator.clone(), vote_height);
+        let votes = Votes::from([vote.clone()]);
+        let voting_powers = HashMap::from([(vote, voting_power.clone())]);
 
         let vote_info = NewVotes::new(votes, &voting_powers)?;
 
-        assert_eq!(vote_info.voters(), BTreeSet::from([validator()]));
+        assert_eq!(vote_info.voters(), BTreeSet::from([validator.clone()]));
         let votes: BTreeSet<_> = vote_info.into_iter().collect();
         assert_eq!(
             votes,
-            BTreeSet::from([(validator(), vote_height(), voting_power())]),
+            BTreeSet::from([(validator, vote_height, voting_power,)]),
         );
         Ok(())
     }
 
     #[test]
     fn test_vote_info_new_error() -> Result<()> {
-        let validator = address::testing::established_address_1;
-        let vote_height = || BlockHeight(100);
-        let vote = || (validator(), vote_height());
-        let votes = Votes::from([vote()]);
-        // voting powers map is missing vote
+        let votes = Votes::from([(
+            address::testing::established_address_1(),
+            BlockHeight(100),
+        )]);
         let voting_powers = HashMap::default();
 
         let result = NewVotes::new(votes, &voting_powers);
@@ -278,13 +277,12 @@ mod tests {
 
     #[test]
     fn test_vote_info_without_voters() -> Result<()> {
-        let validator = address::testing::established_address_1;
-        let vote_height = || BlockHeight(100);
-        let voting_power = || FractionalVotingPower::new(1, 3).unwrap();
-        let vote = || (validator(), vote_height());
-        let votes = Votes::from([vote()]);
-        let voting_powers = HashMap::from([(vote(), voting_power())]);
-        let validator = validator();
+        let validator = address::testing::established_address_1();
+        let vote_height = BlockHeight(100);
+        let voting_power = FractionalVotingPower::new(1, 3)?;
+        let vote = (validator.clone(), vote_height);
+        let votes = Votes::from([vote.clone()]);
+        let voting_powers = HashMap::from([(vote, voting_power)]);
         let vote_info = NewVotes::new(votes, &voting_powers)?;
 
         let (vote_info, removed) = vote_info.without_voters(vec![&validator]);
@@ -310,14 +308,14 @@ mod tests {
             HashSet::from([(
                 validator.clone(),
                 already_voted_height,
-                FractionalVotingPower::new(1, 3).unwrap(),
+                FractionalVotingPower::new(1, 3)?,
             )]),
         )?;
 
         let votes = Votes::from([(validator.clone(), BlockHeight(1000))]);
         let voting_powers = HashMap::from([(
             (validator, BlockHeight(1000)),
-            FractionalVotingPower::new(1, 3).unwrap(),
+            FractionalVotingPower::new(1, 3)?,
         )]);
         let vote_info = NewVotes::new(votes, &voting_powers)?;
 
@@ -341,16 +339,16 @@ mod tests {
             HashSet::from([(
                 address::testing::established_address_1(),
                 BlockHeight(10),
-                FractionalVotingPower::new(3, 4).unwrap(), // this is > 2/3
+                FractionalVotingPower::new(3, 4)?, // this is > 2/3
             )]),
         )?;
 
-        let validator = address::testing::established_address_2;
-        let vote_height = || BlockHeight(100);
-        let voting_power = || FractionalVotingPower::new(1, 3).unwrap();
-        let vote = || (validator(), vote_height());
-        let votes = Votes::from([vote()]);
-        let voting_powers = HashMap::from([(vote(), voting_power())]);
+        let validator = address::testing::established_address_2();
+        let vote_height = BlockHeight(100);
+        let voting_power = FractionalVotingPower::new(1, 3)?;
+        let vote = (validator, vote_height);
+        let votes = Votes::from([vote.clone()]);
+        let voting_powers = HashMap::from([(vote, voting_power)]);
         let vote_info = NewVotes::new(votes, &voting_powers)?;
 
         let (tally_post, changed_keys) =
@@ -374,7 +372,7 @@ mod tests {
             HashSet::from([(
                 address::testing::established_address_1(),
                 BlockHeight(10),
-                FractionalVotingPower::new(1, 3).unwrap(),
+                FractionalVotingPower::new(1, 3)?,
             )]),
         )?;
         votes::storage::write(&mut storage, &keys, &event, &tally_pre)?;
@@ -403,17 +401,17 @@ mod tests {
             HashSet::from([(
                 address::testing::established_address_1(),
                 BlockHeight(10),
-                FractionalVotingPower::new(1, 3).unwrap(),
+                FractionalVotingPower::new(1, 3)?,
             )]),
         )?;
         votes::storage::write(&mut storage, &keys, &event, &tally_pre)?;
 
-        let validator = address::testing::established_address_2;
-        let vote_height = || BlockHeight(100);
-        let voting_power = || FractionalVotingPower::new(1, 3).unwrap();
-        let vote = || (validator(), vote_height());
-        let votes = Votes::from([vote()]);
-        let voting_powers = HashMap::from([(vote(), voting_power())]);
+        let validator = address::testing::established_address_2();
+        let vote_height = BlockHeight(100);
+        let voting_power = FractionalVotingPower::new(1, 3)?;
+        let vote = (validator, vote_height);
+        let votes = Votes::from([vote.clone()]);
+        let voting_powers = HashMap::from([(vote.clone(), voting_power)]);
         let vote_info = NewVotes::new(votes, &voting_powers)?;
 
         let (tally_post, changed_keys) =
@@ -422,10 +420,10 @@ mod tests {
         assert_eq!(
             tally_post,
             Tally {
-                voting_power: FractionalVotingPower::new(2, 3).unwrap(),
+                voting_power: FractionalVotingPower::new(2, 3)?,
                 seen_by: BTreeMap::from([
                     (address::testing::established_address_1(), 10.into()),
-                    vote(),
+                    vote,
                 ]),
                 seen: false,
             }
@@ -440,7 +438,7 @@ mod tests {
     /// Tests the case where a single vote is applied, and the tally is now
     /// seen.
     #[test]
-    fn test_calculate_one_vote_seen() {
+    fn test_calculate_one_vote_seen() -> Result<()> {
         let mut storage = TestStorage::default();
 
         let event = arbitrary_event();
@@ -452,30 +450,29 @@ mod tests {
             HashSet::from([(
                 address::testing::established_address_1(),
                 BlockHeight(10),
-                FractionalVotingPower::new(1, 3).unwrap(),
+                FractionalVotingPower::new(1, 3)?,
             )]),
-        )
-        .unwrap();
-        votes::storage::write(&mut storage, &keys, &event, &tally_pre).unwrap();
+        )?;
+        votes::storage::write(&mut storage, &keys, &event, &tally_pre)?;
 
-        let validator = address::testing::established_address_2;
-        let vote_height = || BlockHeight(100);
-        let voting_power = || FractionalVotingPower::new(2, 3).unwrap();
-        let vote = || (validator(), vote_height());
-        let votes = Votes::from([vote()]);
-        let voting_powers = HashMap::from([(vote(), voting_power())]);
-        let vote_info = NewVotes::new(votes, &voting_powers).unwrap();
+        let validator = address::testing::established_address_2();
+        let vote_height = BlockHeight(100);
+        let voting_power = FractionalVotingPower::new(2, 3)?;
+        let vote = (validator, vote_height);
+        let votes = Votes::from([vote.clone()]);
+        let voting_powers = HashMap::from([(vote.clone(), voting_power)]);
+        let vote_info = NewVotes::new(votes, &voting_powers)?;
 
         let (tally_post, changed_keys) =
-            calculate(&mut storage, &keys, vote_info).unwrap();
+            calculate(&mut storage, &keys, vote_info)?;
 
         assert_eq!(
             tally_post,
             Tally {
-                voting_power: FractionalVotingPower::new(1, 1).unwrap(),
+                voting_power: FractionalVotingPower::new(1, 1)?,
                 seen_by: BTreeMap::from([
                     (address::testing::established_address_1(), 10.into()),
-                    vote(),
+                    vote,
                 ]),
                 seen: true,
             }
@@ -484,12 +481,13 @@ mod tests {
             changed_keys,
             BTreeSet::from([keys.voting_power(), keys.seen_by(), keys.seen()])
         );
+        Ok(())
     }
 
     #[test]
-    fn test_keys_changed_all() {
-        let voting_power_a = FractionalVotingPower::new(1, 3).unwrap();
-        let voting_power_b = FractionalVotingPower::new(2, 3).unwrap();
+    fn test_keys_changed_all() -> Result<()> {
+        let voting_power_a = FractionalVotingPower::new(1, 3)?;
+        let voting_power_b = FractionalVotingPower::new(2, 3)?;
 
         let seen_a = false;
         let seen_b = true;
@@ -521,11 +519,12 @@ mod tests {
             changed_keys,
             BTreeSet::from([keys.seen(), keys.seen_by(), keys.voting_power()])
         );
+        Ok(())
     }
 
     #[test]
-    fn test_keys_changed_none() {
-        let voting_power = FractionalVotingPower::new(1, 3).unwrap();
+    fn test_keys_changed_none() -> Result<()> {
+        let voting_power = FractionalVotingPower::new(1, 3)?;
         let seen = false;
         let seen_by = BTreeMap::from([(
             address::testing::established_address_1(),
@@ -543,5 +542,6 @@ mod tests {
         let changed_keys = keys_changed(&keys, &pre, &post);
 
         assert!(changed_keys.is_empty());
+        Ok(())
     }
 }

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -285,7 +285,7 @@ mod tests {
             &keys,
             HashSet::from([(
                 address::testing::established_address_1(),
-                BlockHeight(100),
+                BlockHeight(10),
                 FractionalVotingPower::new(1, 3).unwrap(),
             )]),
         )?;
@@ -311,7 +311,7 @@ mod tests {
             &keys,
             HashSet::from([(
                 address::testing::established_address_1(),
-                BlockHeight(100),
+                BlockHeight(10),
                 FractionalVotingPower::new(1, 3).unwrap(),
             )]),
         )?;

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -67,7 +67,7 @@ impl IntoIterator for VoteInfo {
 
 /// Calculate an updated [`Tally`] based on one that is in storage under `keys`,
 /// with some new `voters`.
-pub(in super::super) fn calculate_updated<D, H, T>(
+pub(in super::super) fn calculate<D, H, T>(
     store: &mut Storage<D, H>,
     keys: &vote_tallies::Keys<T>,
     vote_info: VoteInfo,
@@ -107,8 +107,7 @@ where
 }
 
 /// Takes an existing [`Tally`] and calculates the new [`Tally`] based on new
-/// voters from `vote_info`. Returns an error if any new voters have already
-/// voted previously.
+/// voters from `vote_info`.
 fn calculate_tally_post(pre: &Tally, vote_info: VoteInfo) -> Result<Tally> {
     let previous_voters: BTreeSet<_> = pre.seen_by.keys().cloned().collect();
     let new_voters = vote_info.voters();
@@ -308,7 +307,7 @@ mod tests {
         let vote_info = VoteInfo::new(Votes::default(), &HashMap::default())?;
 
         let (tally_post, changed_keys) =
-            calculate_updated(&mut storage, &keys, vote_info)?;
+            calculate(&mut storage, &keys, vote_info)?;
 
         assert_eq!(tally_post, tally_pre);
         assert!(changed_keys.is_empty());
@@ -341,7 +340,7 @@ mod tests {
         let vote_info = VoteInfo::new(votes, &voting_powers)?;
 
         let (tally_post, changed_keys) =
-            calculate_updated(&mut storage, &keys, vote_info)?;
+            calculate(&mut storage, &keys, vote_info)?;
 
         assert_eq!(
             tally_post,
@@ -388,7 +387,7 @@ mod tests {
         let vote_info = VoteInfo::new(votes, &voting_powers).unwrap();
 
         let (tally_post, changed_keys) =
-            calculate_updated(&mut storage, &keys, vote_info).unwrap();
+            calculate(&mut storage, &keys, vote_info).unwrap();
 
         assert_eq!(
             tally_post,

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -18,9 +18,11 @@ pub(in super::super) struct NewVotes {
 }
 
 impl NewVotes {
-    /// Constructs a new [`NewVotes`]. For all `votes` provided, a corresponding
-    /// [`FractionalVotingPower`] must be provided in `voting_powers` also,
-    /// otherwise an error will be returned.
+    /// Constructs a new [`NewVotes`].
+    ///
+    /// For all `votes` provided, a corresponding [`FractionalVotingPower`] must
+    /// be provided in `voting_powers` also, otherwise an error will be
+    /// returned.
     pub fn new(
         votes: Votes,
         voting_powers: &HashMap<(Address, BlockHeight), FractionalVotingPower>,

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -198,3 +198,40 @@ fn validate_update<T>(
 
     Ok(keys_changed)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::address;
+
+    #[test]
+    fn test_vote_info_new_empty() -> Result<()> {
+        let voting_powers = HashMap::default();
+
+        let vote_info = VoteInfo::new(Votes::default(), &voting_powers)?;
+
+        assert!(vote_info.voters().is_empty());
+        assert_eq!(vote_info.into_iter().count(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_vote_info_new_single_voter() -> Result<()> {
+        let validator = address::testing::established_address_1;
+        let vote_height = || BlockHeight(100);
+        let voting_power = || FractionalVotingPower::new(1, 3).unwrap();
+        let vote = || (validator(), vote_height());
+        let votes = Votes::from([vote()]);
+        let voting_powers = HashMap::from([(vote(), voting_power())]);
+
+        let vote_info = VoteInfo::new(votes, &voting_powers)?;
+
+        assert_eq!(vote_info.voters(), BTreeSet::from([validator()]));
+        let votes: BTreeSet<_> = vote_info.into_iter().collect();
+        assert_eq!(
+            votes,
+            BTreeSet::from([(validator(), vote_height(), voting_power())]),
+        );
+        Ok(())
+    }
+}

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -305,7 +305,6 @@ mod tests {
         let mut storage = TestStorage::default();
 
         let (event, keys) = arbitrary_event();
-        let (event, keys) = arbitrary_event();
         let tally_pre = setup_tally(
             &mut storage,
             &event,

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -116,7 +116,7 @@ where
             "Ignoring duplicate voter"
         );
     }
-    let tally_post = calculate_tally_post(&tally_pre, vote_info)
+    let tally_post = apply(&tally_pre, vote_info)
         .expect("We deduplicated voters already, so this should never error");
 
     let changed_keys = keys_changed(keys, &tally_pre, &tally_post);
@@ -144,9 +144,9 @@ where
 /// Takes an existing [`Tally`] and calculates the new [`Tally`] based on new
 /// voters from `vote_info`. An error is returned if any validator which
 /// previously voted is present in `vote_info`.
-fn calculate_tally_post(pre: &Tally, vote_info: VoteInfo) -> Result<Tally> {
-    let mut voting_power_post = pre.voting_power.clone();
-    let mut seen_by_post = pre.seen_by.clone();
+fn apply(tally: &Tally, vote_info: VoteInfo) -> Result<Tally> {
+    let mut voting_power_post = tally.voting_power.clone();
+    let mut seen_by_post = tally.seen_by.clone();
     for (validator, vote_height, voting_power) in vote_info {
         if let Some(already_voted_height) =
             seen_by_post.insert(validator.clone(), vote_height)

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -84,7 +84,7 @@ where
     );
     let tally_pre = super::storage::read(store, keys)?;
     let tally_post = calculate_tally_post(&tally_pre, vote_info)?;
-    let changed_keys = validate_update(keys, &tally_pre, &tally_post)?;
+    let changed_keys = validate(keys, &tally_pre, &tally_post)?;
 
     if tally_post.seen {
         tracing::info!(
@@ -137,7 +137,7 @@ fn calculate_tally_post(pre: &Tally, vote_info: VoteInfo) -> Result<Tally> {
 /// Validates that `post` is an updated version of `pre`, and returns keys which
 /// changed. This function serves as a sort of validity predicate for this
 /// native transaction, which is otherwise not checked by anything else.
-fn validate_update<T>(
+fn validate<T>(
     keys: &vote_tallies::Keys<T>,
     pre: &Tally,
     post: &Tally,

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -450,4 +450,26 @@ mod tests {
             BTreeSet::from([keys.seen(), keys.seen_by(), keys.voting_power()])
         );
     }
+
+    #[test]
+    fn test_keys_changed_none() {
+        let voting_power = FractionalVotingPower::new(1, 3).unwrap();
+        let seen = false;
+        let seen_by = BTreeMap::from([(
+            address::testing::established_address_1(),
+            BlockHeight(10),
+        )]);
+
+        let event = arbitrary_event();
+        let keys = vote_tallies::Keys::from(&event);
+        let pre = Tally {
+            voting_power,
+            seen,
+            seen_by,
+        };
+        let post = pre.clone();
+        let changed_keys = keys_changed(&keys, &pre, &post);
+
+        assert!(changed_keys.is_empty());
+    }
 }

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -205,9 +205,26 @@ mod tests {
 
     use super::*;
     use crate::ledger::protocol::transactions::votes;
+    use crate::ledger::protocol::transactions::votes::update::tests::helpers::arbitrary_event;
     use crate::ledger::storage::testing::TestStorage;
     use crate::types::address;
     use crate::types::ethereum_events::EthereumEvent;
+
+    mod helpers {
+        use super::*;
+
+        /// Returns an arbitrary piece of data that can be tallied, and the keys
+        /// for it.
+        pub(super) fn arbitrary_event()
+        -> (EthereumEvent, vote_tallies::Keys<EthereumEvent>) {
+            let event = EthereumEvent::TransfersToNamada {
+                nonce: 0.into(),
+                transfers: vec![],
+            };
+            let keys = vote_tallies::Keys::from(&event);
+            (event, keys)
+        }
+    }
 
     #[test]
     fn test_vote_info_new_empty() -> Result<()> {
@@ -243,11 +260,7 @@ mod tests {
     #[test]
     fn test_calculate_updated_empty() -> Result<()> {
         let mut storage = TestStorage::default();
-        let event = EthereumEvent::TransfersToNamada {
-            nonce: 0.into(),
-            transfers: vec![],
-        };
-        let keys = vote_tallies::Keys::from(&event);
+        let (event, keys) = arbitrary_event();
         let tally_pre = Tally {
             voting_power: FractionalVotingPower::new(1, 3).unwrap(),
             seen_by: BTreeMap::from([(
@@ -270,11 +283,8 @@ mod tests {
     #[test]
     fn test_calculate_updated_one_vote_not_seen() -> Result<()> {
         let mut storage = TestStorage::default();
-        let event = EthereumEvent::TransfersToNamada {
-            nonce: 0.into(),
-            transfers: vec![],
-        };
-        let keys = vote_tallies::Keys::from(&event);
+
+        let (event, keys) = arbitrary_event();
         let tally_pre = Tally {
             voting_power: FractionalVotingPower::new(1, 3).unwrap(),
             seen_by: BTreeMap::from([(

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -295,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_updated_empty() -> Result<()> {
+    fn test_calculate_empty() -> Result<()> {
         let mut storage = TestStorage::default();
         let event = arbitrary_event();
         let keys = vote_tallies::Keys::from(&event);
@@ -321,7 +321,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_updated_one_vote_not_seen() -> Result<()> {
+    fn test_calculate_one_vote_not_seen() -> Result<()> {
         let mut storage = TestStorage::default();
 
         let event = arbitrary_event();
@@ -368,7 +368,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_updated_one_vote_seen() {
+    fn test_calculate_one_vote_seen() {
         let mut storage = TestStorage::default();
 
         let event = arbitrary_event();

--- a/shared/src/ledger/protocol/transactions/votes/update.rs
+++ b/shared/src/ledger/protocol/transactions/votes/update.rs
@@ -100,7 +100,7 @@ where
     tracing::info!(
         ?keys.prefix,
         validators = ?vote_info.voters(),
-        "Recording validators as having voted for this event"
+        "Calculating validators' votes applied to an existing tally"
     );
     let tally_pre = super::storage::read(store, keys)?;
     if tally_pre.seen {
@@ -124,12 +124,12 @@ where
     if tally_post.seen {
         tracing::info!(
             ?keys.prefix,
-            "Event has been seen by a quorum of validators",
+            "Tally has been seen by a quorum of validators",
         );
     } else {
         tracing::debug!(
             ?keys.prefix,
-            "Event is not yet seen by a quorum of validators",
+            "Tally is not yet seen by a quorum of validators",
         );
     };
 
@@ -202,8 +202,7 @@ mod tests {
     mod helpers {
         use super::*;
 
-        /// Returns an arbitrary piece of data that can be tallied, and the keys
-        /// for it.
+        /// Returns an arbitrary piece of data that can have votes tallied against it.
         pub(super) fn arbitrary_event() -> EthereumEvent {
             EthereumEvent::TransfersToNamada {
                 nonce: 0.into(),

--- a/shared/src/types/voting_power.rs
+++ b/shared/src/types/voting_power.rs
@@ -8,7 +8,7 @@ use num_rational::Ratio;
 
 /// A fraction of the total voting power. This should always be a reduced
 /// fraction that is between zero and one inclusive.
-#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
 pub struct FractionalVotingPower(Ratio<u64>);
 
 impl FractionalVotingPower {

--- a/shared/src/types/voting_power.rs
+++ b/shared/src/types/voting_power.rs
@@ -1,5 +1,6 @@
 //! This module contains types related with validator voting power calculations.
 
+use std::iter::Sum;
 use std::ops::{Add, AddAssign};
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
@@ -41,6 +42,12 @@ impl Default for FractionalVotingPower {
 impl From<&FractionalVotingPower> for (u64, u64) {
     fn from(ratio: &FractionalVotingPower) -> Self {
         (ratio.0.numer().to_owned(), ratio.0.denom().to_owned())
+    }
+}
+
+impl Sum for FractionalVotingPower {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::default(), Add::add)
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/197

This PR makes it so that votes are applied for things (e.g. Ethereum events) which already exist in storage but that are not yet `seen = true`. There are also a couple of small changes to the `FractionalVotingPower` type.