### PR TITLE
Only dequeue Ethereum events if the vext signer is equal to the validator executing `FinalizeBlock`

### DIFF
--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -151,8 +151,17 @@ where
                 TxType::Protocol(protocol_tx) => match protocol_tx.tx {
                     #[cfg(not(feature = "abcipp"))]
                     ProtocolTxType::EthEventsVext(ref ext) => {
-                        for event in ext.data.ethereum_events.iter() {
-                            self.mode.dequeue_eth_event(event);
+                        if self
+                            .mode
+                            .get_validator_address()
+                            .map(|validator| {
+                                validator == &ext.data.validator_addr
+                            })
+                            .unwrap_or(false)
+                        {
+                            for event in ext.data.ethereum_events.iter() {
+                                self.mode.dequeue_eth_event(event);
+                            }
                         }
                         Event::new_tx_event(&tx_type, height.0)
                     }
@@ -162,10 +171,19 @@ where
                     }
                     #[cfg(feature = "abcipp")]
                     ProtocolTxType::EthereumEvents(ref digest) => {
-                        for event in
-                            digest.events.iter().map(|signed| &signed.event)
+                        if self
+                            .mode
+                            .get_validator_address()
+                            .map(|validator| {
+                                validator == &ext.data.validator_addr
+                            })
+                            .unwrap_or(false)
                         {
-                            self.mode.dequeue_eth_event(event);
+                            for event in
+                                digest.events.iter().map(|signed| &signed.event)
+                            {
+                                self.mode.dequeue_eth_event(event);
+                            }
                         }
                         Event::new_tx_event(&tx_type, height.0)
                     }

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -152,7 +152,7 @@ where
                     #[cfg(not(feature = "abcipp"))]
                     ProtocolTxType::EthEventsVext(ref ext) => {
                         for event in ext.data.ethereum_events.iter() {
-                            self.mode.deque_eth_event(event);
+                            self.mode.dequeue_eth_event(event);
                         }
                         Event::new_tx_event(&tx_type, height.0)
                     }
@@ -165,7 +165,7 @@ where
                         for event in
                             digest.events.iter().map(|signed| &signed.event)
                         {
-                            self.mode.deque_eth_event(event);
+                            self.mode.dequeue_eth_event(event);
                         }
                         Event::new_tx_event(&tx_type, height.0)
                     }

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -222,7 +222,6 @@ impl EthereumReceiver {
     }
 }
 
-#[allow(dead_code)]
 impl ShellMode {
     /// Get the validator address if ledger is in validator mode
     pub fn get_validator_address(&self) -> Option<&address::Address> {
@@ -258,6 +257,7 @@ impl ShellMode {
     }
 
     /// Get the Ethereum bridge keypair for this validator.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn get_eth_bridge_keypair(&self) -> Option<&common::SecretKey> {
         match self {
             ShellMode::Validator {
@@ -277,6 +277,7 @@ impl ShellMode {
 
     /// If this node is a validator, broadcast a tx
     /// to the mempool using the broadcaster subprocess
+    #[cfg_attr(feature = "abcipp", allow(dead_code))]
     pub fn broadcast(&self, data: Vec<u8>) {
         if let Self::Validator {
             broadcast_sender, ..

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -213,12 +213,12 @@ impl EthereumReceiver {
         self.queue.iter().cloned().collect()
     }
 
-    /// Given a list of events, remove them from the queue if present
-    /// Note that this method preserves the sorting and de-duplication
+    /// Remove the given [`EthereumEvent`] from the queue, if present.
+    ///
+    /// **INVARIANT:** This method preserves the sorting and de-duplication
     /// of events in the queue.
-    #[allow(dead_code)]
-    pub fn remove(&mut self, events: &[EthereumEvent]) {
-        self.queue.retain(|event| !events.contains(event));
+    pub fn remove_event(&mut self, event: &EthereumEvent) {
+        self.queue.remove(event);
     }
 }
 
@@ -234,12 +234,8 @@ impl ShellMode {
 
     /// Remove an Ethereum event from the internal queue
     pub fn dequeue_eth_event(&mut self, event: &EthereumEvent) {
-        if let ShellMode::Validator {
-            ethereum_recv: EthereumReceiver { ref mut queue, .. },
-            ..
-        } = self
-        {
-            queue.remove(event);
+        if let ShellMode::Validator { ethereum_recv, .. } = self {
+            ethereum_recv.remove_event(event);
         }
     }
 

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -233,7 +233,7 @@ impl ShellMode {
     }
 
     /// Remove an Ethereum event from the internal queue
-    pub fn deque_eth_event(&mut self, event: &EthereumEvent) {
+    pub fn dequeue_eth_event(&mut self, event: &EthereumEvent) {
         if let ShellMode::Validator {
             ethereum_recv: EthereumReceiver { ref mut queue, .. },
             ..


### PR DESCRIPTION
Fixes #818