### PR TITLE
Run `make check-abcipp` in CI

### DIFF
--- a/.changelog/unreleased/ci/824-abcipp-ci.md
+++ b/.changelog/unreleased/ci/824-abcipp-ci.md
@@ -1,0 +1,1 @@
+- Run `make check-abcipp` in CI ([#824](https://github.com/anoma/namada/pull/824))

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,6 +29,10 @@ jobs:
         os: [ubuntu-latest]
         nightly_version: [nightly-2022-11-03]
         make:
+          - name: Check ABCI++
+            command: check-abcipp
+            cache_subkey: abcipp
+            cache_version: v1
           - name: Clippy
             command: clippy
             cache_subkey: clippy


### PR DESCRIPTION
Implicitly depends on https://github.com/anoma/namada/pull/754, which adds `make check-abcipp`

This PR makes it so that we run `make check-abcipp` in CI, to ensure that code continues to compile with the `abcipp` feature.