### PR TITLE
Add `max_proposal_bytes` ledger param

### DIFF
--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -12,6 +12,7 @@ use namada::ledger::pos::{GenesisValidator, PosParams};
 use namada::types::address::Address;
 #[cfg(not(feature = "dev"))]
 use namada::types::chain::ChainId;
+use namada::types::chain::ProposalBytes;
 use namada::types::key::dkg_session_keys::DkgPublicKey;
 use namada::types::key::*;
 use namada::types::time::{DateTimeUtc, DurationSecs};
@@ -32,6 +33,7 @@ pub mod genesis_config {
     use namada::ledger::parameters::EpochDuration;
     use namada::ledger::pos::{GenesisValidator, PosParams};
     use namada::types::address::Address;
+    use namada::types::chain::ProposalBytes;
     use namada::types::key::dkg_session_keys::DkgPublicKey;
     use namada::types::key::*;
     use namada::types::time::Rfc3339String;
@@ -222,17 +224,30 @@ pub mod genesis_config {
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct ParametersConfig {
-        // Minimum number of blocks per epoch.
+        /// Max payload size, in bytes, for a tx batch proposal.
+        ///
+        /// Block proposers may never return a `PrepareProposal`
+        /// response containing `txs` with a byte length greater
+        /// than whatever is configured through this parameter.
+        ///
+        /// Note that this parameter's value will always be strictly
+        /// smaller than a Tendermint block's `MaxBytes` consensus
+        /// parameter. Currently, we hard cap `max_proposal_bytes`
+        /// at 90 MiB in Namada, which leaves at least 10 MiB of
+        /// room for header data, evidence and protobuf
+        /// serialization overhead in Tendermint blocks.
+        pub max_proposal_bytes: ProposalBytes,
+        /// Minimum number of blocks per epoch.
         // XXX: u64 doesn't work with toml-rs!
         pub min_num_of_blocks: u64,
-        // Maximum duration per block (in seconds).
+        /// Maximum duration per block (in seconds).
         // TODO: this is i64 because datetime wants it
         pub max_expected_time_per_block: i64,
-        // Hashes of whitelisted vps array. `None` value or an empty array
-        // disables whitelisting.
+        /// Hashes of whitelisted vps array. `None` value or an empty array
+        /// disables whitelisting.
         pub vp_whitelist: Option<Vec<String>>,
-        // Hashes of whitelisted txs array. `None` value or an empty array
-        // disables whitelisting.
+        /// Hashes of whitelisted txs array. `None` value or an empty array
+        /// disables whitelisting.
         pub tx_whitelist: Option<Vec<String>>,
         /// Filename of implicit accounts validity predicate WASM code
         pub implicit_vp: String,
@@ -574,6 +589,7 @@ pub mod genesis_config {
                     parameters.max_expected_time_per_block,
                 )
                 .into(),
+            max_proposal_bytes: parameters.max_proposal_bytes,
             vp_whitelist: parameters.vp_whitelist.unwrap_or_default(),
             tx_whitelist: parameters.tx_whitelist.unwrap_or_default(),
             implicit_vp_code_path,
@@ -796,6 +812,8 @@ pub struct ImplicitAccount {
     BorshDeserialize,
 )]
 pub struct Parameters {
+    // Max payload size, in bytes, for a tx batch proposal.
+    pub max_proposal_bytes: ProposalBytes,
     /// Epoch duration
     pub epoch_duration: EpochDuration,
     /// Maximum expected time per block
@@ -867,6 +885,7 @@ pub fn genesis() -> Genesis {
             min_duration: namada::types::time::Duration::seconds(600).into(),
         },
         max_expected_time_per_block: namada::types::time::DurationSecs(30),
+        max_proposal_bytes: Default::default(),
         vp_whitelist: vec![],
         tx_whitelist: vec![],
         implicit_vp_code_path: vp_implicit_path.into(),

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -65,6 +65,7 @@ where
         // Initialize protocol parameters
         let genesis::Parameters {
             epoch_duration,
+            max_proposal_bytes,
             max_expected_time_per_block,
             vp_whitelist,
             tx_whitelist,
@@ -98,6 +99,7 @@ where
         }
         let parameters = Parameters {
             epoch_duration,
+            max_proposal_bytes,
             max_expected_time_per_block,
             vp_whitelist,
             tx_whitelist,

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -14,7 +14,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 
 use crate::config;
-use crate::facade::tendermint::Genesis;
+use crate::facade::tendermint::{block, Genesis};
 use crate::facade::tendermint_config::net::Address as TendermintAddress;
 use crate::facade::tendermint_config::{
     Error as TendermintError, TendermintConfig,
@@ -380,6 +380,16 @@ async fn write_tm_genesis(
     genesis.genesis_time = genesis_time
         .try_into()
         .expect("Couldn't convert DateTimeUtc to Tendermint Time");
+    genesis.consensus_params.block = Some(block::Size {
+        // maximum size of a serialized Tendermint block
+        // cannot go over 100 MiB
+        max_bytes: (100 << 20) - 1, /* unsure if we are dealing with an open
+                                     * range, so it's better to subtract one,
+                                     * here */
+        // gas is metered app-side, so we disable it
+        // at the Tendermint level
+        max_gas: -1,
+    });
     #[cfg(feature = "abcipp")]
     {
         genesis.consensus_params.timeout.commit =

--- a/core/src/ledger/parameters/storage.rs
+++ b/core/src/ledger/parameters/storage.rs
@@ -12,6 +12,7 @@ const POS_GAIN_P_KEY: &str = "pos_gain_p";
 const POS_GAIN_D_KEY: &str = "pos_gain_d";
 const STAKED_RATIO_KEY: &str = "staked_ratio_key";
 const POS_INFLATION_AMOUNT_KEY: &str = "pos_inflation_amount_key";
+const MAX_PROPOSAL_BYTES_KEY: &str = "max_proposal_bytes";
 
 /// Returns if the key is a parameter key.
 pub fn is_parameter_key(key: &Key) -> bool {
@@ -104,6 +105,14 @@ pub fn is_pos_inflation_amount_key(key: &Key) -> bool {
         DbKeySeg::AddressSeg(addr),
         DbKeySeg::StringSeg(pos_inflation_amount),
     ] if addr == &ADDRESS && pos_inflation_amount == POS_INFLATION_AMOUNT_KEY)
+}
+
+/// Returns if the key is the max proposal bytes key.
+pub fn is_max_proposal_bytes_key(key: &Key) -> bool {
+    matches!(&key.segments[..], [
+        DbKeySeg::AddressSeg(addr),
+        DbKeySeg::StringSeg(max_proposal_bytes),
+    ] if addr == &ADDRESS && max_proposal_bytes == MAX_PROPOSAL_BYTES_KEY)
 }
 
 /// Storage key used for epoch parameter.
@@ -202,6 +211,16 @@ pub fn get_pos_inflation_amount_key() -> Key {
         segments: vec![
             DbKeySeg::AddressSeg(ADDRESS),
             DbKeySeg::StringSeg(POS_INFLATION_AMOUNT_KEY.to_string()),
+        ],
+    }
+}
+
+/// Storage key used for the max proposal bytes.
+pub fn get_max_proposal_bytes_key() -> Key {
+    Key {
+        segments: vec![
+            DbKeySeg::AddressSeg(ADDRESS),
+            DbKeySeg::StringSeg(MAX_PROPOSAL_BYTES_KEY.to_string()),
         ],
     }
 }

--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -1279,6 +1279,7 @@ mod tests {
                 ..Default::default()
             };
             let mut parameters = Parameters {
+                max_proposal_bytes: Default::default(),
                 epoch_duration: epoch_duration.clone(),
                 max_expected_time_per_block: Duration::seconds(max_expected_time_per_block).into(),
                 vp_whitelist: vec![],

--- a/genesis/dev.toml
+++ b/genesis/dev.toml
@@ -146,6 +146,8 @@ min_num_of_blocks = 10
 max_expected_time_per_block = 30
 # Expected epochs per year (also sets the minimum duration of an epoch in seconds)
 epochs_per_year = 525_600
+# Max payload size, in bytes, for a tx batch proposal.
+max_proposal_bytes = 22020096
 
 # Proof of stake parameters.
 [pos_params]

--- a/genesis/e2e-tests-single-node.toml
+++ b/genesis/e2e-tests-single-node.toml
@@ -151,6 +151,8 @@ filename = "vp_masp.wasm"
 min_num_of_blocks = 4
 # Maximum expected time per block (in seconds).
 max_expected_time_per_block = 30
+# Max payload size, in bytes, for a tx batch proposal.
+max_proposal_bytes = 22020096
 # vp whitelist
 vp_whitelist = []
 # tx whitelist

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -2226,6 +2226,7 @@ fn proposal_submission() -> Result<()> {
         |genesis| {
             let parameters = ParametersConfig {
                 epochs_per_year: epochs_per_year_from_min_duration(1),
+                max_proposal_bytes: Default::default(),
                 min_num_of_blocks: 1,
                 max_expected_time_per_block: 1,
                 vp_whitelist: Some(get_all_wasms_hashes(


### PR DESCRIPTION
Allows us to configure the ledger with a `max_proposal_bytes` param, that is used to limit the maximum size of a batch of transactions proposed by some Tendermint consensus round leader.