### PR TITLE
Run Ethereum bridge CI against more branches (`eth-bridge-integration`)

### DIFF
--- a/.changelog/unreleased/ci/834-ethbridge-ci-stacked-prs.md
+++ b/.changelog/unreleased/ci/834-ethbridge-ci-stacked-prs.md
@@ -1,0 +1,2 @@
+- Run Ethereum bridge CI against more branches
+  ([#834](https://github.com/anoma/namada/pull/834))

--- a/.github/workflows/build-and-test-bridge.yml
+++ b/.github/workflows/build-and-test-bridge.yml
@@ -8,6 +8,7 @@ on:
   pull_request_target:
     branches:
       - eth-bridge-integration
+      - "**/ethbridge/**"
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 


### PR DESCRIPTION
This should go into `main` as well in https://github.com/anoma/namada/pull/834

I accidentally overwrote https://github.com/anoma/namada/pull/798 when merging `v0.10.1` into `eth-bridge-integration`, this puts that change back