### PR TITLE
Build Tendermint v0.37-rc1 binaries in CI

### DIFF
--- a/.changelog/unreleased/ci/839-build-tendermint-v0.37.0-rc1-ci.md
+++ b/.changelog/unreleased/ci/839-build-tendermint-v0.37.0-rc1-ci.md
@@ -1,0 +1,2 @@
+- Build an updated Tendermint binary in CI
+  ([#839](https://github.com/anoma/namada/pull/839))

--- a/.github/workflows/build-tendermint.yml
+++ b/.github/workflows/build-tendermint.yml
@@ -23,7 +23,10 @@ jobs:
         make:
           - name: tendermint-unreleased
             repository: heliaxdev/tendermint
-            tendermint_version: ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
+            tendermint_version: ad825dcadbd4b98c3f91ce5a711e4fb36a69c377  # approximately v0.1.3-abciplus
+          - name: tendermint
+            repository: tendermint/tendermint
+            tendermint_version: v0.37.0-rc1
 
     steps:
       - name: Build ${{ matrix.make.name }}


### PR DESCRIPTION
Relates to https://github.com/anoma/namada/issues/825

Builds Tendermint v0.37.0-rc1 in CI, alongside the current one. We don't run tests against this new version of Tendermint yet.