### PR TITLE
Optimize checking for whether we need to configure the Ethereum oracle or not

### DIFF
--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -127,13 +127,7 @@ where
         if let Some(config) = genesis.ethereum_bridge_params {
             tracing::debug!("Initializing Ethereum bridge storage.");
             config.init_storage(&mut self.storage);
-            if let ShellMode::Validator {
-                eth_oracle: Some(_),
-                ..
-            } = self.mode
-            {
-                self.ensure_ethereum_oracle_started();
-            }
+            self.start_ethereum_oracle_if_necessary();
         } else {
             self.storage
                 .write(

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -127,6 +127,13 @@ where
         if let Some(config) = genesis.ethereum_bridge_params {
             tracing::debug!("Initializing Ethereum bridge storage.");
             config.init_storage(&mut self.storage);
+            if let ShellMode::Validator {
+                eth_oracle: Some(_),
+                ..
+            } = self.mode
+            {
+                self.ensure_ethereum_oracle_started();
+            }
         } else {
             self.storage
                 .write(

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -488,12 +488,7 @@ where
             // TODO: config event log params
             event_log: EventLog::default(),
         };
-        // if we've already synced past genesis, then we may be able to
-        // start any Ethereum oracle straight away rather than waiting to
-        // sync/commit another block
-        if shell.storage.last_height > BlockHeight(0) {
-            shell.start_ethereum_oracle_if_necessary();
-        }
+        shell.start_ethereum_oracle_if_necessary();
         shell
     }
 

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -691,6 +691,9 @@ where
             )
         });
 
+        // NOTE: the oracle isn't started through governance votes, so we don't
+        // check to see if we need to start it after epoch transitions
+
         let root = self.storage.merkle_root();
         tracing::info!(
             "Committed block hash: {}, height: {}",

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -737,20 +737,19 @@ where
         } = &mut self.mode
         {
             if *eth_oracle_started {
+                tracing::info!("Not starting oracle as it was already started");
                 return;
             }
             if matches!(
                 self.storage.check_bridge_status(),
                 namada::ledger::eth_bridge::EthBridgeStatus::Disabled
             ) {
+                tracing::info!(
+                    "Not starting oracle as the Ethereum bridge is disabled"
+                );
                 return;
             }
             let Some(config) = EthereumBridgeConfig::read(&self.storage) else {
-                // if we don't have a bridge configuration yet, it could
-                // be that it will become available in a later block
-                // (or possibly not, if the bridge hasn't been
-                // launched yet) - in any case, we don't need to
-                // start our Ethereum oracle just right now
                 return;
             };
             let config = oracle::config::Config {

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -491,7 +491,7 @@ where
         // if we've already synced past genesis, then we may be able to
         // start any Ethereum oracle straight away rather than waiting to
         // sync/commit another block
-        if shell.storage.block.height > BlockHeight(0) {
+        if shell.storage.last_height > BlockHeight(0) {
             shell.start_ethereum_oracle_if_necessary();
         }
         shell

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -740,10 +740,7 @@ where
                 tracing::info!("Not starting oracle as it was already started");
                 return;
             }
-            if matches!(
-                self.storage.check_bridge_status(),
-                namada::ledger::eth_bridge::EthBridgeStatus::Disabled
-            ) {
+            if self.storage.is_bridge_active() {
                 tracing::info!(
                     "Not starting oracle as the Ethereum bridge is disabled"
                 );

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -750,6 +750,9 @@ where
                 return;
             }
             let Some(config) = EthereumBridgeConfig::read(&self.storage) else {
+                tracing::info!(
+                    "Not starting oracle as the Ethereum bridge config couldn't be found in storage"
+                );
                 return;
             };
             let config = oracle::config::Config {

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use namada::ledger::eth_bridge::EthereumBridgeConfig;
+use namada::ledger::eth_bridge::{EthBridgeQueries, EthereumBridgeConfig};
 use namada::ledger::events::log::EventLog;
 use namada::ledger::events::Event;
 use namada::ledger::gas::BlockGasMeter;
@@ -737,6 +737,12 @@ where
         } = &mut self.mode
         {
             if *eth_oracle_started {
+                return;
+            }
+            if matches!(
+                self.storage.check_bridge_status(),
+                namada::ledger::eth_bridge::EthBridgeStatus::Disabled
+            ) {
                 return;
             }
             let Some(config) = EthereumBridgeConfig::read(&self.storage) else {

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -695,9 +695,6 @@ where
                 e
             )
         });
-        // TODO(namada#1041): we check the Ethereum oracle is started on every
-        // block commit, but this is hardly necessary
-        self.start_ethereum_oracle_if_necessary();
 
         let root = self.storage.merkle_root();
         tracing::info!(

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -54,9 +54,8 @@ pub enum EthBridgeEnabled {
 
 pub trait EthBridgeQueries {
     /// Check if the bridge is disabled, enabled, or
-    /// scheduled to be enabled at a specified epoch. Returns `None` if the
-    /// status cannot be found in storage.
-    fn check_bridge_status(&self) -> Option<EthBridgeStatus>;
+    /// scheduled to be enabled at a specified epoch.
+    fn check_bridge_status(&self) -> EthBridgeStatus;
 
     /// Returns a boolean indicating whether the bridge
     /// is currently active.
@@ -151,22 +150,21 @@ where
     D: storage::DB + for<'iter> storage::DBIter<'iter>,
     H: storage::StorageHasher,
 {
-    fn check_bridge_status(&self) -> Option<EthBridgeStatus> {
-        let status = BorshDeserialize::try_from_slice(
+    fn check_bridge_status(&self) -> EthBridgeStatus {
+        BorshDeserialize::try_from_slice(
             self.read(&active_key())
                 .expect(
                     "Reading the Ethereum bridge active key shouldn't fail.",
                 )
-                .0?
+                .0
+                .expect("The Ethereum bridge active key should be in storage")
                 .as_slice(),
         )
-        .expect("Deserializing the Ethereum bridge active key shouldn't fail.");
-        Some(status)
+        .expect("Deserializing the Ethereum bridge active key shouldn't fail.")
     }
 
     fn is_bridge_active(&self) -> bool {
-        if let Some(EthBridgeStatus::Enabled(enabled_at)) =
-            self.check_bridge_status()
+        if let EthBridgeStatus::Enabled(enabled_at) = self.check_bridge_status()
         {
             match enabled_at {
                 EthBridgeEnabled::AtGenesis => true,


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/1041

This PR makes it so that we don't unnecessarily check if we need to start the Ethereum oracle after every commit anymore (see https://github.com/anoma/namada/pull/810#discussion_r1073270956)

Most Ethereum bridge parameters should only ever be configured by hardforking and updating the network config toml (e.g. smart contract Ethereum addresses), that is, they shouldn't be changed via a transaction in a block (i.e. not via a governance proposal). For this reason, there are only two places we need to initially configure the oracle:

- `InitChain` - if the Ethereum bridge parameters are in the network config toml, we can start our oracle
- when creating the `Shell` on node start up - if we have synced/committed at least one block, then we're past `InitChain`, in which case the Ethereum bridge parameters may be on chain so we can do the check straightaway rather than needing to wait for a block to be committed