### PR TITLE
Release NAM from the bridge pool to redeem wNAM transfers from Ethereum

### DIFF
--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -88,6 +88,13 @@ impl Amount {
             .checked_add(amount.micro)
             .map(|micro| Self { micro })
     }
+
+    /// Checked subtraction on amounts
+    pub fn checked_sub(&self, amount: &Amount) -> Option<Self> {
+        self.micro
+            .checked_sub(amount.micro)
+            .map(|micro| Self { micro })
+    }
 }
 
 impl serde::Serialize for Amount {

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -71,18 +71,31 @@ where
         receiver,
     } in transfers
     {
-        if asset != &wrapped_native_erc20 {
-            let mut changed =
-                mint_wrapped_erc20s(storage, asset, receiver, amount)?;
-            changed_keys.append(&mut changed)
+        let mut changed = if asset != &wrapped_native_erc20 {
+            mint_wrapped_erc20s(storage, asset, receiver, amount)?
         } else {
-            tracing::warn!(
-                "Redemption of the wrapped native token is not yet supported \
-                 - (receiver - {receiver}, amount - {amount})"
-            )
-        }
+            redeem_native_token(storage, receiver, amount)?
+        };
+        changed_keys.append(&mut changed)
     }
     Ok(changed_keys)
+}
+
+/// Redeems `amount` of the native token for `receiver` from escrow.
+fn redeem_native_token<D, H>(
+    _storage: &mut Storage<D, H>,
+    receiver: &Address,
+    amount: &token::Amount,
+) -> Result<BTreeSet<Key>>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    tracing::warn!(
+        "Redemption of the wrapped native token is not yet supported - \
+         (receiver - {receiver}, amount - {amount})"
+    );
+    Ok(BTreeSet::default())
 }
 
 /// Mints `amount` of a wrapped ERC20 `asset` for `receiver`.

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -333,10 +333,10 @@ where
 mod tests {
     use assert_matches::assert_matches;
     use borsh::BorshSerialize;
+    use eyre::Result;
     use namada_core::ledger::parameters::{
         update_epoch_parameter, EpochDuration,
     };
-    use eyre::Result;
     use namada_core::ledger::storage::testing::TestStorage;
     use namada_core::ledger::storage::types::encode;
     use namada_core::types::address::gen_established_address;

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -42,8 +42,6 @@ where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
-    // TODO: double check and/or otherwise make explicit link between ERC20
-    // amounts and our Amount micros units
     match &event {
         EthereumEvent::TransfersToNamada { transfers, .. } => {
             act_on_transfers_to_namada(storage, transfers)

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -85,7 +85,6 @@ where
 }
 
 /// Redeems `amount` of the native token for `receiver` from escrow.
-/// TODO: unit/integration tests
 fn redeem_native_token<D, H>(
     storage: &mut Storage<D, H>,
     receiver: &Address,
@@ -117,7 +116,6 @@ where
                 "Bridge pool should always have enough native tokens to \
                  redeem any confirmed transfers",
             );
-    // TODO: ? how best to handle overflows here?
     let receiver_native_token_balance_post = receiver_native_token_balance_pre
         .checked_add(amount)
         .expect("Receiver's balance is full");

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -92,26 +92,26 @@ where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
-    let bridge_pool_native_token_balance_key =
-        token::balance_key(&storage.native_token, &BRIDGE_POOL_ADDRESS);
+    let eth_bridge_native_token_balance_key =
+        token::balance_key(&storage.native_token, &BRIDGE_ADDRESS);
     let receiver_native_token_balance_key =
         token::balance_key(&storage.native_token, receiver);
 
-    let bridge_pool_native_token_balance_pre: token::Amount =
-        StorageRead::read(storage, &bridge_pool_native_token_balance_key)?
+    let eth_bridge_native_token_balance_pre: token::Amount =
+        StorageRead::read(storage, &eth_bridge_native_token_balance_key)?
             .expect(
-                "Bridge pool must always have an explicit balance of the \
+                "Ethereum bridge must always have an explicit balance of the \
                  native token",
             );
     let receiver_native_token_balance_pre: token::Amount =
         StorageRead::read(storage, &receiver_native_token_balance_key)?
             .unwrap_or_default();
 
-    let bridge_pool_native_token_balance_post =
-        bridge_pool_native_token_balance_pre
+    let eth_bridge_native_token_balance_post =
+        eth_bridge_native_token_balance_pre
             .checked_sub(amount)
             .expect(
-                "Bridge pool should always have enough native tokens to \
+                "Ethereum bridge should always have enough native tokens to \
                  redeem any confirmed transfers",
             );
     let receiver_native_token_balance_post = receiver_native_token_balance_pre
@@ -120,8 +120,8 @@ where
 
     StorageWrite::write(
         storage,
-        &bridge_pool_native_token_balance_key,
-        bridge_pool_native_token_balance_post,
+        &eth_bridge_native_token_balance_key,
+        eth_bridge_native_token_balance_post,
     )?;
     StorageWrite::write(
         storage,
@@ -132,14 +132,14 @@ where
     tracing::info!(
         %amount,
         %receiver,
-        %bridge_pool_native_token_balance_pre,
-        %bridge_pool_native_token_balance_post,
+        %eth_bridge_native_token_balance_pre,
+        %eth_bridge_native_token_balance_post,
         %receiver_native_token_balance_pre,
         %receiver_native_token_balance_post,
         "Redeemed native token for wrapped ERC20 token"
     );
     Ok(BTreeSet::from([
-        bridge_pool_native_token_balance_key,
+        eth_bridge_native_token_balance_key,
         receiver_native_token_balance_key,
     ]))
 }
@@ -737,7 +737,7 @@ mod tests {
 
         let bridge_pool_initial_balance = Amount::from(100_000_000);
         let bridge_pool_native_token_balance_key =
-            token::balance_key(&storage.native_token, &BRIDGE_POOL_ADDRESS);
+            token::balance_key(&storage.native_token, &BRIDGE_ADDRESS);
         StorageWrite::write(
             &mut storage,
             &bridge_pool_native_token_balance_key,

--- a/tests/src/e2e/eth_bridge_tests.rs
+++ b/tests/src/e2e/eth_bridge_tests.rs
@@ -370,6 +370,7 @@ async fn test_wnam_transfer() -> Result<()> {
 
     let mut ledger = bg_ledger.foreground();
     ledger.exp_string("Redeemed native token for wrapped ERC20 token")?;
+    let _bg_ledger = ledger.background();
 
     // check NAM balance of receiver and bridge pool
     let receiver_balance = find_balance(

--- a/tests/src/e2e/helpers.rs
+++ b/tests/src/e2e/helpers.rs
@@ -6,13 +6,16 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 use std::{env, time};
 
+use borsh::BorshDeserialize;
 use color_eyre::eyre::Result;
 use color_eyre::owo_colors::OwoColorize;
+use data_encoding::HEXLOWER;
 use escargot::CargoBuild;
 use eyre::eyre;
 use namada::types::address::Address;
 use namada::types::key::*;
 use namada::types::storage::Epoch;
+use namada::types::token;
 use namada_apps::config::genesis::genesis_config;
 use namada_apps::config::{Config, TendermintMode};
 
@@ -42,6 +45,39 @@ pub fn find_address(test: &Test, alias: impl AsRef<str>) -> Result<Address> {
     })?;
     println!("Found {}", address);
     Ok(address)
+}
+
+/// Find the balance of specific token for an account.
+pub fn find_balance(
+    test: &Test,
+    node: &Who,
+    token: &Address,
+    owner: &Address,
+) -> Result<token::Amount> {
+    let ledger_address = get_actor_rpc(test, node);
+    let balance_key = token::balance_key(token, owner);
+    let mut bytes = run!(
+        test,
+        Bin::Client,
+        &[
+            "query-bytes",
+            "--storage-key",
+            &balance_key.to_string(),
+            "--ledger-address",
+            &ledger_address,
+        ],
+        Some(10)
+    )?;
+    let (_, matched) = bytes.exp_regex("Found data: 0x.*")?;
+    let data_str = strip_trailing_newline(&matched)
+        .trim()
+        .rsplit_once(' ')
+        .unwrap()
+        .1[2..]
+        .to_string();
+    let amount =
+        token::Amount::try_from_slice(&HEXLOWER.decode(data_str.as_bytes())?)?;
+    Ok(amount)
 }
 
 /// Find the address of the node's RPC endpoint.

--- a/tests/src/e2e/helpers.rs
+++ b/tests/src/e2e/helpers.rs
@@ -77,6 +77,7 @@ pub fn find_balance(
         .to_string();
     let amount =
         token::Amount::try_from_slice(&HEXLOWER.decode(data_str.as_bytes())?)?;
+    bytes.assert_success();
     Ok(amount)
 }
 


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/989

This PR makes it so that NAM is released from the bridge's account's balance, for confirmed wNAM transfers. Also adds an e2e helper `find_balance` for getting the balance of a Namada address for a specific regular token (e.g. NAM, i.e. not multitoken)

The end-to-end test currently gives the bridge VP an initial balance of NAM, which isn't realistic - this test should be updated so that the bridge VP gets it's balance of NAM from a transfer on chain.