### PR TITLE
Removed MerkleValue type

### DIFF
--- a/shared/src/ledger/queries/shell.rs
+++ b/shared/src/ledger/queries/shell.rs
@@ -207,7 +207,7 @@ where
                     .storage
                     .get_existence_proof(
                         &storage_key,
-                        value.clone().into(),
+                        value.clone(),
                         request.height,
                     )
                     .into_storage_result()?;
@@ -264,7 +264,7 @@ where
         for PrefixValue { key, value } in &data {
             let mut proof = ctx
                 .storage
-                .get_existence_proof(key, value.clone().into(), request.height)
+                .get_existence_proof(key, value.clone(), request.height)
                 .into_storage_result()?;
             ops.append(&mut proof.ops);
         }

--- a/shared/src/ledger/storage/merkle_tree.rs
+++ b/shared/src/ledger/storage/merkle_tree.rs
@@ -22,8 +22,7 @@ use crate::tendermint::merkle::proof::{Proof, ProofOp};
 use crate::types::address::{Address, InternalAddress};
 use crate::types::hash::Hash;
 use crate::types::storage::{
-    DbKeySeg, Error as StorageError, Key, MembershipProof, MerkleValue,
-    StringKey, TreeBytes,
+    DbKeySeg, Error as StorageError, Key, MembershipProof, StringKey, TreeBytes,
 };
 
 #[allow(missing_docs)]
@@ -51,6 +50,9 @@ pub enum Error {
 
 /// Result for functions that may fail
 type Result<T> = std::result::Result<T, Error>;
+
+/// Type alias for bytes to be put into the Merkle storage
+pub(super) type StorageBytes = Vec<u8>;
 
 /// Type aliases for the different merkle trees and backing stores
 pub type SmtStore = DefaultStore<SmtHash, Hash, 32>;
@@ -278,9 +280,11 @@ impl<H: StorageHasher + Default> MerkleTree<H> {
         &mut self,
         store_type: &StoreType,
         key: &Key,
-        value: MerkleValue,
+        value: impl AsRef<[u8]>,
     ) -> Result<()> {
-        let sub_root = self.tree_mut(store_type).subtree_update(key, value)?;
+        let sub_root = self
+            .tree_mut(store_type)
+            .subtree_update(key, value.as_ref())?;
         // update the base tree with the updated sub root without hashing
         if *store_type != StoreType::Base {
             let base_key = H::hash(store_type.to_string());
@@ -296,13 +300,9 @@ impl<H: StorageHasher + Default> MerkleTree<H> {
     }
 
     /// Update the tree with the given key and value
-    pub fn update(
-        &mut self,
-        key: &Key,
-        value: impl Into<MerkleValue>,
-    ) -> Result<()> {
+    pub fn update(&mut self, key: &Key, value: impl AsRef<[u8]>) -> Result<()> {
         let (store_type, sub_key) = StoreType::sub_key(key)?;
-        self.update_tree(&store_type, &sub_key, value.into())
+        self.update_tree(&store_type, &sub_key, value)
     }
 
     /// Delete the value corresponding to the given key
@@ -335,7 +335,7 @@ impl<H: StorageHasher + Default> MerkleTree<H> {
     pub fn get_sub_tree_existence_proof(
         &self,
         keys: &[Key],
-        values: Vec<MerkleValue>,
+        values: Vec<StorageBytes>,
     ) -> Result<MembershipProof> {
         let first_key = keys.iter().next().ok_or_else(|| {
             Error::InvalidMerkleKey(
@@ -675,7 +675,7 @@ mod test {
         let MembershipProof::ICS23(proof) = tree
             .get_sub_tree_existence_proof(
                 std::array::from_ref(&ibc_key),
-                vec![ibc_val.clone().into()],
+                vec![ibc_val.clone()],
             )
             .unwrap();
         let proof = tree.get_tendermint_proof(&ibc_key, proof).unwrap();
@@ -730,7 +730,7 @@ mod test {
         let MembershipProof::ICS23(proof) = tree
             .get_sub_tree_existence_proof(
                 std::array::from_ref(&pos_key),
-                vec![pos_val.clone().into()],
+                vec![pos_val.clone()],
             )
             .unwrap();
         let proof = tree.get_tendermint_proof(&pos_key, proof).unwrap();

--- a/shared/src/ledger/storage/mod.rs
+++ b/shared/src/ledger/storage/mod.rs
@@ -46,7 +46,7 @@ use crate::types::chain::{ChainId, CHAIN_ID_LENGTH};
 use crate::types::storage::TxQueue;
 use crate::types::storage::{
     BlockHash, BlockHeight, BlockResults, Epoch, Epochs, Header, Key, KeySeg,
-    MembershipProof, MerkleValue, TxIndex, BLOCK_HASH_LENGTH,
+    MembershipProof, TxIndex, BLOCK_HASH_LENGTH,
 };
 use crate::types::time::DateTimeUtc;
 use crate::types::token;
@@ -625,7 +625,7 @@ where
     pub fn get_existence_proof(
         &self,
         key: &Key,
-        value: MerkleValue,
+        value: Vec<u8>,
         height: BlockHeight,
     ) -> Result<Proof> {
         if height >= self.get_block_height().0 {

--- a/shared/src/ledger/storage/traits.rs
+++ b/shared/src/ledger/storage/traits.rs
@@ -8,13 +8,12 @@ use arse_merkle_tree::{Key as TreeKey, H256};
 use ics23::commitment_proof::Proof as Ics23Proof;
 use ics23::{CommitmentProof, ExistenceProof};
 use sha2::{Digest, Sha256};
+use crate::ledger::storage::merkle_tree::StorageBytes;
 
 use super::merkle_tree::{Amt, Error, Smt};
 use super::{ics23_specs, IBC_KEY_LIMIT};
 use crate::types::hash::Hash;
-use crate::types::storage::{
-    Key, MembershipProof, MerkleValue, StringKey, TreeBytes,
-};
+use crate::types::storage::{Key, MembershipProof, StringKey, TreeBytes};
 
 /// Trait for reading from a merkle tree that is a sub-tree
 /// of the global merkle tree.
@@ -25,7 +24,7 @@ pub trait SubTreeRead {
     fn subtree_membership_proof(
         &self,
         keys: &[Key],
-        values: Vec<MerkleValue>,
+        values: Vec<StorageBytes>,
     ) -> Result<MembershipProof, Error>;
 }
 
@@ -36,7 +35,7 @@ pub trait SubTreeWrite {
     fn subtree_update(
         &mut self,
         key: &Key,
-        value: MerkleValue,
+        value: &[u8],
     ) -> Result<Hash, Error>;
     /// Delete a key from the sub-tree
     fn subtree_delete(&mut self, key: &Key) -> Result<Hash, Error>;
@@ -53,13 +52,13 @@ impl<'a, H: StorageHasher + Default> SubTreeRead for &'a Smt<H> {
     fn subtree_membership_proof(
         &self,
         keys: &[Key],
-        mut values: Vec<MerkleValue>,
+        mut values: Vec<StorageBytes>,
     ) -> Result<MembershipProof, Error> {
         if keys.len() != 1 || values.len() != 1 {
             return Err(Error::Ics23MultiLeaf);
         }
         let key: &Key = &keys[0];
-        let MerkleValue::Bytes(value) = values.remove(0);
+        let value = values.remove(0);
         let cp = self.membership_proof(&H::hash(key.to_string()).into())?;
         // Replace the values and the leaf op for the verification
         match cp.proof.expect("The proof should exist") {
@@ -82,11 +81,9 @@ impl<'a, H: StorageHasher + Default> SubTreeWrite for &'a mut Smt<H> {
     fn subtree_update(
         &mut self,
         key: &Key,
-        value: MerkleValue,
+        value: &[u8],
     ) -> Result<Hash, Error> {
-        let value = match value {
-            MerkleValue::Bytes(bytes) => H::hash(bytes.as_slice()),
-        };
+        let value = H::hash(value);
         self.update(H::hash(key.to_string()).into(), value.into())
             .map(Hash::from)
             .map_err(|err| Error::MerkleTree(err.to_string()))
@@ -112,7 +109,7 @@ impl<'a, H: StorageHasher + Default> SubTreeRead for &'a Amt<H> {
     fn subtree_membership_proof(
         &self,
         keys: &[Key],
-        _: Vec<MerkleValue>,
+        _: Vec<StorageBytes>,
     ) -> Result<MembershipProof, Error> {
         if keys.len() != 1 {
             return Err(Error::Ics23MultiLeaf);
@@ -139,12 +136,10 @@ impl<'a, H: StorageHasher + Default> SubTreeWrite for &'a mut Amt<H> {
     fn subtree_update(
         &mut self,
         key: &Key,
-        value: MerkleValue,
+        value: &[u8],
     ) -> Result<Hash, Error> {
         let key = StringKey::try_from_bytes(key.to_string().as_bytes())?;
-        let value = match value {
-            MerkleValue::Bytes(bytes) => TreeBytes::from(bytes),
-        };
+        let value = TreeBytes::from(value.as_ref().to_owned());
         self.update(key, value)
             .map(Into::into)
             .map_err(|err| Error::MerkleTree(err.to_string()))

--- a/shared/src/types/storage.rs
+++ b/shared/src/types/storage.rs
@@ -356,27 +356,6 @@ impl FromStr for Key {
     }
 }
 
-/// An enum representing the different types of values
-/// that can be passed into Anoma's storage.
-///
-/// This is a multi-store organized as
-/// several Merkle trees, each of which is
-/// responsible for understanding how to parse
-/// this value.
-pub enum MerkleValue {
-    /// raw bytes
-    Bytes(Vec<u8>),
-}
-
-impl<T> From<T> for MerkleValue
-where
-    T: AsRef<[u8]>,
-{
-    fn from(bytes: T) -> Self {
-        Self::Bytes(bytes.as_ref().to_owned())
-    }
-}
-
 /// Storage keys that are utf8 encoded strings
 #[derive(Eq, PartialEq, Copy, Clone, Hash)]
 pub struct StringKey {


### PR DESCRIPTION
The design of the merkle tree is that each subtree should handle it's own particulars and the top level storage should be unaware of these details. The MerkleValue type violated this principal by requiring top level storage to correctly cast values to the right type which would then be checked by the sub-trees. This caused bugs and made strained the storage API. This PR removes this type.