### PR TITLE
test/core: run less cases on `update_epoch_after_its_duration` test

### DIFF
--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -1210,6 +1210,7 @@ pub mod testing {
 mod tests {
     use chrono::{TimeZone, Utc};
     use proptest::prelude::*;
+    use proptest::test_runner::Config;
     use rust_decimal_macros::dec;
 
     use super::testing::*;
@@ -1258,6 +1259,10 @@ mod tests {
     }
 
     proptest! {
+        #![proptest_config(Config {
+            cases: 10,
+            .. Config::default()
+        })]
         /// Test that:
         /// 1. When the minimum blocks have been created since the epoch
         ///    start height and minimum time passed since the epoch start time,


### PR DESCRIPTION
the test takes too long with default number of cases