### PR TITLE
do not try to reveal MASP sentinel key used for shielded txs

### DIFF
--- a/apps/src/lib/client/signing.rs
+++ b/apps/src/lib/client/signing.rs
@@ -3,7 +3,7 @@
 
 use borsh::BorshSerialize;
 use namada::proto::Tx;
-use namada::types::address::{Address, ImplicitAddress};
+use namada::types::address::{masp_tx_key, Address, ImplicitAddress};
 use namada::types::key::*;
 use namada::types::storage::Epoch;
 use namada::types::transaction::{hash_tx, Fee, WrapperTx};
@@ -120,7 +120,10 @@ pub async fn tx_signer(
         TxSigningKey::SecretKey(signing_key) => {
             // Check if the signing key needs to reveal its PK first
             let pk: common::PublicKey = signing_key.ref_to();
-            super::tx::reveal_pk_if_needed(ctx, &pk, args).await;
+            // Do not try to reveal MASP sentinel key
+            if masp_tx_key().ref_to() != pk {
+                super::tx::reveal_pk_if_needed(ctx, &pk, args).await;
+            }
             signing_key
         }
         TxSigningKey::None => {

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -1648,8 +1648,7 @@ pub async fn submit_transfer(mut ctx: Context, args: args::TxTransfer) {
         .expect("Encoding tx data shouldn't fail");
 
     let tx = Tx::new(tx_code, Some(data));
-    let signing_address = TxSigningKey::WalletAddress(args.source.to_address());
-    process_tx(ctx, &args.tx, tx, signing_address).await;
+    process_tx(ctx, &args.tx, tx, default_signer).await;
 }
 
 pub async fn submit_ibc_transfer(ctx: Context, args: args::TxIbcTransfer) {


### PR DESCRIPTION
Implicit accounts auto-reveal is interacting badly with the masp sentinel key (masp_tx_key) - a tx from shielded address tries to auto-reveal the PK for this key when it calls `fn tx_signer`, which fails with e.g.:

```
Submitting a tx to reveal the public key for address atest1d9khqw36xvcnswzzx4p5zvpkxfp5vd3hxaznz33jxv6yyvfcx9rrjwp5gse5gd348ycny3zrt9hd7k...
Unable to load the keypair from the wallet for the implicit address atest1d9khqw36xvcnswzzx4p5zvpkxfp5vd3hxaznz33jxv6yyvfcx9rrjwp5gse5gd348ycny3zrt9hd7k. Failed with: No matching key found
```

This PR skips auto-reveal for the sentinel key.