### PR TITLE
Fix end-to-end test flakes involving more than one validator

### DIFF
--- a/shared/src/proto/types.rs
+++ b/shared/src/proto/types.rs
@@ -52,8 +52,10 @@ pub trait SignedSerialize<T> {
     /// A byte vector containing the serialized data.
     type Output: AsRef<[u8]>;
 
-    /// Encodes `data` as a byte vector,
-    /// with some arbitrary serialization method.
+    /// Encodes `data` as a byte vector, with some arbitrary serialization
+    /// method. The returned output *must* be deterministic based on
+    /// `data`, so that two callers signing the same `data` will be
+    /// signing the same `Self::Output`.
     fn serialize(data: &T) -> Self::Output;
 }
 

--- a/shared/src/proto/types.rs
+++ b/shared/src/proto/types.rs
@@ -53,7 +53,9 @@ pub trait SignedSerialize<T> {
     type Output: AsRef<[u8]>;
 
     /// Encodes `data` as a byte vector, with some arbitrary serialization
-    /// method. The returned output *must* be deterministic based on
+    /// method.
+    ///
+    /// The returned output *must* be deterministic based on
     /// `data`, so that two callers signing the same `data` will be
     /// signing the same `Self::Output`.
     fn serialize(data: &T) -> Self::Output;

--- a/shared/src/types/vote_extensions/validator_set_update.rs
+++ b/shared/src/types/vote_extensions/validator_set_update.rs
@@ -413,6 +413,31 @@ mod tests {
         );
     }
 
+    /// Checks that comparing two [`VotingPowersMap`] items with different
+    /// voting powers results in the item with the lesser voting power being
+    /// regarded as "greater".
+    #[test]
+    fn test_compare_voting_powers_map_items_different_voting_powers() {
+        let validator_a = EthAddrBook {
+            hot_key_addr: EthAddress([0; 20]),
+            cold_key_addr: EthAddress([0; 20]),
+        };
+        let validator_a_voting_power = 200.into();
+        let validator_b = EthAddrBook {
+            hot_key_addr: EthAddress([1; 20]),
+            cold_key_addr: EthAddress([1; 20]),
+        };
+        let validator_b_voting_power = 100.into();
+
+        assert_eq!(
+            compare_voting_powers_map_items(
+                &(&validator_a, &validator_a_voting_power),
+                &(&validator_b, &validator_b_voting_power),
+            ),
+            Ordering::Less
+        );
+    }
+
     /// Checks that [`VotingPowersMapExt::get_abi_encoded`] gives a
     /// deterministic result in the case where there are multiple validators
     /// with the same voting power.

--- a/shared/src/types/vote_extensions/validator_set_update.rs
+++ b/shared/src/types/vote_extensions/validator_set_update.rs
@@ -206,9 +206,8 @@ fn compare_voting_powers_map_items(
     let (first_power, second_power) = (first.1, second.1);
     let (first_addr, second_addr) = (first.0, second.0);
     match second_power.cmp(first_power) {
-        Ordering::Less => Ordering::Less,
         Ordering::Equal => first_addr.cmp(second_addr),
-        Ordering::Greater => Ordering::Greater,
+        ordering => ordering,
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/767 (current e2e flakes in CI)

The issue was that `VotingPowersMap::get_abi_encoded` wasn't completely deterministic if there were validators present in the `HashMap` with the same voting power. Interestingly, this issue only occurred in tests run with the `--release` profile.

This PR:
- makes `VotingPowersMap::get_abi_encoded` deterministic
- adds some test coverage regarding the ordering of `VotingPowersMap` items
- updates some docstrings to mention requirements around determinism