### PR TITLE
 Removed MerkleValue type.

### DIFF
--- a/shared/src/ledger/storage/merkle_tree.rs
+++ b/shared/src/ledger/storage/merkle_tree.rs
@@ -26,8 +26,7 @@ use crate::types::address::{Address, InternalAddress};
 use crate::types::hash::Hash;
 use crate::types::keccak::KeccakHash;
 use crate::types::storage::{
-    DbKeySeg, Error as StorageError, Key, MembershipProof, MerkleValue,
-    StringKey, TreeBytes,
+    DbKeySeg, Error as StorageError, Key, MembershipProof, StringKey, TreeBytes,
 };
 
 #[allow(missing_docs)]
@@ -315,9 +314,11 @@ impl<H: StorageHasher + Default> MerkleTree<H> {
         &mut self,
         store_type: &StoreType,
         key: &Key,
-        value: MerkleValue,
+        value: impl AsRef<[u8]>,
     ) -> Result<()> {
-        let sub_root = self.tree_mut(store_type).subtree_update(key, value)?;
+        let sub_root = self
+            .tree_mut(store_type)
+            .subtree_update(key, value.as_ref())?;
         // update the base tree with the updated sub root without hashing
         if *store_type != StoreType::Base {
             let base_key = H::hash(&store_type.to_string());
@@ -333,13 +334,9 @@ impl<H: StorageHasher + Default> MerkleTree<H> {
     }
 
     /// Update the tree with the given key and value
-    pub fn update(
-        &mut self,
-        key: &Key,
-        value: impl Into<MerkleValue>,
-    ) -> Result<()> {
+    pub fn update(&mut self, key: &Key, value: impl AsRef<[u8]>) -> Result<()> {
         let (store_type, sub_key) = StoreType::sub_key(key)?;
-        self.update_tree(&store_type, &sub_key, value.into())
+        self.update_tree(&store_type, &sub_key, value)
     }
 
     /// Delete the value corresponding to the given key
@@ -376,7 +373,7 @@ impl<H: StorageHasher + Default> MerkleTree<H> {
     pub fn get_sub_tree_existence_proof(
         &self,
         keys: &[Key],
-        values: Vec<MerkleValue>,
+        values: Vec<Vec<u8>>,
     ) -> Result<MembershipProof> {
         let first_key = keys.iter().next().ok_or_else(|| {
             Error::InvalidMerkleKey(
@@ -733,7 +730,7 @@ mod test {
         let proof = match tree
             .get_sub_tree_existence_proof(
                 std::array::from_ref(&ibc_key),
-                vec![ibc_val.clone().into()],
+                vec![ibc_val.clone()],
             )
             .unwrap()
         {
@@ -792,7 +789,7 @@ mod test {
         let proof = match tree
             .get_sub_tree_existence_proof(
                 std::array::from_ref(&pos_key),
-                vec![pos_val.clone().into()],
+                vec![pos_val.clone()],
             )
             .unwrap()
         {

--- a/shared/src/ledger/storage/traits.rs
+++ b/shared/src/ledger/storage/traits.rs
@@ -14,6 +14,7 @@ use super::merkle_tree::{Amt, Error, Smt};
 use super::{ics23_specs, IBC_KEY_LIMIT};
 use crate::ledger::eth_bridge::storage::bridge_pool::BridgePoolTree;
 use crate::types::eth_bridge_pool::PendingTransfer;
+use crate::ledger::storage::merkle_tree::StorageBytes;
 use crate::types::hash::Hash;
 use crate::types::storage::{Key, MembershipProof, StringKey, TreeBytes};
 
@@ -26,7 +27,7 @@ pub trait SubTreeRead {
     fn subtree_membership_proof(
         &self,
         keys: &[Key],
-        values: Vec<Vec<u8>>,
+        values: Vec<StorageBytes>,
     ) -> Result<MembershipProof, Error>;
 }
 
@@ -54,7 +55,7 @@ impl<'a, H: StorageHasher + Default> SubTreeRead for &'a Smt<H> {
     fn subtree_membership_proof(
         &self,
         keys: &[Key],
-        mut values: Vec<Vec<u8>>,
+        mut values: Vec<StorageBytes>,
     ) -> Result<MembershipProof, Error> {
         if keys.len() != 1 || values.len() != 1 {
             return Err(Error::Ics23MultiLeaf);
@@ -111,7 +112,7 @@ impl<'a, H: StorageHasher + Default> SubTreeRead for &'a Amt<H> {
     fn subtree_membership_proof(
         &self,
         keys: &[Key],
-        _: Vec<Vec<u8>>,
+        _: Vec<StorageBytes>,
     ) -> Result<MembershipProof, Error> {
         if keys.len() != 1 {
             return Err(Error::Ics23MultiLeaf);
@@ -165,7 +166,7 @@ impl<'a> SubTreeRead for &'a BridgePoolTree {
     fn subtree_membership_proof(
         &self,
         _: &[Key],
-        values: Vec<Vec<u8>>,
+        values: Vec<StorageBytes>,
     ) -> Result<MembershipProof, Error> {
         let values = values
             .iter()

--- a/shared/src/ledger/storage/traits.rs
+++ b/shared/src/ledger/storage/traits.rs
@@ -13,8 +13,8 @@ use sha2::{Digest, Sha256};
 use super::merkle_tree::{Amt, Error, Smt};
 use super::{ics23_specs, IBC_KEY_LIMIT};
 use crate::ledger::eth_bridge::storage::bridge_pool::BridgePoolTree;
-use crate::types::eth_bridge_pool::PendingTransfer;
 use crate::ledger::storage::merkle_tree::StorageBytes;
+use crate::types::eth_bridge_pool::PendingTransfer;
 use crate::types::hash::Hash;
 use crate::types::storage::{Key, MembershipProof, StringKey, TreeBytes};
 

--- a/shared/src/ledger/storage/traits.rs
+++ b/shared/src/ledger/storage/traits.rs
@@ -5,6 +5,7 @@ use std::fmt;
 
 use arse_merkle_tree::traits::{Hasher, Value};
 use arse_merkle_tree::{Key as TreeKey, H256};
+use borsh::BorshDeserialize;
 use ics23::commitment_proof::Proof as Ics23Proof;
 use ics23::{CommitmentProof, ExistenceProof};
 use sha2::{Digest, Sha256};
@@ -12,10 +13,9 @@ use sha2::{Digest, Sha256};
 use super::merkle_tree::{Amt, Error, Smt};
 use super::{ics23_specs, IBC_KEY_LIMIT};
 use crate::ledger::eth_bridge::storage::bridge_pool::BridgePoolTree;
+use crate::types::eth_bridge_pool::PendingTransfer;
 use crate::types::hash::Hash;
-use crate::types::storage::{
-    Key, MembershipProof, MerkleValue, StringKey, TreeBytes,
-};
+use crate::types::storage::{Key, MembershipProof, StringKey, TreeBytes};
 
 /// Trait for reading from a merkle tree that is a sub-tree
 /// of the global merkle tree.
@@ -26,7 +26,7 @@ pub trait SubTreeRead {
     fn subtree_membership_proof(
         &self,
         keys: &[Key],
-        values: Vec<MerkleValue>,
+        values: Vec<Vec<u8>>,
     ) -> Result<MembershipProof, Error>;
 }
 
@@ -37,7 +37,7 @@ pub trait SubTreeWrite {
     fn subtree_update(
         &mut self,
         key: &Key,
-        value: MerkleValue,
+        value: &[u8],
     ) -> Result<Hash, Error>;
     /// Delete a key from the sub-tree
     fn subtree_delete(&mut self, key: &Key) -> Result<Hash, Error>;
@@ -54,16 +54,13 @@ impl<'a, H: StorageHasher + Default> SubTreeRead for &'a Smt<H> {
     fn subtree_membership_proof(
         &self,
         keys: &[Key],
-        mut values: Vec<MerkleValue>,
+        mut values: Vec<Vec<u8>>,
     ) -> Result<MembershipProof, Error> {
         if keys.len() != 1 || values.len() != 1 {
             return Err(Error::Ics23MultiLeaf);
         }
         let key: &Key = &keys[0];
-        let value = match values.remove(0) {
-            MerkleValue::Bytes(b) => b,
-            _ => return Err(Error::InvalidValue),
-        };
+        let value = values.remove(0);
         let cp = self.membership_proof(&H::hash(key.to_string()).into())?;
         // Replace the values and the leaf op for the verification
         match cp.proof.expect("The proof should exist") {
@@ -86,12 +83,9 @@ impl<'a, H: StorageHasher + Default> SubTreeWrite for &'a mut Smt<H> {
     fn subtree_update(
         &mut self,
         key: &Key,
-        value: MerkleValue,
+        value: &[u8],
     ) -> Result<Hash, Error> {
-        let value = match value {
-            MerkleValue::Bytes(bytes) => H::hash(bytes.as_slice()),
-            _ => return Err(Error::InvalidValue),
-        };
+        let value = H::hash(value);
         self.update(H::hash(key.to_string()).into(), value.into())
             .map(Hash::from)
             .map_err(|err| Error::MerkleTree(err.to_string()))
@@ -117,7 +111,7 @@ impl<'a, H: StorageHasher + Default> SubTreeRead for &'a Amt<H> {
     fn subtree_membership_proof(
         &self,
         keys: &[Key],
-        _: Vec<MerkleValue>,
+        _: Vec<Vec<u8>>,
     ) -> Result<MembershipProof, Error> {
         if keys.len() != 1 {
             return Err(Error::Ics23MultiLeaf);
@@ -144,13 +138,10 @@ impl<'a, H: StorageHasher + Default> SubTreeWrite for &'a mut Amt<H> {
     fn subtree_update(
         &mut self,
         key: &Key,
-        value: MerkleValue,
+        value: &[u8],
     ) -> Result<Hash, Error> {
         let key = StringKey::try_from_bytes(key.to_string().as_bytes())?;
-        let value = match value {
-            MerkleValue::Bytes(bytes) => TreeBytes::from(bytes),
-            _ => return Err(Error::InvalidValue),
-        };
+        let value = TreeBytes::from(value.as_ref().to_owned());
         self.update(key, value)
             .map(Into::into)
             .map_err(|err| Error::MerkleTree(err.to_string()))
@@ -174,13 +165,12 @@ impl<'a> SubTreeRead for &'a BridgePoolTree {
     fn subtree_membership_proof(
         &self,
         _: &[Key],
-        values: Vec<MerkleValue>,
+        values: Vec<Vec<u8>>,
     ) -> Result<MembershipProof, Error> {
         let values = values
-            .into_iter()
-            .filter_map(|val| match val {
-                MerkleValue::BridgePoolTransfer(transfer) => Some(transfer),
-                _ => None,
+            .iter()
+            .filter_map(|val| {
+                PendingTransfer::try_from_slice(val.as_slice()).ok()
             })
             .collect();
         self.get_membership_proof(values)
@@ -190,17 +180,9 @@ impl<'a> SubTreeRead for &'a BridgePoolTree {
 }
 
 impl<'a> SubTreeWrite for &'a mut BridgePoolTree {
-    fn subtree_update(
-        &mut self,
-        key: &Key,
-        value: MerkleValue,
-    ) -> Result<Hash, Error> {
-        if let MerkleValue::BridgePoolTransfer(_) = value {
-            self.insert_key(key)
-                .map_err(|err| Error::MerkleTree(err.to_string()))
-        } else {
-            Err(Error::InvalidValue)
-        }
+    fn subtree_update(&mut self, key: &Key, _: &[u8]) -> Result<Hash, Error> {
+        self.insert_key(key)
+            .map_err(|err| Error::MerkleTree(err.to_string()))
     }
 
     fn subtree_delete(&mut self, key: &Key) -> Result<Hash, Error> {

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -20,7 +20,6 @@ use crate::bytes::ByteBuf;
 use crate::ledger::eth_bridge::storage::bridge_pool::BridgePoolProof;
 use crate::ledger::storage::IBC_KEY_LIMIT;
 use crate::types::address::{self, Address};
-use crate::types::eth_bridge_pool::PendingTransfer;
 use crate::types::hash::Hash;
 use crate::types::keccak::{KeccakHash, TryFromError};
 use crate::types::time::DateTimeUtc;
@@ -345,48 +344,6 @@ impl FromStr for Key {
 
     fn from_str(s: &str) -> Result<Self> {
         Key::parse(s)
-    }
-}
-
-/// An enum representing the different types of values
-/// that can be passed into Anoma's storage.
-///
-/// This is a multi-store organized as
-/// several Merkle trees, each of which is
-/// responsible for understanding how to parse
-/// this value.
-#[derive(Debug, Clone)]
-pub enum MerkleValue {
-    /// raw bytes
-    Bytes(Vec<u8>),
-    /// A transfer to be put in the Ethereum bridge pool.
-    BridgePoolTransfer(PendingTransfer),
-}
-
-impl<T> From<T> for MerkleValue
-where
-    T: AsRef<[u8]>,
-{
-    fn from(bytes: T) -> Self {
-        Self::Bytes(bytes.as_ref().to_owned())
-    }
-}
-
-impl From<PendingTransfer> for MerkleValue {
-    fn from(transfer: PendingTransfer) -> Self {
-        Self::BridgePoolTransfer(transfer)
-    }
-}
-
-impl MerkleValue {
-    /// Get the natural byte representation of the value
-    pub fn to_bytes(self) -> Vec<u8> {
-        match self {
-            Self::Bytes(bytes) => bytes,
-            Self::BridgePoolTransfer(transfer) => {
-                transfer.try_to_vec().unwrap()
-            }
-        }
     }
 }
 


### PR DESCRIPTION
The design of the merkle tree is that each subtree should handle it's own particulars and the top level storage should be unaware of these details. The MerkleValue type violated this principal by requiring top level storage to correctly cast values to the right type which would then be checked by the sub-trees. This caused bugs and made strained the storage API. This PR removes this type.

PR #846 is the corresponding PR to main.