### PR TITLE
Fix allocator logic in `ProcessProposal`

### DIFF
--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -1603,4 +1603,75 @@ mod test_process_proposal {
             ),
         );
     }
+
+    /// Test that if we reject wrapper txs
+    /// when they shouldn't be included in blocks.
+    ///
+    /// Currently, the conditions to reject wrapper
+    /// txs are simply to check if we are at the 2nd
+    /// or 3rd height offset within an epoch.
+    #[test]
+    fn test_include_only_protocol_txs() {
+        let (mut shell, _recv, _) = test_utils::setup_at_height(1u64);
+        let keypair = gen_keypair();
+        let tx = Tx::new(
+            "wasm_code".as_bytes().to_owned(),
+            Some(b"transaction data".to_vec()),
+        );
+        let wrapper = WrapperTx::new(
+            Fee {
+                amount: 1234.into(),
+                token: shell.storage.native_token.clone(),
+            },
+            &keypair,
+            Epoch(0),
+            0.into(),
+            tx,
+            Default::default(),
+        )
+        .sign(&keypair)
+        .expect("Test failed")
+        .to_bytes();
+        for height in [1u64, 2] {
+            shell.storage.last_height = height.into();
+            #[cfg(feature = "abcipp")]
+            let response = {
+                let request = ProcessProposal {
+                    txs: vec![wrapper.clone(), get_empty_eth_ev_digest(&shell)],
+                };
+                if let Err(TestError::RejectProposal(mut resp)) =
+                    shell.process_proposal(request)
+                {
+                    assert_eq!(resp.len(), 2);
+                    resp.remove(0)
+                } else {
+                    panic!("Test failed")
+                }
+            };
+            #[cfg(not(feature = "abcipp"))]
+            let response = {
+                let request = ProcessProposal {
+                    txs: vec![wrapper.clone()],
+                };
+                if let Err(TestError::RejectProposal(mut resp)) =
+                    shell.process_proposal(request)
+                {
+                    assert_eq!(resp.len(), 1);
+                    resp.remove(0)
+                } else {
+                    panic!("Test failed")
+                }
+            };
+            assert_eq!(
+                response.result.code,
+                u32::from(ErrorCodes::AllocationError)
+            );
+            assert_eq!(
+                response.result.info,
+                String::from(
+                    "Wrapper txs not allowed at the current block height"
+                ),
+            );
+        }
+    }
 }

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -549,7 +549,7 @@ where
                         .into(),
                     };
                 }
-                if hints::unlikely(!self.can_include_encrypted_txs()) {
+                if hints::unlikely(self.encrypted_txs_not_allowed()) {
                     return TxResult {
                         code: ErrorCodes::AllocationError.into(),
                         info: "Wrapper txs not allowed at the current block \
@@ -629,9 +629,9 @@ where
         }
     }
 
-    /// Checks if it is possible to include encrypted txs at the current block
-    /// height.
-    fn can_include_encrypted_txs(&self) -> bool {
+    /// Checks if it is not possible to include encrypted txs at the current
+    /// block height.
+    fn encrypted_txs_not_allowed(&self) -> bool {
         let is_2nd_height_off = self.storage.is_deciding_offset_within_epoch(1);
         let is_3rd_height_off = self.storage.is_deciding_offset_within_epoch(2);
         is_2nd_height_off || is_3rd_height_off

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -1604,8 +1604,7 @@ mod test_process_proposal {
         );
     }
 
-    /// Test that if we reject wrapper txs
-    /// when they shouldn't be included in blocks.
+    /// Test if we reject wrapper txs when they shouldn't be included in blocks.
     ///
     /// Currently, the conditions to reject wrapper
     /// txs are simply to check if we are at the 2nd

--- a/documentation/specs/src/base-ledger/block-space-allocator.md
+++ b/documentation/specs/src/base-ledger/block-space-allocator.md
@@ -158,6 +158,11 @@ MaxProposalBytes$ bytes of the available block space at $H$ (or any block
 height, in fact).
 * If all decrypted transactions from $H-1$ have been included in the proposal 
 $P$, for height $H$.
+* That no encrypted transactions were included in the proposal $P$, if no
+encrypted transactions should be included at $H$.
+    - N.b. the conditions to reject encrypted transactions are still not clearly
+    specced out, therefore they will be left out of this section, for the
+    time being.
 
 Should any of these conditions not be met at some arbitrary round $R$ of $H$, 
 all honest validators $V_h : V_h \subseteq V$ will reject the proposal $P$. 


### PR DESCRIPTION
We were not checking if encrypted txs should have been rejected at a certain block height. This is now fixed.