### PR TITLE
Added config parameter for the size of the oracle buffer

### DIFF
--- a/apps/src/lib/config/ethereum_bridge/ledger.rs
+++ b/apps/src/lib/config/ethereum_bridge/ledger.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 /// Default [Ethereum JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/) endpoint used by the oracle
 pub const DEFAULT_ORACLE_RPC_ENDPOINT: &str = "http://127.0.0.1:8545";
 
+/// The default maximum number of Ethereum events the channel between
+/// the oracle and the shell can hold.
+pub const ORACLE_CHANNEL_BUFFER_SIZE: usize = 1000;
+
 /// The mode in which to run the Ethereum bridge.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Mode {
@@ -34,6 +38,10 @@ pub struct Config {
     /// The Ethereum JSON-RPC endpoint that the Ethereum event oracle will use
     /// to listen for events from the Ethereum bridge smart contracts
     pub oracle_rpc_endpoint: String,
+    /// The size of bounded channel between the Ethereum oracle and main
+    /// ledger subprocesses. This is the number of Ethereum events that
+    /// can be held in the channel. The default is 1000.
+    pub channel_buffer_size: usize,
 }
 
 impl Default for Config {
@@ -41,6 +49,7 @@ impl Default for Config {
         Self {
             mode: Mode::Managed,
             oracle_rpc_endpoint: DEFAULT_ORACLE_RPC_ENDPOINT.to_owned(),
+            channel_buffer_size: ORACLE_CHANNEL_BUFFER_SIZE,
         }
     }
 }

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -44,10 +44,6 @@ const ENV_VAR_TOKIO_THREADS: &str = "NAMADA_TOKIO_THREADS";
 /// Env. var to set a number of Rayon global worker threads
 const ENV_VAR_RAYON_THREADS: &str = "NAMADA_RAYON_THREADS";
 
-/// The maximum number of Ethereum events the channel between
-/// the oracle and the shell can hold.
-const ORACLE_CHANNEL_BUFFER_SIZE: usize = 1000;
-
 // Until ABCI++ is ready, the shim provides the service implementation.
 // We will add this part back in once the shim is no longer needed.
 //```
@@ -654,7 +650,8 @@ async fn maybe_start_ethereum_oracle(
     let ethereum_url = config.ethereum_bridge.oracle_rpc_endpoint.clone();
 
     // Start the oracle for listening to Ethereum events
-    let (eth_sender, eth_receiver) = mpsc::channel(ORACLE_CHANNEL_BUFFER_SIZE);
+    let (eth_sender, eth_receiver) =
+        mpsc::channel(config.ethereum_bridge.channel_buffer_size);
 
     match config.ethereum_bridge.mode {
         ethereum_bridge::ledger::Mode::Managed

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -892,6 +892,7 @@ mod test_utils {
     use tokio::sync::mpsc::{Sender, UnboundedReceiver};
 
     use super::*;
+    use crate::config::ethereum_bridge::ledger::ORACLE_CHANNEL_BUFFER_SIZE;
     use crate::facade::tendermint_proto::abci::{
         RequestInitChain, RequestProcessProposal,
     };
@@ -900,7 +901,6 @@ mod test_utils {
         FinalizeBlock, ProcessedTx,
     };
     use crate::node::ledger::storage::{PersistentDB, PersistentStorageHasher};
-    use crate::config::ethereum_bridge::ledger::ORACLE_CHANNEL_BUFFER_SIZE;
 
     #[derive(Error, Debug)]
     pub enum TestError {

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -900,7 +900,7 @@ mod test_utils {
         FinalizeBlock, ProcessedTx,
     };
     use crate::node::ledger::storage::{PersistentDB, PersistentStorageHasher};
-    use crate::node::ledger::ORACLE_CHANNEL_BUFFER_SIZE;
+    use crate::config::ethereum_bridge::ledger::ORACLE_CHANNEL_BUFFER_SIZE;
 
     #[derive(Error, Debug)]
     pub enum TestError {

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -33,8 +33,8 @@ impl utils::GetVoters for HashSet<EthMsgUpdate> {
 
 /// Applies derived state changes to storage, based on Ethereum `events` which
 /// were newly seen by some active validator(s) in the last epoch. For `events`
-/// which have been seen by enough voting power, extra state changes may take
-/// place, such as minting of wrapped ERC20s.
+/// which have been seen by enough voting power ( > 2/3 ), extra state changes
+/// may take place, such as minting of wrapped ERC20s.
 ///
 /// This function is deterministic based on some existing blockchain state and
 /// the passed `events`.


### PR DESCRIPTION
This closes Issue #540. The size of the channel between the oracle and the ledger had a hardcoded default of 1000. This is now configurable in the oracle config params.