### PR TITLE
Change vext behavior if the bridge is inactive

### DIFF
--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -2,6 +2,7 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
+use namada::ledger::eth_bridge::EthBridgeStatus;
 use namada::ledger::parameters::Parameters;
 use namada::ledger::pos::{into_tm_voting_power, PosParams};
 use namada::ledger::storage::traits::StorageHasher;
@@ -126,6 +127,13 @@ where
         if let Some(config) = genesis.ethereum_bridge_params {
             tracing::debug!("Initializing Ethereum bridge storage.");
             config.init_storage(&mut self.storage);
+        } else {
+            self.storage
+                .write(
+                    &namada::eth_bridge::storage::active_key(),
+                    EthBridgeStatus::Disabled.try_to_vec().unwrap(),
+                )
+                .unwrap();
         }
 
         // Depends on parameters being initialized

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1268,6 +1268,19 @@ mod test_utils {
         }
     }
 
+    /// Set the Ethereum bridge to be inactive
+    pub(super) fn deactivate_bridge(shell: &mut TestShell) {
+        use namada::eth_bridge::storage::active_key;
+        use namada::eth_bridge::storage::eth_bridge_queries::EthBridgeStatus;
+        shell
+            .storage
+            .write(
+                &active_key(),
+                EthBridgeStatus::Disabled.try_to_vec().expect("Test failed"),
+            )
+            .expect("Test failed");
+    }
+
     /// We test that on shell shutdown, the tx queue gets persisted in a DB, and
     /// on startup it is read successfully
     #[test]

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -314,8 +314,7 @@ where
                 );
                         false
                     })
-            }
-            else {
+            } else {
                 false
             }
         } else {

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -270,23 +270,24 @@ where
         if !self.storage.is_bridge_active() {
             ext.is_none()
         } else {
-            if ext.is_none() {
-                return false;
-            }
-            self.validate_eth_events_vext(
-                ext.unwrap(),
-            self.storage.get_current_decision_height(),
-            )
-            .then_some(true)
-            .unwrap_or_else(|| {
-                tracing::warn!(
-                    ?req.validator_address,
-                    ?req.hash,
-                    req.height,
-                    "Received Ethereum events vote extension that didn't validate"
-                );
+            if let Some(ext) = ext {
+                self.validate_eth_events_vext(
+                    ext,
+                    self.storage.get_current_decision_height(),
+                )
+                .then_some(true)
+                .unwrap_or_else(| | {
+                    tracing::warn!(
+                        ?req.validator_address,
+                        ?req.hash,
+                        req.height,
+                        "Received Ethereum events vote extension that didn't validate"
+                    );
+                    false
+                })
+            } else {
                 false
-            })
+            }
         }
     }
 
@@ -298,23 +299,25 @@ where
         ext: Option<bridge_pool_roots::SignedVext>,
     ) -> bool {
         if self.storage.is_bridge_active() {
-            if ext.is_none() {
-                return false;
-            }
-            self.validate_bp_roots_vext(
-                ext.unwrap(),
-                self.storage.last_height,
-            )
-            .then_some(true)
-            .unwrap_or_else(|| {
-                tracing::warn!(
+            if let Some(ext) = ext {
+                self.validate_bp_roots_vext(
+                    ext.unwrap(),
+                    self.storage.last_height,
+                )
+                    .then_some(true)
+                    .unwrap_or_else(|| {
+                        tracing::warn!(
                     ?req.validator_address,
                     ?req.hash,
                     req.height,
                     "Received Bridge pool root vote extension that didn't validate"
                 );
-                    false
-                })
+                        false
+                    })
+            }
+            else {
+                false
+            }
         } else {
             ext.is_none()
         }

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -10,8 +10,6 @@ use namada::ledger::eth_bridge::{EthBridgeQueries, SendValsetUpd};
 #[cfg(feature = "abcipp")]
 use namada::ledger::pos::PosQueries;
 use namada::proto::{SignableEthBytes, Signed};
-#[cfg(not(feature = "abcipp"))]
-use namada::types::storage::Epoch;
 use namada::types::transaction::protocol::ProtocolTxType;
 #[cfg(feature = "abcipp")]
 use namada::types::vote_extensions::VoteExtensionDigest;
@@ -95,7 +93,10 @@ where
     /// Extend PreCommit votes with [`ethereum_events::Vext`] instances.
     pub fn extend_vote_with_ethereum_events(
         &mut self,
-    ) -> Signed<ethereum_events::Vext> {
+    ) -> Option<Signed<ethereum_events::Vext>> {
+        if !self.storage.is_bridge_active() {
+            return None;
+        }
         let validator_addr = self
             .mode
             .get_validator_address()
@@ -124,11 +125,16 @@ where
             _ => unreachable!("{VALIDATOR_EXPECT_MSG}"),
         };
 
-        ext.sign(protocol_key)
+        Some(ext.sign(protocol_key))
     }
 
     /// Extend PreCommit votes with [`bridge_pool_roots::Vext`] instances.
-    pub fn extend_vote_with_bp_roots(&self) -> Signed<bridge_pool_roots::Vext> {
+    pub fn extend_vote_with_bp_roots(
+        &self,
+    ) -> Option<Signed<bridge_pool_roots::Vext>> {
+        if !self.storage.is_bridge_active() {
+            return None;
+        }
         let validator_addr = self
             .mode
             .get_validator_address()
@@ -150,7 +156,7 @@ where
         };
         let protocol_key =
             self.mode.get_protocol_key().expect(VALIDATOR_EXPECT_MSG);
-        ext.sign(protocol_key)
+        Some(ext.sign(protocol_key))
     }
 
     /// Extend PreCommit votes with [`validator_set_update::Vext`]
@@ -252,22 +258,29 @@ where
     pub fn verify_ethereum_events(
         &self,
         req: &request::VerifyVoteExtension,
-        ext: Signed<ethereum_events::Vext>,
+        ext: Option<Signed<ethereum_events::Vext>>,
     ) -> bool {
-        self.validate_eth_events_vext(
-            ext,
+        if !self.storage.is_bridge_active() {
+            ext.is_none()
+        } else {
+            if ext.is_none() {
+                return false;
+            }
+            self.validate_eth_events_vext(
+                ext.unwrap(),
             self.storage.get_current_decision_height(),
-        )
-        .then_some(true)
-        .unwrap_or_else(|| {
-            tracing::warn!(
-                ?req.validator_address,
-                ?req.hash,
-                req.height,
-                "Received Ethereum events vote extension that didn't validate"
-            );
-            false
-        })
+            )
+            .then_some(true)
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    ?req.validator_address,
+                    ?req.hash,
+                    req.height,
+                    "Received Ethereum events vote extension that didn't validate"
+                );
+                false
+            })
+        }
     }
 
     /// Check if [`bridge_pool_roots::Vext`] instances are valid.
@@ -275,22 +288,29 @@ where
     pub fn verify_bridge_pool_root(
         &self,
         req: &request::VerifyVoteExtension,
-        ext: Signed<bridge_pool_roots::Vext>,
+        ext: Option<bridge_pool_roots::SignedVext>,
     ) -> bool {
-        self.validate_bp_roots_vext(
-            ext,
-            self.storage.last_height,
-        )
-        .then_some(true)
-        .unwrap_or_else(|| {
-            tracing::warn!(
-                ?req.validator_address,
-                ?req.hash,
-                req.height,
-                "Received Bridge pool root vote extension that didn't validate"
-            );
-            false
-        })
+        if self.storage.is_bridge_active() {
+            if ext.is_none() {
+                return false;
+            }
+            self.validate_bp_roots_vext(
+                ext.unwrap(),
+                self.storage.last_height,
+            )
+            .then_some(true)
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    ?req.validator_address,
+                    ?req.hash,
+                    req.height,
+                    "Received Bridge pool root vote extension that didn't validate"
+                );
+                    false
+                })
+        } else {
+            ext.is_none()
+        }
     }
 
     /// Check if [`validator_set_update::Vext`] instances are valid.
@@ -344,6 +364,107 @@ where
                 false
             })
     }
+
+    /// Given a slice of [`TxBytes`], return an iterator over the
+    /// ones we could deserialize to vote extension protocol txs.
+    #[cfg(not(feature = "abcipp"))]
+    pub fn deserialize_vote_extensions<'shell>(
+        &'shell self,
+        txs: &'shell [TxBytes],
+        protocol_tx_indices: &'shell mut VecIndexSet<u128>,
+    ) -> impl Iterator<Item = TxBytes> + 'shell {
+        use namada::types::transaction::protocol::ProtocolTx;
+        let current_epoch = self.storage.get_current_epoch().0;
+
+        txs.iter().enumerate().filter_map(move |(index, tx_bytes)| {
+            let tx = match Tx::try_from(tx_bytes.as_slice()) {
+                Ok(tx) => tx,
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        "Failed to deserialize tx in \
+                         deserialize_vote_extensions"
+                    );
+                    return None;
+                }
+            };
+            match process_tx(tx).ok()? {
+                TxType::Protocol(ProtocolTx {
+                    tx:
+                        ProtocolTxType::EthEventsVext(_)
+                        | ProtocolTxType::BridgePoolVext(_),
+                    ..
+                }) => {
+                    if self.storage.is_bridge_active() {
+                        // mark tx for inclusion
+                        protocol_tx_indices.insert(index);
+                        Some(tx_bytes.clone())
+                    } else {
+                        None
+                    }
+                }
+                TxType::Protocol(ProtocolTx {
+                    tx: ProtocolTxType::ValSetUpdateVext(ext),
+                    ..
+                }) => {
+                    // mark tx, so it's skipped when
+                    // building the batch of remaining txs
+                    protocol_tx_indices.insert(index);
+
+                    // only include non-stale validator set updates
+                    // in block proposals. it might be sitting long
+                    // enough in the mempool for it to no longer be
+                    // relevant to propose (e.g. the new epoch was
+                    // installed before this validator set update got
+                    // a chance to be decided). unfortunately, we won't
+                    // be able to remove it from the mempool this way,
+                    // but it will eventually be evicted, getting replaced
+                    // by newer txs.
+                    (ext.data.signing_epoch == current_epoch)
+                        .then(|| tx_bytes.clone())
+                }
+                _ => None,
+            }
+        })
+    }
+
+    /// Deserializes `vote_extensions` as [`VoteExtension`] instances, filtering
+    /// out invalid data, and splits these into [`ethereum_events::Vext`]
+    /// and [`validator_set_update::Vext`] instances.
+    #[cfg(feature = "abcipp")]
+    #[allow(clippy::type_complexity)]
+    pub fn split_vote_extensions(
+        &self,
+        vote_extensions: Vec<ExtendedVoteInfo>,
+    ) -> (
+        Option<Vec<Signed<ethereum_events::Vext>>>,
+        Option<Vec<Signed<bridge_pool_roots::Vext>>>,
+        Vec<validator_set_update::SignedVext>,
+    ) {
+        let mut eth_evs = vec![];
+        let mut bp_roots = vec![];
+        let mut valset_upds = vec![];
+        let bridge_active = self.storage.is_bridge_active();
+
+        for ext in deserialize_vote_extensions(vote_extensions) {
+            if let Some(validator_set_update) = ext.validator_set_update {
+                valset_upds.push(validator_set_update);
+            }
+            if bridge_active {
+                if let Some(events) = ext.ethereum_events {
+                    eth_evs.push(events);
+                }
+                if let Some(roots) = ext.bridge_pool_root {
+                    bp_roots.push(roots);
+                }
+            }
+        }
+        if bridge_active {
+            (Some(eth_evs), Some(bp_roots), valset_upds)
+        } else {
+            (None, None, valset_upds)
+        }
+    }
 }
 
 /// Given a `Vec` of [`ExtendedVoteInfo`], return an iterator over the
@@ -365,63 +486,6 @@ pub fn deserialize_vote_extensions(
     })
 }
 
-/// Given a slice of [`TxBytes`], return an iterator over the
-/// ones we could deserialize to vote extension protocol txs.
-#[cfg(not(feature = "abcipp"))]
-pub fn deserialize_vote_extensions<'shell>(
-    txs: &'shell [TxBytes],
-    protocol_tx_indices: &'shell mut VecIndexSet<u128>,
-    current_epoch: Epoch,
-) -> impl Iterator<Item = TxBytes> + 'shell {
-    use namada::types::transaction::protocol::ProtocolTx;
-
-    txs.iter().enumerate().filter_map(move |(index, tx_bytes)| {
-        let tx = match Tx::try_from(tx_bytes.as_slice()) {
-            Ok(tx) => tx,
-            Err(err) => {
-                tracing::warn!(
-                    ?err,
-                    "Failed to deserialize tx in deserialize_vote_extensions"
-                );
-                return None;
-            }
-        };
-        match process_tx(tx).ok()? {
-            TxType::Protocol(ProtocolTx {
-                tx:
-                    ProtocolTxType::EthEventsVext(_)
-                    | ProtocolTxType::BridgePoolVext(_),
-                ..
-            }) => {
-                // mark tx for inclusion
-                protocol_tx_indices.insert(index);
-                Some(tx_bytes.clone())
-            }
-            TxType::Protocol(ProtocolTx {
-                tx: ProtocolTxType::ValSetUpdateVext(ext),
-                ..
-            }) => {
-                // mark tx, so it's skipped when
-                // building the batch of remaining txs
-                protocol_tx_indices.insert(index);
-
-                // only include non-stale validator set updates
-                // in block proposals. it might be sitting long
-                // enough in the mempool for it to no longer be
-                // relevant to propose (e.g. the new epoch was
-                // installed before this validator set update got
-                // a chance to be decided). unfortunately, we won't
-                // be able to remove it from the mempool this way,
-                // but it will eventually be evicted, getting replaced
-                // by newer txs.
-                (ext.data.signing_epoch == current_epoch)
-                    .then(|| tx_bytes.clone())
-            }
-            _ => None,
-        }
-    })
-}
-
 /// Yields an iterator over the [`ProtocolTxType`] transactions
 /// in a [`VoteExtensionDigest`].
 #[cfg(feature = "abcipp")]
@@ -429,7 +493,8 @@ pub fn iter_protocol_txs(
     digest: VoteExtensionDigest,
 ) -> impl Iterator<Item = ProtocolTxType> {
     [
-        Some(ProtocolTxType::EthereumEvents(digest.ethereum_events)),
+        digest.ethereum_events.map(ProtocolTxType::EthereumEvents),
+        digest.bridge_pool_roots.map(ProtocolTxType::BridgePool),
         digest
             .validator_set_update
             .map(ProtocolTxType::ValidatorSetUpdate),
@@ -450,36 +515,10 @@ pub fn iter_protocol_txs(
         validator_set_update,
     } = ext;
     [
-        Some(ProtocolTxType::EthEventsVext(ethereum_events)),
-        Some(ProtocolTxType::BridgePoolVext(bridge_pool_root)),
+        ethereum_events.map(ProtocolTxType::EthEventsVext),
+        bridge_pool_root.map(ProtocolTxType::BridgePoolVext),
         validator_set_update.map(ProtocolTxType::ValSetUpdateVext),
     ]
     .into_iter()
     .flatten()
-}
-
-/// Deserializes `vote_extensions` as [`VoteExtension`] instances, filtering
-/// out invalid data, and splits these into [`ethereum_events::Vext`]
-/// and [`validator_set_update::Vext`] instances.
-#[cfg(feature = "abcipp")]
-pub fn split_vote_extensions(
-    vote_extensions: Vec<ExtendedVoteInfo>,
-) -> (
-    Vec<Signed<ethereum_events::Vext>>,
-    Vec<Signed<bridge_pool_roots::Vext>>,
-    Vec<validator_set_update::SignedVext>,
-) {
-    let mut eth_evs = vec![];
-    let mut bp_roots = vec![];
-    let mut valset_upds = vec![];
-
-    for ext in deserialize_vote_extensions(vote_extensions) {
-        if let Some(validator_set_update) = ext.validator_set_update {
-            valset_upds.push(validator_set_update);
-        }
-        eth_evs.push(ext.ethereum_events);
-        bp_roots.push(ext.bridge_pool_root);
-    }
-
-    (eth_evs, bp_roots, valset_upds)
 }

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -269,25 +269,23 @@ where
     ) -> bool {
         if !self.storage.is_bridge_active() {
             ext.is_none()
-        } else {
-            if let Some(ext) = ext {
-                self.validate_eth_events_vext(
-                    ext,
-                    self.storage.get_current_decision_height(),
-                )
-                .then_some(true)
-                .unwrap_or_else(| | {
-                    tracing::warn!(
-                        ?req.validator_address,
-                        ?req.hash,
-                        req.height,
-                        "Received Ethereum events vote extension that didn't validate"
-                    );
-                    false
-                })
-            } else {
+        } else if let Some(ext) = ext {
+            self.validate_eth_events_vext(
+                ext,
+                self.storage.get_current_decision_height(),
+            )
+            .then_some(true)
+            .unwrap_or_else(| | {
+                tracing::warn!(
+                    ?req.validator_address,
+                    ?req.hash,
+                    req.height,
+                    "Received Ethereum events vote extension that didn't validate"
+                );
                 false
-            }
+            })
+        } else {
+            false
         }
     }
 
@@ -301,19 +299,19 @@ where
         if self.storage.is_bridge_active() {
             if let Some(ext) = ext {
                 self.validate_bp_roots_vext(
-                    ext.unwrap(),
+                    ext,
                     self.storage.last_height,
                 )
-                    .then_some(true)
-                    .unwrap_or_else(|| {
-                        tracing::warn!(
-                    ?req.validator_address,
-                    ?req.hash,
-                    req.height,
-                    "Received Bridge pool root vote extension that didn't validate"
-                );
-                        false
-                    })
+                .then_some(true)
+                .unwrap_or_else(|| {
+                    tracing::warn!(
+                        ?req.validator_address,
+                        ?req.hash,
+                        req.height,
+                        "Received Bridge pool root vote extension that didn't validate"
+                    );
+                    false
+                })
             } else {
                 false
             }

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -386,7 +386,10 @@ mod test_bp_vote_extensions {
             sig,
         }
         .sign(shell.mode.get_protocol_key().expect("Test failed"));
-        assert_eq!(vote_ext, shell.extend_vote_with_bp_roots());
+        assert_eq!(
+            vote_ext,
+            shell.extend_vote_with_bp_roots().expect("Test failed")
+        );
         assert!(
             shell.validate_bp_roots_vext(vote_ext, shell.storage.last_height,)
         )
@@ -422,7 +425,7 @@ mod test_bp_vote_extensions {
         }
         .sign(shell.mode.get_protocol_key().expect("Test failed"));
 
-        assert_eq!(vote_extension.bridge_pool_root, bp_root);
+        assert_eq!(vote_extension.bridge_pool_root, Some(bp_root));
         let req = request::VerifyVoteExtension {
             hash: vec![],
             validator_address: address

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -416,9 +416,10 @@ mod test_vote_extensions {
 
         let [event_first, event_second]: [EthereumEvent; 2] = vote_extension
             .ethereum_events
+            .clone()
+            .expect("Test failed")
             .data
             .ethereum_events
-            .clone()
             .try_into()
             .expect("Test failed");
 
@@ -474,7 +475,7 @@ mod test_vote_extensions {
                 .to_vec(),
             height: 0,
             vote_extension: VoteExtension {
-                ethereum_events: ethereum_events.clone(),
+                ethereum_events: Some(ethereum_events.clone()),
                 bridge_pool_root: {
                     let to_sign = [
                         KeccakHash([0; 32]).encode().into_inner(),
@@ -489,12 +490,16 @@ mod test_vote_extensions {
                         to_sign,
                     )
                     .sig;
-                    bridge_pool_roots::Vext {
-                        block_height: shell.storage.last_height,
-                        validator_addr: address,
-                        sig,
-                    }
-                    .sign(shell.mode.get_protocol_key().expect("Test failed"))
+                    Some(
+                        bridge_pool_roots::Vext {
+                            block_height: shell.storage.last_height,
+                            validator_addr: address,
+                            sig,
+                        }
+                        .sign(
+                            shell.mode.get_protocol_key().expect("Test failed"),
+                        ),
+                    )
                 },
                 validator_set_update: None,
             }
@@ -635,8 +640,8 @@ mod test_vote_extensions {
                 validator_address: address.try_to_vec().expect("Test failed"),
                 height: 0,
                 vote_extension: VoteExtension {
-                    ethereum_events: signed_vext,
-                    bridge_pool_root: bp_root,
+                    ethereum_events: Some(signed_vext),
+                    bridge_pool_root: Some(bp_root),
                     validator_set_update: None,
                 }
                 .try_to_vec()

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -378,8 +378,8 @@ mod test_vote_extensions {
             };
             let req = request::VerifyVoteExtension {
                 vote_extension: VoteExtension {
-                    ethereum_events,
-                    bridge_pool_root: bp_root,
+                    ethereum_events: Some(ethereum_events),
+                    bridge_pool_root: Some(bp_root),
                     validator_set_update,
                 }
                 .try_to_vec()
@@ -458,8 +458,8 @@ mod test_vote_extensions {
             };
             let req = request::VerifyVoteExtension {
                 vote_extension: VoteExtension {
-                    ethereum_events,
-                    bridge_pool_root: bp_root,
+                    ethereum_events: Some(ethereum_events),
+                    bridge_pool_root: Some(bp_root),
                     validator_set_update,
                 }
                 .try_to_vec()
@@ -620,8 +620,8 @@ mod test_vote_extensions {
             };
             let req = request::VerifyVoteExtension {
                 vote_extension: VoteExtension {
-                    ethereum_events,
-                    bridge_pool_root: bp_root,
+                    ethereum_events: Some(ethereum_events),
+                    bridge_pool_root: Some(bp_root),
                     validator_set_update: validator_set_update.clone(),
                 }
                 .try_to_vec()

--- a/core/src/ledger/eth_bridge/storage/mod.rs
+++ b/core/src/ledger/eth_bridge/storage/mod.rs
@@ -7,6 +7,8 @@ use crate::types::address::nam;
 use crate::types::storage::{DbKeySeg, Key, KeySeg};
 use crate::types::token::balance_key;
 
+/// Sub-key for storing the acitve / inactive status of the Ethereum bridge.
+pub const ACTIVE_SUBKEY: &str = "active_status";
 /// Sub-key for storing the minimum confirmations parameter
 pub const MIN_CONFIRMATIONS_SUBKEY: &str = "min_confirmations";
 /// Sub-key for storing the Ethereum address for wNam.
@@ -30,6 +32,17 @@ pub fn escrow_key() -> Key {
 pub fn is_eth_bridge_key(key: &Key) -> bool {
     key == &escrow_key()
         || matches!(key.segments.get(0), Some(first_segment) if first_segment == &ADDRESS.to_db_key())
+}
+
+/// A key for storing the active / inactive status
+/// of the Ethereum bridge.
+pub fn active_key() -> Key {
+    Key {
+        segments: vec![
+            DbKeySeg::AddressSeg(ADDRESS),
+            DbKeySeg::StringSeg(ACTIVE_SUBKEY.into()),
+        ],
+    }
 }
 
 /// Storage key for the minimum confirmations parameter.

--- a/core/src/types/vote_extensions.rs
+++ b/core/src/types/vote_extensions.rs
@@ -15,9 +15,9 @@ use crate::proto::Signed;
 )]
 pub struct VoteExtension {
     /// Vote extension data related with Ethereum events.
-    pub ethereum_events: Signed<ethereum_events::Vext>,
+    pub ethereum_events: Option<Signed<ethereum_events::Vext>>,
     /// A signature of the Ethereum bridge pool root and nonce.
-    pub bridge_pool_root: bridge_pool_roots::SignedVext,
+    pub bridge_pool_root: Option<bridge_pool_roots::SignedVext>,
     /// Vote extension data related with validator set updates.
     pub validator_set_update: Option<validator_set_update::SignedVext>,
 }
@@ -35,10 +35,10 @@ pub struct VoteExtension {
 #[cfg(feature = "abcipp")]
 pub struct VoteExtensionDigest {
     /// The digest of Ethereum events vote extension signatures.
-    pub ethereum_events: ethereum_events::VextDigest,
+    pub ethereum_events: Option<ethereum_events::VextDigest>,
     /// A set of signatures for the current Ethereum bridge pool root and
     /// nonce.
-    pub bridge_pool_roots: bridge_pool_roots::MultiSignedVext,
+    pub bridge_pool_roots: Option<bridge_pool_roots::MultiSignedVext>,
     /// The digest of validator set updates vote extension signatures.
     pub validator_set_update: Option<validator_set_update::VextDigest>,
 }

--- a/core/src/types/vote_extensions/bridge_pool_roots.rs
+++ b/core/src/types/vote_extensions/bridge_pool_roots.rs
@@ -98,3 +98,9 @@ impl IntoIterator for MultiSignedVext {
         self.0.into_iter()
     }
 }
+
+impl From<SignedVext> for MultiSignedVext {
+    fn from(vext: SignedVext) -> Self {
+        Self(HashSet::from([vext]))
+    }
+}

--- a/ethereum_bridge/src/parameters.rs
+++ b/ethereum_bridge/src/parameters.rs
@@ -10,6 +10,7 @@ use namada_core::types::ethereum_events::EthAddress;
 use namada_core::types::storage::Key;
 use serde::{Deserialize, Serialize};
 
+use crate::storage::eth_bridge_queries::{EthBridgeEnabled, EthBridgeStatus};
 use crate::{bridge_pool_vp, storage as bridge_storage, vp};
 
 /// Represents a configuration value for the minimum number of
@@ -155,10 +156,17 @@ impl EthereumBridgeConfig {
                     governance,
                 },
         } = self;
+        let active_key = bridge_storage::active_key();
         let min_confirmations_key = bridge_storage::min_confirmations_key();
         let native_erc20_key = bridge_storage::native_erc20_key();
         let bridge_contract_key = bridge_storage::bridge_contract_key();
         let governance_contract_key = bridge_storage::governance_contract_key();
+        storage
+            .write(
+                &active_key,
+                encode(&EthBridgeStatus::Enabled(EthBridgeEnabled::AtGenesis)),
+            )
+            .unwrap();
         storage
             .write(&min_confirmations_key, encode(min_confirmations))
             .unwrap();

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -1,4 +1,5 @@
-use borsh::BorshDeserialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+use namada_core::ledger::eth_bridge::storage::active_key;
 use namada_core::ledger::eth_bridge::storage::bridge_pool::get_nonce_key;
 use namada_core::ledger::storage;
 use namada_core::ledger::storage::{Storage, StoreType};
@@ -22,7 +23,35 @@ pub enum SendValsetUpd {
     AtPrevHeight,
 }
 
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+/// An enum indicating if the Ethereum bridge is enabled.
+pub enum EthBridgeStatus {
+    Disabled,
+    Enabled(EthBridgeEnabled),
+}
+
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+/// Enum indicating if the bridge was initialized at genesis
+/// or a later epoch.
+pub enum EthBridgeEnabled {
+    AtGenesis,
+    AtEpoch(
+        // bridge is enabled from this epoch
+        // onwards. a validator set proof must
+        // exist for this epoch.
+        Epoch,
+    ),
+}
+
 pub trait EthBridgeQueries {
+    /// Check if the bridge is disabled, enabled, or
+    /// scheduled to be enabled at a specified epoch.
+    fn check_bridge_status(&self) -> EthBridgeStatus;
+
+    /// Returns a boolean indicating whether the bridge
+    /// is currently active.
+    fn is_bridge_active(&self) -> bool;
+
     /// Fetch the first [`BlockHeight`] of the last [`Epoch`]
     /// committed to storage.
     fn get_epoch_start_height(&self) -> BlockHeight;
@@ -73,6 +102,34 @@ where
     D: storage::DB + for<'iter> storage::DBIter<'iter>,
     H: storage::StorageHasher,
 {
+    fn check_bridge_status(&self) -> EthBridgeStatus {
+        BorshDeserialize::try_from_slice(
+            self.read(&active_key())
+                .expect(
+                    "Reading the Ethereum bridge active key shouldn't fail.",
+                )
+                .0
+                .expect("The Ethereum bridge active key should be in storage")
+                .as_slice(),
+        )
+        .expect("Deserializing the Ethereum bridge active key shouldn't fail.")
+    }
+
+    fn is_bridge_active(&self) -> bool {
+        if let EthBridgeStatus::Enabled(enabled_at) = self.check_bridge_status()
+        {
+            match enabled_at {
+                EthBridgeEnabled::AtGenesis => true,
+                EthBridgeEnabled::AtEpoch(epoch) => {
+                    let current_epoch = self.get_current_epoch().0;
+                    epoch <= current_epoch
+                }
+            }
+        } else {
+            false
+        }
+    }
+
     #[inline]
     fn get_epoch_start_height(&self) -> BlockHeight {
         // NOTE: the first stored height in `fst_block_heights_of_each_epoch`

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -18,7 +18,10 @@ pub use {
     tendermint_abcipp as tendermint,
     tendermint_proto_abcipp as tendermint_proto,
 };
-pub use {namada_core as core, namada_proof_of_stake as proof_of_stake};
+pub use {
+    namada_core as core, namada_ethereum_bridge as eth_bridge,
+    namada_proof_of_stake as proof_of_stake,
+};
 pub mod ledger;
 pub use namada_core::proto;
 pub mod types;


### PR DESCRIPTION
* Adds a storage key indicating the active status of the bridge. 
* Adds a quick query method to check if the bridge is active.
* Makes sure the vexts / protocol txs for eth events and bridge pool roots are not issued if the bridge is not active.
* Makes sure the vexts / protocol txs are not accepted if the the bridge is not active.
