### PR TITLE
Start running CI against Tendermint v0.37.0-rc1

### DIFF
--- a/.changelog/unreleased/ci/872-run-tendermint-v0.37.0-rc1-ci.md
+++ b/.changelog/unreleased/ci/872-run-tendermint-v0.37.0-rc1-ci.md
@@ -1,0 +1,2 @@
+- Use an updated Tendermint binary in CI
+  ([#872](https://github.com/anoma/namada/pull/872))

--- a/.github/workflows/build-and-test-bridge.yml
+++ b/.github/workflows/build-and-test-bridge.yml
@@ -151,7 +151,7 @@ jobs:
             suffix: ''
             cache_key: namada
             cache_version: v2
-            tendermint_artifact: tendermint-unreleased-ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
+            tendermint_artifact: tendermint-v0.37.0-rc1
 
     env:
       CARGO_INCREMENTAL: 0
@@ -357,14 +357,14 @@ jobs:
             index: 0
             cache_key: namada
             cache_version: v2
-            tendermint_artifact: tendermint-unreleased-ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
+            tendermint_artifact: tendermint-v0.37.0-rc1
             wait_for: namada-release-eth (ubuntu-20.04, 1.7.0, ABCI Release build, namada-e2e-release, v2)
           - name: e2e
             suffix: ''
             index: 1
             cache_key: namada
             cache_version: v2
-            tendermint_artifact: tendermint-unreleased-ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
+            tendermint_artifact: tendermint-v0.37.0-rc1
             wait_for: namada-release-eth (ubuntu-20.04, 1.7.0, ABCI Release build, namada-e2e-release, v2)
 
     env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -153,7 +153,7 @@ jobs:
             suffix: ''
             cache_key: namada
             cache_version: v2
-            tendermint_artifact: tendermint-unreleased-ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
+            tendermint_artifact: tendermint-v0.37.0-rc1
 
     env:
       CARGO_INCREMENTAL: 0
@@ -359,14 +359,14 @@ jobs:
             index: 0
             cache_key: namada
             cache_version: v2
-            tendermint_artifact: tendermint-unreleased-ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
+            tendermint_artifact: tendermint-v0.37.0-rc1
             wait_for: namada-release (ubuntu-20.04, 1.7.0, ABCI Release build, namada-e2e-release, v2)
           - name: e2e
             suffix: ''
             index: 1
             cache_key: namada
             cache_version: v2
-            tendermint_artifact: tendermint-unreleased-ad825dcadbd4b98c3f91ce5a711e4fb36a69c377
+            tendermint_artifact: tendermint-v0.37.0-rc1
             wait_for: namada-release (ubuntu-20.04, 1.7.0, ABCI Release build, namada-e2e-release, v2)
 
     env:


### PR DESCRIPTION
Merging this PR should close https://github.com/anoma/namada/issues/825

Depends on https://github.com/anoma/namada/pull/838 and https://github.com/anoma/namada/pull/839 - those PRs must be merged first, and the new Tendermint binary already built and available in CI

This PR makes it so that we start using our updated Tendermint fork in CI when running tests