### PR TITLE
Fix validator commission change wasm test

### DIFF
--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -563,15 +563,14 @@ pub trait PosActions: PosReadOnly {
                 }
             };
         let params = self.read_pos_params()?;
-
         let rate_at_pipeline = *commission_rates
             .get_at_offset(current_epoch, DynEpochOffset::PipelineLen, &params)
             .expect("Could not find a rate in given epoch");
+
+        // Return early with no further changes if there is no rate change
+        // instead of returning an error
         if new_rate == rate_at_pipeline {
-            return Err(CommissionRateChangeError::ChangeIsZero(
-                validator.clone(),
-            )
-            .into());
+            return Ok(());
         }
 
         let rate_before_pipeline = *commission_rates
@@ -1018,8 +1017,6 @@ pub enum CommissionRateChangeError {
     NegativeRate(Decimal, Address),
     #[error("Rate change of {0} is too large for validator {1}")]
     RateChangeTooLarge(Decimal, Address),
-    #[error("The rate change is 0 for validator {0}")]
-    ChangeIsZero(Address),
     #[error(
         "There is no maximum rate change written in storage for validator {0}"
     )]

--- a/wasm/wasm_source/src/tx_change_validator_commission.rs
+++ b/wasm/wasm_source/src/tx_change_validator_commission.rs
@@ -104,9 +104,6 @@ mod tests {
             .read_validator_commission_rate(&commission_change.validator)?
             .unwrap();
 
-        dbg!(&commission_rates_pre);
-        dbg!(&commission_rates_post);
-
         // Before pipeline, the commission rates should not change
         for epoch in 0..pos_params.pipeline_len {
             assert_eq!(

--- a/wasm/wasm_source/src/tx_change_validator_commission.rs
+++ b/wasm/wasm_source/src/tx_change_validator_commission.rs
@@ -18,6 +18,8 @@ fn apply_tx(ctx: &mut Ctx, tx_data: Vec<u8>) -> TxResult {
 
 #[cfg(test)]
 mod tests {
+    use std::cmp;
+
     use namada::ledger::pos::{PosParams, PosVP};
     use namada::proto::Tx;
     use namada::types::storage::Epoch;
@@ -160,13 +162,24 @@ mod tests {
             .prop_map(|num| Decimal::from(num) / Decimal::from(100_000_u64))
     }
 
+    fn arb_new_rate(
+        min: Decimal,
+        max: Decimal,
+        rate_pre: Decimal,
+    ) -> impl Strategy<Value = Decimal> {
+        arb_rate(min, max).prop_filter(
+            "New rate must not be equal to the previous epoch's rate",
+            move |v| v != &rate_pre,
+        )
+    }
+
     fn arb_commission_change(
         rate_pre: Decimal,
         max_change: Decimal,
     ) -> impl Strategy<Value = transaction::pos::CommissionChange> {
-        let min = rate_pre - max_change;
-        let max = rate_pre + max_change;
-        (arb_established_address(), arb_rate(min, max)).prop_map(
+        let min = cmp::max(rate_pre - max_change, Decimal::ZERO);
+        let max = cmp::min(rate_pre + max_change, Decimal::ONE);
+        (arb_established_address(), arb_new_rate(min, max, rate_pre)).prop_map(
             |(validator, new_rate)| transaction::pos::CommissionChange {
                 validator: Address::Established(validator),
                 new_rate,


### PR DESCRIPTION
Resolving the wasm test error seen in https://github.com/anoma/namada/pull/926#issuecomment-1363805447. This was due to an arbitrary value for a new commission rate that was the same as the previous rate, which threw an error from within `PosActions::change_validator_commission_rate`.

The arb values for a new rate within `tx_change_validator_commission.rs` are now prevented from being the same as the previous rate.

Additionally, the previous `ChangeIsZero` error is removed, and if a tx to change the commission rate to the same as the previous one is submitted, the code instead returns early rather than attempt to make storage changes. The last commit can be removed if we prefer to keep the `ChangeIsZero` error.