### PR TITLE
Add `EthereumBridgeConfig::read` method

### DIFF
--- a/ethereum_bridge/src/parameters.rs
+++ b/ethereum_bridge/src/parameters.rs
@@ -5,8 +5,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use namada_core::ledger::storage;
 use namada_core::ledger::storage::types::encode;
 use namada_core::ledger::storage::Storage;
-use namada_core::types::ethereum_events::EthAddress;
 use namada_core::ledger::storage_api::StorageRead;
+use namada_core::types::ethereum_events::EthAddress;
 use namada_core::types::storage::Key;
 use serde::{Deserialize, Serialize};
 
@@ -343,20 +343,6 @@ mod tests {
     )]
     fn test_ethereum_bridge_config_storage_partially_configured() {
         let mut storage = TestStorage::default();
-        let config = EthereumBridgeConfig {
-            min_confirmations: MinimumConfirmations::default(),
-            contracts: Contracts {
-                native_erc20: EthAddress([42; 20]),
-                bridge: UpgradeableContract {
-                    address: EthAddress([23; 20]),
-                    version: ContractVersion::default(),
-                },
-                governance: UpgradeableContract {
-                    address: EthAddress([18; 20]),
-                    version: ContractVersion::default(),
-                },
-            },
-        };
         // Write a valid min_confirmations value
         let min_confirmations_key = bridge_storage::min_confirmations_key();
         storage

--- a/ethereum_bridge/src/parameters.rs
+++ b/ethereum_bridge/src/parameters.rs
@@ -242,6 +242,7 @@ impl EthereumBridgeConfig {
 #[cfg(test)]
 mod tests {
     use eyre::Result;
+    use namada_core::ledger::storage::testing::TestStorage;
     use namada_core::types::ethereum_events::EthAddress;
 
     use crate::parameters::{
@@ -273,5 +274,29 @@ mod tests {
 
         assert_eq!(config, deserialized);
         Ok(())
+    }
+
+    #[test]
+    fn test_ethereum_bridge_config_read_write_storage() {
+        let mut storage = TestStorage::default();
+        let config = EthereumBridgeConfig {
+            min_confirmations: MinimumConfirmations::default(),
+            contracts: Contracts {
+                native_erc20: EthAddress([42; 20]),
+                bridge: UpgradeableContract {
+                    address: EthAddress([23; 20]),
+                    version: ContractVersion::default(),
+                },
+                governance: UpgradeableContract {
+                    address: EthAddress([18; 20]),
+                    version: ContractVersion::default(),
+                },
+            },
+        };
+        config.init_storage(&mut storage);
+
+        let read = EthereumBridgeConfig::read(&storage).unwrap();
+
+        assert_eq!(config, read);
     }
 }

--- a/ethereum_bridge/src/parameters.rs
+++ b/ethereum_bridge/src/parameters.rs
@@ -61,6 +61,7 @@ impl Default for ContractVersion {
 
 /// Represents an Ethereum contract that may be upgraded.
 #[derive(
+    Copy,
     Clone,
     Debug,
     Eq,
@@ -80,6 +81,7 @@ pub struct UpgradeableContract {
 /// Represents all the Ethereum contracts that need to be directly know about by
 /// validators.
 #[derive(
+    Copy,
     Clone,
     Debug,
     Eq,
@@ -101,6 +103,7 @@ pub struct Contracts {
 
 /// Represents chain parameters for the Ethereum bridge.
 #[derive(
+    Copy,
     Clone,
     Debug,
     Eq,

--- a/ethereum_bridge/src/parameters.rs
+++ b/ethereum_bridge/src/parameters.rs
@@ -34,6 +34,18 @@ impl Default for MinimumConfirmations {
     }
 }
 
+impl From<NonZeroU64> for MinimumConfirmations {
+    fn from(value: NonZeroU64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<MinimumConfirmations> for NonZeroU64 {
+    fn from(value: MinimumConfirmations) -> Self {
+        value.0
+    }
+}
+
 /// Represents a configuration value for the version of a contract that can be
 /// upgraded. Starts from 1.
 #[derive(

--- a/ethereum_bridge/src/parameters.rs
+++ b/ethereum_bridge/src/parameters.rs
@@ -194,7 +194,7 @@ impl EthereumBridgeConfig {
             &min_confirmations_key,
         )
         .unwrap_or_else(|err| {
-            panic!("Could not Borsh-deserialize {min_confirmations_key}: {err:?}")
+            panic!("Could not read {min_confirmations_key}: {err:?}")
         }) else {
             // The bridge has not been configured yet
             return None;
@@ -229,7 +229,7 @@ where
     H: storage::traits::StorageHasher,
 {
     StorageRead::read::<T>(storage, key).map_or_else(
-        |err| panic!("Could not Borsh-deserialize {key}: {err:?}"),
+        |err| panic!("Could not read {key}: {err:?}"),
         |value| {
             value.unwrap_or_else(|| {
                 panic!(
@@ -312,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Could not Borsh-deserialize")]
+    #[should_panic(expected = "Could not read")]
     fn test_ethereum_bridge_config_storage_corrupt() {
         let mut storage = TestStorage::default();
         let config = EthereumBridgeConfig {

--- a/ethereum_bridge/src/parameters.rs
+++ b/ethereum_bridge/src/parameters.rs
@@ -218,6 +218,8 @@ impl EthereumBridgeConfig {
     }
 }
 
+/// Reads the value of `key` from `storage` and deserializes it, or panics
+/// otherwise.
 fn must_read_key<DB, H, T: BorshDeserialize>(
     storage: &Storage<DB, H>,
     key: &Key,


### PR DESCRIPTION
Needed for https://github.com/anoma/namada/pull/810

This PR adds an `EthereumBridgeConfig::read` method and makes some other miscellaneous changes to the structs in `parameters.rs`

This is the only file being changed in PR https://github.com/anoma/namada/pull/810 that is under the `shared` directory, and so may move to `core`