### PR TITLE
Updates to tendermint patching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,6 +2749,33 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.14.0"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582#0da70aba510010aa0b1248afd3ece2b7bc200582"
+dependencies = [
+ "bytes 1.2.1",
+ "derive_more",
+ "flex-error",
+ "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582)",
+ "ics23",
+ "num-traits 0.2.15",
+ "prost",
+ "prost-types",
+ "safe-regex",
+ "serde 1.0.147",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "subtle-encoding",
+ "tendermint 0.23.6",
+ "tendermint-light-client-verifier 0.23.6",
+ "tendermint-proto 0.23.6",
+ "tendermint-testgen 0.23.6",
+ "time 0.3.17",
+ "tracing 0.1.37",
+]
+
+[[package]]
+name = "ibc"
+version = "0.14.0"
 source = "git+https://github.com/heliaxdev/ibc-rs?rev=9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d#9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d"
 dependencies = [
  "bytes 1.2.1",
@@ -2774,30 +2801,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "ibc"
-version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+name = "ibc-proto"
+version = "0.17.1"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582#0da70aba510010aa0b1248afd3ece2b7bc200582"
 dependencies = [
+ "base64 0.13.1",
  "bytes 1.2.1",
- "derive_more",
- "flex-error",
- "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
- "ics23",
- "num-traits 0.2.15",
  "prost",
  "prost-types",
- "safe-regex",
  "serde 1.0.147",
- "serde_derive",
- "serde_json",
- "sha2 0.10.6",
- "subtle-encoding",
- "tendermint 0.23.6",
- "tendermint-light-client-verifier 0.23.6",
  "tendermint-proto 0.23.6",
- "tendermint-testgen 0.23.6",
- "time 0.3.17",
- "tracing 0.1.37",
+ "tonic",
 ]
 
 [[package]]
@@ -2814,23 +2828,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ibc-proto"
-version = "0.17.1"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
-dependencies = [
- "base64 0.13.1",
- "bytes 1.2.1",
- "prost",
- "prost-types",
- "serde 1.0.147",
- "tendermint-proto 0.23.6",
- "tonic",
-]
-
-[[package]]
 name = "ibc-relayer"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582#0da70aba510010aa0b1248afd3ece2b7bc200582"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2846,8 +2846,8 @@ dependencies = [
  "http",
  "humantime",
  "humantime-serde",
- "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
- "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582)",
+ "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582)",
  "itertools",
  "k256",
  "moka",
@@ -3650,10 +3650,10 @@ dependencies = [
  "ferveo",
  "ferveo-common",
  "group-threshold-cryptography",
+ "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582)",
  "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d)",
- "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582)",
  "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d)",
- "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
  "ics23",
  "itertools",
  "libsecp256k1",
@@ -3775,8 +3775,8 @@ dependencies = [
  "toml",
  "tonic",
  "tower",
+ "tower-abci 0.1.0 (git+https://github.com/heliaxdev/tower-abci?rev=44efa6b5851667a0dfcff304bbdf8bbac04ded25)",
  "tower-abci 0.1.0 (git+https://github.com/heliaxdev/tower-abci?rev=f6463388fc319b6e210503b43b3aecf6faf6b200)",
- "tower-abci 0.1.0 (git+https://github.com/heliaxdev/tower-abci.git?rev=fcc0014d0bda707109901abfa1b2f782d242f082)",
  "tracing 0.1.37",
  "tracing-log",
  "tracing-subscriber 0.3.16",
@@ -3829,8 +3829,8 @@ dependencies = [
  "eyre",
  "file-serve",
  "fs_extra",
- "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
- "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582)",
+ "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582)",
  "ibc-relayer",
  "itertools",
  "namada",
@@ -6069,7 +6069,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "async-trait",
  "bytes 1.2.1",
@@ -6112,7 +6112,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "flex-error",
  "serde 1.0.147",
@@ -6125,7 +6125,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -6188,7 +6188,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "bytes 1.2.1",
  "flex-error",
@@ -6238,7 +6238,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -6286,7 +6286,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",
@@ -6744,13 +6744,13 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/tower-abci?rev=f6463388fc319b6e210503b43b3aecf6faf6b200#f6463388fc319b6e210503b43b3aecf6faf6b200"
+source = "git+https://github.com/heliaxdev/tower-abci?rev=44efa6b5851667a0dfcff304bbdf8bbac04ded25#44efa6b5851667a0dfcff304bbdf8bbac04ded25"
 dependencies = [
  "bytes 1.2.1",
  "futures 0.3.25",
  "pin-project",
  "prost",
- "tendermint-proto 0.23.5",
+ "tendermint-proto 0.23.6",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -6762,13 +6762,13 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/tower-abci.git?rev=fcc0014d0bda707109901abfa1b2f782d242f082#fcc0014d0bda707109901abfa1b2f782d242f082"
+source = "git+https://github.com/heliaxdev/tower-abci?rev=f6463388fc319b6e210503b43b3aecf6faf6b200#f6463388fc319b6e210503b43b3aecf6faf6b200"
 dependencies = [
  "bytes 1.2.1",
  "futures 0.3.25",
  "pin-project",
  "prost",
- "tendermint-proto 0.23.6",
+ "tendermint-proto 0.23.5",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,23 +34,6 @@ async-process = {git = "https://github.com/heliaxdev/async-process.git", rev = "
 # borsh-derive-internal = {path = "../borsh-rs/borsh-derive-internal"}
 # borsh-schema-derive-internal = {path = "../borsh-rs/borsh-schema-derive-internal"}
 
-# patched to a commit on the `eth-bridge-integration+consensus-timeout` branch of our fork
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-config = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-testgen = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-
-# patched to a commit on the `eth-bridge-integration` branch of our fork
-ibc = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-proto = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-relayer = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-
-# patched to a commit on the `eth-bridge-integration` branch of our fork
-tower-abci = {git = "https://github.com/heliaxdev/tower-abci.git", rev = "fcc0014d0bda707109901abfa1b2f782d242f082"}
-
 [profile.release]
 lto = true
 opt-level = 3

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -123,10 +123,10 @@ tendermint-abcipp = {package = "tendermint", git = "https://github.com/heliaxdev
 tendermint-config-abcipp = {package = "tendermint-config", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-proto-abcipp = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-rpc-abcipp = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", features = ["http-client", "websocket-client"], optional = true}
-tendermint = {version = "0.23.6", optional = true}
-tendermint-config = {version = "0.23.6", optional = true}
-tendermint-proto = {version = "0.23.6", optional = true}
-tendermint-rpc = {version = "0.23.6", features = ["http-client", "websocket-client"], optional = true}
+tendermint = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", optional = true}
+tendermint-config = {package = "tendermint-config", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", optional = true}
+tendermint-proto = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", optional = true}
+tendermint-rpc = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", features = ["http-client", "websocket-client"], optional = true}
 thiserror = "1.0.30"
 tokio = {version = "1.8.2", features = ["full"]}
 toml = "0.5.8"
@@ -135,7 +135,7 @@ tower = "0.4"
 # Also, using the same version of tendermint-rs as we do here.
 # with a patch for https://github.com/penumbra-zone/tower-abci/issues/7.
 tower-abci-abcipp = {package = "tower-abci", git = "https://github.com/heliaxdev/tower-abci", rev = "f6463388fc319b6e210503b43b3aecf6faf6b200", optional = true}
-tower-abci = {version = "0.1.0", optional = true}
+tower-abci = {package = "tower-abci", git = "https://github.com/heliaxdev/tower-abci", rev = "44efa6b5851667a0dfcff304bbdf8bbac04ded25", optional = true}
 tracing = "0.1.30"
 tracing-log = "0.1.2"
 tracing-subscriber = {version = "0.3.7", features = ["env-filter"]}

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -101,8 +101,8 @@ tpke = {package = "group-threshold-cryptography", optional = true, git = "https:
 # TODO using the same version of tendermint-rs as we do here.
 ibc-abcipp = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", rev = "9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d", default-features = false, optional = true}
 ibc-proto-abcipp = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", rev = "9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d", default-features = false, optional = true}
-ibc = {version = "0.14.0", default-features = false, optional = true}
-ibc-proto = {version = "0.17.1", default-features = false, optional = true}
+ibc = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", rev = "0da70aba510010aa0b1248afd3ece2b7bc200582", default-features = false, optional = true}
+ibc-proto = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", rev = "0da70aba510010aa0b1248afd3ece2b7bc200582", default-features = false, optional = true}
 ics23 = "0.7.0"
 itertools = "0.10.0"
 loupe = {version = "0.1.3", optional = true}
@@ -128,9 +128,9 @@ tempfile = {version = "3.2.0", optional = true}
 tendermint-abcipp = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-rpc-abcipp = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", features = ["http-client"], optional = true}
 tendermint-proto-abcipp = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
-tendermint = {version = "0.23.6", optional = true}
-tendermint-rpc = {version = "0.23.6", features = ["http-client"], optional = true}
-tendermint-proto = {version = "0.23.6", optional = true}
+tendermint = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", optional = true}
+tendermint-rpc = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", features = ["http-client"], optional = true}
+tendermint-proto = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", optional = true}
 thiserror = "1.0.30"
 tracing = "0.1.30"
 wasmer = {version = "=2.2.0", optional = true}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,18 +17,18 @@ namada_vp_prelude = {path = "../vp_prelude"}
 namada_tx_prelude = {path = "../tx_prelude"}
 chrono = {version = "0.4.22", default-features = false, features = ["clock", "std"]}
 concat-idents = "1.1.2"
-ibc = {version = "0.14.0", default-features = false}
-ibc-proto = {version = "0.17.1", default-features = false}
-ibc-relayer = {version = "0.14.0", default-features = false}
+ibc = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", rev = "0da70aba510010aa0b1248afd3ece2b7bc200582", default-features = false}
+ibc-proto = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", rev = "0da70aba510010aa0b1248afd3ece2b7bc200582", default-features = false}
+ibc-relayer = {package = "ibc-relayer", git = "https://github.com/heliaxdev/ibc-rs", rev = "0da70aba510010aa0b1248afd3ece2b7bc200582", default-features = false}
 prost = "0.9.0"
 serde_json = {version = "1.0.65"}
 sha2 = "0.9.3"
 test-log = {version = "0.2.7", default-features = false, features = ["trace"]}
 tempfile = "3.2.0"
-tendermint = "0.23.6"
-tendermint-config = "0.23.6"
-tendermint-proto = "0.23.6"
-tendermint-rpc = {version = "0.23.6", features = ["http-client"]}
+tendermint = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
+tendermint-config = {package = "tendermint-config", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
+tendermint-proto = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
+tendermint-rpc = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba", features = ["http-client"]}
 tokio = {version = "1.8.2", features = ["full"]}
 tracing = "0.1.30"
 tracing-subscriber = {version = "0.3.7", default-features = false, features = ["env-filter", "fmt"]}

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582#0da70aba510010aa0b1248afd3ece2b7bc200582"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1915,7 +1915,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.17.1"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582#0da70aba510010aa0b1248afd3ece2b7bc200582"
 dependencies = [
  "base64",
  "bytes",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "ibc-relayer"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582#0da70aba510010aa0b1248afd3ece2b7bc200582"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "flex-error",
  "serde",
@@ -4042,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -4075,7 +4075,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "bytes",
  "flex-error",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -13,19 +13,6 @@ borsh = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4
 borsh-derive = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 borsh-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 borsh-schema-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
-# patched to a commit on the `eth-bridge-integration+consensus-timeout` branch of our fork
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-config = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-testgen = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-
-# patched to a commit on the `eth-bridge-integration` branch of our fork
-ibc = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-proto = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-relayer = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
 
 [profile.release]
 # smaller and faster wasm (https://rustwasm.github.io/book/reference/code-size.html#compiling-with-link-time-optimizations-lto)

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582#0da70aba510010aa0b1248afd3ece2b7bc200582"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1915,7 +1915,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.17.1"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582#0da70aba510010aa0b1248afd3ece2b7bc200582"
 dependencies = [
  "base64",
  "bytes",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "ibc-relayer"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=0da70aba510010aa0b1248afd3ece2b7bc200582#0da70aba510010aa0b1248afd3ece2b7bc200582"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3991,7 +3991,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "flex-error",
  "serde",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -4067,7 +4067,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "bytes",
  "flex-error",
@@ -4084,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",

--- a/wasm_for_tests/wasm_source/Cargo.toml
+++ b/wasm_for_tests/wasm_source/Cargo.toml
@@ -37,19 +37,6 @@ borsh = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4
 borsh-derive = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 borsh-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 borsh-schema-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
-# patched to a commit on the `eth-bridge-integration+consensus-timeout` branch of our fork
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-config = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-testgen = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-
-# patched to a commit on the `eth-bridge-integration` branch of our fork
-ibc = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-proto = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-relayer = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
 
 [dev-dependencies]
 namada_tests = {path = "../../tests"}


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/825

This PR makes it so that we pull in tendermint-related dependencies directly via a `git` source as we used before. e.g.
```toml
tendermint = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
```
This makes more sense as the namada code does hard depend on our forks, and doesn't work with upstream tendermint-rs packages. By specifying our forks as direct dependencies, there is no longer a need to patch in the correct versions via the workspace `Cargo.toml`s. Unfortunately we obscure the versions of our forks from our `Cargo.toml`s, but the versions will still show up in `cargo tree` and when running `cargo build`, `cargo check`, etc.

The motivation for changing this in the first place was to make patching over tendermint-rs easier, but it is still possible to do this by patching one git source to a different once (see https://github.com/rust-lang/cargo/issues/5478 for why this is required) although it is a bit hacky e.g.

```toml
# example patch that we might have in the `eth-bridge-integration` branch, if we had to use a different version to what was in `main`
[patch."https://github.com/heliaxdev/tendermint-rs"]
tendermint = {git = "https://github.com/heliaxdev/tendermint-rs.git?branch=eth-bridge-integration", rev = "..."}
```