### PR TITLE
Add vote extensions for bridge pool roots + batch nonce

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-release:
 	NAMADA_DEV=false $(cargo) build --release --package namada_apps --manifest-path Cargo.toml
 
 build-debug:
-	ANOMA_DEV=false $(cargo) build --package namada_apps --manifest-path Cargo.toml
+	NAMADA_DEV=false $(cargo) build --package namada_apps --manifest-path Cargo.toml
 
 install-release:
 	NAMADA_DEV=false $(cargo) install --path ./apps --locked

--- a/apps/src/lib/client/eth_bridge_pool.rs
+++ b/apps/src/lib/client/eth_bridge_pool.rs
@@ -37,8 +37,6 @@ pub async fn add_to_eth_bridge_pool(
             recipient,
             sender: ctx.get(sender),
             amount,
-            // TODO: Add real nonce
-            nonce: Default::default(),
         },
         gas_fee: GasFee {
             amount: gas_amount,

--- a/apps/src/lib/node/ledger/shell/block_space_alloc/states.rs
+++ b/apps/src/lib/node/ledger/shell/block_space_alloc/states.rs
@@ -28,6 +28,8 @@ mod protocol_txs;
 mod remaining_txs;
 
 use super::{AllocFailure, BlockSpaceAllocator};
+#[allow(unused_imports)]
+use crate::node::ledger::shell::block_space_alloc;
 
 /// Convenience wrapper for a [`BlockSpaceAllocator`] state that allocates
 /// encrypted transactions.
@@ -44,21 +46,21 @@ pub enum EncryptedTxBatchAllocator {
 /// a new batch of DKG decrypted transactions.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub enum BuildingDecryptedTxBatch {}
 
 /// The leader of the current Tendermint round is building
 /// a new batch of Namada protocol transactions.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub enum BuildingProtocolTxBatch {}
 
 /// The leader of the current Tendermint round is building
 /// a new batch of DKG encrypted transactions.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub struct BuildingEncryptedTxBatch<Mode> {
     /// One of [`WithEncryptedTxs`] and [`WithoutEncryptedTxs`].
     _mode: Mode,
@@ -70,25 +72,25 @@ pub struct BuildingEncryptedTxBatch<Mode> {
 /// block, yet.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub enum FillingRemainingSpace {}
 
 /// Allow block proposals to include encrypted txs.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub enum WithEncryptedTxs {}
 
 /// Prohibit block proposals from including encrypted txs.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub enum WithoutEncryptedTxs {}
 
 /// Try to allocate a new transaction on a [`BlockSpaceAllocator`] state.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub trait TryAlloc {
     /// Try to allocate space for a new transaction.
     fn try_alloc(&mut self, tx: &[u8]) -> Result<(), AllocFailure>;
@@ -101,7 +103,7 @@ pub trait TryAlloc {
 /// [`NextStateWithoutEncryptedTxs`].
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub trait NextStateImpl<Transition = ()> {
     /// The next state in the [`BlockSpaceAllocator`] state machine.
     type Next;
@@ -115,7 +117,7 @@ pub trait NextStateImpl<Transition = ()> {
 /// state with encrypted txs in a block.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub trait NextStateWithEncryptedTxs: NextStateImpl<WithEncryptedTxs> {
     /// Transition to the next state in the [`BlockSpaceAllocator`] state,
     /// ensuring we include encrypted txs in a block.
@@ -134,7 +136,7 @@ impl<S> NextStateWithEncryptedTxs for S where S: NextStateImpl<WithEncryptedTxs>
 /// state without encrypted txs in a block.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub trait NextStateWithoutEncryptedTxs:
     NextStateImpl<WithoutEncryptedTxs>
 {
@@ -158,7 +160,7 @@ impl<S> NextStateWithoutEncryptedTxs for S where
 /// state with a null transition function.
 ///
 /// For more info, read the module docs of
-/// [`crate::node::ledger::shell::prepare_proposal::block_space_alloc::states`].
+/// [`block_space_alloc::states`].
 pub trait NextState: NextStateImpl {
     /// Transition to the next state in the [`BlockSpaceAllocator`] state,
     /// using a null transiiton function.

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -168,6 +168,7 @@ where
                         }
                         Event::new_tx_event(&tx_type, height.0)
                     }
+                    ProtocolTxType::BridgePoolVext(_) => continue,
                     ProtocolTxType::ValSetUpdateVext(_) => {
                         Event::new_tx_event(&tx_type, height.0)
                     }

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -334,7 +334,7 @@ where
                         .expect("encode public key"),
                 )
                 .expect("Unable to set genesis user public key");
-            // Account balance (tokens no staked in PoS)
+            // Account balance (tokens not staked in PoS)
             self.storage
                 .write(
                     &token::balance_key(&self.storage.native_token, addr),

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -494,7 +494,7 @@ where
                     root,
                     height
                 );
-                response.last_block_app_hash = root.0;
+                response.last_block_app_hash = root.0.to_vec();
                 response.last_block_height =
                     height.try_into().expect("Invalid block height");
             }
@@ -668,7 +668,7 @@ where
             root,
             self.storage.last_height,
         );
-        response.data = root.0;
+        response.data = root.0.to_vec();
 
         #[cfg(not(feature = "abcipp"))]
         {
@@ -731,6 +731,26 @@ where
                             response.code = 1;
                             response.log = format!(
                                 "{INVALID_MSG}: Invalid Ethereum events vote \
+                                 extension: {err}",
+                            );
+                        } else {
+                            response.log = String::from(VALID_MSG);
+                        }
+                    }
+                    #[cfg(not(feature = "abcipp"))]
+                    Ok(TxType::Protocol(ProtocolTx {
+                        tx: ProtocolTxType::BridgePoolVext(ext),
+                        ..
+                    })) => {
+                        if let Err(err) = self
+                            .validate_bp_roots_vext_and_get_it_back(
+                                ext,
+                                self.storage.last_height,
+                            )
+                        {
+                            response.code = 1;
+                            response.log = format!(
+                                "{INVALID_MSG}: Invalid Brige pool roots vote \
                                  extension: {err}",
                             );
                         } else {

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -3,9 +3,9 @@
 #[cfg(not(feature = "abcipp"))]
 use index_set::vec::VecIndexSet;
 use namada::core::hints;
-use namada::ledger::pos::PosQueries;
 #[cfg(feature = "abcipp")]
-use namada::ledger::pos::SendValsetUpd;
+use namada::ledger::eth_bridge::{EthBridgeQueries, SendValsetUpd};
+use namada::ledger::pos::PosQueries;
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::{DBIter, DB};
 use namada::proto::Tx;

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -483,14 +483,24 @@ mod test_prepare_proposal {
     use namada::ledger::pos::namada_proof_of_stake::types::WeightedValidator;
     use namada::ledger::pos::namada_proof_of_stake::PosBase;
     use namada::ledger::pos::PosQueries;
+    #[cfg(feature = "abcipp")]
+    use namada::proto::SignedKeccakAbi;
     use namada::proto::{Signed, SignedTxData};
+    #[cfg(feature = "abcipp")]
+    use namada::types::eth_abi::Encode;
     use namada::types::ethereum_events::EthereumEvent;
+    #[cfg(feature = "abcipp")]
+    use namada::types::ethereum_events::Uint;
+    #[cfg(feature = "abcipp")]
+    use namada::types::keccak::KeccakHash;
     #[cfg(feature = "abcipp")]
     use namada::types::key::common;
     use namada::types::key::RefTo;
     use namada::types::storage::{BlockHeight, Epoch};
     use namada::types::transaction::protocol::ProtocolTxType;
     use namada::types::transaction::{Fee, TxType, WrapperTx};
+    #[cfg(feature = "abcipp")]
+    use namada::types::vote_extensions::bridge_pool_roots;
     use namada::types::vote_extensions::ethereum_events;
     #[cfg(feature = "abcipp")]
     use namada::types::vote_extensions::VoteExtension;
@@ -566,29 +576,48 @@ mod test_prepare_proposal {
 
     #[cfg(feature = "abcipp")]
     fn get_local_last_commit(shell: &TestShell) -> Option<ExtendedCommitInfo> {
+        let validator_addr = shell
+            .mode
+            .get_validator_address()
+            .expect("Test failed")
+            .to_owned();
         let evts = {
-            let validator_addr = shell
-                .mode
-                .get_validator_address()
-                .expect("Test failed")
-                .to_owned();
-
             let prev_height = shell.storage.last_height;
-
-            let ext = ethereum_events::Vext::empty(prev_height, validator_addr);
-
+            let ext = ethereum_events::Vext::empty(
+                prev_height,
+                validator_addr.clone(),
+            );
             let protocol_key = match &shell.mode {
                 ShellMode::Validator { data, .. } => {
                     &data.keys.protocol_keypair
                 }
                 _ => panic!("Test failed"),
             };
-
             ext.sign(protocol_key)
+        };
+
+        let bp_root = {
+            let to_sign = [
+                KeccakHash([0; 32]).encode().into_inner(),
+                Uint::from(0).encode().into_inner(),
+            ]
+            .concat();
+            let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+                to_sign,
+            )
+            .sig;
+            bridge_pool_roots::Vext {
+                block_height: shell.storage.last_height,
+                validator_addr,
+                sig,
+            }
+            .sign(shell.mode.get_protocol_key().expect("Test failed"))
         };
 
         let vote_extension = VoteExtension {
             ethereum_events: evts,
+            bridge_pool_root: bp_root,
             validator_set_update: None,
         }
         .try_to_vec()
@@ -864,7 +893,7 @@ mod test_prepare_proposal {
         };
         let ethereum_events = {
             let ext = ethereum_events::Vext {
-                validator_addr,
+                validator_addr: validator_addr.clone(),
                 block_height: LAST_HEIGHT,
                 ethereum_events: vec![ethereum_event],
             }
@@ -872,8 +901,27 @@ mod test_prepare_proposal {
             assert!(ext.verify(&protocol_key.ref_to()).is_ok());
             ext
         };
+        let bp_root = {
+            let to_sign = [
+                KeccakHash([0; 32]).encode().into_inner(),
+                Uint::from(0).encode().into_inner(),
+            ]
+            .concat();
+            let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+                to_sign,
+            )
+            .sig;
+            bridge_pool_roots::Vext {
+                block_height: shell.storage.last_height,
+                validator_addr,
+                sig,
+            }
+            .sign(shell.mode.get_protocol_key().expect("Test failed"))
+        };
         let vote_extension = VoteExtension {
             ethereum_events,
+            bridge_pool_root: bp_root,
             validator_set_update: None,
         };
         let vote = ExtendedVoteInfo {
@@ -1035,10 +1083,34 @@ mod test_prepare_proposal {
             assert!(ext.verify(&protocol_key.ref_to()).is_ok());
             ext
         };
+
         #[cfg(feature = "abcipp")]
         {
+            let bp_root = {
+                let to_sign = [
+                    KeccakHash([0; 32]).encode().into_inner(),
+                    Uint::from(0).encode().into_inner(),
+                ]
+                .concat();
+                let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                    shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+                    to_sign,
+                )
+                .sig;
+                bridge_pool_roots::Vext {
+                    block_height: shell.storage.last_height,
+                    validator_addr: shell
+                        .mode
+                        .get_validator_address()
+                        .unwrap()
+                        .clone(),
+                    sig,
+                }
+                .sign(shell.mode.get_protocol_key().expect("Test failed"))
+            };
             let vote_extension = VoteExtension {
                 ethereum_events: signed_eth_ev_vote_extension,
+                bridge_pool_root: bp_root,
                 validator_set_update: None,
             };
             let vote = ExtendedVoteInfo {

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -484,7 +484,7 @@ mod test_prepare_proposal {
     use namada::ledger::pos::namada_proof_of_stake::PosBase;
     use namada::ledger::pos::PosQueries;
     #[cfg(feature = "abcipp")]
-    use namada::proto::SignedKeccakAbi;
+    use namada::proto::SignedAbiBytes;
     use namada::proto::{Signed, SignedTxData};
     #[cfg(feature = "abcipp")]
     use namada::types::eth_abi::Encode;
@@ -602,7 +602,7 @@ mod test_prepare_proposal {
                 Uint::from(0).encode().into_inner(),
             ]
             .concat();
-            let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+            let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
                 shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                 to_sign,
             )
@@ -907,7 +907,7 @@ mod test_prepare_proposal {
                 Uint::from(0).encode().into_inner(),
             ]
             .concat();
-            let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+            let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
                 shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                 to_sign,
             )
@@ -1092,7 +1092,7 @@ mod test_prepare_proposal {
                     Uint::from(0).encode().into_inner(),
                 ]
                 .concat();
-                let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -484,15 +484,11 @@ mod test_prepare_proposal {
     use namada::ledger::pos::namada_proof_of_stake::PosBase;
     use namada::ledger::pos::PosQueries;
     #[cfg(feature = "abcipp")]
-    use namada::proto::SignedAbiBytes;
+    use namada::proto::SignableEthBytes;
     use namada::proto::{Signed, SignedTxData};
-    #[cfg(feature = "abcipp")]
-    use namada::types::eth_abi::Encode;
     use namada::types::ethereum_events::EthereumEvent;
     #[cfg(feature = "abcipp")]
     use namada::types::ethereum_events::Uint;
-    #[cfg(feature = "abcipp")]
-    use namada::types::keccak::KeccakHash;
     #[cfg(feature = "abcipp")]
     use namada::types::key::common;
     use namada::types::key::RefTo;
@@ -597,12 +593,8 @@ mod test_prepare_proposal {
         };
 
         let bp_root = {
-            let to_sign = [
-                KeccakHash([0; 32]).encode().into_inner(),
-                Uint::from(0).encode().into_inner(),
-            ]
-            .concat();
-            let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+            let to_sign = [[0; 32], Uint::from(0).to_bytes()].concat();
+            let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
                 shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                 to_sign,
             )
@@ -902,12 +894,8 @@ mod test_prepare_proposal {
             ext
         };
         let bp_root = {
-            let to_sign = [
-                KeccakHash([0; 32]).encode().into_inner(),
-                Uint::from(0).encode().into_inner(),
-            ]
-            .concat();
-            let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+            let to_sign = [[0; 32], Uint::from(0).to_bytes()].concat();
+            let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
                 shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                 to_sign,
             )
@@ -1087,12 +1075,8 @@ mod test_prepare_proposal {
         #[cfg(feature = "abcipp")]
         {
             let bp_root = {
-                let to_sign = [
-                    KeccakHash([0; 32]).encode().into_inner(),
-                    Uint::from(0).encode().into_inner(),
-                ]
-                .concat();
-                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+                let to_sign = [[0; 32], Uint::from(0).to_bytes()].concat();
+                let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -26,6 +26,8 @@ use super::block_space_alloc::{AllocFailure, BlockSpaceAllocator};
 #[cfg(feature = "abcipp")]
 use crate::facade::tendermint_proto::abci::ExtendedCommitInfo;
 use crate::facade::tendermint_proto::abci::RequestPrepareProposal;
+#[allow(unused_imports)]
+use crate::node::ledger::shell::block_space_alloc;
 #[cfg(not(feature = "abcipp"))]
 use crate::node::ledger::shell::vote_extensions::deserialize_vote_extensions;
 #[cfg(feature = "abcipp")]

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -439,6 +439,24 @@ where
                              extensions was invalid: {err}"
                         ),
                     }),
+                ProtocolTxType::BridgePoolVext(ext) => self
+                    .validate_bp_roots_vext_and_get_it_back(
+                        ext,
+                        self.storage.last_height,
+                    )
+                    .map(|_| TxResult {
+                        code: ErrorCodes::Ok.into(),
+                        info: "Process Proposal accepted this transaction"
+                            .into(),
+                    })
+                    .unwrap_or_else(|err| TxResult {
+                        code: ErrorCodes::InvalidVoteExtension.into(),
+                        info: format!(
+                            "Process proposal rejected this proposal because \
+                             one of the included Bridge pool root's vote \
+                             extensions was invalid: {err}"
+                        ),
+                    }),
                 ProtocolTxType::ValSetUpdateVext(ext) => self
                     .validate_valset_upd_vext_and_get_it_back(
                         ext,

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -4,7 +4,8 @@
 use data_encoding::HEXUPPER;
 use namada::core::hints;
 use namada::core::ledger::storage::Storage;
-use namada::ledger::pos::{PosQueries, SendValsetUpd};
+use namada::ledger::eth_bridge::{EthBridgeQueries, SendValsetUpd};
+use namada::ledger::pos::PosQueries;
 use namada::types::transaction::protocol::ProtocolTxType;
 #[cfg(feature = "abcipp")]
 use namada::types::voting_power::FractionalVotingPower;

--- a/apps/src/lib/node/ledger/shell/queries.rs
+++ b/apps/src/lib/node/ledger/shell/queries.rs
@@ -121,7 +121,8 @@ where
 #[cfg(test)]
 #[cfg(not(feature = "abcipp"))]
 mod test_queries {
-    use namada::ledger::pos::{PosQueries, SendValsetUpd};
+    use namada::ledger::eth_bridge::{EthBridgeQueries, SendValsetUpd};
+    use namada::ledger::pos::PosQueries;
     use namada::types::storage::Epoch;
 
     use super::*;

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -297,8 +297,7 @@ pub fn deserialize_vote_extensions(
 }
 
 /// Given a slice of [`TxBytes`], return an iterator over the
-/// ones we could deserialize to vote extension [`ProtocolTx`]
-/// instances.
+/// ones we could deserialize to vote extension protocol txs.
 #[cfg(not(feature = "abcipp"))]
 pub fn deserialize_vote_extensions<'shell>(
     txs: &'shell [TxBytes],

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -60,6 +60,8 @@ pub enum VoteExtensionError {
          equivalent field in storage."
     )]
     DivergesFromStorage,
+    #[error("The signature of the Bridge pool root is invalid")]
+    InvalidBPRootSig,
 }
 
 impl<D, H> Shell<D, H>

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -7,7 +7,9 @@ pub mod val_set_update;
 use borsh::BorshDeserialize;
 #[cfg(not(feature = "abcipp"))]
 use index_set::vec::VecIndexSet;
-use namada::ledger::pos::{PosQueries, SendValsetUpd};
+use namada::ledger::eth_bridge::{EthBridgeQueries, SendValsetUpd};
+#[cfg(feature = "abcipp")]
+use namada::ledger::pos::PosQueries;
 use namada::proto::Signed;
 use namada::types::transaction::protocol::ProtocolTxType;
 #[cfg(feature = "abcipp")]

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -9,7 +9,7 @@ use index_set::vec::VecIndexSet;
 use namada::ledger::eth_bridge::{EthBridgeQueries, SendValsetUpd};
 #[cfg(feature = "abcipp")]
 use namada::ledger::pos::PosQueries;
-use namada::proto::{Signed, SignedAbiBytes};
+use namada::proto::{SignableEthBytes, Signed};
 use namada::types::transaction::protocol::ProtocolTxType;
 #[cfg(feature = "abcipp")]
 use namada::types::vote_extensions::VoteExtensionDigest;
@@ -141,7 +141,7 @@ where
             .mode
             .get_eth_bridge_keypair()
             .expect(VALIDATOR_EXPECT_MSG);
-        let signed = Signed::<Vec<u8>, SignedAbiBytes>::new(eth_key, to_sign);
+        let signed = Signed::<Vec<u8>, SignableEthBytes>::new(eth_key, to_sign);
 
         let ext = bridge_pool_roots::Vext {
             block_height: self.storage.last_height,

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -151,9 +151,7 @@ where
                 .0
                 .expect("Reading Bridge pool nonce shouldn't fail."),
         )
-        .expect("Deserializing Bridge pool nonce shouldn't fail.")
-        .encode()
-        .into_inner();
+        .expect("Deserializing Bridge pool nonce shouldn't fail.");
         let to_sign = [bp_root.encode().into_inner(), nonce].concat();
         let eth_key = self
             .mode

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -21,7 +21,7 @@ where
     /// pool root and nonce.
     ///
     /// Checks that at epoch of the provided height:
-    ///  * The Tendermint address corresponds to an active validator.
+    ///  * The inner Namada address corresponds to an active validator.
     ///  * The validator correctly signed the extension.
     ///  * The validator signed over the correct height inside of the extension.
     ///  * Check that the inner signature is valid.

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -116,7 +116,7 @@ where
 
         let bp_root = self.storage.get_bridge_pool_root().0;
         let nonce = self.storage.get_bridge_pool_nonce().to_bytes();
-        let signed = Signed::<Vec<u8>, SignedAbiBytes>::new_from(
+        let signed = Signed::<Vec<u8>, SignableEthBytes>::new_from(
             [bp_root, nonce].concat(),
             ext.data.sig.clone(),
         );
@@ -189,10 +189,8 @@ mod test_vote_extensions {
         PosQueries, ValidatorConsensusKeys, WeightedValidator,
     };
     use namada::proof_of_stake::types::ValidatorEthKey;
-    use namada::proto::{Signed, SignedAbiBytes};
-    use namada::types::eth_abi::Encode;
+    use namada::proto::{SignableEthBytes, Signed};
     use namada::types::ethereum_events::Uint;
-    use namada::types::keccak::KeccakHash;
     use namada::types::key::*;
     use namada::types::storage::BlockHeight;
     use namada::types::vote_extensions::bridge_pool_roots;
@@ -270,7 +268,8 @@ mod test_vote_extensions {
 
         // Check that Bertha's vote extensions pass validation.
         let to_sign = [[0; 32], Uint::from(0).to_bytes()].concat();
-        let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(&hot_key, to_sign).sig;
+        let sig =
+            Signed::<Vec<u8>, SignableEthBytes>::new(&hot_key, to_sign).sig;
         let vote_ext = bridge_pool_roots::Vext {
             block_height: shell.storage.get_current_decision_height(),
             validator_addr: bertha_address(),
@@ -296,7 +295,7 @@ mod test_vote_extensions {
             .expect("Test failed")
             .clone();
         let to_sign = [[0; 32], Uint::from(0).to_bytes()].concat();
-        let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+        let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
             shell.mode.get_eth_bridge_keypair().expect("Test failed"),
             to_sign,
         )
@@ -326,7 +325,7 @@ mod test_vote_extensions {
             .clone();
         let to_sign = [[0; 32], Uint::from(0).to_bytes()].concat();
         let sig =
-            Signed::<Vec<u8>, SignedAbiBytes>::new(&signing_key, to_sign).sig;
+            Signed::<Vec<u8>, SignableEthBytes>::new(&signing_key, to_sign).sig;
         let bp_root = bridge_pool_roots::Vext {
             block_height: shell.storage.get_current_decision_height(),
             validator_addr: address,
@@ -351,7 +350,7 @@ mod test_vote_extensions {
             .clone();
         add_validator(&mut shell);
         let to_sign = [[0; 32], Uint::from(0).to_bytes()].concat();
-        let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+        let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
             shell.mode.get_eth_bridge_keypair().expect("Test failed"),
             to_sign,
         )
@@ -374,12 +373,8 @@ mod test_vote_extensions {
     fn reject_incorrect_block_number() {
         let (shell, _, _) = setup_at_height(3u64);
         let address = shell.mode.get_validator_address().unwrap().clone();
-        let to_sign = [
-            KeccakHash([0; 32]).encode().into_inner(),
-            Uint::from(0).encode().into_inner(),
-        ]
-        .concat();
-        let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+        let to_sign = [[0; 32], Uint::from(0).to_bytes()].concat();
+        let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
             shell.mode.get_eth_bridge_keypair().expect("Test failed"),
             to_sign,
         )
@@ -402,12 +397,8 @@ mod test_vote_extensions {
     fn test_reject_genesis_vexts() {
         let (shell, _, _) = setup();
         let address = shell.mode.get_validator_address().unwrap().clone();
-        let to_sign = [
-            KeccakHash([0; 32]).encode().into_inner(),
-            Uint::from(0).encode().into_inner(),
-        ]
-        .concat();
-        let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+        let to_sign = [[0; 32], Uint::from(0).to_bytes()].concat();
+        let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
             shell.mode.get_eth_bridge_keypair().expect("Test failed"),
             to_sign,
         )
@@ -429,12 +420,8 @@ mod test_vote_extensions {
     fn test_incorrect_nonce() {
         let (shell, _, _) = setup();
         let address = shell.mode.get_validator_address().unwrap().clone();
-        let to_sign = [
-            KeccakHash([0; 32]).encode().into_inner(),
-            Uint::from(10).encode().into_inner(),
-        ]
-        .concat();
-        let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+        let to_sign = [[0; 32], Uint::from(10).to_bytes()].concat();
+        let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
             shell.mode.get_eth_bridge_keypair().expect("Test failed"),
             to_sign,
         )
@@ -456,12 +443,8 @@ mod test_vote_extensions {
     fn test_incorrect_root() {
         let (shell, _, _) = setup();
         let address = shell.mode.get_validator_address().unwrap().clone();
-        let to_sign = [
-            KeccakHash([1; 32]).encode().into_inner(),
-            Uint::from(0).encode().into_inner(),
-        ]
-        .concat();
-        let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+        let to_sign = [[1; 32], Uint::from(0).to_bytes()].concat();
+        let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
             shell.mode.get_eth_bridge_keypair().expect("Test failed"),
             to_sign,
         )

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -1,0 +1,509 @@
+//! Extend Tendermint votes with signatures of the Ethereum
+//! bridge pool root and nonce seen by a quorum of validators.
+
+use namada::ledger::pos::PosQueries;
+use namada::ledger::storage::traits::StorageHasher;
+use namada::ledger::storage::{DBIter, DB};
+use namada::proto::{Signable, Signed};
+use namada::types::storage::BlockHeight;
+use namada::types::token;
+
+use super::*;
+use crate::node::ledger::shell::Shell;
+
+impl<D, H> Shell<D, H>
+where
+    D: DB + for<'iter> DBIter<'iter> + Sync + 'static,
+    H: StorageHasher + Sync + 'static,
+{
+    /// Validates a vote extension issued at the provided
+    /// block height signing over the latest Ethereum bridge
+    /// pool root and nonce.
+    ///
+    /// Checks that at epoch of the provided height:
+    ///  * The Tendermint address corresponds to an active validator.
+    ///  * The validator correctly signed the extension.
+    ///  * The validator signed over the correct height inside of the extension.
+    ///  * Check that the inner signature is valid.
+    #[inline]
+    #[allow(dead_code)]
+    pub fn validate_bp_roots_vext(
+        &self,
+        ext: Signed<bridge_pool_roots::Vext>,
+        last_height: BlockHeight,
+    ) -> bool {
+        self.validate_bp_roots_vext_and_get_it_back(ext, last_height)
+            .is_ok()
+    }
+
+    /// This method behaves exactly like [`Self::validate_bp_roots_vext`],
+    /// with the added bonus of returning the vote extension back, if it
+    /// is valid.
+    pub fn validate_bp_roots_vext_and_get_it_back(
+        &self,
+        ext: Signed<bridge_pool_roots::Vext>,
+        last_height: BlockHeight,
+    ) -> std::result::Result<
+        (token::Amount, Signed<bridge_pool_roots::Vext>),
+        VoteExtensionError,
+    > {
+        #[cfg(feature = "abcipp")]
+        if ext.data.block_height != last_height {
+            tracing::error!(
+                ext_height = ?ext.data.block_height,
+                ?last_height,
+                "Bridge pool root's vote extension issued for a block height \
+                 different from the expected last height."
+            );
+            return Err(VoteExtensionError::UnexpectedBlockHeight);
+        }
+        #[cfg(not(feature = "abcipp"))]
+        if ext.data.block_height > last_height {
+            tracing::error!(
+                ext_height = ?ext.data.block_height,
+                ?last_height,
+                "Bridge pool root's vote extension issued for a block height \
+                 higher than the chain's last height."
+            );
+            return Err(VoteExtensionError::UnexpectedBlockHeight);
+        }
+        if last_height.0 == 0 {
+            tracing::error!("Dropping vote extension issued at genesis");
+            return Err(VoteExtensionError::IssuedAtGenesis);
+        }
+
+        let validator = &ext.data.validator_addr;
+        // get the public key associated with this validator
+        //
+        // NOTE(not(feature = "abciplus")): for ABCI++, we should pass
+        // `last_height` here, instead of `ext.data.block_height`
+        let ext_height_epoch =
+            match self.storage.get_epoch(ext.data.block_height) {
+                Some(epoch) => epoch,
+                _ => {
+                    tracing::error!(
+                        block_height = ?ext.data.block_height,
+                        "The epoch of the Bridge pool root's vote extension's \
+                         block height should always be known",
+                    );
+                    return Err(VoteExtensionError::UnexpectedEpoch);
+                }
+            };
+        let (voting_power, pk) = self
+            .storage
+            .get_validator_from_address(validator, Some(ext_height_epoch))
+            .map_err(|err| {
+                tracing::error!(
+                    ?err,
+                    %validator,
+                    "Could not get public key from Storage for some validator, \
+                     while validating Bridge pool root's vote extension"
+                );
+                VoteExtensionError::PubKeyNotInStorage
+            })?;
+        // verify the signature of the vote extension
+        ext.verify(&pk).map_err(|err| {
+            tracing::error!(
+                ?err,
+                ?ext.sig,
+                ?pk,
+                %validator,
+                "Failed to verify the signature of an Bridge pool root's vote \
+                 extension issued by some validator"
+            );
+            VoteExtensionError::VerifySigFailed
+        })?;
+
+        let bp_root: KeccakHash = self
+            .storage
+            .block
+            .tree
+            .sub_root(&StoreType::BridgePool)
+            .into();
+        let nonce = Uint::try_from_slice(
+            &self
+                .storage
+                .read(&get_nonce_key())
+                .expect("Reading Bridge pool nonce shouldn't fail.")
+                .0
+                .expect("Reading Bridge pool nonce shouldn't fail."),
+        )
+        .expect("Deserializing Bridge pool nonce shouldn't fail.")
+        .encode()
+        .into_inner();
+        let signed = [bp_root.encode().into_inner(), nonce].concat();
+        let epoched_pk = self
+            .storage
+            .read_validator_eth_hot_key(validator)
+            .expect("A validator should have an Ethereum hot key in storage.");
+        let pk = epoched_pk
+            .get(ext_height_epoch)
+            .expect("We should have an Ethereum hot key for the given epoch");
+        common::SigScheme::verify_signature_raw(
+            pk,
+            SignedKeccakAbi::as_signable(&signed).as_ref(),
+            &ext.data.sig,
+        )
+        .map_err(|err| {
+            tracing::error!(
+                ?err,
+                ?ext.data.sig,
+                ?pk,
+                %validator,
+                "Failed to verify the signature of an Bridge pool root \
+                issued by some validator."
+            );
+            VoteExtensionError::InvalidBPRootSig
+        })
+        .map(|_| (voting_power, ext))
+    }
+
+    /// Takes an iterator over Bridge pool root vote extension instances,
+    /// and returns another iterator. The latter yields
+    /// valid Brige pool root vote extensions, or the reason why these
+    /// are invalid, in the form of a [`VoteExtensionError`].
+    #[inline]
+    pub fn validate_bp_roots_vext_list<'iter>(
+        &'iter self,
+        vote_extensions: impl IntoIterator<Item = Signed<bridge_pool_roots::Vext>>
+        + 'iter,
+    ) -> impl Iterator<
+        Item = std::result::Result<
+            (token::Amount, Signed<bridge_pool_roots::Vext>),
+            VoteExtensionError,
+        >,
+    > + 'iter {
+        vote_extensions.into_iter().map(|vote_extension| {
+            self.validate_bp_roots_vext_and_get_it_back(
+                vote_extension,
+                self.storage.last_height,
+            )
+        })
+    }
+
+    /// Takes a list of signed Bridge pool root vote extensions,
+    /// and filters out invalid instances.
+    #[inline]
+    pub fn filter_invalid_bp_roots_vexts<'iter>(
+        &'iter self,
+        vote_extensions: impl IntoIterator<Item = Signed<bridge_pool_roots::Vext>>
+        + 'iter,
+    ) -> impl Iterator<Item = (token::Amount, Signed<bridge_pool_roots::Vext>)> + 'iter
+    {
+        self.validate_bp_roots_vext_list(vote_extensions)
+            .filter_map(|ext| ext.ok())
+    }
+}
+
+#[cfg(test)]
+mod test_vote_extensions {
+    use borsh::BorshSerialize;
+    use namada::ledger::pos;
+    use namada::ledger::pos::namada_proof_of_stake::PosBase;
+    use namada::ledger::pos::{
+        PosQueries, ValidatorConsensusKeys, WeightedValidator,
+    };
+    use namada::proof_of_stake::types::ValidatorEthKey;
+    use namada::proto::{Signed, SignedKeccakAbi};
+    use namada::types::eth_abi::Encode;
+    use namada::types::ethereum_events::Uint;
+    use namada::types::keccak::KeccakHash;
+    use namada::types::key::*;
+    use namada::types::storage::BlockHeight;
+    use namada::types::vote_extensions::bridge_pool_roots;
+
+    use crate::node::ledger::shell::test_utils::*;
+    use crate::node::ledger::shims::abcipp_shim_types::shim::request::FinalizeBlock;
+    use crate::wallet::defaults::{bertha_address, bertha_keypair};
+
+    /// Make Bertha a validator.
+    fn add_validator(shell: &mut TestShell) {
+        // We make a change so that there Bertha is
+        // a validator in the next epoch
+        let mut current_validators = shell.storage.read_validator_set();
+        let mut vals = current_validators
+            .get(0)
+            .expect("Test failed")
+            .active
+            .clone();
+        vals.insert(WeightedValidator {
+            bonded_stake: 100,
+            address: bertha_address(),
+        });
+        current_validators.data.insert(
+            1,
+            Some(pos::types::ValidatorSet {
+                active: vals,
+                inactive: Default::default(),
+            }),
+        );
+        shell.storage.write_validator_set(&current_validators);
+
+        // register Bertha's protocol key
+        let pk_key = protocol_pk_key(&bertha_address());
+        shell
+            .storage
+            .write(
+                &pk_key,
+                bertha_keypair()
+                    .ref_to()
+                    .try_to_vec()
+                    .expect("Test failed."),
+            )
+            .expect("Test failed.");
+
+        // change pipeline length to 1
+        let mut params = shell.storage.read_pos_params();
+        params.pipeline_len = 1;
+
+        // register Bertha's consensus key
+        let consensus_key = gen_keypair();
+        shell.storage.write_validator_consensus_key(
+            &bertha_address(),
+            &ValidatorConsensusKeys::init(consensus_key.ref_to(), 0, &params),
+        );
+
+        // register Bertha's ethereum keys.
+        let hot_key = gen_secp256k1_keypair();
+        let cold_key = gen_secp256k1_keypair();
+        shell.storage.write_validator_eth_hot_key(
+            &bertha_address(),
+            &ValidatorEthKey::init(hot_key.ref_to(), 0, &params),
+        );
+        shell.storage.write_validator_eth_cold_key(
+            &bertha_address(),
+            &ValidatorEthKey::init(cold_key.ref_to(), 0, &params),
+        );
+
+        // we advance forward to the next epoch
+        let mut req = FinalizeBlock::default();
+        req.header.time = namada::types::time::DateTimeUtc::now();
+        shell.storage.last_height = BlockHeight(15);
+        shell.finalize_block(req).expect("Test failed");
+        shell.commit();
+        assert_eq!(shell.storage.get_current_epoch().0.0, 1);
+
+        // Check that Bertha's vote extensions pass validation.
+        let to_sign = [
+            KeccakHash([0; 32]).encode().into_inner(),
+            Uint::from(0).encode().into_inner(),
+        ]
+        .concat();
+        let sig =
+            Signed::<Vec<u8>, SignedKeccakAbi>::new(&hot_key, to_sign).sig;
+        let vote_ext = bridge_pool_roots::Vext {
+            block_height: shell.storage.get_current_decision_height(),
+            validator_addr: bertha_address(),
+            sig,
+        }
+        .sign(&bertha_keypair());
+
+        assert!(shell.validate_bp_roots_vext(
+            vote_ext,
+            shell.storage.get_current_decision_height(),
+        ));
+    }
+
+    /// Test that the function crafting the bridge pool root
+    /// vext creates the expected payload. Check that this
+    /// payload passes validation.
+    #[test]
+    fn test_happy_flow() {
+        let (mut shell, _, _) = setup_at_height(3u64);
+        let address = shell
+            .mode
+            .get_validator_address()
+            .expect("Test failed")
+            .clone();
+        let to_sign = [
+            KeccakHash([0; 32]).encode().into_inner(),
+            Uint::from(0).encode().into_inner(),
+        ]
+        .concat();
+        let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+            shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+            to_sign,
+        )
+        .sig;
+        let vote_ext = bridge_pool_roots::Vext {
+            block_height: shell.storage.last_height,
+            validator_addr: address,
+            sig,
+        }
+        .sign(shell.mode.get_protocol_key().expect("Test failed"));
+        assert_eq!(vote_ext, shell.extend_vote_with_bp_roots());
+        assert!(shell.validate_bp_roots_vext(
+            vote_ext,
+            shell.storage.get_current_decision_height()
+        ))
+    }
+
+    /// Test that Bridge pool roots signed by a non-validator are rejected
+    /// even if the vext is signed by a validator
+    #[test]
+    fn test_bp_roots_must_be_signed_by_validator() {
+        let (shell, _, _) = setup_at_height(3u64);
+        let signing_key = gen_keypair();
+        let address = shell
+            .mode
+            .get_validator_address()
+            .expect("Test failed")
+            .clone();
+        let to_sign =
+            [&*KeccakHash([0; 32]).encode(), &*Uint::from(0).encode()].concat();
+        let sig =
+            Signed::<Vec<u8>, SignedKeccakAbi>::new(&signing_key, to_sign).sig;
+        let bp_root = bridge_pool_roots::Vext {
+            block_height: shell.storage.get_current_decision_height(),
+            validator_addr: address,
+            sig,
+        }
+        .sign(shell.mode.get_protocol_key().expect("Test failed"));
+        assert!(!shell.validate_bp_roots_vext(
+            bp_root,
+            shell.storage.get_current_decision_height(),
+        ))
+    }
+
+    /// Test that Bridge pool root vext and inner signature
+    /// are from the same validator.
+    #[test]
+    fn test_bp_root_sigs_from_same_validator() {
+        let (mut shell, _broadcaster, _) = setup_at_height(3u64);
+        let address = shell
+            .mode
+            .get_validator_address()
+            .expect("Test failed")
+            .clone();
+        add_validator(&mut shell);
+        let to_sign = [
+            KeccakHash([0; 32]).encode().into_inner(),
+            Uint::from(0).encode().into_inner(),
+        ]
+        .concat();
+        let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+            shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+            to_sign,
+        )
+        .sig;
+        let bp_root = bridge_pool_roots::Vext {
+            block_height: shell.storage.get_current_decision_height(),
+            validator_addr: address,
+            sig,
+        }
+        .sign(&bertha_keypair());
+        assert!(!shell.validate_bp_roots_vext(
+            bp_root,
+            shell.storage.get_current_decision_height(),
+        ))
+    }
+
+    /// Test that an [`bridge_pool_roots::Vext`] that labels its included
+    /// block height as greater than the latest block height is rejected.
+    #[test]
+    fn reject_incorrect_block_number() {
+        let (shell, _, _) = setup_at_height(3u64);
+        let address = shell.mode.get_validator_address().unwrap().clone();
+        let to_sign = [
+            KeccakHash([0; 32]).encode().into_inner(),
+            Uint::from(0).encode().into_inner(),
+        ]
+        .concat();
+        let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+            shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+            to_sign,
+        )
+        .sig;
+        let bp_root = bridge_pool_roots::Vext {
+            block_height: shell.storage.last_height + 1,
+            validator_addr: address,
+            sig,
+        }
+        .sign(shell.mode.get_protocol_key().expect("Test failed"));
+
+        assert!(
+            !shell.validate_bp_roots_vext(bp_root, shell.storage.last_height)
+        )
+    }
+
+    /// Test if we reject Bridge pool roots vote extensions
+    /// issued at genesis.
+    #[test]
+    fn test_reject_genesis_vexts() {
+        let (shell, _, _) = setup();
+        let address = shell.mode.get_validator_address().unwrap().clone();
+        let to_sign = [
+            KeccakHash([0; 32]).encode().into_inner(),
+            Uint::from(0).encode().into_inner(),
+        ]
+        .concat();
+        let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+            shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+            to_sign,
+        )
+        .sig;
+        let bp_root = bridge_pool_roots::Vext {
+            block_height: 0.into(),
+            validator_addr: address,
+            sig,
+        }
+        .sign(shell.mode.get_protocol_key().expect("Test failed"));
+        assert!(
+            !shell.validate_bp_roots_vext(bp_root, shell.storage.last_height)
+        )
+    }
+
+    /// Test that a bridge pool root vext is rejected
+    /// if the nonce is incorrect.
+    #[test]
+    fn test_incorrect_nonce() {
+        let (shell, _, _) = setup();
+        let address = shell.mode.get_validator_address().unwrap().clone();
+        let to_sign = [
+            KeccakHash([0; 32]).encode().into_inner(),
+            Uint::from(10).encode().into_inner(),
+        ]
+        .concat();
+        let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+            shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+            to_sign,
+        )
+        .sig;
+        let bp_root = bridge_pool_roots::Vext {
+            block_height: shell.storage.last_height,
+            validator_addr: address,
+            sig,
+        }
+        .sign(shell.mode.get_protocol_key().expect("Test failed"));
+        assert!(
+            !shell.validate_bp_roots_vext(bp_root, shell.storage.last_height)
+        )
+    }
+
+    /// Test that a bridge pool root vext is rejected
+    /// if the root is incorrect.
+    #[test]
+    fn test_incorrect_root() {
+        let (shell, _, _) = setup();
+        let address = shell.mode.get_validator_address().unwrap().clone();
+        let to_sign = [
+            KeccakHash([1; 32]).encode().into_inner(),
+            Uint::from(0).encode().into_inner(),
+        ]
+        .concat();
+        let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+            shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+            to_sign,
+        )
+        .sig;
+        let bp_root = bridge_pool_roots::Vext {
+            block_height: shell.storage.last_height,
+            validator_addr: address,
+            sig,
+        }
+        .sign(shell.mode.get_protocol_key().expect("Test failed"));
+        assert!(
+            !shell.validate_bp_roots_vext(bp_root, shell.storage.last_height)
+        )
+    }
+}

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -332,10 +332,9 @@ mod test_vote_extensions {
         }
         .sign(shell.mode.get_protocol_key().expect("Test failed"));
         assert_eq!(vote_ext, shell.extend_vote_with_bp_roots());
-        assert!(shell.validate_bp_roots_vext(
-            vote_ext,
-            shell.storage.get_current_decision_height()
-        ))
+        assert!(
+            shell.validate_bp_roots_vext(vote_ext, shell.storage.last_height,)
+        )
     }
 
     /// Test that Bridge pool roots signed by a non-validator are rejected

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -296,7 +296,7 @@ mod test_vote_extensions {
     use namada::ledger::pos::namada_proof_of_stake::PosBase;
     use namada::ledger::pos::PosQueries;
     #[cfg(feature = "abcipp")]
-    use namada::proto::{Signed, SignedKeccakAbi};
+    use namada::proto::{Signed, SignedAbiBytes};
     #[cfg(feature = "abcipp")]
     use namada::types::eth_abi::Encode;
     #[cfg(feature = "abcipp")]
@@ -469,7 +469,7 @@ mod test_vote_extensions {
                         Uint::from(0).encode().into_inner(),
                     ]
                     .concat();
-                    let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                    let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
                         shell
                             .mode
                             .get_eth_bridge_keypair()
@@ -602,7 +602,7 @@ mod test_vote_extensions {
                     Uint::from(0).encode().into_inner(),
                 ]
                 .concat();
-                let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -296,7 +296,7 @@ mod test_vote_extensions {
     use namada::ledger::pos::namada_proof_of_stake::PosBase;
     use namada::ledger::pos::PosQueries;
     #[cfg(feature = "abcipp")]
-    use namada::proto::{Signed, SignedAbiBytes};
+    use namada::proto::{SignableEthBytes, Signed};
     #[cfg(feature = "abcipp")]
     use namada::types::eth_abi::Encode;
     #[cfg(feature = "abcipp")]
@@ -469,7 +469,7 @@ mod test_vote_extensions {
                         Uint::from(0).encode().into_inner(),
                     ]
                     .concat();
-                    let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+                    let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
                         shell
                             .mode
                             .get_eth_bridge_keypair()
@@ -602,7 +602,7 @@ mod test_vote_extensions {
                     Uint::from(0).encode().into_inner(),
                 ]
                 .concat();
-                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+                let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -310,7 +310,17 @@ mod test_vote_extensions {
     use namada::ledger::pos;
     use namada::ledger::pos::namada_proof_of_stake::PosBase;
     use namada::ledger::pos::PosQueries;
+    #[cfg(feature = "abcipp")]
+    use namada::proto::{Signed, SignedKeccakAbi};
+    #[cfg(feature = "abcipp")]
+    use namada::types::eth_abi::Encode;
+    #[cfg(feature = "abcipp")]
+    use namada::types::ethereum_events::Uint;
+    #[cfg(feature = "abcipp")]
+    use namada::types::keccak::KeccakHash;
     use namada::types::key::RefTo;
+    #[cfg(feature = "abcipp")]
+    use namada::types::vote_extensions::bridge_pool_roots;
     #[cfg(feature = "abcipp")]
     use namada::types::vote_extensions::ethereum_events;
     use namada::types::vote_extensions::validator_set_update;
@@ -362,12 +372,31 @@ mod test_vote_extensions {
                 shell.mode.get_protocol_key().expect("Test failed");
             let ethereum_events = ethereum_events::Vext::empty(
                 shell.storage.get_current_decision_height(),
-                validator_addr,
+                validator_addr.clone(),
             )
             .sign(protocol_key);
+            let bp_root = {
+                let to_sign = [
+                    KeccakHash([0; 32]).encode().into_inner(),
+                    Uint::from(0).encode().into_inner(),
+                ]
+                .concat();
+                let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                    shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+                    to_sign,
+                )
+                .sig;
+                bridge_pool_roots::Vext {
+                    block_height: shell.storage.last_height,
+                    validator_addr,
+                    sig,
+                }
+                .sign(shell.mode.get_protocol_key().expect("Test failed"))
+            };
             let req = request::VerifyVoteExtension {
                 vote_extension: VoteExtension {
                     ethereum_events,
+                    bridge_pool_root: bp_root,
                     validator_set_update,
                 }
                 .try_to_vec()
@@ -422,12 +451,31 @@ mod test_vote_extensions {
         {
             let ethereum_events = ethereum_events::Vext::empty(
                 shell.storage.get_current_decision_height(),
-                validator_addr,
+                validator_addr.clone(),
             )
             .sign(&_protocol_key);
+            let bp_root = {
+                let to_sign = [
+                    KeccakHash([0; 32]).encode().into_inner(),
+                    Uint::from(0).encode().into_inner(),
+                ]
+                .concat();
+                let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                    shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+                    to_sign,
+                )
+                .sig;
+                bridge_pool_roots::Vext {
+                    block_height: shell.storage.last_height,
+                    validator_addr,
+                    sig,
+                }
+                .sign(shell.mode.get_protocol_key().expect("Test failed"))
+            };
             let req = request::VerifyVoteExtension {
                 vote_extension: VoteExtension {
                     ethereum_events,
+                    bridge_pool_root: bp_root,
                     validator_set_update,
                 }
                 .try_to_vec()
@@ -564,12 +612,31 @@ mod test_vote_extensions {
                 shell.mode.get_protocol_key().expect("Test failed");
             let ethereum_events = ethereum_events::Vext::empty(
                 shell.storage.get_current_decision_height(),
-                validator_addr,
+                validator_addr.clone(),
             )
             .sign(protocol_key);
+            let bp_root = {
+                let to_sign = [
+                    KeccakHash([0; 32]).encode().into_inner(),
+                    Uint::from(0).encode().into_inner(),
+                ]
+                .concat();
+                let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                    shell.mode.get_eth_bridge_keypair().expect("Test failed"),
+                    to_sign,
+                )
+                .sig;
+                bridge_pool_roots::Vext {
+                    block_height: shell.storage.last_height,
+                    validator_addr,
+                    sig,
+                }
+                .sign(shell.mode.get_protocol_key().expect("Test failed"))
+            };
             let req = request::VerifyVoteExtension {
                 vote_extension: VoteExtension {
                     ethereum_events,
+                    bridge_pool_root: bp_root,
                     validator_set_update: validator_set_update.clone(),
                 }
                 .try_to_vec()

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -311,7 +311,7 @@ mod test_vote_extensions {
     use namada::ledger::pos::namada_proof_of_stake::PosBase;
     use namada::ledger::pos::PosQueries;
     #[cfg(feature = "abcipp")]
-    use namada::proto::{Signed, SignedKeccakAbi};
+    use namada::proto::{Signed, SignedAbiBytes};
     #[cfg(feature = "abcipp")]
     use namada::types::eth_abi::Encode;
     #[cfg(feature = "abcipp")]
@@ -381,7 +381,7 @@ mod test_vote_extensions {
                     Uint::from(0).encode().into_inner(),
                 ]
                 .concat();
-                let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )
@@ -460,7 +460,7 @@ mod test_vote_extensions {
                     Uint::from(0).encode().into_inner(),
                 ]
                 .concat();
-                let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )
@@ -621,7 +621,7 @@ mod test_vote_extensions {
                     Uint::from(0).encode().into_inner(),
                 ]
                 .concat();
-                let sig = Signed::<Vec<u8>, SignedKeccakAbi>::new(
+                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -311,7 +311,7 @@ mod test_vote_extensions {
     use namada::ledger::pos::namada_proof_of_stake::PosBase;
     use namada::ledger::pos::PosQueries;
     #[cfg(feature = "abcipp")]
-    use namada::proto::{Signed, SignedAbiBytes};
+    use namada::proto::{SignableEthBytes, Signed};
     #[cfg(feature = "abcipp")]
     use namada::types::eth_abi::Encode;
     #[cfg(feature = "abcipp")]
@@ -381,7 +381,7 @@ mod test_vote_extensions {
                     Uint::from(0).encode().into_inner(),
                 ]
                 .concat();
-                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+                let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )
@@ -460,7 +460,7 @@ mod test_vote_extensions {
                     Uint::from(0).encode().into_inner(),
                 ]
                 .concat();
-                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+                let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )
@@ -621,7 +621,7 @@ mod test_vote_extensions {
                     Uint::from(0).encode().into_inner(),
                 ]
                 .concat();
-                let sig = Signed::<Vec<u8>, SignedAbiBytes>::new(
+                let sig = Signed::<Vec<u8>, SignableEthBytes>::new(
                     shell.mode.get_eth_bridge_keypair().expect("Test failed"),
                     to_sign,
                 )

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -306,6 +306,7 @@ mod test_vote_extensions {
     #[cfg(feature = "abcipp")]
     #[cfg(feature = "abcipp")]
     use borsh::BorshSerialize;
+    use namada::ledger::eth_bridge::EthBridgeQueries;
     use namada::ledger::pos;
     use namada::ledger::pos::namada_proof_of_stake::PosBase;
     use namada::ledger::pos::PosQueries;

--- a/core/src/ledger/eth_bridge/storage/bridge_pool.rs
+++ b/core/src/ledger/eth_bridge/storage/bridge_pool.rs
@@ -217,7 +217,7 @@ impl BridgePoolTree {
     /// bridge pool.
     ///
     /// It should have one string segment which should
-    /// parse into a [Hash]
+    /// parse into a [`struct@Hash`].
     fn parse_key(key: &Key) -> Result<KeccakHash, Error> {
         if key.segments.len() == 1 {
             match &key.segments[0] {

--- a/core/src/proto/mod.rs
+++ b/core/src/proto/mod.rs
@@ -4,7 +4,7 @@ pub mod generated;
 mod types;
 
 pub use types::{
-    Dkg, Error, Signable, Signed, SignedAbiBytes, SignedTxData, Tx,
+    Dkg, Error, Signable, SignableEthBytes, Signed, SignedTxData, Tx,
 };
 
 #[cfg(test)]

--- a/core/src/proto/mod.rs
+++ b/core/src/proto/mod.rs
@@ -4,7 +4,7 @@ pub mod generated;
 mod types;
 
 pub use types::{
-    Dkg, Error, Signable, Signed, SignedKeccakAbi, SignedTxData, Tx,
+    Dkg, Error, Signable, Signed, SignedAbiBytes, SignedTxData, Tx,
 };
 
 #[cfg(test)]

--- a/core/src/proto/mod.rs
+++ b/core/src/proto/mod.rs
@@ -3,7 +3,9 @@
 pub mod generated;
 mod types;
 
-pub use types::{Dkg, Error, Signed, SignedSerialize, SignedTxData, Tx};
+pub use types::{
+    Dkg, Error, Signable, Signed, SignedKeccakAbi, SignedTxData, Tx,
+};
 
 #[cfg(test)]
 mod tests {

--- a/core/src/proto/types.rs
+++ b/core/src/proto/types.rs
@@ -79,7 +79,7 @@ pub struct SerializeWithBorsh;
 /// Tag type that indicates we should use ABI serialization
 /// to sign data in a [`Signed`] wrapper.
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub struct SignedAbiBytes;
+pub struct SignableEthBytes;
 
 impl<T: BorshSerialize> Signable<T> for SerializeWithBorsh {
     type Output = Vec<u8>;
@@ -90,7 +90,7 @@ impl<T: BorshSerialize> Signable<T> for SerializeWithBorsh {
     }
 }
 
-impl<T: AsRef<[u8]>> Signable<T> for SignedAbiBytes {
+impl<T: AsRef<[u8]>> Signable<T> for SignableEthBytes {
     type Output = Vec<u8>;
 
     fn as_signable(data: &T) -> Vec<u8> {

--- a/core/src/proto/types.rs
+++ b/core/src/proto/types.rs
@@ -8,10 +8,12 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tiny_keccak::{Hasher as KeccakHasher, Keccak};
 
 use super::generated::types;
 #[cfg(any(feature = "tendermint", feature = "tendermint-abcipp"))]
 use crate::tendermint_proto::abci::ResponseDeliverTx;
+use crate::types::keccak::KeccakHash;
 use crate::types::key::*;
 use crate::types::time::DateTimeUtc;
 #[cfg(feature = "ferveo-tpke")]
@@ -58,7 +60,7 @@ pub struct SignedTxData {
 
 /// A serialization method to provide to [`Signed`], such
 /// that we may sign serialized data.
-pub trait SignedSerialize<T> {
+pub trait Signable<T> {
     /// A byte vector containing the serialized data.
     type Output: AsRef<[u8]>;
 
@@ -68,7 +70,7 @@ pub trait SignedSerialize<T> {
     /// The returned output *must* be deterministic based on
     /// `data`, so that two callers signing the same `data` will be
     /// signing the same `Self::Output`.
-    fn serialize(data: &T) -> Self::Output;
+    fn as_signable(data: &T) -> Self::Output;
 }
 
 /// Tag type that indicates we should use [`BorshSerialize`]
@@ -76,12 +78,41 @@ pub trait SignedSerialize<T> {
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct SerializeWithBorsh;
 
-impl<T: BorshSerialize> SignedSerialize<T> for SerializeWithBorsh {
+/// Tag type that indicates we should use ABI serialization
+/// to sign data in a [`Signed`] wrapper.
+#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct SignedKeccakAbi;
+
+impl<T: BorshSerialize> Signable<T> for SerializeWithBorsh {
     type Output = Vec<u8>;
 
-    fn serialize(data: &T) -> Vec<u8> {
+    fn as_signable(data: &T) -> Vec<u8> {
         data.try_to_vec()
             .expect("Encoding data for signing shouldn't fail")
+    }
+}
+
+impl<T: AsRef<[u8]>> Signable<T> for SignedKeccakAbi {
+    type Output = KeccakHash;
+
+    fn as_signable(data: &T) -> KeccakHash {
+        let mut output = [0; 32];
+
+        let eth_message = {
+            let message = data.as_ref();
+
+            let mut eth_message =
+                format!("\x19Ethereum Signed Message:\n{}", message.len())
+                    .into_bytes();
+            eth_message.extend_from_slice(message);
+            eth_message
+        };
+
+        let mut state = Keccak::v256();
+        state.update(&eth_message);
+        state.finalize(&mut output);
+
+        KeccakHash(output)
     }
 }
 
@@ -153,10 +184,10 @@ impl<T, S> Signed<T, S> {
     }
 }
 
-impl<T, S: SignedSerialize<T>> Signed<T, S> {
+impl<T, S: Signable<T>> Signed<T, S> {
     /// Initialize a new [`Signed`] instance.
     pub fn new(keypair: &common::SecretKey, data: T) -> Self {
-        let to_sign = S::serialize(&data);
+        let to_sign = S::as_signable(&data);
         let sig = common::SigScheme::sign(keypair, to_sign.as_ref());
         Self::new_from(data, sig)
     }
@@ -167,7 +198,7 @@ impl<T, S: SignedSerialize<T>> Signed<T, S> {
         &self,
         pk: &common::PublicKey,
     ) -> std::result::Result<(), VerifySigError> {
-        let bytes = S::serialize(&self.data);
+        let bytes = S::as_signable(&self.data);
         common::SigScheme::verify_signature_raw(pk, bytes.as_ref(), &self.sig)
     }
 }

--- a/core/src/types/eth_abi.rs
+++ b/core/src/types/eth_abi.rs
@@ -8,7 +8,7 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 pub use ethabi::token::Token;
 use tiny_keccak::{Hasher, Keccak};
 
-use crate::proto::{Signable, SignedAbiBytes};
+use crate::proto::{Signable, SignableEthBytes};
 use crate::types::keccak::{keccak_hash, KeccakHash};
 
 /// A container for data types that are able to be Ethereum ABI-encoded.
@@ -67,15 +67,13 @@ pub trait Encode<const N: usize>: Sized {
     /// Encodes a slice of [`Token`] instances, and returns the
     /// keccak hash of the encoded string appended to an Ethereum
     /// signature header. This can then be signed.
-    fn signable_keccak256(&self) -> KeccakHash {
+    fn signable_keccak256(&self) -> Vec<u8> {
         let mut output = [0; 32];
         let message = self.encode().into_inner();
-        let signable_bytes = SignedAbiBytes::as_signable(&message);
         let mut state = Keccak::v256();
-        state.update(&signable_bytes);
+        state.update(&message);
         state.finalize(&mut output);
-
-        KeccakHash(output)
+        SignableEthBytes::as_signable(&output)
     }
 }
 

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -4,11 +4,12 @@ use std::fmt::Display;
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use ethabi::Uint as ethUint;
+use ethabi::{Token, Uint as ethUint};
 use eyre::{eyre, Context};
 use serde::{Deserialize, Serialize};
 
 use crate::types::address::Address;
+use crate::types::eth_abi::Encode;
 use crate::types::hash::Hash;
 use crate::types::keccak::KeccakHash;
 use crate::types::storage::{DbKeySeg, KeySeg};
@@ -32,6 +33,12 @@ use crate::types::token::Amount;
 )]
 pub struct Uint(pub [u64; 4]);
 
+impl Encode<1> for Uint {
+    fn tokenize(&self) -> [Token; 1] {
+        [Token::Uint(self.into())]
+    }
+}
+
 impl From<ethUint> for Uint {
     fn from(value: ethUint) -> Self {
         Self(value.0)
@@ -40,6 +47,12 @@ impl From<ethUint> for Uint {
 
 impl From<Uint> for ethUint {
     fn from(value: Uint) -> Self {
+        Self(value.0)
+    }
+}
+
+impl From<&Uint> for ethUint {
+    fn from(value: &Uint) -> Self {
         Self(value.0)
     }
 }

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -33,6 +33,14 @@ use crate::types::token::Amount;
 )]
 pub struct Uint(pub [u64; 4]);
 
+impl Uint {
+    fn to_bytes(self) -> Vec<u8> {
+        let mut bytes = vec![];
+        ethUint::from(self).to_little_endian(&mut bytes);
+        bytes
+    }
+}
+
 impl Encode<1> for Uint {
     fn tokenize(&self) -> [Token; 1] {
         [Token::Uint(self.into())]

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -34,8 +34,10 @@ use crate::types::token::Amount;
 pub struct Uint(pub [u64; 4]);
 
 impl Uint {
-    fn to_bytes(self) -> Vec<u8> {
-        let mut bytes = vec![];
+    /// Convert to a little endian byte representation of
+    /// a uint256.
+    pub fn to_bytes(self) -> [u8; 32] {
+        let mut bytes = [0; 32];
         ethUint::from(self).to_little_endian(&mut bytes);
         bytes
     }

--- a/core/src/types/keccak.rs
+++ b/core/src/types/keccak.rs
@@ -6,9 +6,11 @@ use std::fmt::Display;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use data_encoding::HEXUPPER;
+use ethabi::Token;
 use thiserror::Error;
 use tiny_keccak::{Hasher, Keccak};
 
+use crate::types::eth_abi::Encode;
 use crate::types::hash::{Hash, HASH_LENGTH};
 
 /// Errors for converting / parsing Keccak hashes
@@ -91,6 +93,12 @@ impl TryFrom<&str> for KeccakHash {
     }
 }
 
+impl AsRef<[u8]> for KeccakHash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 /// Hash bytes using Keccak
 pub fn keccak_hash(bytes: &[u8]) -> KeccakHash {
     let mut output = [0; 32];
@@ -100,4 +108,10 @@ pub fn keccak_hash(bytes: &[u8]) -> KeccakHash {
     hasher.finalize(&mut output);
 
     KeccakHash(output)
+}
+
+impl Encode<1> for KeccakHash {
+    fn tokenize(&self) -> [Token; 1] {
+        [Token::FixedBytes(self.0.to_vec())]
+    }
 }

--- a/core/src/types/transaction/protocol.rs
+++ b/core/src/types/transaction/protocol.rs
@@ -36,7 +36,7 @@ mod protocol_txs {
     use crate::types::key::*;
     use crate::types::transaction::{EllipticCurve, TxError, TxType};
     use crate::types::vote_extensions::{
-        ethereum_events, validator_set_update,
+        bridge_pool_roots, ethereum_events, validator_set_update,
     };
 
     const TX_NEW_DKG_KP_WASM: &str = "tx_update_dkg_session_keypair.wasm";
@@ -86,6 +86,8 @@ mod protocol_txs {
         ValidatorSetUpdate(validator_set_update::VextDigest),
         /// Ethereum events seen by some validator
         EthEventsVext(ethereum_events::SignedVext),
+        /// Signatures over the Ethereum bridge pool merkle root.
+        BridgePoolVext(bridge_pool_roots::SignedVext),
         /// Validator set update signed by some validator
         ValSetUpdateVext(validator_set_update::SignedVext),
     }

--- a/core/src/types/vote_extensions.rs
+++ b/core/src/types/vote_extensions.rs
@@ -1,5 +1,6 @@
 //! This module contains types necessary for processing vote extensions.
 
+pub mod bridge_pool_roots;
 pub mod ethereum_events;
 pub mod validator_set_update;
 
@@ -15,6 +16,8 @@ use crate::proto::Signed;
 pub struct VoteExtension {
     /// Vote extension data related with Ethereum events.
     pub ethereum_events: Signed<ethereum_events::Vext>,
+    /// A signature of the Ethereum bridge pool root and nonce.
+    pub bridge_pool_root: bridge_pool_roots::SignedVext,
     /// Vote extension data related with validator set updates.
     pub validator_set_update: Option<validator_set_update::SignedVext>,
 }

--- a/core/src/types/vote_extensions/bridge_pool_roots.rs
+++ b/core/src/types/vote_extensions/bridge_pool_roots.rs
@@ -23,7 +23,7 @@ use crate::types::storage::BlockHeight;
     BorshDeserialize,
     BorshSchema,
 )]
-pub struct BridePoolRootVext {
+pub struct BridgePoolRootVext {
     /// The validator sending the vote extension
     pub validator_addr: Address,
     /// The block height at which the vote extensions was
@@ -39,12 +39,12 @@ pub struct BridePoolRootVext {
 }
 
 /// Alias for [`BridgePoolRootVext`].
-pub type Vext = BridePoolRootVext;
+pub type Vext = BridgePoolRootVext;
 
 /// A signed [`BridgePoolRootVext`].
 /// Note that this is serialized with Ethereum's
 /// ABI encoding schema.
-pub type SignedVext = Signed<BridePoolRootVext>;
+pub type SignedVext = Signed<BridgePoolRootVext>;
 
 impl Vext {
     /// Creates a new signed [`Vext`].

--- a/core/src/types/vote_extensions/bridge_pool_roots.rs
+++ b/core/src/types/vote_extensions/bridge_pool_roots.rs
@@ -1,0 +1,55 @@
+//! Vote extension types for adding a signature
+//! of the bridge pool merkle root to be added
+//! to storage. This will be used to generate
+//! bridge pool inclusion proofs for Ethereum.
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+
+use crate::proto::Signed;
+use crate::types::address::Address;
+use crate::types::key::common;
+use crate::types::key::common::Signature;
+use crate::types::storage::BlockHeight;
+
+/// A vote extension containing a validator's signature
+/// of the current root and nonce of the
+/// Ethereum bridge pool.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+)]
+pub struct BridePoolRootVext {
+    /// The validator sending the vote extension
+    pub validator_addr: Address,
+    /// The block height at which the vote extensions was
+    /// sent.
+    ///
+    /// This can be used as replay protection as well
+    /// as allowing validators to  query the epoch with
+    /// the appropriate validator set to verify signatures
+    pub block_height: BlockHeight,
+    /// The actual signature being submitted.
+    /// This is a signature over KeccakHash(root || nonce).
+    pub sig: Signature,
+}
+
+/// Alias for [`BridgePoolRootVext`].
+pub type Vext = BridePoolRootVext;
+
+/// A signed [`BridgePoolRootVext`].
+/// Note that this is serialized with Ethereum's
+/// ABI encoding schema.
+pub type SignedVext = Signed<BridePoolRootVext>;
+
+impl Vext {
+    /// Creates a new signed [`Vext`].
+    #[inline]
+    pub fn sign(&self, sk: &common::SecretKey) -> SignedVext {
+        SignedVext::new(sk, self.clone())
+    }
+}

--- a/core/src/types/vote_extensions/bridge_pool_roots.rs
+++ b/core/src/types/vote_extensions/bridge_pool_roots.rs
@@ -25,6 +25,9 @@ use crate::types::storage::BlockHeight;
 )]
 pub struct BridgePoolRootVext {
     /// The validator sending the vote extension
+    /// TODO: the validator's address is temporarily being included
+    /// until we're able to map a Tendermint address to a validator
+    /// address (see <https://github.com/anoma/namada/issues/200>)
     pub validator_addr: Address,
     /// The block height at which the vote extensions was
     /// sent.

--- a/core/src/types/vote_extensions/validator_set_update.rs
+++ b/core/src/types/vote_extensions/validator_set_update.rs
@@ -345,7 +345,7 @@ mod tag {
             let (KeccakHash(bridge_hash), KeccakHash(gov_hash)) = ext
                 .voting_powers
                 .get_bridge_and_gov_hashes(ext.block_height);
-            let KeccakHash(output) = AbiEncode::signed_keccak256(&[
+            let KeccakHash(output) = AbiEncode::signable_keccak256(&[
                 Token::String("updateValidatorsSet".into()),
                 Token::FixedBytes(bridge_hash.to_vec()),
                 Token::FixedBytes(gov_hash.to_vec()),

--- a/core/src/types/vote_extensions/validator_set_update.rs
+++ b/core/src/types/vote_extensions/validator_set_update.rs
@@ -339,19 +339,18 @@ mod tag {
     pub struct SerializeWithAbiEncode;
 
     impl Signable<Vext> for SerializeWithAbiEncode {
-        type Output = [u8; 32];
+        type Output = Vec<u8>;
 
         fn as_signable(ext: &Vext) -> Self::Output {
             let (KeccakHash(bridge_hash), KeccakHash(gov_hash)) = ext
                 .voting_powers
                 .get_bridge_and_gov_hashes(ext.block_height);
-            let KeccakHash(output) = AbiEncode::signable_keccak256(&[
+            AbiEncode::signable_keccak256(&[
                 Token::String("updateValidatorsSet".into()),
                 Token::FixedBytes(bridge_hash.to_vec()),
                 Token::FixedBytes(gov_hash.to_vec()),
                 bheight_to_token(ext.block_height),
-            ]);
-            output
+            ])
         }
     }
 }

--- a/core/src/types/vote_extensions/validator_set_update.rs
+++ b/core/src/types/vote_extensions/validator_set_update.rs
@@ -329,7 +329,7 @@ mod tag {
     use serde::{Deserialize, Serialize};
 
     use super::{bheight_to_token, Vext, VotingPowersMapExt};
-    use crate::proto::SignedSerialize;
+    use crate::proto::Signable;
     use crate::types::eth_abi::{AbiEncode, Encode, Token};
     use crate::types::keccak::KeccakHash;
 
@@ -338,10 +338,10 @@ mod tag {
     #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]
     pub struct SerializeWithAbiEncode;
 
-    impl SignedSerialize<Vext> for SerializeWithAbiEncode {
+    impl Signable<Vext> for SerializeWithAbiEncode {
         type Output = [u8; 32];
 
-        fn serialize(ext: &Vext) -> Self::Output {
+        fn as_signable(ext: &Vext) -> Self::Output {
             let (KeccakHash(bridge_hash), KeccakHash(gov_hash)) = ext
                 .voting_powers
                 .get_bridge_and_gov_hashes(ext.block_height);

--- a/ethereum_bridge/src/bridge_pool_vp.rs
+++ b/ethereum_bridge/src/bridge_pool_vp.rs
@@ -1,7 +1,10 @@
 use borsh::BorshSerialize;
-use namada_core::ledger::eth_bridge::storage::bridge_pool::BRIDGE_POOL_ADDRESS;
+use namada_core::ledger::eth_bridge::storage::bridge_pool::{
+    get_nonce_key, BRIDGE_POOL_ADDRESS,
+};
 use namada_core::ledger::storage::{DBIter, Storage, StorageHasher, DB};
 use namada_core::types::address::nam;
+use namada_core::types::ethereum_events::Uint;
 use namada_core::types::token::{balance_key, Amount};
 
 /// Initialize the storage owned by the Bridge Pool VP.
@@ -25,4 +28,12 @@ where
             "Initializing the escrow balance of the Bridge pool VP shouldn't \
              fail.",
         );
+    storage
+        .write(
+            &get_nonce_key(),
+            Uint::from(0)
+                .try_to_vec()
+                .expect("Serializing a Uint should not fail."),
+        )
+        .expect("Initializing the Bridge pool nonce shouldn't fail.");
 }

--- a/ethereum_bridge/src/parameters.rs
+++ b/ethereum_bridge/src/parameters.rs
@@ -5,7 +5,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use namada_core::ledger::storage;
 use namada_core::ledger::storage::types::encode;
 use namada_core::ledger::storage::Storage;
+use namada_core::ledger::storage_api::StorageRead;
 use namada_core::types::ethereum_events::EthAddress;
+use namada_core::types::storage::Key;
 use serde::{Deserialize, Serialize};
 
 use crate::{bridge_pool_vp, storage as bridge_storage, vp};
@@ -31,6 +33,18 @@ impl Default for MinimumConfirmations {
         // SAFETY: The only way the API contract of `NonZeroU64` can be violated
         // is if we construct values of this type using 0 as argument.
         Self(unsafe { NonZeroU64::new_unchecked(100) })
+    }
+}
+
+impl From<NonZeroU64> for MinimumConfirmations {
+    fn from(value: NonZeroU64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<MinimumConfirmations> for NonZeroU64 {
+    fn from(value: MinimumConfirmations) -> Self {
+        value.0
     }
 }
 
@@ -61,6 +75,7 @@ impl Default for ContractVersion {
 
 /// Represents an Ethereum contract that may be upgraded.
 #[derive(
+    Copy,
     Clone,
     Debug,
     Eq,
@@ -80,6 +95,7 @@ pub struct UpgradeableContract {
 /// Represents all the Ethereum contracts that need to be directly know about by
 /// validators.
 #[derive(
+    Copy,
     Clone,
     Debug,
     Eq,
@@ -101,6 +117,7 @@ pub struct Contracts {
 
 /// Represents chain parameters for the Ethereum bridge.
 #[derive(
+    Copy,
     Clone,
     Debug,
     Eq,
@@ -157,13 +174,80 @@ impl EthereumBridgeConfig {
         // Initialize the storage for the Bridge Pool VP.
         bridge_pool_vp::init_storage(storage);
     }
+
+    /// Reads the latest [`EthereumBridgeConfig`] from storage. If it is not
+    /// present, `None` will be returned - this could be the case if the bridge
+    /// has not been bootstrapped yet. Panics if the storage appears to be
+    /// corrupt.
+    pub fn read<DB, H>(storage: &Storage<DB, H>) -> Option<Self>
+    where
+        DB: storage::DB + for<'iter> storage::DBIter<'iter>,
+        H: storage::traits::StorageHasher,
+    {
+        let min_confirmations_key = bridge_storage::min_confirmations_key();
+        let native_erc20_key = bridge_storage::native_erc20_key();
+        let bridge_contract_key = bridge_storage::bridge_contract_key();
+        let governance_contract_key = bridge_storage::governance_contract_key();
+
+        let Some(min_confirmations) = StorageRead::read::<MinimumConfirmations>(
+            storage,
+            &min_confirmations_key,
+        )
+        .unwrap_or_else(|err| {
+            panic!("Could not read {min_confirmations_key}: {err:?}")
+        }) else {
+            // The bridge has not been configured yet
+            return None;
+        };
+
+        // These reads must succeed otherwise the storage is corrupt or a
+        // read failed
+        let native_erc20 = must_read_key(storage, &native_erc20_key);
+        let bridge_contract = must_read_key(storage, &bridge_contract_key);
+        let governance_contract =
+            must_read_key(storage, &governance_contract_key);
+
+        Some(Self {
+            min_confirmations,
+            contracts: Contracts {
+                native_erc20,
+                bridge: bridge_contract,
+                governance: governance_contract,
+            },
+        })
+    }
+}
+
+/// Reads the value of `key` from `storage` and deserializes it, or panics
+/// otherwise.
+fn must_read_key<DB, H, T: BorshDeserialize>(
+    storage: &Storage<DB, H>,
+    key: &Key,
+) -> T
+where
+    DB: storage::DB + for<'iter> storage::DBIter<'iter>,
+    H: storage::traits::StorageHasher,
+{
+    StorageRead::read::<T>(storage, key).map_or_else(
+        |err| panic!("Could not read {key}: {err:?}"),
+        |value| {
+            value.unwrap_or_else(|| {
+                panic!(
+                    "Ethereum bridge appears to be only partially configured! \
+                     There was no value for {key}"
+                )
+            })
+        },
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use eyre::Result;
+    use namada_core::ledger::storage::testing::TestStorage;
     use namada_core::types::ethereum_events::EthAddress;
 
+    use super::*;
     use crate::parameters::{
         ContractVersion, Contracts, EthereumBridgeConfig, MinimumConfirmations,
         UpgradeableContract,
@@ -193,5 +277,84 @@ mod tests {
 
         assert_eq!(config, deserialized);
         Ok(())
+    }
+
+    #[test]
+    fn test_ethereum_bridge_config_read_write_storage() {
+        let mut storage = TestStorage::default();
+        let config = EthereumBridgeConfig {
+            min_confirmations: MinimumConfirmations::default(),
+            contracts: Contracts {
+                native_erc20: EthAddress([42; 20]),
+                bridge: UpgradeableContract {
+                    address: EthAddress([23; 20]),
+                    version: ContractVersion::default(),
+                },
+                governance: UpgradeableContract {
+                    address: EthAddress([18; 20]),
+                    version: ContractVersion::default(),
+                },
+            },
+        };
+        config.init_storage(&mut storage);
+
+        let read = EthereumBridgeConfig::read(&storage).unwrap();
+
+        assert_eq!(config, read);
+    }
+
+    #[test]
+    fn test_ethereum_bridge_config_uninitialized() {
+        let storage = TestStorage::default();
+        let read = EthereumBridgeConfig::read(&storage);
+
+        assert!(read.is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "Could not read")]
+    fn test_ethereum_bridge_config_storage_corrupt() {
+        let mut storage = TestStorage::default();
+        let config = EthereumBridgeConfig {
+            min_confirmations: MinimumConfirmations::default(),
+            contracts: Contracts {
+                native_erc20: EthAddress([42; 20]),
+                bridge: UpgradeableContract {
+                    address: EthAddress([23; 20]),
+                    version: ContractVersion::default(),
+                },
+                governance: UpgradeableContract {
+                    address: EthAddress([18; 20]),
+                    version: ContractVersion::default(),
+                },
+            },
+        };
+        config.init_storage(&mut storage);
+        let min_confirmations_key = bridge_storage::min_confirmations_key();
+        storage
+            .write(&min_confirmations_key, vec![42, 1, 2, 3, 4])
+            .unwrap();
+
+        // This should panic because the min_confirmations value is not valid
+        EthereumBridgeConfig::read(&storage);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Ethereum bridge appears to be only partially configured!"
+    )]
+    fn test_ethereum_bridge_config_storage_partially_configured() {
+        let mut storage = TestStorage::default();
+        // Write a valid min_confirmations value
+        let min_confirmations_key = bridge_storage::min_confirmations_key();
+        storage
+            .write(
+                &min_confirmations_key,
+                MinimumConfirmations::default().try_to_vec().unwrap(),
+            )
+            .unwrap();
+
+        // This should panic as the other config values are not written
+        EthereumBridgeConfig::read(&storage);
     }
 }

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -1,0 +1,141 @@
+use namada_core::ledger::storage;
+use namada_core::ledger::storage::Storage;
+use namada_core::types::address::Address;
+use namada_core::types::ethereum_events::EthAddress;
+use namada_core::types::storage::Epoch;
+use namada_core::types::token;
+use namada_core::types::vote_extensions::validator_set_update::EthAddrBook;
+use namada_proof_of_stake::pos_queries::PosQueries;
+use namada_proof_of_stake::PosBase;
+
+/// This enum is used as a parameter to
+/// [`PosQueries::can_send_validator_set_update`].
+pub enum SendValsetUpd {
+    /// Check if it is possible to send a validator set update
+    /// vote extension at the current block height.
+    Now,
+    /// Check if it is possible to send a validator set update
+    /// vote extension at the previous block height.
+    AtPrevHeight,
+}
+
+pub trait EthBridgeQueries {
+    /// Determines if it is possible to send a validator set update vote
+    /// extension at the provided [`BlockHeight`] in [`SendValsetUpd`].
+    fn can_send_validator_set_update(&self, can_send: SendValsetUpd) -> bool;
+
+    /// For a given Namada validator, return its corresponding Ethereum bridge
+    /// address.
+    fn get_ethbridge_from_namada_addr(
+        &self,
+        validator: &Address,
+        epoch: Option<Epoch>,
+    ) -> Option<EthAddress>;
+
+    /// For a given Namada validator, return its corresponding Ethereum
+    /// governance address.
+    fn get_ethgov_from_namada_addr(
+        &self,
+        validator: &Address,
+        epoch: Option<Epoch>,
+    ) -> Option<EthAddress>;
+
+    /// Extension of [`Self::get_active_validators`], which additionally returns
+    /// all Ethereum addresses of some validator.
+    fn get_active_eth_addresses<'db>(
+        &'db self,
+        epoch: Option<Epoch>,
+    ) -> Box<dyn Iterator<Item = (EthAddrBook, Address, token::Amount)> + 'db>;
+}
+
+impl<D, H> EthBridgeQueries for Storage<D, H>
+where
+    D: storage::DB + for<'iter> storage::DBIter<'iter>,
+    H: storage::StorageHasher,
+{
+    #[cfg(feature = "abcipp")]
+    #[inline]
+    fn can_send_validator_set_update(&self, _can_send: SendValsetUpd) -> bool {
+        // TODO: implement this method for ABCI++; should only be able to send
+        // a validator set update at the second block of an epoch
+        false
+    }
+
+    #[cfg(not(feature = "abcipp"))]
+    #[inline]
+    fn can_send_validator_set_update(&self, can_send: SendValsetUpd) -> bool {
+        if matches!(can_send, SendValsetUpd::AtPrevHeight) {
+            // when checking vote extensions in Prepare
+            // and ProcessProposal, we simply return true
+            true
+        } else {
+            // offset of 1 => are we at the 2nd
+            // block within the epoch?
+            self.is_deciding_offset_within_epoch(1)
+        }
+    }
+
+    #[inline]
+    fn get_ethbridge_from_namada_addr(
+        &self,
+        validator: &Address,
+        epoch: Option<Epoch>,
+    ) -> Option<EthAddress> {
+        let epoch = epoch.unwrap_or_else(|| self.get_current_epoch().0);
+        self.read_validator_eth_hot_key(validator)
+            .as_ref()
+            .and_then(|epk| epk.get(epoch).and_then(|pk| pk.try_into().ok()))
+    }
+
+    #[inline]
+    fn get_ethgov_from_namada_addr(
+        &self,
+        validator: &Address,
+        epoch: Option<Epoch>,
+    ) -> Option<EthAddress> {
+        let epoch = epoch.unwrap_or_else(|| self.get_current_epoch().0);
+        self.read_validator_eth_cold_key(validator)
+            .as_ref()
+            .and_then(|epk| epk.get(epoch).and_then(|pk| pk.try_into().ok()))
+    }
+
+    #[inline]
+    fn get_active_eth_addresses<'db>(
+        &'db self,
+        epoch: Option<Epoch>,
+    ) -> Box<dyn Iterator<Item = (EthAddrBook, Address, token::Amount)> + 'db>
+    {
+        let epoch = epoch.unwrap_or_else(|| self.get_current_epoch().0);
+        Box::new(self.get_active_validators(Some(epoch)).into_iter().map(
+            move |validator| {
+                let hot_key_addr = self
+                    .get_ethbridge_from_namada_addr(
+                        &validator.address,
+                        Some(epoch),
+                    )
+                    .expect(
+                        "All Namada validators should have an Ethereum bridge \
+                         key",
+                    );
+                let cold_key_addr = self
+                    .get_ethgov_from_namada_addr(
+                        &validator.address,
+                        Some(epoch),
+                    )
+                    .expect(
+                        "All Namada validators should have an Ethereum \
+                         governance key",
+                    );
+                let eth_addr_book = EthAddrBook {
+                    hot_key_addr,
+                    cold_key_addr,
+                };
+                (
+                    eth_addr_book,
+                    validator.address,
+                    validator.bonded_stake.into(),
+                )
+            },
+        ))
+    }
+}

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -1,7 +1,8 @@
 use namada_core::ledger::storage;
 use namada_core::ledger::storage::Storage;
 use namada_core::types::address::Address;
-use namada_core::types::ethereum_events::EthAddress;
+use namada_core::types::ethereum_events::{EthAddress, Uint};
+use namada_core::types::keccak::KeccakHash;
 use namada_core::types::storage::Epoch;
 use namada_core::types::token;
 use namada_core::types::vote_extensions::validator_set_update::EthAddrBook;
@@ -20,6 +21,15 @@ pub enum SendValsetUpd {
 }
 
 pub trait EthBridgeQueries {
+
+    /// Get the latest nonce for the Ethereum bridge
+    /// pool.
+    fn get_bride_pool_nonce(&self) -> Uint;
+
+    /// Get the latest root of the Ethereum bridge
+    /// pool Merkle tree.
+    fn get_bridge_pool_root(&self) -> KeccakHash;
+
     /// Determines if it is possible to send a validator set update vote
     /// extension at the provided [`BlockHeight`] in [`SendValsetUpd`].
     fn can_send_validator_set_update(&self, can_send: SendValsetUpd) -> bool;

--- a/ethereum_bridge/src/storage/mod.rs
+++ b/ethereum_bridge/src/storage/mod.rs
@@ -1,4 +1,6 @@
 //! Functionality for accessing the storage subspace
 pub use namada_core::ledger::eth_bridge::storage::bridge_pool;
+pub mod eth_bridge_queries;
 pub mod vote_tallies;
+
 pub use namada_core::ledger::eth_bridge::storage::{wrapped_erc20s, *};

--- a/shared/src/ledger/eth_bridge.rs
+++ b/shared/src/ledger/eth_bridge.rs
@@ -2,3 +2,4 @@
 pub use namada_core::ledger::eth_bridge::storage::wrapped_erc20s;
 pub use namada_core::ledger::eth_bridge::{ADDRESS, INTERNAL_ADDRESS};
 pub use namada_ethereum_bridge::parameters::*;
+pub use namada_ethereum_bridge::storage::eth_bridge_queries::*;

--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -451,7 +451,6 @@ mod test_bridge_pool_vp {
                 sender: bertha_address(),
                 recipient: EthAddress([0; 20]),
                 amount: 0.into(),
-                nonce: 0u64.into(),
             },
             gas_fee: GasFee {
                 amount: 0.into(),
@@ -609,7 +608,6 @@ mod test_bridge_pool_vp {
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),
                 amount: TOKENS.into(),
-                nonce: 1u64.into(),
             },
             gas_fee: GasFee {
                 amount: GAS_FEE.into(),
@@ -870,9 +868,8 @@ mod test_bridge_pool_vp {
                     transfer: TransferToEthereum {
                         asset: EthAddress([0; 20]),
                         sender: bertha_address(),
-                        recipient: EthAddress([1; 20]),
+                        recipient: EthAddress([11; 20]),
                         amount: 100.into(),
-                        nonce: 10u64.into(),
                     },
                     gas_fee: GasFee {
                         amount: GAS_FEE.into(),
@@ -901,9 +898,8 @@ mod test_bridge_pool_vp {
                     transfer: TransferToEthereum {
                         asset: EthAddress([0; 20]),
                         sender: bertha_address(),
-                        recipient: EthAddress([1; 20]),
+                        recipient: EthAddress([11; 20]),
                         amount: 100.into(),
-                        nonce: 10u64.into(),
                     },
                     gas_fee: GasFee {
                         amount: GAS_FEE.into(),
@@ -1032,7 +1028,6 @@ mod test_bridge_pool_vp {
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),
                 amount: 0.into(),
-                nonce: 1u64.into(),
             },
             gas_fee: GasFee {
                 amount: 0.into(),
@@ -1104,7 +1099,6 @@ mod test_bridge_pool_vp {
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),
                 amount: 100.into(),
-                nonce: 1u64.into(),
             },
             gas_fee: GasFee {
                 amount: 100.into(),
@@ -1196,7 +1190,6 @@ mod test_bridge_pool_vp {
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),
                 amount: 100.into(),
-                nonce: 1u64.into(),
             },
             gas_fee: GasFee {
                 amount: 100.into(),
@@ -1306,7 +1299,6 @@ mod test_bridge_pool_vp {
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),
                 amount: 100.into(),
-                nonce: 1u64.into(),
             },
             gas_fee: GasFee {
                 amount: 100.into(),

--- a/shared/src/ledger/queries/shell.rs
+++ b/shared/src/ledger/queries/shell.rs
@@ -398,7 +398,7 @@ where
         let signed_root: MultiSignedMerkleRoot = match ctx
             .storage
             .read(&get_signed_root_key())
-            .expect("Reading the database should not faile")
+            .expect("Reading the database should not fail")
         {
             (Some(bytes), _) => {
                 BorshDeserialize::try_from_slice(bytes.as_slice()).unwrap()
@@ -458,8 +458,6 @@ where
                     validator_args: Default::default(),
                     root: signed_root,
                     proof,
-                    // TODO: Use real nonce
-                    nonce: 0.into(),
                 })
                 .try_to_vec()
                 .into_storage_result()?;
@@ -625,7 +623,6 @@ mod test {
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
                 amount: 0.into(),
-                nonce: 0.into(),
             },
             gas_fee: GasFee {
                 amount: 0.into(),
@@ -666,7 +663,6 @@ mod test {
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
                 amount: 0.into(),
-                nonce: 0.into(),
             },
             gas_fee: GasFee {
                 amount: 0.into(),
@@ -726,7 +722,6 @@ mod test {
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
                 amount: 0.into(),
-                nonce: 0.into(),
             },
             gas_fee: GasFee {
                 amount: 0.into(),
@@ -748,6 +743,7 @@ mod test {
             sigs: Default::default(),
             root: transfer.keccak256(),
             height: Default::default(),
+            nonce: 0.into(),
         };
 
         // commit the changes and increase block height
@@ -802,8 +798,6 @@ mod test {
             validator_args: Default::default(),
             root: signed_root,
             proof,
-            // TODO: Use a real nonce
-            nonce: 0.into(),
         }
         .encode()
         .into_inner();
@@ -822,7 +816,6 @@ mod test {
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
                 amount: 0.into(),
-                nonce: 0.into(),
             },
             gas_fee: GasFee {
                 amount: 0.into(),
@@ -844,6 +837,7 @@ mod test {
             sigs: Default::default(),
             root: transfer.keccak256(),
             height: Default::default(),
+            nonce: 0.into(),
         };
 
         // commit the changes and increase block height

--- a/tests/src/native_vp/eth_bridge_pool.rs
+++ b/tests/src/native_vp/eth_bridge_pool.rs
@@ -125,7 +125,6 @@ mod test_bridge_pool_vp {
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
                 amount: Amount::from(TOKENS),
-                nonce: Default::default(),
             },
             gas_fee: GasFee {
                 amount: Amount::from(GAS_FEE),
@@ -147,7 +146,6 @@ mod test_bridge_pool_vp {
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
                 amount: Amount::from(TOKENS),
-                nonce: Default::default(),
             },
             gas_fee: GasFee {
                 amount: Amount::from(GAS_FEE),
@@ -169,7 +167,6 @@ mod test_bridge_pool_vp {
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
                 amount: Amount::from(TOKENS),
-                nonce: Default::default(),
             },
             gas_fee: GasFee {
                 amount: Amount::from(GAS_FEE),


### PR DESCRIPTION
This PR partially addresses #423.

* Nonces are no longer tracked on individual transfers but are signed along with the root of the bp merkle tree as a batch nonce
* The batch nonces and merkle roots are signed and broadcast as protocol txs. 
* Validation logis for the new protocol txs have been added. They should pass mempool validation and process proposal.
* Prepare proposal should include  these protocol txs in their proposal.

Finalize block logic has not yet been implemented. 
ABCI++ logic has not been implemented.