### PR TITLE
Run Ethereum bridge CI for stacked PRs

### DIFF
--- a/.github/workflows/build-and-test-bridge.yml
+++ b/.github/workflows/build-and-test-bridge.yml
@@ -8,6 +8,7 @@ on:
   pull_request_target:
     branches:
       - eth-bridge-integration
+      - '**/ethbridge/**'
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 


### PR DESCRIPTION
Should run e2e CI for PRs that target other Ethereum bridge branches

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1

I'm not sure if this will actually work until we try merging it to `eth-bridge-integration` (and maybe `main` also?)