### PR TITLE
fix/933 minor inconsistent formatting in docs

### DIFF
--- a/documentation/specs/src/base-ledger/default-account.md
+++ b/documentation/specs/src/base-ledger/default-account.md
@@ -1,3 +1,3 @@
-## Default account
+# Default account
 
 The default account validity predicate authorises transactions on the basis of a cryptographic signature.

--- a/documentation/specs/src/base-ledger/fungible-token.md
+++ b/documentation/specs/src/base-ledger/fungible-token.md
@@ -1,3 +1,3 @@
-## Fungible token
+# Fungible token
 
 The fungible token validity predicate authorises token balance changes on the basis of conservation-of-supply and approval-by-sender.

--- a/documentation/specs/src/base-ledger/multisignature.md
+++ b/documentation/specs/src/base-ledger/multisignature.md
@@ -45,7 +45,7 @@ To verify the correctness of the signatures, this VP will proceed with a two-ste
 
 Step 1 allows us to short-circuit the validation process and avoid unnecessary processing and storage access. Each signature will be validated **only** against the public key found in the list at the specified index. Step 2 will halt as soon as it retrieves enough valid signatures to match the threshold, meaning that the remaining signatures will not be verified.
 
-## Addresses
+## Addresses
 
 The vp introduced in the previous section is available for `established` addresses. To generate a multisig account we need to modify the `InitAccount` struct to support multiple public keys and a threshold, as follows:
 


### PR DESCRIPTION
# What does this PR do
Changes the first headers in 2 pages in documentation from H2 to H1 as they are first on the page.