### PR TITLE
Fix cache key in build-and-test-bridge.yml

### DIFF
--- a/.github/workflows/build-and-test-bridge.yml
+++ b/.github/workflows/build-and-test-bridge.yml
@@ -250,7 +250,7 @@ jobs:
         make:
           - name: ABCI Release build
             suffix: ''
-            cache_key: anoma-e2e-release
+            cache_key: namada-e2e-release
             cache_version: "v2"
 
     env:


### PR DESCRIPTION
Before running e2e tests in CI, we wait for a job with the name `namada-release-eth (ubuntu-latest, 1.7.0, ABCI Release build, namada-e2e-release, v2)` to finish. Currently, this job is called `namada-release-eth (ubuntu-latest, 1.7.0, ABCI Release build, anoma-e2e-release, v2)`, this PR attempts to update it so that it matches the expected name.

CI won't pass in this PR - we need to merge this branch and then see with another PR whether it worked or not.