### PR TITLE
Ensure minimum confirmations are enforced for pending Ethereum events

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/events.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/events.rs
@@ -126,7 +126,8 @@ pub mod eth_events {
             match signature {
                 signatures::TRANSFER_TO_NAMADA_SIG => {
                     RawTransfersToNamada::decode(data).map(|txs| PendingEvent {
-                        confirmations: txs.confirmations.into(),
+                        confirmations: min_confirmations
+                            .max(txs.confirmations.into()),
                         block_height,
                         event: EthereumEvent::TransfersToNamada {
                             nonce: txs.nonce,
@@ -137,7 +138,8 @@ pub mod eth_events {
                 signatures::TRANSFER_TO_ETHEREUM_SIG => {
                     RawTransfersToEthereum::decode(data).map(|txs| {
                         PendingEvent {
-                            confirmations: txs.confirmations.into(),
+                            confirmations: min_confirmations
+                                .max(txs.confirmations.into()),
                             block_height,
                             event: EthereumEvent::TransfersToEthereum {
                                 nonce: txs.nonce,

--- a/apps/src/lib/node/ledger/ethereum_node/events.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/events.rs
@@ -807,7 +807,7 @@ pub mod eth_events {
         /// Test that for Ethereum events for which a custom number of
         /// confirmations may be specified, if a value lower than the
         /// protocol-specified minimum confirmations is attempted to be used,
-        /// then the protcol-specified minimum confirmations is used instead.
+        /// then the protocol-specified minimum confirmations is used instead.
         #[test]
         fn test_min_confirmations_enforced() -> Result<()> {
             let arbitrary_block_height: Uint256 = 123u64.into();


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/598

This PR makes sure that when building a `PendingTransfer` from a`RawTransfersToNamada` or`RawTransfersToEthereum` event, if the custom confirmations specified is less than (the protocol specified) `min_confirmations`, then `min_confirmations` is used instead.