### PR TITLE
Update TransferToEthereum event definition

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
@@ -351,6 +351,7 @@ fn process_queue(
 mod test_oracle {
     use std::num::NonZeroU64;
 
+    use namada::types::address::testing::gen_established_address;
     use namada::types::ethereum_events::{EthAddress, TransferToEthereum};
     use tokio::sync::oneshot::channel;
     use tokio::time::timeout;
@@ -621,14 +622,16 @@ mod test_oracle {
         .encode();
 
         // confirmed after 125 blocks
+        let gas_payer = gen_established_address();
         let second_event = RawTransfersToEthereum {
             transfers: vec![TransferToEthereum {
                 amount: Default::default(),
                 asset: EthAddress([0; 20]),
                 receiver: EthAddress([1; 20]),
+                gas_amount: Default::default(),
+                gas_payer: gas_payer.clone(),
             }],
             nonce: 1.into(),
-            confirmations: 125,
         }
         .encode();
 
@@ -695,6 +698,8 @@ mod test_oracle {
                     amount: Default::default(),
                     asset: EthAddress([0; 20]),
                     receiver: EthAddress([1; 20]),
+                    gas_amount: Default::default(),
+                    gas_payer,
                 }
             );
         } else {

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -297,6 +297,7 @@ mod test_vote_extensions {
     use namada::ledger::pos::PosQueries;
     #[cfg(feature = "abcipp")]
     use namada::proto::{SignableEthBytes, Signed};
+    use namada::types::address::testing::gen_established_address;
     #[cfg(feature = "abcipp")]
     use namada::types::eth_abi::Encode;
     #[cfg(feature = "abcipp")]
@@ -336,6 +337,8 @@ mod test_vote_extensions {
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
                 receiver: EthAddress([2; 20]),
+                gas_amount: 10.into(),
+                gas_payer: gen_established_address(),
             }],
         };
         let event_2 = EthereumEvent::TransfersToEthereum {
@@ -344,6 +347,8 @@ mod test_vote_extensions {
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
                 receiver: EthAddress([2; 20]),
+                gas_amount: 10.into(),
+                gas_payer: gen_established_address(),
             }],
         };
         let event_3 = EthereumEvent::NewContract {
@@ -390,6 +395,8 @@ mod test_vote_extensions {
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
                 receiver: EthAddress([2; 20]),
+                gas_amount: 10.into(),
+                gas_payer: gen_established_address(),
             }],
         };
         let event_2 = EthereumEvent::NewContract {
@@ -446,6 +453,8 @@ mod test_vote_extensions {
                     amount: 100.into(),
                     asset: EthAddress([1; 20]),
                     receiver: EthAddress([2; 20]),
+                    gas_amount: 10.into(),
+                    gas_payer: gen_established_address(),
                 }],
             }],
             block_height: shell.storage.get_current_decision_height(),
@@ -522,6 +531,8 @@ mod test_vote_extensions {
                     amount: 100.into(),
                     asset: EthAddress([1; 20]),
                     receiver: EthAddress([2; 20]),
+                    gas_amount: 10.into(),
+                    gas_payer: gen_established_address(),
                 }],
             }],
             block_height: signed_height,
@@ -585,6 +596,8 @@ mod test_vote_extensions {
                     amount: 100.into(),
                     asset: EthAddress([1; 20]),
                     receiver: EthAddress([2; 20]),
+                    gas_amount: 10.into(),
+                    gas_payer: gen_established_address(),
                 }],
             }],
             block_height: shell.storage.last_height,
@@ -658,6 +671,8 @@ mod test_vote_extensions {
                     amount: 100.into(),
                     asset: EthAddress([1; 20]),
                     receiver: EthAddress([2; 20]),
+                    gas_amount: 10.into(),
+                    gas_payer: gen_established_address(),
                 }],
             }],
             block_height: shell.storage.last_height,

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -278,6 +278,10 @@ pub struct TransferToEthereum {
     pub asset: EthAddress,
     /// The address receiving assets on Ethereum
     pub receiver: EthAddress,
+    /// The amount of fees (in NAM)
+    pub gas_amount: Amount,
+    /// The account of fee payer.
+    pub gas_payer: Address,
 }
 
 /// struct for whitelisting a token from Ethereum.


### PR DESCRIPTION
To calculate a transfer hash from this TransferToEthereum event

The latest smart contract returns [the event](https://github.com/anoma/ethereum-bridge/blob/c6389e5d8aeae0eb24d33dd83836c9ff4aace6a6/contracts/contract/Bridge.sol#L119) with the transfer info.
`TransferToErc`: https://github.com/anoma/ethereum-bridge/blob/c6389e5d8aeae0eb24d33dd83836c9ff4aace6a6/contracts/interface/ICommon.sol#L23