### PR TITLE
Fix some CI in `eth-bridge-integration`

### DIFF
--- a/.github/workflows/build-and-test-bridge.yml
+++ b/.github/workflows/build-and-test-bridge.yml
@@ -349,7 +349,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2022-05-20]
+        nightly_version: [nightly-2022-11-03]
         mold_version: [1.7.0]
         make:
           - name: e2e

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -6,16 +6,19 @@ use std::path::Path;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use derivative::Derivative;
-use namada::ledger::eth_bridge::parameters::{
-    Contracts, EthereumBridgeConfig, UpgradeableContract,
-};
+use namada::ledger::eth_bridge::parameters::EthereumBridgeConfig;
+#[cfg(feature = "dev")]
+use namada::ledger::eth_bridge::parameters::{Contracts, UpgradeableContract};
 use namada::ledger::governance::parameters::GovParams;
 use namada::ledger::parameters::EpochDuration;
 use namada::ledger::pos::{GenesisValidator, PosParams};
-use namada::types::address::{wnam, Address};
+#[cfg(feature = "dev")]
+use namada::types::address::wnam;
+use namada::types::address::Address;
 #[cfg(not(feature = "dev"))]
 use namada::types::chain::ChainId;
 use namada::types::chain::ProposalBytes;
+#[cfg(feature = "dev")]
 use namada::types::ethereum_events::EthAddress;
 use namada::types::key::dkg_session_keys::DkgPublicKey;
 use namada::types::key::*;

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -458,6 +458,12 @@ async fn write_tm_genesis(
         .expect("Couldn't convert DateTimeUtc to Tendermint Time");
     #[cfg(not(feature = "abcipp"))]
     {
+        // NOTE(feature = "abcipp"): this setting of the block consensus
+        // parameters is guarded for the time being as it is different for
+        // Tendermint v0.37 to the ABCI++-compatible tendermint-rs we were using
+        // previously. Once ABCI++ is finished, hopefully the layout of
+        // these block consensus parameters will be similar if not the
+        // same.
         genesis.consensus_params.block = Some(block::Size {
             // maximum size of a serialized Tendermint block
             // cannot go over 100 MiB

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -19,7 +19,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 
 use crate::config;
-use crate::facade::tendermint::{block, Genesis};
+#[cfg(not(feature = "abcipp"))]
+use crate::facade::tendermint::block;
+use crate::facade::tendermint::Genesis;
 use crate::facade::tendermint_config::net::Address as TendermintAddress;
 use crate::facade::tendermint_config::{
     Error as TendermintError, TendermintConfig,
@@ -454,16 +456,21 @@ async fn write_tm_genesis(
     genesis.genesis_time = genesis_time
         .try_into()
         .expect("Couldn't convert DateTimeUtc to Tendermint Time");
-    genesis.consensus_params.block = Some(block::Size {
-        // maximum size of a serialized Tendermint block
-        // cannot go over 100 MiB
-        max_bytes: (100 << 20) - 1, /* unsure if we are dealing with an open
-                                     * range, so it's better to subtract one,
-                                     * here */
-        // gas is metered app-side, so we disable it
-        // at the Tendermint level
-        max_gas: -1,
-    });
+    #[cfg(not(feature = "abcipp"))]
+    {
+        genesis.consensus_params.block = Some(block::Size {
+            // maximum size of a serialized Tendermint block
+            // cannot go over 100 MiB
+            max_bytes: (100 << 20) - 1, /* unsure if we are dealing with an
+                                         * open
+                                         * range, so it's better to subtract
+                                         * one,
+                                         * here */
+            // gas is metered app-side, so we disable it
+            // at the Tendermint level
+            max_gas: -1,
+        });
+    }
     #[cfg(feature = "abcipp")]
     {
         genesis.consensus_params.timeout.commit =


### PR DESCRIPTION
- make sure there are no `cargo check` warnings when `dev` feature isn't enabled (this isn't yet checked in CI I don't think)
- make sure abcipp compiles
- update nightly version in CI for eth bridge (this is fixed in `main` already)