### PR TITLE
Reduce serialized size of `BlockResults`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "index-set"
+version = "0.7.1"
+source = "git+https://github.com/heliaxdev/index-set?tag=v0.7.1#dc24cdbbe3664514d59f1a4c4031863fc565f1c2"
+dependencies = [
+ "borsh",
+ "serde 1.0.147",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3777,7 +3786,6 @@ dependencies = [
  "assert_matches",
  "bech32",
  "bellman",
- "bit-vec",
  "borsh",
  "chrono",
  "data-encoding",
@@ -3791,6 +3799,7 @@ dependencies = [
  "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs?rev=9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d)",
  "ibc-proto 0.17.1 (git+https://github.com/heliaxdev/ibc-rs.git?rev=f4703dfe2c1f25cc431279ab74f10f3e0f6827e2)",
  "ics23",
+ "index-set",
  "itertools",
  "libsecp256k1",
  "masp_primitives",

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -52,7 +52,7 @@ where
         }
 
         // Tracks the accepted transactions
-        self.storage.block.results = BlockResults::with_len(req.txs.len());
+        self.storage.block.results = BlockResults::default();
         for (tx_index, processed_tx) in req.txs.iter().enumerate() {
             let tx = if let Ok(tx) = Tx::try_from(processed_tx.tx.as_ref()) {
                 tx

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -60,7 +60,6 @@ ark-serialize = {version = "0.3"}
 arse-merkle-tree = {package = "sparse-merkle-tree", git = "https://github.com/heliaxdev/sparse-merkle-tree", rev = "04ad1eeb28901b57a7599bbe433b3822965dabe8", default-features = false, features = ["std", "borsh"]}
 bech32 = "0.8.0"
 bellman = "0.11.2"
-bit-vec = "0.6.3"
 borsh = "0.9.0"
 chrono = {version = "0.4.22", default-features = false, features = ["clock", "std"]}
 data-encoding = "2.3.2"
@@ -75,6 +74,7 @@ ibc-proto = {version = "0.17.1", default-features = false, optional = true}
 ibc-abcipp = {package = "ibc", git = "https://github.com/heliaxdev/ibc-rs", rev = "9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d", default-features = false, optional = true}
 ibc-proto-abcipp = {package = "ibc-proto", git = "https://github.com/heliaxdev/ibc-rs", rev = "9fcc1c8c19db6af50806ffe5b2f6c214adcbfd5d", default-features = false, optional = true}
 ics23 = "0.7.0"
+index-set = {git = "https://github.com/heliaxdev/index-set", tag = "v0.7.1", features = ["serialize-borsh", "serialize-serde"]}
 itertools = "0.10.0"
 libsecp256k1 = {git = "https://github.com/heliaxdev/libsecp256k1", rev = "bbb3bd44a49db361f21d9db80f9a087c194c0ae9", default-features = false, features = ["std", "static-context"]}
 masp_primitives = { git = "https://github.com/anoma/masp", rev = "bee40fc465f6afbd10558d12fe96eb1742eee45c" }

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -8,10 +8,10 @@ use std::str::FromStr;
 
 use arse_merkle_tree::traits::Value;
 use arse_merkle_tree::{InternalKey, Key as TreeKey};
-use bit_vec::BitVec;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use data_encoding::BASE32HEX_NOPAD;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use index_set::vec::VecIndexSet;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::bytes::ByteBuf;
@@ -92,24 +92,8 @@ impl From<TxIndex> for u32 {
     }
 }
 
-fn serialize_bitvec<S>(x: &BitVec, s: S) -> std::result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    Serialize::serialize(&x.to_bytes(), s)
-}
-
-fn deserialize_bitvec<'de, D>(
-    deserializer: D,
-) -> std::result::Result<BitVec, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: Vec<u8> = Deserialize::deserialize(deserializer)?;
-    Ok(BitVec::from_bytes(&s))
-}
-
-/// Represents the accepted transactions in a block
+/// Represents the indices of the accepted transactions
+/// in a block.
 #[derive(
     Clone,
     PartialEq,
@@ -120,46 +104,36 @@ where
     Debug,
     Serialize,
     Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
     Default,
 )]
-pub struct BlockResults(
-    #[serde(serialize_with = "serialize_bitvec")]
-    #[serde(deserialize_with = "deserialize_bitvec")]
-    BitVec,
-);
+pub struct BlockResults(VecIndexSet<u128>);
 
 impl BlockResults {
-    /// Create `len` rejection results
-    pub fn with_len(len: usize) -> Self {
-        BlockResults(BitVec::from_elem(len, true))
+    /// Accept the tx at the given position.
+    #[inline]
+    pub fn accept(&mut self, index: usize) {
+        self.0.remove(index)
     }
 
-    /// Accept the tx at the given position
-    pub fn accept(&mut self, idx: usize) {
-        self.0.set(idx, false)
+    /// Reject the tx at the given position.
+    #[inline]
+    pub fn reject(&mut self, index: usize) {
+        self.0.insert(index)
     }
 
-    /// Reject the tx at the given position
-    pub fn reject(&mut self, idx: usize) {
-        self.0.set(idx, true)
+    /// Check if the tx at the given position is accepted.
+    #[inline]
+    pub fn is_accepted(&self, index: usize) -> bool {
+        !self.0.contains(index)
     }
 
-    /// Check if the tx at the given position is accepted
-    pub fn is_accepted(&self, idx: usize) -> bool {
-        !self.0[idx]
-    }
-}
-
-impl BorshSerialize for BlockResults {
-    fn serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        BorshSerialize::serialize(&self.0.to_bytes(), writer)
-    }
-}
-
-impl BorshDeserialize for BlockResults {
-    fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
-        let vec: Vec<_> = BorshDeserialize::deserialize(buf)?;
-        Ok(Self(BitVec::from_bytes(&vec)))
+    /// Return an iterator over the removed txs
+    /// in this [`BlockResults`] instance.
+    #[inline]
+    pub fn iter_removed(&self) -> impl Iterator<Item = usize> + '_ {
+        self.0.iter()
     }
 }
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2048,6 +2048,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "index-set"
+version = "0.7.1"
+source = "git+https://github.com/heliaxdev/index-set?tag=v0.7.1#dc24cdbbe3664514d59f1a4c4031863fc565f1c2"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,7 +2506,6 @@ dependencies = [
  "ark-serialize",
  "bech32",
  "bellman",
- "bit-vec",
  "borsh",
  "chrono",
  "data-encoding",
@@ -2507,6 +2515,7 @@ dependencies = [
  "ibc",
  "ibc-proto",
  "ics23",
+ "index-set",
  "itertools",
  "libsecp256k1",
  "masp_primitives",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -2048,6 +2048,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "index-set"
+version = "0.7.1"
+source = "git+https://github.com/heliaxdev/index-set?tag=v0.7.1#dc24cdbbe3664514d59f1a4c4031863fc565f1c2"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,7 +2506,6 @@ dependencies = [
  "ark-serialize",
  "bech32",
  "bellman",
- "bit-vec",
  "borsh",
  "chrono",
  "data-encoding",
@@ -2507,6 +2515,7 @@ dependencies = [
  "ibc",
  "ibc-proto",
  "ics23",
+ "index-set",
  "itertools",
  "libsecp256k1",
  "masp_primitives",


### PR DESCRIPTION
We replace `bit-vec` with the index set implementations in https://github.com/heliaxdev/index-set, with the goal of reducing the serialized size (in bytes) of `BlockResults` instances. The representation of `index_set::vec::VecIndexSet` is more compact than the bit vector implementation we previously depended on.