### PR TITLE
Let `namadac utils join-network` use a local release archive

### DIFF
--- a/.changelog/unreleased/improvements/795-namadac-utils-join-network-local.md
+++ b/.changelog/unreleased/improvements/795-namadac-utils-join-network-local.md
@@ -1,0 +1,2 @@
+- Let namadac utils join-network use a local release archive
+  ([#795](https://github.com/anoma/namada/pull/795))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -3216,7 +3216,7 @@ pub mod args {
 
     #[derive(Clone, Debug)]
     pub struct JoinNetwork {
-        pub chain_id: ChainId,
+        pub chain_id: Option<ChainId>,
         pub genesis_validator: Option<String>,
         pub pre_genesis_path: Option<PathBuf>,
         pub dont_prefetch_wasm: bool,
@@ -3224,7 +3224,7 @@ pub mod args {
 
     impl Args for JoinNetwork {
         fn parse(matches: &ArgMatches) -> Self {
-            let chain_id = CHAIN_ID.parse(matches);
+            let chain_id = CHAIN_ID_OPT.parse(matches);
             let genesis_validator = GENESIS_VALIDATOR.parse(matches);
             let pre_genesis_path = PRE_GENESIS_PATH.parse(matches);
             let dont_prefetch_wasm = DONT_PREFETCH_WASM.parse(matches);
@@ -3237,7 +3237,7 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(CHAIN_ID.def().about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository."))
+            app.arg(CHAIN_ID_OPT.def().about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository."))
                 .arg(GENESIS_VALIDATOR.def().about("The alias of the genesis validator that you want to set up as, if any."))
                 .arg(PRE_GENESIS_PATH.def().about("The path to the pre-genesis directory for genesis validator, if any. Defaults to \"{base-dir}/pre-genesis/{genesis-validator}\"."))
             .arg(DONT_PREFETCH_WASM.def().about(

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1608,6 +1608,7 @@ pub mod args {
     const RAW_ADDRESS_OPT: ArgOpt<Address> = RAW_ADDRESS.opt();
     const RAW_PUBLIC_KEY_OPT: ArgOpt<common::PublicKey> = arg_opt("public-key");
     const RECEIVER: Arg<String> = arg("receiver");
+    const RELEASE_ARCHIVE: Arg<PathBuf> = arg("release-archive");
     const SCHEME: ArgDefault<SchemeType> =
         arg_default("scheme", DefaultFn(|| SchemeType::Ed25519));
     const SIGNER: ArgOpt<WalletAddress> = arg_opt("signer");
@@ -3216,6 +3217,7 @@ pub mod args {
     #[derive(Clone, Debug)]
     pub struct JoinNetwork {
         pub chain_id: ChainId,
+        pub release_archive: PathBuf,
         pub genesis_validator: Option<String>,
         pub pre_genesis_path: Option<PathBuf>,
         pub dont_prefetch_wasm: bool,
@@ -3224,11 +3226,13 @@ pub mod args {
     impl Args for JoinNetwork {
         fn parse(matches: &ArgMatches) -> Self {
             let chain_id = CHAIN_ID.parse(matches);
+            let release_archive = RELEASE_ARCHIVE.parse(matches);
             let genesis_validator = GENESIS_VALIDATOR.parse(matches);
             let pre_genesis_path = PRE_GENESIS_PATH.parse(matches);
             let dont_prefetch_wasm = DONT_PREFETCH_WASM.parse(matches);
             Self {
                 chain_id,
+                release_archive,
                 genesis_validator,
                 pre_genesis_path,
                 dont_prefetch_wasm,
@@ -3236,12 +3240,31 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(CHAIN_ID.def().about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository."))
-                .arg(GENESIS_VALIDATOR.def().about("The alias of the genesis validator that you want to set up as, if any."))
-                .arg(PRE_GENESIS_PATH.def().about("The path to the pre-genesis directory for genesis validator, if any. Defaults to \"{base-dir}/pre-genesis/{genesis-validator}\"."))
-            .arg(DONT_PREFETCH_WASM.def().about(
-                "Do not pre-fetch WASM.",
-            ))
+            app.arg(
+                    CHAIN_ID
+                        .def()
+                        .about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository.")
+                        .conflicts_with(RELEASE_ARCHIVE.name)
+                )
+                .arg(
+                    RELEASE_ARCHIVE
+                        .def()
+                        .about("The path to a local release archive (.tar.gz).")
+                )
+                .arg(
+                    GENESIS_VALIDATOR
+                        .def()
+                        .about("The alias of the genesis validator that you want to set up as, if any.")
+                )
+                .arg(
+                    PRE_GENESIS_PATH
+                        .def()
+                        .about("The path to the pre-genesis directory for genesis validator, if any. Defaults to \"{base-dir}/pre-genesis/{genesis-validator}\".")
+                )
+                .arg(
+                    DONT_PREFETCH_WASM
+                        .def()
+                        .about("Do not pre-fetch WASM."))
         }
     }
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -3217,7 +3217,6 @@ pub mod args {
     #[derive(Clone, Debug)]
     pub struct JoinNetwork {
         pub chain_id: ChainId,
-        pub release_archive: PathBuf,
         pub genesis_validator: Option<String>,
         pub pre_genesis_path: Option<PathBuf>,
         pub dont_prefetch_wasm: bool,
@@ -3226,13 +3225,11 @@ pub mod args {
     impl Args for JoinNetwork {
         fn parse(matches: &ArgMatches) -> Self {
             let chain_id = CHAIN_ID.parse(matches);
-            let release_archive = RELEASE_ARCHIVE.parse(matches);
             let genesis_validator = GENESIS_VALIDATOR.parse(matches);
             let pre_genesis_path = PRE_GENESIS_PATH.parse(matches);
             let dont_prefetch_wasm = DONT_PREFETCH_WASM.parse(matches);
             Self {
                 chain_id,
-                release_archive,
                 genesis_validator,
                 pre_genesis_path,
                 dont_prefetch_wasm,
@@ -3240,31 +3237,12 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(
-                    CHAIN_ID
-                        .def()
-                        .about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository.")
-                        .conflicts_with(RELEASE_ARCHIVE.name)
-                )
-                .arg(
-                    RELEASE_ARCHIVE
-                        .def()
-                        .about("The path to a local release archive (.tar.gz).")
-                )
-                .arg(
-                    GENESIS_VALIDATOR
-                        .def()
-                        .about("The alias of the genesis validator that you want to set up as, if any.")
-                )
-                .arg(
-                    PRE_GENESIS_PATH
-                        .def()
-                        .about("The path to the pre-genesis directory for genesis validator, if any. Defaults to \"{base-dir}/pre-genesis/{genesis-validator}\".")
-                )
-                .arg(
-                    DONT_PREFETCH_WASM
-                        .def()
-                        .about("Do not pre-fetch WASM."))
+            app.arg(CHAIN_ID.def().about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository."))
+                .arg(GENESIS_VALIDATOR.def().about("The alias of the genesis validator that you want to set up as, if any."))
+                .arg(PRE_GENESIS_PATH.def().about("The path to the pre-genesis directory for genesis validator, if any. Defaults to \"{base-dir}/pre-genesis/{genesis-validator}\"."))
+            .arg(DONT_PREFETCH_WASM.def().about(
+                "Do not pre-fetch WASM.",
+            ))
         }
     }
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1608,7 +1608,7 @@ pub mod args {
     const RAW_ADDRESS_OPT: ArgOpt<Address> = RAW_ADDRESS.opt();
     const RAW_PUBLIC_KEY_OPT: ArgOpt<common::PublicKey> = arg_opt("public-key");
     const RECEIVER: Arg<String> = arg("receiver");
-    const RELEASE_ARCHIVE: Arg<PathBuf> = arg("release-archive");
+    const RELEASE_ARCHIVE: ArgOpt<PathBuf> = arg_opt("release-archive");
     const SCHEME: ArgDefault<SchemeType> =
         arg_default("scheme", DefaultFn(|| SchemeType::Ed25519));
     const SIGNER: ArgOpt<WalletAddress> = arg_opt("signer");
@@ -3217,6 +3217,7 @@ pub mod args {
     #[derive(Clone, Debug)]
     pub struct JoinNetwork {
         pub chain_id: Option<ChainId>,
+        pub release_archive: Option<PathBuf>,
         pub genesis_validator: Option<String>,
         pub pre_genesis_path: Option<PathBuf>,
         pub dont_prefetch_wasm: bool,
@@ -3225,11 +3226,13 @@ pub mod args {
     impl Args for JoinNetwork {
         fn parse(matches: &ArgMatches) -> Self {
             let chain_id = CHAIN_ID_OPT.parse(matches);
+            let release_archive = RELEASE_ARCHIVE.parse(matches);
             let genesis_validator = GENESIS_VALIDATOR.parse(matches);
             let pre_genesis_path = PRE_GENESIS_PATH.parse(matches);
             let dont_prefetch_wasm = DONT_PREFETCH_WASM.parse(matches);
             Self {
                 chain_id,
+                release_archive,
                 genesis_validator,
                 pre_genesis_path,
                 dont_prefetch_wasm,
@@ -3237,12 +3240,18 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(CHAIN_ID_OPT.def().about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository."))
+            app.arg(CHAIN_ID_OPT.def().about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository.").conflicts_with(RELEASE_ARCHIVE.name))
+                .arg(RELEASE_ARCHIVE.def().about("The path to a release archive (.tar.gz)."))
                 .arg(GENESIS_VALIDATOR.def().about("The alias of the genesis validator that you want to set up as, if any."))
                 .arg(PRE_GENESIS_PATH.def().about("The path to the pre-genesis directory for genesis validator, if any. Defaults to \"{base-dir}/pre-genesis/{genesis-validator}\"."))
             .arg(DONT_PREFETCH_WASM.def().about(
                 "Do not pre-fetch WASM.",
             ))
+            .group(
+                ArgGroup::new("source")
+                    .args(&[CHAIN_ID_OPT.name, RELEASE_ARCHIVE.name])
+                    .required(true),
+            )
         }
     }
 

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -117,15 +117,6 @@ pub async fn join_network(
             )
         });
 
-    let wasm_dir = global_args.wasm_dir.as_ref().cloned().or_else(|| {
-        if let Ok(wasm_dir) = env::var(ENV_VAR_WASM_DIR) {
-            let wasm_dir: PathBuf = wasm_dir.into();
-            Some(wasm_dir)
-        } else {
-            None
-        }
-    });
-
     let release_filename = format!("{}.tar.gz", chain_id);
     let release_url = format!(
         "{}/{}",
@@ -213,6 +204,15 @@ pub async fn join_network(
             .await
             .unwrap();
     }
+
+    let wasm_dir = global_args.wasm_dir.as_ref().cloned().or_else(|| {
+        if let Ok(wasm_dir) = env::var(ENV_VAR_WASM_DIR) {
+            let wasm_dir: PathBuf = wasm_dir.into();
+            Some(wasm_dir)
+        } else {
+            None
+        }
+    });
 
     // Move wasm-dir and update config if it's non-default
     if let Some(wasm_dir) = wasm_dir.as_ref() {

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -114,6 +114,15 @@ pub async fn join_network(
             )
         });
 
+    let wasm_dir = global_args.wasm_dir.as_ref().cloned().or_else(|| {
+        if let Ok(wasm_dir) = env::var(ENV_VAR_WASM_DIR) {
+            let wasm_dir: PathBuf = wasm_dir.into();
+            Some(wasm_dir)
+        } else {
+            None
+        }
+    });
+
     // If the base-dir is non-default, unpack the archive into a temp dir inside
     // first.
     let cwd = env::current_dir().unwrap();
@@ -242,15 +251,6 @@ pub async fn join_network(
             .await
             .unwrap();
     }
-
-    let wasm_dir = global_args.wasm_dir.as_ref().cloned().or_else(|| {
-        if let Ok(wasm_dir) = env::var(ENV_VAR_WASM_DIR) {
-            let wasm_dir: PathBuf = wasm_dir.into();
-            Some(wasm_dir)
-        } else {
-            None
-        }
-    });
 
     // Move wasm-dir and update config if it's non-default
     if let Some(wasm_dir) = wasm_dir.as_ref() {

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -113,6 +113,9 @@ pub async fn join_network(
             )
         });
 
+    // TODO: get chain ID from argument (if provided), *or* from unpacking the
+    // release archive
+    let chain_id = chain_id.unwrap();
     // Check if the base-dir has already got this chain ID
     if fs::canonicalize(base_dir.join(chain_id.as_str()))
         .await

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -1110,7 +1110,7 @@ fn exit_if_chain_dir_exists(base_dir: &Path, chain_id: &ChainId) {
 fn unpack_release<R: std::io::Read>(tgz: R, unpack_dir: &Path) {
     let decoder = GzDecoder::new(tgz);
     let mut archive = tar::Archive::new(decoder);
-    archive.unpack(&unpack_dir).unwrap()
+    archive.unpack(unpack_dir).unwrap()
 }
 
 /// Returns the [`ChainId`] of the chain for a release archive unpacked at

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -50,7 +50,6 @@ pub async fn join_network(
     global_args: args::Global,
     args::JoinNetwork {
         chain_id,
-        release_archive,
         genesis_validator,
         pre_genesis_path,
         dont_prefetch_wasm,

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -50,6 +50,7 @@ pub async fn join_network(
     global_args: args::Global,
     args::JoinNetwork {
         chain_id,
+        release_archive,
         genesis_validator,
         pre_genesis_path,
         dont_prefetch_wasm,


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/710

This PR would make it so that a local .tar.gz can be used for joining a network, rather than having to download it from a remote server at the same time that you run `namadac utils join-network`. e.g.

```shell
namadac utils join-network --release-archive ~/Downloads/local.8d5fac7ce84a1a7a8b8c48e2.tar.gz
```

TODO
- [ ] test with a real release downloaded from https://github.com/heliaxdev/anoma-network-config
- [ ] prereview