### PR TITLE
Add some tests covering the application of duplicate Ethereum events/vote extensions

### DIFF
--- a/ethereum_bridge/Cargo.toml
+++ b/ethereum_bridge/Cargo.toml
@@ -26,7 +26,9 @@ abciplus = [
     "namada_proof_of_stake/abciplus",
 ]
 
-testing = []
+testing = [
+    "rand"
+]
 
 [dependencies]
 namada_core = {path = "../core", default-features = false, features = ["secp256k1-sign-verify", "ferveo-tpke"]}
@@ -36,6 +38,7 @@ eyre = "0.6.8"
 itertools = "0.10.0"
 serde = {version = "1.0.125", features = ["derive"]}
 serde_json = "1.0.62"
+rand = {version = "0.8", default-features = false, optional = true}
 tendermint-abcipp = {package = "tendermint", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}
 tendermint-rpc-abcipp = {package = "tendermint-rpc", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", features = ["http-client"], optional = true}
 tendermint-proto-abcipp = {package = "tendermint-proto", git = "https://github.com/heliaxdev/tendermint-rs", rev = "95c52476bc37927218374f94ac8e2a19bd35bec9", optional = true}

--- a/ethereum_bridge/Cargo.toml
+++ b/ethereum_bridge/Cargo.toml
@@ -26,6 +26,8 @@ abciplus = [
     "namada_proof_of_stake/abciplus",
 ]
 
+testing = []
+
 [dependencies]
 namada_core = {path = "../core", default-features = false, features = ["secp256k1-sign-verify", "ferveo-tpke"]}
 namada_proof_of_stake = {path = "../proof_of_stake", default-features = false}

--- a/ethereum_bridge/src/lib.rs
+++ b/ethereum_bridge/src/lib.rs
@@ -2,6 +2,6 @@ pub mod bridge_pool_vp;
 pub mod parameters;
 pub mod protocol;
 pub mod storage;
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 pub mod vp;

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -419,10 +419,12 @@ mod tests {
     pub fn test_apply_derived_tx_duplicates() -> Result<()> {
         let validator_a = address::testing::established_address_2();
         let validator_b = address::testing::established_address_3();
-        let mut storage = testing::setup_storage(HashSet::from_iter(vec![
-            validator_a.clone(),
-            validator_b,
-        ]));
+        let (mut storage, _) = test_utils::setup_storage_with_validators(
+            HashMap::from_iter(vec![
+                (validator_a.clone(), 100_u64.into()),
+                (validator_b, 100_u64.into()),
+            ]),
+        );
 
         let event = EthereumEvent::TransfersToNamada {
             nonce: 1.into(),

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -167,40 +167,6 @@ where
     Ok((changed, confirmed))
 }
 
-#[cfg(any(test, feature = "testing"))]
-pub mod testing {
-    use std::collections::{BTreeSet, HashSet};
-
-    use namada_core::ledger::storage::mockdb::MockDB;
-    use namada_core::ledger::storage::testing::TestStorage;
-    use namada_core::ledger::storage::{Sha256Hasher, Storage};
-    use namada_core::types::address::Address;
-    use namada_proof_of_stake::epoched::Epoched;
-    use namada_proof_of_stake::types::{ValidatorSet, WeightedValidator};
-    use namada_proof_of_stake::PosBase;
-
-    /// Set up a `TestStorage` initialized at genesis with validators of equal
-    /// power.
-    pub fn setup_storage(
-        active_validators: HashSet<Address>,
-    ) -> Storage<MockDB, Sha256Hasher> {
-        let mut storage = TestStorage::default();
-        let validator_set = ValidatorSet {
-            active: active_validators
-                .into_iter()
-                .map(|address| WeightedValidator {
-                    bonded_stake: 100_u64,
-                    address,
-                })
-                .collect(),
-            inactive: BTreeSet::default(),
-        };
-        let validator_sets = Epoched::init_at_genesis(validator_set, 1);
-        storage.write_validator_set(&validator_sets);
-        storage
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeSet, HashMap, HashSet};

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -403,6 +403,68 @@ mod tests {
     }
 
     #[test]
+    /// Test that attempts made to apply duplicate
+    /// [`MultiSignedEthEvent`]s in a single [`apply_derived_tx`] call don't
+    /// result in duplicate votes in storage.
+    pub fn test_apply_derived_tx_duplicates() -> Result<()> {
+        let validator_a = address::testing::established_address_2();
+        let validator_b = address::testing::established_address_3();
+        let mut storage = set_up_test_storage(HashSet::from_iter(vec![
+            validator_a.clone(),
+            validator_b,
+        ]));
+
+        let event = EthereumEvent::TransfersToNamada {
+            nonce: 1.into(),
+            transfers: vec![TransferToNamada {
+                amount: Amount::from(100),
+                asset: DAI_ERC20_ETH_ADDRESS,
+                receiver: address::testing::established_address_1(),
+            }],
+        };
+        // two votes for the same event from validator A
+        let signers = BTreeSet::from([(validator_a.clone(), BlockHeight(100))]);
+        let multisigned = MultiSignedEthEvent {
+            event: event.clone(),
+            signers,
+        };
+
+        let multisigneds = vec![multisigned.clone(), multisigned];
+
+        let result = apply_derived_tx(&mut storage, multisigneds);
+        let tx_result = match result {
+            Ok(tx_result) => tx_result,
+            Err(err) => panic!("unexpected error: {:#?}", err),
+        };
+
+        let eth_msg_keys = vote_tallies::Keys::from(&event);
+        assert_eq!(
+            tx_result.changed_keys,
+            BTreeSet::from_iter(vec![
+                eth_msg_keys.body(),
+                eth_msg_keys.seen(),
+                eth_msg_keys.seen_by(),
+                eth_msg_keys.voting_power(),
+            ]),
+            "One vote for the Ethereum event should have been recorded",
+        );
+
+        let (seen_by_bytes, _) = storage.read(&eth_msg_keys.seen_by())?;
+        let seen_by_bytes = seen_by_bytes.unwrap();
+        assert_eq!(
+            Votes::try_from_slice(&seen_by_bytes)?,
+            Votes::from([(validator_a, BlockHeight(100))])
+        );
+
+        let (voting_power_bytes, _) =
+            storage.read(&eth_msg_keys.voting_power())?;
+        let voting_power_bytes = voting_power_bytes.unwrap();
+        assert_eq!(<(u64, u64)>::try_from_slice(&voting_power_bytes)?, (1, 2));
+
+        Ok(())
+    }
+
+    #[test]
     /// Assert we don't return anything if we try to get the votes for an empty
     /// set of updates
     pub fn test_get_votes_for_updates_empty() {

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -167,15 +167,47 @@ where
     Ok((changed, confirmed))
 }
 
+#[cfg(any(test, feature = "testing"))]
+pub mod testing {
+    use std::collections::{BTreeSet, HashSet};
+
+    use namada_core::ledger::storage::mockdb::MockDB;
+    use namada_core::ledger::storage::testing::TestStorage;
+    use namada_core::ledger::storage::{Sha256Hasher, Storage};
+    use namada_core::types::address::Address;
+    use namada_proof_of_stake::epoched::Epoched;
+    use namada_proof_of_stake::types::{ValidatorSet, WeightedValidator};
+    use namada_proof_of_stake::PosBase;
+
+    /// Set up a `TestStorage` initialized at genesis with validators of equal
+    /// power.
+    pub fn setup_storage(
+        active_validators: HashSet<Address>,
+    ) -> Storage<MockDB, Sha256Hasher> {
+        let mut storage = TestStorage::default();
+        let validator_set = ValidatorSet {
+            active: active_validators
+                .into_iter()
+                .map(|address| WeightedValidator {
+                    bonded_stake: 100_u64,
+                    address,
+                })
+                .collect(),
+            inactive: BTreeSet::default(),
+        };
+        let validator_sets = Epoched::init_at_genesis(validator_set, 1);
+        storage.write_validator_set(&validator_sets);
+        storage
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeSet, HashMap, HashSet};
 
     use borsh::BorshDeserialize;
     use namada_core::ledger::eth_bridge::storage::wrapped_erc20s;
-    use namada_core::ledger::storage::mockdb::MockDB;
     use namada_core::ledger::storage::testing::TestStorage;
-    use namada_core::ledger::storage::traits::Sha256Hasher;
     use namada_core::types::address;
     use namada_core::types::ethereum_events::testing::{
         arbitrary_amount, arbitrary_eth_address, arbitrary_nonce,
@@ -185,10 +217,6 @@ mod tests {
         EthereumEvent, TransferToNamada,
     };
     use namada_core::types::token::Amount;
-    use namada_proof_of_stake::epoched::Epoched;
-    use namada_proof_of_stake::storage::ValidatorSet;
-    use namada_proof_of_stake::types::WeightedValidator;
-    use namada_proof_of_stake::PosBase;
 
     use super::*;
     use crate::protocol::transactions::utils::GetVoters;
@@ -276,34 +304,13 @@ mod tests {
         Ok(())
     }
 
-    /// Set up a `TestStorage` initialized at genesis with validators of equal
-    /// power
-    fn set_up_test_storage(
-        active_validators: HashSet<Address>,
-    ) -> Storage<MockDB, Sha256Hasher> {
-        let mut storage = TestStorage::default();
-        let validator_set = ValidatorSet {
-            active: active_validators
-                .into_iter()
-                .map(|address| WeightedValidator {
-                    bonded_stake: 100_u64,
-                    address,
-                })
-                .collect(),
-            inactive: BTreeSet::default(),
-        };
-        let validator_sets = Epoched::init_at_genesis(validator_set, 1);
-        storage.write_validator_set(&validator_sets);
-        storage
-    }
-
     #[test]
     /// Test applying a single transfer via `apply_derived_tx`, where an event
     /// has enough voting power behind it for it to be applied at the same time
     /// that it is recorded in storage
     fn test_apply_derived_tx_new_event_mint_immediately() {
         let sole_validator = address::testing::established_address_2();
-        let mut storage = set_up_test_storage(HashSet::from_iter(vec![
+        let mut storage = testing::setup_storage(HashSet::from_iter(vec![
             sole_validator.clone(),
         ]));
         let receiver = address::testing::established_address_1();
@@ -360,7 +367,7 @@ mod tests {
     fn test_apply_derived_tx_new_event_dont_mint() {
         let validator_a = address::testing::established_address_2();
         let validator_b = address::testing::established_address_3();
-        let mut storage = set_up_test_storage(HashSet::from_iter(vec![
+        let mut storage = testing::setup_storage(HashSet::from_iter(vec![
             validator_a.clone(),
             validator_b,
         ]));
@@ -409,7 +416,7 @@ mod tests {
     pub fn test_apply_derived_tx_duplicates() -> Result<()> {
         let validator_a = address::testing::established_address_2();
         let validator_b = address::testing::established_address_3();
-        let mut storage = set_up_test_storage(HashSet::from_iter(vec![
+        let mut storage = testing::setup_storage(HashSet::from_iter(vec![
             validator_a.clone(),
             validator_b,
         ]));

--- a/ethereum_bridge/src/protocol/transactions/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/mod.rs
@@ -9,7 +9,7 @@ mod read;
 mod update;
 mod utils;
 pub mod validator_set_update;
-mod votes;
+pub mod votes;
 
 use std::collections::BTreeSet;
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -73,6 +73,7 @@ ibc-mocks-abcipp = [
 # for integration tests and test utilies
 testing = [
   "namada_core/testing",
+  "namada_ethereum_bridge/testing",
   "namada_proof_of_stake/testing",
   "async-client",
   "proptest",

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -560,7 +560,7 @@ fn merge_vp_results(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::HashMap;
 
     use borsh::BorshDeserialize;
     use eyre::Result;
@@ -572,9 +572,9 @@ mod tests {
     use namada_core::types::token::Amount;
     use namada_core::types::vote_extensions::ethereum_events::EthereumEventsVext;
     use namada_core::types::{address, key};
-    use namada_ethereum_bridge::protocol::transactions::ethereum_events;
     use namada_ethereum_bridge::protocol::transactions::votes::Votes;
     use namada_ethereum_bridge::storage::vote_tallies;
+    use namada_ethereum_bridge::test_utils;
 
     use super::*;
 
@@ -585,11 +585,12 @@ mod tests {
     fn test_apply_protocol_tx_duplicate_eth_events_vext() -> Result<()> {
         let validator_a = address::testing::established_address_2();
         let validator_b = address::testing::established_address_3();
-        let mut storage =
-            ethereum_events::testing::setup_storage(HashSet::from_iter(vec![
-                validator_a.clone(),
-                validator_b,
-            ]));
+        let (mut storage, _) = test_utils::setup_storage_with_validators(
+            HashMap::from_iter(vec![
+                (validator_a.clone(), 100_u64.into()),
+                (validator_b, 100_u64.into()),
+            ]),
+        );
         let event = EthereumEvent::TransfersToNamada {
             nonce: 1.into(),
             transfers: vec![TransferToNamada {

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -557,3 +557,73 @@ fn merge_vp_results(
         errors,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use borsh::BorshDeserialize;
+    use eyre::Result;
+    use namada_core::types::ethereum_events::testing::DAI_ERC20_ETH_ADDRESS;
+    use namada_core::types::ethereum_events::{
+        EthereumEvent, TransferToNamada,
+    };
+    use namada_core::types::storage::BlockHeight;
+    use namada_core::types::token::Amount;
+    use namada_core::types::vote_extensions::ethereum_events::EthereumEventsVext;
+    use namada_core::types::{address, key};
+    use namada_ethereum_bridge::protocol::transactions::ethereum_events;
+    use namada_ethereum_bridge::protocol::transactions::votes::Votes;
+    use namada_ethereum_bridge::storage::vote_tallies;
+
+    use super::*;
+
+    #[test]
+    /// Tests that if the same [`ProtocolTxType::EthEventsVext`] is applied
+    /// twice within the same block, it doesn't result in voting power being
+    /// double counted.
+    fn test_apply_protocol_tx_duplicate_eth_events_vext() -> Result<()> {
+        let validator_a = address::testing::established_address_2();
+        let validator_b = address::testing::established_address_3();
+        let mut storage =
+            ethereum_events::testing::setup_storage(HashSet::from_iter(vec![
+                validator_a.clone(),
+                validator_b,
+            ]));
+        let event = EthereumEvent::TransfersToNamada {
+            nonce: 1.into(),
+            transfers: vec![TransferToNamada {
+                amount: Amount::from(100),
+                asset: DAI_ERC20_ETH_ADDRESS,
+                receiver: address::testing::established_address_4(),
+            }],
+        };
+        let vext = EthereumEventsVext {
+            block_height: BlockHeight(100),
+            validator_addr: address::testing::established_address_2(),
+            ethereum_events: vec![event.clone()],
+        };
+        let signing_key = key::testing::keypair_1();
+        let signed = vext.sign(&signing_key);
+        let tx = ProtocolTxType::EthEventsVext(signed);
+
+        apply_protocol_tx(tx.clone(), &mut storage)?;
+        apply_protocol_tx(tx, &mut storage)?;
+
+        let eth_msg_keys = vote_tallies::Keys::from(&event);
+        let (seen_by_bytes, _) = storage.read(&eth_msg_keys.seen_by())?;
+        let seen_by_bytes = seen_by_bytes.unwrap();
+        assert_eq!(
+            Votes::try_from_slice(&seen_by_bytes)?,
+            Votes::from([(validator_a, BlockHeight(100))])
+        );
+
+        // the vote should have only be applied once
+        let (voting_power_bytes, _) =
+            storage.read(&eth_msg_keys.voting_power())?;
+        let voting_power_bytes = voting_power_bytes.unwrap();
+        assert_eq!(<(u64, u64)>::try_from_slice(&voting_power_bytes)?, (1, 2));
+
+        Ok(())
+    }
+}

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2819,6 +2819,7 @@ dependencies = [
  "itertools",
  "namada_core",
  "namada_proof_of_stake",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tendermint",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -2819,6 +2819,7 @@ dependencies = [
  "itertools",
  "namada_core",
  "namada_proof_of_stake",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tendermint",


### PR DESCRIPTION
This PR adds test cases to cover a couple of scenarios discussed where a validator could attempt to vote twice on the same event:
- by including the same Ethereum event twice in a single vote extension
- by submitting multiple vote extensions for the same block height, each vote extension containing a same Ethereum event