### PR TITLE
Ensure fake Ethereum events endpoint doesn't shut down immediately

### DIFF
--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -25,7 +25,7 @@ use serde_json::json;
 use setup::constants::*;
 
 use super::helpers::{get_height, wait_for_block_height};
-use super::setup::{disable_eth_fullnode, get_all_wasms_hashes};
+use super::setup::{get_all_wasms_hashes, set_ethereum_bridge_mode};
 use crate::e2e::helpers::{
     find_address, find_voting_power, get_actor_rpc, get_epoch,
 };
@@ -39,7 +39,12 @@ use crate::{run, run_as};
 fn run_ledger() -> Result<()> {
     let test = setup::single_node_net()?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     let cmd_combinations = vec![vec!["ledger"], vec!["ledger", "run"]];
 
@@ -72,8 +77,18 @@ fn test_node_connectivity() -> Result<()> {
     let test =
         setup::network(|genesis| setup::add_validators(1, genesis), None)?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(1));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(1),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run 2 genesis validator ledger nodes and 1 non-validator node
     let args = ["ledger"];
@@ -175,7 +190,12 @@ fn test_node_connectivity() -> Result<()> {
 fn test_anoma_shuts_down_if_tendermint_dies() -> Result<()> {
     let test = setup::single_node_net()?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run the ledger node
     let mut ledger =
@@ -214,7 +234,12 @@ fn test_anoma_shuts_down_if_tendermint_dies() -> Result<()> {
 fn run_ledger_load_state_and_reset() -> Result<()> {
     let test = setup::single_node_net()?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run the ledger node
     let mut ledger =
@@ -283,7 +308,12 @@ fn run_ledger_load_state_and_reset() -> Result<()> {
 fn ledger_txs_and_queries() -> Result<()> {
     let test = setup::network(|genesis| genesis, None)?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run the ledger node
     let mut ledger =
@@ -457,7 +487,12 @@ fn ledger_txs_and_queries() -> Result<()> {
 fn invalid_transactions() -> Result<()> {
     let test = setup::single_node_net()?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run the ledger node
     let mut ledger =
@@ -609,7 +644,12 @@ fn pos_bonds() -> Result<()> {
         None,
     )?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run the ledger node
     let mut ledger =
@@ -810,7 +850,12 @@ fn pos_init_validator() -> Result<()> {
         None,
     )?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run the ledger node
     let mut ledger =
@@ -979,7 +1024,12 @@ fn ledger_many_txs_in_a_block() -> Result<()> {
         Some("10s"),
     )?);
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run the ledger node
     let mut ledger =
@@ -1089,7 +1139,12 @@ fn proposal_submission() -> Result<()> {
         None,
     )?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     let anomac_help = vec!["--help"];
 
@@ -1451,7 +1506,12 @@ fn proposal_submission() -> Result<()> {
 fn proposal_offline() -> Result<()> {
     let test = setup::network(|genesis| genesis, None)?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run the ledger node
     let mut ledger =
@@ -2002,8 +2062,18 @@ fn double_signing_gets_slashed() -> Result<()> {
     let test =
         setup::network(|genesis| setup::add_validators(1, genesis), None)?;
 
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(0));
-    disable_eth_fullnode(&test, &test.net.chain_id, &Who::Validator(1));
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+    );
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(1),
+        ethereum_bridge::ledger::Mode::Off,
+    );
 
     // 1. Run 2 genesis validator ledger nodes
     let args = ["ledger"];

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -76,10 +76,16 @@ pub fn update_actor_config<F>(
         .unwrap();
 }
 
-/// Disable the Ethereum fullnode of `who`.
-pub fn disable_eth_fullnode(test: &Test, chain_id: &ChainId, who: &Who) {
+/// Configures the Ethereum bridge mode of `who`. This should be done before
+/// `who` starts running.
+pub fn set_ethereum_bridge_mode(
+    test: &Test,
+    chain_id: &ChainId,
+    who: &Who,
+    mode: ethereum_bridge::ledger::Mode,
+) {
     update_actor_config(test, chain_id, who, |config| {
-        config.ledger.ethereum_bridge.mode = ethereum_bridge::ledger::Mode::Off;
+        config.ledger.ethereum_bridge.mode = mode;
     });
 }
 


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/781

This PR changes the fake Ethereum events endpoint to be managed using `AbortableSpawner` and an abort channel, and adds an end-to-end test to check that it starts up.

This mode will be used in end-to-end tests for https://github.com/anoma/namada/pull/768.