### PR TITLE
Start using Tendermint v0.37.0-rc1 and compatible Rust crates

### DIFF
--- a/.changelog/unreleased/improvements/838-tendermint-v0.37-integration.md
+++ b/.changelog/unreleased/improvements/838-tendermint-v0.37-integration.md
@@ -1,0 +1,2 @@
+- Update tendermint-rs, ibc-rs and tower-abci crates for Tendermint v0.37.0-rc1
+  ([#838](https://github.com/anoma/namada/pull/838))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,12 +2784,12 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c#f7e59c81298c1e44dfabe1155a36ac4efdad478c"
 dependencies = [
  "bytes 1.2.1",
  "derive_more",
  "flex-error",
- "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c)",
  "ics23",
  "num-traits 0.2.15",
  "prost",
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.17.1"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c#f7e59c81298c1e44dfabe1155a36ac4efdad478c"
 dependencies = [
  "base64 0.13.1",
  "bytes 1.2.1",
@@ -2838,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "ibc-relayer"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c#f7e59c81298c1e44dfabe1155a36ac4efdad478c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2854,8 +2854,8 @@ dependencies = [
  "http",
  "humantime",
  "humantime-serde",
- "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
- "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c)",
+ "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c)",
  "itertools",
  "k256",
  "moka",
@@ -3648,9 +3648,9 @@ dependencies = [
  "data-encoding",
  "derivative",
  "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d)",
- "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c)",
  "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d)",
- "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c)",
  "itertools",
  "libsecp256k1",
  "loupe",
@@ -3767,8 +3767,8 @@ dependencies = [
  "toml",
  "tonic",
  "tower",
+ "tower-abci 0.1.0 (git+https://github.com/heliaxdev/tower-abci?rev=659d799f2a94238cd45725738624b7f51b96287f)",
  "tower-abci 0.1.0 (git+https://github.com/heliaxdev/tower-abci?rev=f6463388fc319b6e210503b43b3aecf6faf6b200)",
- "tower-abci 0.1.0 (git+https://github.com/heliaxdev/tower-abci.git?rev=fcc0014d0bda707109901abfa1b2f782d242f082)",
  "tracing 0.1.37",
  "tracing-log",
  "tracing-subscriber 0.3.16",
@@ -3795,9 +3795,9 @@ dependencies = [
  "ferveo-common",
  "group-threshold-cryptography",
  "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d)",
- "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c)",
  "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d)",
- "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c)",
  "ics23",
  "index-set",
  "itertools",
@@ -3877,8 +3877,8 @@ dependencies = [
  "eyre",
  "file-serve",
  "fs_extra",
- "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
- "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
+ "ibc 0.14.0 (git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c)",
+ "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c)",
  "ibc-relayer",
  "itertools",
  "namada",
@@ -6131,7 +6131,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "async-trait",
  "bytes 1.2.1",
@@ -6174,7 +6174,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "flex-error",
  "serde 1.0.147",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -6221,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -6250,7 +6250,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "bytes 1.2.1",
  "flex-error",
@@ -6300,7 +6300,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -6348,7 +6348,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",
@@ -6806,13 +6806,13 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/tower-abci?rev=f6463388fc319b6e210503b43b3aecf6faf6b200#f6463388fc319b6e210503b43b3aecf6faf6b200"
+source = "git+https://github.com/heliaxdev/tower-abci?rev=659d799f2a94238cd45725738624b7f51b96287f#659d799f2a94238cd45725738624b7f51b96287f"
 dependencies = [
  "bytes 1.2.1",
  "futures 0.3.25",
  "pin-project",
  "prost",
- "tendermint-proto 0.23.5",
+ "tendermint-proto 0.23.6",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -6824,13 +6824,13 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/tower-abci.git?rev=fcc0014d0bda707109901abfa1b2f782d242f082#fcc0014d0bda707109901abfa1b2f782d242f082"
+source = "git+https://github.com/heliaxdev/tower-abci?rev=f6463388fc319b6e210503b43b3aecf6faf6b200#f6463388fc319b6e210503b43b3aecf6faf6b200"
 dependencies = [
  "bytes 1.2.1",
  "futures 0.3.25",
  "pin-project",
  "prost",
- "tendermint-proto 0.23.6",
+ "tendermint-proto 0.23.5",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,23 +35,6 @@ async-process = {git = "https://github.com/heliaxdev/async-process.git", rev = "
 # borsh-derive-internal = {path = "../borsh-rs/borsh-derive-internal"}
 # borsh-schema-derive-internal = {path = "../borsh-rs/borsh-schema-derive-internal"}
 
-# patched to a commit on the `eth-bridge-integration+consensus-timeout` branch of our fork
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-config = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-testgen = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-
-# patched to a commit on the `eth-bridge-integration` branch of our fork
-ibc = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-proto = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-relayer = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-
-# patched to a commit on the `eth-bridge-integration` branch of our fork
-tower-abci = {git = "https://github.com/heliaxdev/tower-abci.git", rev = "fcc0014d0bda707109901abfa1b2f782d242f082"}
-
 # patched to the yanked 1.2.0 until masp updates bitvec
 funty = { git = "https://github.com/bitvecto-rs/funty/", rev = "7ef0d890fbcd8b3def1635ac1a877fc298488446" }
 

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -124,10 +124,10 @@ tendermint-abcipp = {package = "tendermint", git = "https://github.com/heliaxdev
 tendermint-config-abcipp = {package = "tendermint-config", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-proto-abcipp = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-rpc-abcipp = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", features = ["http-client", "websocket-client"], optional = true}
-tendermint = {version = "0.23.6", optional = true}
-tendermint-config = {version = "0.23.6", optional = true}
-tendermint-proto = {version = "0.23.6", optional = true}
-tendermint-rpc = {version = "0.23.6", features = ["http-client", "websocket-client"], optional = true}
+tendermint = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", optional = true}
+tendermint-config = {package = "tendermint-config", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", optional = true}
+tendermint-proto = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", optional = true}
+tendermint-rpc = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", features = ["http-client", "websocket-client"], optional = true}
 thiserror = "1.0.30"
 tokio = {version = "1.8.2", features = ["full"]}
 toml = "0.5.8"
@@ -136,7 +136,7 @@ tower = "0.4"
 # Also, using the same version of tendermint-rs as we do here.
 # with a patch for https://github.com/penumbra-zone/tower-abci/issues/7.
 tower-abci-abcipp = {package = "tower-abci", git = "https://github.com/heliaxdev/tower-abci", rev = "f6463388fc319b6e210503b43b3aecf6faf6b200", optional = true}
-tower-abci = {version = "0.1.0", optional = true}
+tower-abci = {package = "tower-abci", git = "https://github.com/heliaxdev/tower-abci", rev = "659d799f2a94238cd45725738624b7f51b96287f", optional = true}
 tracing = "0.1.30"
 tracing-log = "0.1.2"
 tracing-subscriber = {version = "0.3.7", features = ["env-filter"]}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -69,8 +69,8 @@ ferveo = {optional = true, git = "https://github.com/anoma/ferveo"}
 ferveo-common = {git = "https://github.com/anoma/ferveo"}
 tpke = {package = "group-threshold-cryptography", optional = true, git = "https://github.com/anoma/ferveo"}
 # TODO using the same version of tendermint-rs as we do here.
-ibc = {version = "0.14.0", default-features = false, optional = true}
-ibc-proto = {version = "0.17.1", default-features = false, optional = true}
+ibc = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c", default-features = false, optional = true}
+ibc-proto = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c", default-features = false, optional = true}
 ibc-abcipp = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", rev = "9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d", default-features = false, optional = true}
 ibc-proto-abcipp = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", rev = "9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d", default-features = false, optional = true}
 ics23 = "0.7.0"
@@ -89,8 +89,8 @@ rust_decimal_macros = "1.26.1"
 serde = {version = "1.0.125", features = ["derive"]}
 serde_json = "1.0.62"
 sha2 = "0.9.3"
-tendermint = {version = "0.23.6", optional = true}
-tendermint-proto = {version = "0.23.6", optional = true}
+tendermint = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", optional = true}
+tendermint-proto = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", optional = true}
 tendermint-abcipp = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-proto-abcipp = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 thiserror = "1.0.30"

--- a/docker/namada/Dockerfile
+++ b/docker/namada/Dockerfile
@@ -25,7 +25,7 @@ RUN make build-release
 FROM golang:1.18.0 as tendermint-builder
 WORKDIR /app
 
-RUN git clone -b v0.1.4-abciplus --single-branch https://github.com/heliaxdev/tendermint.git && cd tendermint && make build
+RUN git clone -b v0.37.0-rc1 --single-branch https://github.com/tendermint/tendermint.git && cd tendermint && make build
 
 FROM debian:bullseye-slim AS runtime
 ENV NAMADA_BASE_DIR=/.namada 

--- a/scripts/get_tendermint.sh
+++ b/scripts/get_tendermint.sh
@@ -5,10 +5,10 @@ set -Eo pipefail
 # an examplary download-url
 # https://github.com/tendermint/tendermint/releases/download/v0.34.13/tendermint_0.34.13_linux_amd64.tar.gz
 # https://github.com/heliaxdev/tendermint/releases/download/v0.1.1-abcipp/tendermint_0.1.0-abcipp_darwin_amd64.tar.gz
-TM_MAJORMINOR="0.1"
-TM_PATCH="4"
-TM_SUFFIX="-abciplus"
-TM_REPO="https://github.com/heliaxdev/tendermint"
+TM_MAJORMINOR="0.37"
+TM_PATCH="0"
+TM_SUFFIX="-rc1"
+TM_REPO="https://github.com/tendermint/tendermint"
 
 TM_VERSION="${TM_MAJORMINOR}.${TM_PATCH}${TM_SUFFIX}"
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -91,8 +91,8 @@ derivative = "2.2.0"
 # TODO using the same version of tendermint-rs as we do here.
 ibc-abcipp = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", rev = "9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d", default-features = false, optional = true}
 ibc-proto-abcipp = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", rev = "9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d", default-features = false, optional = true}
-ibc = {version = "0.14.0", default-features = false, optional = true}
-ibc-proto = {version = "0.17.1", default-features = false, optional = true}
+ibc = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c", default-features = false, optional = true}
+ibc-proto = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c", default-features = false, optional = true}
 itertools = "0.10.0"
 loupe = {version = "0.1.3", optional = true}
 parity-wasm = {version = "0.45.0", features = ["sign_ext"], optional = true}
@@ -110,9 +110,9 @@ tempfile = {version = "3.2.0", optional = true}
 tendermint-abcipp = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-rpc-abcipp = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", features = ["http-client"], optional = true}
 tendermint-proto-abcipp = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
-tendermint = {version = "0.23.6", optional = true}
-tendermint-rpc = {version = "0.23.6", features = ["http-client"], optional = true}
-tendermint-proto = {version = "0.23.6", optional = true}
+tendermint = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", optional = true}
+tendermint-rpc = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", features = ["http-client"], optional = true}
+tendermint-proto = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", optional = true}
 thiserror = "1.0.30"
 tracing = "0.1.30"
 wasmer = {version = "=2.2.0", optional = true}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,18 +23,18 @@ namada_vp_prelude = {path = "../vp_prelude", default-features = false}
 namada_tx_prelude = {path = "../tx_prelude", default-features = false}
 chrono = {version = "0.4.22", default-features = false, features = ["clock", "std"]}
 concat-idents = "1.1.2"
-ibc = {version = "0.14.0", default-features = false}
-ibc-proto = {version = "0.17.1", default-features = false}
-ibc-relayer = {version = "0.14.0", default-features = false}
+ibc = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c", default-features = false}
+ibc-proto = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c", default-features = false}
+ibc-relayer = {package = "ibc-relayer", git = "https://github.com/heliaxdev/ibc-rs", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c", default-features = false}
 prost = "0.9.0"
 serde_json = {version = "1.0.65"}
 sha2 = "0.9.3"
 test-log = {version = "0.2.7", default-features = false, features = ["trace"]}
 tempfile = "3.2.0"
-tendermint = "0.23.6"
-tendermint-config = "0.23.6"
-tendermint-proto = "0.23.6"
-tendermint-rpc = {version = "0.23.6", features = ["http-client"]}
+tendermint = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}
+tendermint-config = {package = "tendermint-config", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}
+tendermint-proto = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}
+tendermint-rpc = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab", features = ["http-client"]}
 tokio = {version = "1.8.2", features = ["full"]}
 tracing = "0.1.30"
 tracing-subscriber = {version = "0.3.7", default-features = false, features = ["env-filter", "fmt"]}

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c#f7e59c81298c1e44dfabe1155a36ac4efdad478c"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.17.1"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c#f7e59c81298c1e44dfabe1155a36ac4efdad478c"
 dependencies = [
  "base64",
  "bytes",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ibc-relayer"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c#f7e59c81298c1e44dfabe1155a36ac4efdad478c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4077,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "flex-error",
  "serde",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -4153,7 +4153,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "bytes",
  "flex-error",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -4203,7 +4203,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -13,19 +13,6 @@ borsh = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4
 borsh-derive = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 borsh-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 borsh-schema-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
-# patched to a commit on the `eth-bridge-integration+consensus-timeout` branch of our fork
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-config = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-testgen = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-
-# patched to a commit on the `eth-bridge-integration` branch of our fork
-ibc = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-proto = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-relayer = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
 
 [profile.release]
 # smaller and faster wasm (https://rustwasm.github.io/book/reference/code-size.html#compiling-with-link-time-optimizations-lto)

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c#f7e59c81298c1e44dfabe1155a36ac4efdad478c"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.17.1"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c#f7e59c81298c1e44dfabe1155a36ac4efdad478c"
 dependencies = [
  "base64",
  "bytes",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ibc-relayer"
 version = "0.14.0"
-source = "git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2#f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"
+source = "git+https://github.com/heliaxdev/ibc-rs?rev=f7e59c81298c1e44dfabe1155a36ac4efdad478c#f7e59c81298c1e44dfabe1155a36ac4efdad478c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4069,7 +4069,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "tendermint-config"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "flex-error",
  "serde",
@@ -4112,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "contracts",
  "crossbeam-channel 0.4.4",
@@ -4133,7 +4133,7 @@ dependencies = [
 [[package]]
 name = "tendermint-light-client-verifier"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "bytes",
  "flex-error",
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "tendermint-testgen"
 version = "0.23.6"
-source = "git+https://github.com/heliaxdev/tendermint-rs.git?rev=e6c684731f21bffd89886d3e91074b96aee074ba#e6c684731f21bffd89886d3e91074b96aee074ba"
+source = "git+https://github.com/heliaxdev/tendermint-rs?rev=f8f019217130f36eecafac2ad11e35f5bda2ecab#f8f019217130f36eecafac2ad11e35f5bda2ecab"
 dependencies = [
  "ed25519-dalek",
  "gumdrop",

--- a/wasm_for_tests/wasm_source/Cargo.toml
+++ b/wasm_for_tests/wasm_source/Cargo.toml
@@ -37,19 +37,6 @@ borsh = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4
 borsh-derive = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 borsh-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 borsh-schema-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
-# patched to a commit on the `eth-bridge-integration+consensus-timeout` branch of our fork
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-config = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-testgen = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev = "e6c684731f21bffd89886d3e91074b96aee074ba"}
-
-# patched to a commit on the `eth-bridge-integration` branch of our fork
-ibc = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-proto = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
-ibc-relayer = {git = "https://github.com/heliaxdev/ibc-rs.git", rev = "f4703dfe2c1f25cc431279ab74f10f3e0f6827e2"}
 
 [dev-dependencies]
 namada_tests = {path = "../../tests"}


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/825

This PR:
- updates `tendermint-rs`/`ibc-rs`/`tower-abci` crates to Tendermint v0.37.0-rc1 compatible commits from `ledger-main` branches of our forks. These updated crates also work with the current Tendermint binaries we are using in CI (i.e. our Tendermint fork - https://github.com/heliaxdev/tendermint/tree/ledger-main).
- points the Docker image and `get_tendermint.sh` script to start using v0.37.0-rc1

NB: after this PR, you could patch in different `tendermint-rs`/`ibc-rs`/`tower-abci` versions like so below (e.g. to try something out, or maybe in an integration branch which uses different versions of these crates)

```toml

[patch."https://github.com/heliaxdev/tendermint-rs"]
tendermint = {git = "https://github.com/heliaxdev/tendermint-rs?branch=ledger-main", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}
tendermint-config = {git = "https://github.com/heliaxdev/tendermint-rs?branch=ledger-main", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}
tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs?branch=ledger-main", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}
tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs?branch=ledger-main", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}
tendermint-testgen = {git = "https://github.com/heliaxdev/tendermint-rs?branch=ledger-main", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}
tendermint-light-client = {git = "https://github.com/heliaxdev/tendermint-rs?branch=ledger-main", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}
tendermint-light-client-verifier = {git = "https://github.com/heliaxdev/tendermint-rs?branch=ledger-main", rev = "f8f019217130f36eecafac2ad11e35f5bda2ecab"}

[patch."https://github.com/heliaxdev/ibc-rs"]
ibc = {git = "https://github.com/heliaxdev/ibc-rs?branch=ledger-main", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c"}
ibc-proto = {git = "https://github.com/heliaxdev/ibc-rs?branch=ledger-main", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c"}
ibc-relayer = {git = "https://github.com/heliaxdev/ibc-rs?branch=ledger-main", rev = "f7e59c81298c1e44dfabe1155a36ac4efdad478c"}

[patch."https://github.com/heliaxdev/tower-abci"]
tower-abci = {git = "https://github.com/heliaxdev/tower-abci?branch=ledger-main", rev = "659d799f2a94238cd45725738624b7f51b96287f"}
```