### PR TITLE
Handle TransferToEthereum

### DIFF
--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -878,11 +878,12 @@ mod test_finalize_block {
             &KeccakHash([1; 32]),
             3.into(),
         );
+        let value = BlockHeight(4).try_to_vec().expect("Test failed");
         shell
             .storage
             .block
             .tree
-            .update(&get_key_from_hash(&KeccakHash([1; 32])), [])
+            .update(&get_key_from_hash(&KeccakHash([1; 32])), value)
             .expect("Test failed");
         shell
             .storage

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -636,11 +636,12 @@ mod test_bp_vote_extensions {
         let address = shell.mode.get_validator_address().unwrap().clone();
         shell.storage.block.height = 4.into();
         let key = get_key_from_hash(&KeccakHash([1; 32]));
+        let height = shell.storage.block.height.try_to_vec().unwrap();
         shell
             .storage
             .block
             .tree
-            .update(4.into(), &key, [0])
+            .update(&key, height)
             .expect("Test failed");
         shell.commit();
         assert_eq!(
@@ -650,11 +651,12 @@ mod test_bp_vote_extensions {
         shell.storage.block.height = 5.into();
         shell.storage.block.tree.delete(&key).expect("Test failed");
         let key = get_key_from_hash(&KeccakHash([2; 32]));
+        let height = shell.storage.block.height.try_to_vec().unwrap();
         shell
             .storage
             .block
             .tree
-            .update(5.into(), &key, [0])
+            .update(&key, height)
             .expect("Test failed");
         shell.commit();
         assert_eq!(
@@ -704,11 +706,12 @@ mod test_bp_vote_extensions {
         let address = shell.mode.get_validator_address().unwrap().clone();
         shell.storage.block.height = 4.into();
         let key = get_key_from_hash(&KeccakHash([1; 32]));
+        let height = shell.storage.block.height.try_to_vec().unwrap();
         shell
             .storage
             .block
             .tree
-            .update(4.into(), &key, [0])
+            .update(&key, height)
             .expect("Test failed");
         shell.commit();
         assert_eq!(
@@ -718,11 +721,12 @@ mod test_bp_vote_extensions {
         shell.storage.block.height = 5.into();
         shell.storage.block.tree.delete(&key).expect("Test failed");
         let key = get_key_from_hash(&KeccakHash([2; 32]));
+        let height = shell.storage.block.height.try_to_vec().unwrap();
         shell
             .storage
             .block
             .tree
-            .update(5.into(), &key, [0])
+            .update(&key, height)
             .expect("Test failed");
         shell.commit();
         assert_eq!(

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -640,7 +640,7 @@ mod test_bp_vote_extensions {
             .storage
             .block
             .tree
-            .update(&key, [0])
+            .update(4.into(), &key, [0])
             .expect("Test failed");
         shell.commit();
         assert_eq!(
@@ -654,7 +654,7 @@ mod test_bp_vote_extensions {
             .storage
             .block
             .tree
-            .update(&key, [0])
+            .update(5.into(), &key, [0])
             .expect("Test failed");
         shell.commit();
         assert_eq!(
@@ -708,7 +708,7 @@ mod test_bp_vote_extensions {
             .storage
             .block
             .tree
-            .update(&key, [0])
+            .update(4.into(), &key, [0])
             .expect("Test failed");
         shell.commit();
         assert_eq!(
@@ -722,7 +722,7 @@ mod test_bp_vote_extensions {
             .storage
             .block
             .tree
-            .update(&key, [0])
+            .update(5.into(), &key, [0])
             .expect("Test failed");
         shell.commit();
         assert_eq!(

--- a/core/src/ledger/eth_bridge/storage/bridge_pool.rs
+++ b/core/src/ledger/eth_bridge/storage/bridge_pool.rs
@@ -92,9 +92,12 @@ impl BridgePoolTree {
     /// Create a new merkle tree for the Ethereum bridge pool
     pub fn new(
         root: KeccakHash,
-        leaves: BTreeMap<KeccakHash, BlockHeight>,
+        store: BTreeMap<KeccakHash, BlockHeight>,
     ) -> Self {
-        Self { root, leaves }
+        Self {
+            root,
+            leaves: store,
+        }
     }
 
     /// Parse the key to ensure it is of the correct type.

--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -539,7 +539,7 @@ where
         // but with gas and storage bytes len diff accounting
         tracing::debug!("storage write key {}", key,);
         let value = value.as_ref();
-        self.block.tree.update(key, value)?;
+        self.block.tree.update(self.block.height, key, value)?;
 
         let len = value.len();
         let gas = key.len() + len;
@@ -959,23 +959,29 @@ where
         let key = key_prefix
             .push(&"epoch_start_height".to_string())
             .map_err(Error::KeyError)?;
-        self.block
-            .tree
-            .update(&key, types::encode(&self.next_epoch_min_start_height))?;
+        self.block.tree.update(
+            self.block.height,
+            &key,
+            types::encode(&self.next_epoch_min_start_height),
+        )?;
 
         let key = key_prefix
             .push(&"epoch_start_time".to_string())
             .map_err(Error::KeyError)?;
-        self.block
-            .tree
-            .update(&key, types::encode(&self.next_epoch_min_start_time))?;
+        self.block.tree.update(
+            self.block.height,
+            &key,
+            types::encode(&self.next_epoch_min_start_time),
+        )?;
 
         let key = key_prefix
             .push(&"current_epoch".to_string())
             .map_err(Error::KeyError)?;
-        self.block
-            .tree
-            .update(&key, types::encode(&self.block.epoch))?;
+        self.block.tree.update(
+            self.block.height,
+            &key,
+            types::encode(&self.block.epoch),
+        )?;
 
         Ok(())
     }
@@ -1000,7 +1006,7 @@ where
         value: impl AsRef<[u8]>,
     ) -> Result<i64> {
         let value = value.as_ref();
-        self.block.tree.update(key, value)?;
+        self.block.tree.update(self.block.height, key, value)?;
         self.db
             .batch_write_subspace_val(batch, self.block.height, key, value)
     }
@@ -1109,7 +1115,10 @@ where
         // gas and storage bytes len diff accounting, because it can only be
         // used by the protocol that has a direct mutable access to storage
         let val = val.as_ref();
-        self.block.tree.update(key, val).into_storage_result()?;
+        self.block
+            .tree
+            .update(self.block.height, key, val)
+            .into_storage_result()?;
         let _ = self
             .db
             .write_subspace_val(self.block.height, key, val)

--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -28,6 +28,7 @@ use rayon::prelude::ParallelSlice;
 use thiserror::Error;
 pub use traits::{Sha256Hasher, StorageHasher};
 
+use crate::ledger::eth_bridge::storage::bridge_pool::is_pending_transfer_key;
 use crate::ledger::gas::MIN_STORAGE_GAS;
 use crate::ledger::parameters::{self, EpochDuration, Parameters};
 use crate::ledger::storage::merkle_tree::{
@@ -539,7 +540,15 @@ where
         // but with gas and storage bytes len diff accounting
         tracing::debug!("storage write key {}", key,);
         let value = value.as_ref();
-        self.block.tree.update(self.block.height, key, value)?;
+        if is_pending_transfer_key(key) {
+            // The tree of the bright pool stores the current height for the
+            // pending transfer
+            let height =
+                self.block.height.try_to_vec().expect("Encoding failed");
+            self.block.tree.update(key, height)?;
+        } else {
+            self.block.tree.update(key, value)?;
+        }
 
         let len = value.len();
         let gas = key.len() + len;
@@ -959,29 +968,23 @@ where
         let key = key_prefix
             .push(&"epoch_start_height".to_string())
             .map_err(Error::KeyError)?;
-        self.block.tree.update(
-            self.block.height,
-            &key,
-            types::encode(&self.next_epoch_min_start_height),
-        )?;
+        self.block
+            .tree
+            .update(&key, types::encode(&self.next_epoch_min_start_height))?;
 
         let key = key_prefix
             .push(&"epoch_start_time".to_string())
             .map_err(Error::KeyError)?;
-        self.block.tree.update(
-            self.block.height,
-            &key,
-            types::encode(&self.next_epoch_min_start_time),
-        )?;
+        self.block
+            .tree
+            .update(&key, types::encode(&self.next_epoch_min_start_time))?;
 
         let key = key_prefix
             .push(&"current_epoch".to_string())
             .map_err(Error::KeyError)?;
-        self.block.tree.update(
-            self.block.height,
-            &key,
-            types::encode(&self.block.epoch),
-        )?;
+        self.block
+            .tree
+            .update(&key, types::encode(&self.block.epoch))?;
 
         Ok(())
     }
@@ -1006,7 +1009,7 @@ where
         value: impl AsRef<[u8]>,
     ) -> Result<i64> {
         let value = value.as_ref();
-        self.block.tree.update(self.block.height, key, value)?;
+        self.block.tree.update(key, value)?;
         self.db
             .batch_write_subspace_val(batch, self.block.height, key, value)
     }
@@ -1115,10 +1118,7 @@ where
         // gas and storage bytes len diff accounting, because it can only be
         // used by the protocol that has a direct mutable access to storage
         let val = val.as_ref();
-        self.block
-            .tree
-            .update(self.block.height, key, val)
-            .into_storage_result()?;
+        self.block.tree.update(key, val).into_storage_result()?;
         let _ = self
             .db
             .write_subspace_val(self.block.height, key, val)

--- a/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
+++ b/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
@@ -214,10 +214,11 @@ mod test_apply_bp_roots_to_storage {
             &KeccakHash([1; 32]),
             100.into(),
         );
+        let value = BlockHeight(101).try_to_vec().expect("Test failed");
         storage
             .block
             .tree
-            .update(&get_key_from_hash(&KeccakHash([1; 32])), [0])
+            .update(&get_key_from_hash(&KeccakHash([1; 32])), value)
             .expect("Test failed");
         storage
             .write(

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -132,8 +132,7 @@ where
             _ = storage.delete(&key)?;
             _ = pending_keys.remove(&key);
         } else {
-            // The transfer should exist in the bridge pool
-            unreachable!()
+            unreachable!("The transfer should exist in the bridge pool");
         }
 
         _ = changed_keys.insert(key);

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -1,13 +1,29 @@
 //! Logic for acting on events
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
+use std::str::FromStr;
 
+use borsh::BorshDeserialize;
 use eyre::Result;
-use namada_core::ledger::eth_bridge::storage::wrapped_erc20s;
+use namada_core::ledger::eth_bridge::storage::bridge_pool::{
+    get_pending_key, is_pending_transfer_key, BRIDGE_POOL_ADDRESS,
+};
+use namada_core::ledger::eth_bridge::storage::{
+    self as bridge_storage, wrapped_erc20s,
+};
+use namada_core::ledger::eth_bridge::ADDRESS as BRIDGE_ADDRESS;
+use namada_core::ledger::parameters::read_epoch_duration_parameter;
 use namada_core::ledger::storage::traits::StorageHasher;
 use namada_core::ledger::storage::{DBIter, Storage, DB};
-use namada_core::types::ethereum_events::{EthereumEvent, TransferToNamada};
-use namada_core::types::storage::Key;
+use namada_core::types::address::nam;
+use namada_core::types::eth_bridge_pool::PendingTransfer;
+use namada_core::types::ethereum_events::{
+    EthAddress, EthereumEvent, TransferToEthereum, TransferToNamada,
+};
+use namada_core::types::storage::{BlockHeight, Key, KeySeg};
+use namada_core::types::token::{
+    balance_key, multitoken_balance_key, multitoken_balance_prefix,
+};
 
 use crate::protocol::transactions::update;
 
@@ -25,6 +41,9 @@ where
     match &event {
         EthereumEvent::TransfersToNamada { transfers, .. } => {
             act_on_transfers_to_namada(storage, transfers)
+        }
+        EthereumEvent::TransfersToEthereum { transfers, .. } => {
+            act_on_transfers_to_eth(storage, transfers)
         }
         _ => {
             tracing::debug!(?event, "No actions taken for Ethereum event");
@@ -84,21 +103,262 @@ where
     Ok(changed_keys)
 }
 
+fn act_on_transfers_to_eth<D, H>(
+    storage: &mut Storage<D, H>,
+    transfers: &[TransferToEthereum],
+) -> Result<BTreeSet<Key>>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    let mut changed_keys = BTreeSet::default();
+    // all keys of pending transfers
+    let prefix = BRIDGE_POOL_ADDRESS.to_db_key().into();
+    let mut pending_keys: HashSet<Key> = storage
+        .iter_prefix(&prefix)
+        .0
+        .map(|(k, _, _)| {
+            Key::from_str(k.as_str()).expect("Key should be parsable")
+        })
+        .filter(is_pending_transfer_key)
+        .collect();
+
+    // Remove the completed transfers from the bridge pool
+    for event in transfers {
+        let pending_transfer = event.into();
+        let key = get_pending_key(&pending_transfer);
+        if storage.has_key(&key)?.0 {
+            _ = storage.delete(&key)?;
+            _ = pending_keys.remove(&key);
+        } else {
+            return Err(eyre::eyre!(
+                "The transfer doesn't exist in the bridge pool"
+            ));
+        }
+
+        _ = changed_keys.insert(key);
+    }
+
+    if pending_keys.is_empty() {
+        return Ok(changed_keys);
+    }
+
+    // TODO the timeout height is min_num_blocks of an epoch for now
+    let (epoch_duration, _) = read_epoch_duration_parameter(storage)?;
+    let timeout_offset = epoch_duration.min_num_of_blocks;
+
+    // Check time out and refund
+    if storage.block.height.0 > timeout_offset {
+        let timeout_height =
+            BlockHeight(storage.block.height.0 - timeout_offset);
+        for key in pending_keys {
+            let inserted_height =
+                storage.block.tree.get_inserted_height(&key)?;
+            if inserted_height <= timeout_height {
+                let mut keys = refund_transfer(storage, key)?;
+                changed_keys.append(&mut keys);
+            }
+        }
+    }
+
+    Ok(changed_keys)
+}
+
+fn refund_transfer<D, H>(
+    storage: &mut Storage<D, H>,
+    key: Key,
+) -> Result<BTreeSet<Key>>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    let mut changed_key = BTreeSet::default();
+
+    let transfer = match storage.read(&key)?.0 {
+        Some(v) => PendingTransfer::try_from_slice(&v[..])?,
+        None => unreachable!(),
+    };
+
+    // Refund the gas fee
+    let payer_balance_key = balance_key(&nam(), &transfer.gas_fee.payer);
+    let pool_balance_key = balance_key(&nam(), &BRIDGE_POOL_ADDRESS);
+    update::amount(storage, &payer_balance_key, |balance| {
+        balance.receive(&transfer.gas_fee.amount);
+    })?;
+    update::amount(storage, &pool_balance_key, |balance| {
+        balance.spend(&transfer.gas_fee.amount);
+    })?;
+    _ = changed_key.insert(payer_balance_key);
+    _ = changed_key.insert(pool_balance_key);
+
+    // Unescrow the token
+    let native_erc20_addr = match storage
+        .read(&bridge_storage::native_erc20_key())?
+        .0
+    {
+        Some(v) => EthAddress::try_from_slice(&v[..])?,
+        None => {
+            return Err(eyre::eyre!("Could not read wNam key from storage"));
+        }
+    };
+    let (source, target) = if transfer.transfer.asset == native_erc20_addr {
+        let escrow_balance_key = balance_key(&nam(), &BRIDGE_ADDRESS);
+        let sender_balance_key = balance_key(&nam(), &transfer.transfer.sender);
+        (escrow_balance_key, sender_balance_key)
+    } else {
+        let sub_prefix = wrapped_erc20s::sub_prefix(&transfer.transfer.asset);
+        let prefix = multitoken_balance_prefix(&BRIDGE_ADDRESS, &sub_prefix);
+        let escrow_balance_key =
+            multitoken_balance_key(&prefix, &BRIDGE_POOL_ADDRESS);
+        let sender_balance_key =
+            multitoken_balance_key(&prefix, &transfer.transfer.sender);
+        (escrow_balance_key, sender_balance_key)
+    };
+    update::amount(storage, &source, |balance| {
+        balance.spend(&transfer.transfer.amount);
+    })?;
+    update::amount(storage, &target, |balance| {
+        balance.receive(&transfer.transfer.amount);
+    })?;
+    _ = changed_key.insert(source);
+    _ = changed_key.insert(target);
+
+    // Delete the key from the bridge pool
+    _ = storage.delete(&key)?;
+    _ = changed_key.insert(key);
+
+    Ok(changed_key)
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
     use assert_matches::assert_matches;
     use borsh::BorshSerialize;
+    use namada_core::ledger::parameters::{
+        update_epoch_parameter, EpochDuration,
+    };
     use namada_core::ledger::storage::testing::TestStorage;
-    use namada_core::types::address;
+    use namada_core::ledger::storage::types::encode;
+    use namada_core::types::eth_bridge_pool::GasFee;
     use namada_core::types::ethereum_events::testing::{
         arbitrary_eth_address, arbitrary_keccak_hash, arbitrary_nonce,
         DAI_ERC20_ETH_ADDRESS,
     };
+    use namada_core::types::time::DurationSecs;
     use namada_core::types::token::Amount;
+    use namada_core::types::{address, eth_bridge_pool};
 
     use super::*;
+
+    fn init_storage(storage: &mut TestStorage) {
+        // set the timeout height offset
+        let timeout_offset = 10;
+        let epoch_duration = EpochDuration {
+            min_num_of_blocks: timeout_offset,
+            min_duration: DurationSecs(5),
+        };
+        update_epoch_parameter(storage, &epoch_duration).expect("Test failed");
+        // set native ERC20 token
+        let native_erc20_key = bridge_storage::native_erc20_key();
+        let native_erc20 = EthAddress([0; 20]);
+        storage
+            .write(&native_erc20_key, encode(&native_erc20))
+            .expect("Test failed");
+    }
+
+    fn init_bridge_pool(storage: &mut TestStorage) -> Vec<PendingTransfer> {
+        let sender = address::testing::established_address_1();
+        let payer = address::testing::established_address_2();
+
+        // set pending transfers
+        let mut pending_transfers = vec![];
+        for i in 0..2 {
+            let transfer = PendingTransfer {
+                transfer: eth_bridge_pool::TransferToEthereum {
+                    asset: EthAddress([i; 20]),
+                    sender: sender.clone(),
+                    recipient: EthAddress([i + 1; 20]),
+                    amount: Amount::from(10),
+                },
+                gas_fee: GasFee {
+                    amount: Amount::from(1),
+                    payer: payer.clone(),
+                },
+            };
+            let key = get_pending_key(&transfer);
+            _ = storage
+                .write(&key, transfer.try_to_vec().expect("Test failed"))
+                .expect("Test failed");
+
+            pending_transfers.push(transfer);
+        }
+        pending_transfers
+    }
+
+    fn init_balance(
+        storage: &mut TestStorage,
+        pending_transfers: &Vec<PendingTransfer>,
+    ) {
+        // Gas payer
+        let payer = address::testing::established_address_2();
+        let payer_key = balance_key(&nam(), &payer);
+        let payer_balance = Amount::from(0);
+        _ = storage
+            .write(&payer_key, payer_balance.try_to_vec().expect("Test failed"))
+            .expect("Test failed");
+        let pool_key = balance_key(&nam(), &BRIDGE_POOL_ADDRESS);
+        let pool_balance = Amount::from(2);
+        _ = storage
+            .write(&pool_key, pool_balance.try_to_vec().expect("Test failed"))
+            .expect("Test failed");
+
+        for transfer in pending_transfers {
+            if transfer.transfer.asset == EthAddress([0; 20]) {
+                // native ERC20
+                let sender_key = balance_key(&nam(), &transfer.transfer.sender);
+                let sender_balance = Amount::from(0);
+                _ = storage
+                    .write(
+                        &sender_key,
+                        sender_balance.try_to_vec().expect("Test failed"),
+                    )
+                    .expect("Test failed");
+                let escrow_key = balance_key(&nam(), &BRIDGE_ADDRESS);
+                let escrow_balance = Amount::from(10);
+                _ = storage
+                    .write(
+                        &escrow_key,
+                        escrow_balance.try_to_vec().expect("Test failed"),
+                    )
+                    .expect("Test failed");
+            } else {
+                let sub_prefix =
+                    wrapped_erc20s::sub_prefix(&transfer.transfer.asset);
+                let prefix =
+                    multitoken_balance_prefix(&BRIDGE_ADDRESS, &sub_prefix);
+                let sender_key =
+                    multitoken_balance_key(&prefix, &transfer.transfer.sender);
+                let sender_balance = Amount::from(0);
+                _ = storage
+                    .write(
+                        &sender_key,
+                        sender_balance.try_to_vec().expect("Test failed"),
+                    )
+                    .expect("Test failed");
+                let escrow_key =
+                    multitoken_balance_key(&prefix, &BRIDGE_POOL_ADDRESS);
+                let escrow_balance = Amount::from(10);
+                _ = storage
+                    .write(
+                        &escrow_key,
+                        escrow_balance.try_to_vec().expect("Test failed"),
+                    )
+                    .expect("Test failed");
+            };
+        }
+    }
 
     #[test]
     /// Test that we do not make any changes to storage when acting on most
@@ -190,6 +450,141 @@ mod tests {
         for key in vec![receiver_balance_key, wdai_supply_key] {
             let (value, _) = storage.read(&key).unwrap();
             assert_matches!(value, Some(bytes) if bytes == expected_amount);
+        }
+    }
+
+    #[test]
+    /// Test that the transfers are deleted in the bridge pool when we act on a
+    /// TransfersToEthereum
+    fn test_act_on_changes_storage_for_transfers_to_eth() {
+        let mut storage = TestStorage::default();
+        init_storage(&mut storage);
+        let pending_transfers = init_bridge_pool(&mut storage);
+        let pending_keys: HashSet<Key> =
+            pending_transfers.iter().map(get_pending_key).collect();
+
+        let mut transfers = vec![];
+        for transfer in pending_transfers {
+            let transfer_to_eth = TransferToEthereum {
+                amount: transfer.transfer.amount,
+                asset: transfer.transfer.asset,
+                receiver: transfer.transfer.recipient,
+                gas_amount: transfer.gas_fee.amount,
+                gas_payer: transfer.gas_fee.payer,
+            };
+            transfers.push(transfer_to_eth);
+        }
+        let event = EthereumEvent::TransfersToEthereum {
+            nonce: arbitrary_nonce(),
+            transfers,
+        };
+
+        let changed_keys = act_on(&mut storage, &event).unwrap();
+
+        assert!(changed_keys.iter().all(|k| pending_keys.contains(k)));
+        let prefix = BRIDGE_POOL_ADDRESS.to_db_key().into();
+        assert_eq!(storage.iter_prefix(&prefix).0.count(), 0);
+    }
+
+    #[test]
+    /// Test that the transfers time out in the bridge pool then the refund when
+    /// we act on a TransfersToEthereum
+    fn test_act_on_timeout_for_transfers_to_eth() {
+        let mut storage = TestStorage::default();
+        init_storage(&mut storage);
+        // Height 0
+        let pending_transfers = init_bridge_pool(&mut storage);
+        init_balance(&mut storage, &pending_transfers);
+        storage.commit().expect("Test failed");
+        // pending transfers time out
+        storage.block.height = storage.block.height + 10 + 1;
+        // new pending transfer
+        let transfer = PendingTransfer {
+            transfer: eth_bridge_pool::TransferToEthereum {
+                asset: EthAddress([4; 20]),
+                sender: address::testing::established_address_1(),
+                recipient: EthAddress([5; 20]),
+                amount: Amount::from(10),
+            },
+            gas_fee: GasFee {
+                amount: Amount::from(1),
+                payer: address::testing::established_address_1(),
+            },
+        };
+        let key = get_pending_key(&transfer);
+        _ = storage
+            .write(&key, transfer.try_to_vec().expect("Test failed"))
+            .expect("Test failed");
+        storage.commit().expect("Test failed");
+        storage.block.height = storage.block.height + 1;
+
+        // This should only refund
+        let event = EthereumEvent::TransfersToEthereum {
+            nonce: arbitrary_nonce(),
+            transfers: vec![],
+        };
+        let _ = act_on(&mut storage, &event).unwrap();
+
+        // The latest transfer is still pending
+        let prefix = BRIDGE_POOL_ADDRESS.to_db_key().into();
+        assert_eq!(storage.iter_prefix(&prefix).0.count(), 1);
+
+        // Check the gas fee
+        let expected = pending_transfers
+            .iter()
+            .fold(Amount::from(0), |acc, t| acc + t.gas_fee.amount);
+        let payer = address::testing::established_address_2();
+        let payer_key = balance_key(&nam(), &payer);
+        let (value, _) = storage.read(&payer_key).expect("Test failed");
+        let payer_balance =
+            Amount::try_from_slice(&value.expect("Test failed"))
+                .expect("Test failed");
+        assert_eq!(payer_balance, expected);
+        let pool_key = balance_key(&nam(), &BRIDGE_POOL_ADDRESS);
+        let (value, _) = storage.read(&pool_key).expect("Test failed");
+        let pool_balance = Amount::try_from_slice(&value.expect("Test failed"))
+            .expect("Test failed");
+        assert_eq!(pool_balance, Amount::from(0));
+
+        // Check the balances
+        for transfer in pending_transfers {
+            if transfer.transfer.asset == EthAddress([0; 20]) {
+                let sender_key = balance_key(&nam(), &transfer.transfer.sender);
+                let (value, _) =
+                    storage.read(&sender_key).expect("Test failed");
+                let sender_balance =
+                    Amount::try_from_slice(&value.expect("Test failed"))
+                        .expect("Test failed");
+                assert_eq!(sender_balance, transfer.transfer.amount);
+                let escrow_key = balance_key(&nam(), &BRIDGE_ADDRESS);
+                let (value, _) =
+                    storage.read(&escrow_key).expect("Test failed");
+                let escrow_balance =
+                    Amount::try_from_slice(&value.expect("Test failed"))
+                        .expect("Test failed");
+                assert_eq!(escrow_balance, Amount::from(0));
+            } else {
+                let sub_prefix =
+                    wrapped_erc20s::sub_prefix(&transfer.transfer.asset);
+                let prefix =
+                    multitoken_balance_prefix(&BRIDGE_ADDRESS, &sub_prefix);
+                let sender_key =
+                    multitoken_balance_key(&prefix, &transfer.transfer.sender);
+                let (value, _) =
+                    storage.read(&sender_key).expect("Test failed");
+                let sender_balance =
+                    Amount::try_from_slice(&value.expect("Test failed"))
+                        .expect("Test failed");
+                assert_eq!(sender_balance, transfer.transfer.amount);
+                let escrow_key =
+                    multitoken_balance_key(&prefix, &BRIDGE_POOL_ADDRESS);
+                let (value, _) =
+                    storage.read(&escrow_key).expect("Test failed");
+                let escrow_balance =
+                    Amount::try_from_slice(&value.expect("Test failed"))
+                        .expect("Test failed");
+                assert_eq!(escrow_balance, Amount::from(0));
+            }
         }
     }
 }

--- a/ethereum_bridge/src/test_utils.rs
+++ b/ethereum_bridge/src/test_utils.rs
@@ -152,10 +152,11 @@ pub fn commit_bridge_pool_root_at_height<D, H>(
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
+    let value = height.try_to_vec().expect("Encoding failed");
     storage
         .block
         .tree
-        .update(&get_key_from_hash(root), [0])
+        .update(&get_key_from_hash(root), value)
         .unwrap();
     storage.block.height = height;
     storage.commit().unwrap();

--- a/shared/src/ledger/queries/shell.rs
+++ b/shared/src/ledger/queries/shell.rs
@@ -334,6 +334,7 @@ where
 
 #[cfg(test)]
 mod test {
+
     use borsh::BorshDeserialize;
 
     use crate::ledger::queries::testing::TestClient;

--- a/shared/src/ledger/queries/shell.rs
+++ b/shared/src/ledger/queries/shell.rs
@@ -334,7 +334,6 @@ where
 
 #[cfg(test)]
 mod test {
-
     use borsh::BorshDeserialize;
 
     use crate::ledger::queries::testing::TestClient;

--- a/shared/src/ledger/queries/shell/eth_bridge.rs
+++ b/shared/src/ledger/queries/shell/eth_bridge.rs
@@ -74,7 +74,7 @@ where
     };
 
     let transfers: Vec<PendingTransfer> = store
-        .iter()
+        .keys()
         .map(|hash| {
             let res = ctx
                 .storage
@@ -264,7 +264,7 @@ where
 
 #[cfg(test)]
 mod test_ethbridge_router {
-    use std::collections::BTreeSet;
+    use std::collections::BTreeMap;
 
     use borsh::BorshSerialize;
     use namada_core::ledger::eth_bridge::storage::bridge_pool::{
@@ -640,7 +640,7 @@ mod test_ethbridge_router {
 
         let tree = BridgePoolTree::new(
             transfer.keccak256(),
-            BTreeSet::from([transfer.keccak256()]),
+            BTreeMap::from([(transfer.keccak256(), 1.into())]),
         );
         let proof = tree
             .get_membership_proof(vec![transfer])


### PR DESCRIPTION
- Add the inserted height to the Merkle tree of the bridge pool for the timeout checking
- Handle TransferToEthereum event
  - Delete the pending transfers contained in the event
  - Refund and delete for timed-out transfers