### PR TITLE
Allow sign extend opcodes in wasms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4786,9 +4786,9 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.42.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking"
@@ -5259,9 +5259,8 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/wasm-utils?tag=v0.20.0#782bfa7fb5e513b602e66af492cbc4cb1b06f2ba"
 dependencies = [
  "byteorder",
  "log 0.4.17",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -112,13 +112,13 @@ ics23 = "0.7.0"
 itertools = "0.10.0"
 loupe = {version = "0.1.3", optional = true}
 libsecp256k1 = {git = "https://github.com/heliaxdev/libsecp256k1", rev = "bbb3bd44a49db361f21d9db80f9a087c194c0ae9", default-features = false, features = ["std", "static-context"]}
-parity-wasm = {version = "0.42.2", optional = true}
+parity-wasm = {version = "0.45.0", features = ["sign_ext"], optional = true}
 paste = "1.0.9"
 # A fork with state machine testing
 proptest = {git = "https://github.com/heliaxdev/proptest", branch = "tomas/sm", optional = true}
 prost = "0.9.0"
 prost-types = "0.9.0"
-pwasm-utils = {version = "0.18.0", optional = true}
+pwasm-utils = {git = "https://github.com/heliaxdev/wasm-utils", tag = "v0.20.0", features = ["sign_ext"], optional = true}
 rand = {version = "0.8", optional = true}
 # TODO proptest rexports the RngCore trait but the re-implementations only work for version `0.8`. *sigh*
 rand_core = {version = "0.6", optional = true}

--- a/shared/src/vm/mod.rs
+++ b/shared/src/vm/mod.rs
@@ -28,7 +28,7 @@ const UNTRUSTED_WASM_FEATURES: WasmFeatures = WasmFeatures {
     memory64: false,
     mutable_global: false,
     saturating_float_to_int: false,
-    sign_extension: false,
+    sign_extension: true,
     relaxed_simd: false,
     extended_const: false,
 };

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2897,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.42.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking_lot"
@@ -3259,9 +3259,8 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/wasm-utils?tag=v0.20.0#782bfa7fb5e513b602e66af492cbc4cb1b06f2ba"
 dependencies = [
  "byteorder",
  "log",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -2889,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.42.2"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking_lot"
@@ -3251,9 +3251,8 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880b3384fb00b8f6ecccd5d358b93bd2201900ae3daad213791d1864f6441f5c"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/wasm-utils?tag=v0.20.0#782bfa7fb5e513b602e66af492cbc4cb1b06f2ba"
 dependencies = [
  "byteorder",
  "log",


### PR DESCRIPTION
Should enable us to ditch docker to build wasms for local testnets.