### PR TITLE
Add extra `CheckTx` validation

### DIFF
--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -695,6 +695,8 @@ where
     /// Validate a transaction request. On success, the transaction will
     /// included in the mempool and propagated to peers, otherwise it will be
     /// rejected.
+    // TODO: move this to another file after 0.11 merges,
+    // since this method has become fairly large at this point
     pub fn mempool_validate(
         &self,
         tx_bytes: &[u8],

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -737,6 +737,9 @@ where
                             self.storage.last_height,
                         ) {
                             response.log = String::from(VALID_MSG);
+                            // validator set update votes should be decided
+                            // as soon as possible
+                            response.priority = i64::MAX;
                         } else {
                             response.code = 1;
                             response.log = String::from(

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -724,8 +724,9 @@ where
                             response.log = String::from(VALID_MSG);
                         } else {
                             response.code = 1;
-                            response.log = String::from(
-                                "Invalid Ethereum events vote extension",
+                            response.log = format!(
+                                "{INVALID_MSG}: Invalid Ethereum events vote \
+                                 extension",
                             );
                         }
                     }
@@ -744,16 +745,17 @@ where
                             response.priority = i64::MAX;
                         } else {
                             response.code = 1;
-                            response.log = String::from(
-                                "Invalid validator set update vote extension",
+                            response.log = format!(
+                                "{INVALID_MSG}: Invalid validator set update \
+                                 vote extension",
                             );
                         }
                     }
                     Ok(TxType::Protocol(ProtocolTx { tx, .. })) => {
                         response.code = 1;
                         response.log = format!(
-                            "The following protocol tx cannot be added to the \
-                             mempool: {tx:?}"
+                            "{INVALID_MSG}: The following protocol tx cannot \
+                             be added to the mempool: {tx:?}"
                         );
                     }
                     Ok(TxType::Wrapper(_) | TxType::Raw(_)) => {
@@ -774,7 +776,7 @@ where
             }
             Err(msg) => {
                 response.code = 1;
-                response.log = msg.to_string();
+                response.log = format!("{INVALID_MSG}: {msg}");
             }
         }
 

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -758,8 +758,15 @@ where
                              be added to the mempool: {tx:?}"
                         );
                     }
-                    Ok(TxType::Wrapper(_) | TxType::Raw(_)) => {
+                    Ok(TxType::Wrapper(_)) => {
                         response.log = String::from(VALID_MSG);
+                    }
+                    Ok(TxType::Raw(_)) => {
+                        response.code = 1;
+                        response.log = format!(
+                            "{INVALID_MSG}: Raw transactions cannot be \
+                             accepted into the mempool"
+                        );
                     }
                     Ok(TxType::Decrypted(_)) => {
                         response.code = 1;

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -33,6 +33,7 @@ where
     ///  * There are no duplicate Ethereum events in this vote extension, and
     ///    the events are sorted in ascending order.
     #[inline]
+    #[allow(dead_code)]
     pub fn validate_eth_events_vext(
         &self,
         ext: Signed<ethereum_events::Vext>,

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -34,6 +34,7 @@ where
     ///  * The voting powers are normalized to `2^32`, and sorted in descending
     ///    order.
     #[inline]
+    #[allow(dead_code)]
     pub fn validate_valset_upd_vext(
         &self,
         ext: validator_set_update::SignedVext,


### PR DESCRIPTION
Partially resolve https://github.com/anoma/namada/issues/367

We check if:

1) A transaction is successfully validated by `process_tx`.
2) A transaction is not a decrypted tx, because these can only be crafted by block proposers.

We are not charging base fees to invalid encrypted txs, yet. This needs to be specced out, first.