### PR TITLE
Addresses the boundary conditions for the Masp VP predicate

### DIFF
--- a/wasm/wasm_source/src/vp_masp.rs
+++ b/wasm/wasm_source/src/vp_masp.rs
@@ -1,11 +1,57 @@
 use std::cmp::Ordering;
 
 use masp_primitives::asset_type::AssetType;
-use masp_primitives::transaction::components::Amount;
+use masp_primitives::transaction::components::{Amount, TxIn, TxOut};
 /// Multi-asset shielded pool VP.
 use namada_vp_prelude::address::masp;
 use namada_vp_prelude::storage::Epoch;
 use namada_vp_prelude::*;
+
+/// Generates the current asset type given the current epoch and an
+/// unique token address
+fn asset_type_from_epoched_address(epoch: Epoch, token: &Address) -> AssetType {
+    // Timestamp the chosen token with the current epoch
+    let token_bytes = (token, epoch.0)
+        .try_to_vec()
+        .expect("token should serialize");
+    // Generate the unique asset identifier from the unique token address
+    AssetType::new(token_bytes.as_ref()).expect("unable to create asset type")
+}
+
+/// Checks if the asset type matches the expected asset type, Adds a
+/// debug log if the values do not match.
+fn valid_asset_type(
+    asset_type: &AssetType,
+    asset_type_to_test: &AssetType,
+) -> bool {
+    let res =
+        asset_type.get_identifier() == asset_type_to_test.get_identifier();
+    if !res {
+        debug_log!(
+            "The asset type must be derived from the token address and \
+             current epoch"
+        );
+    }
+    res
+}
+
+/// Checks if the reported transparent amount and the unshielded
+/// values agree, if not adds to the debug log
+fn valid_transfer_amount(
+    reporeted_transparent_value: u64,
+    unshielded_transfer_value: u64,
+) -> bool {
+    let res = reporeted_transparent_value == unshielded_transfer_value;
+    if !res {
+        debug_log!(
+            "The unshielded amount {} disagrees with the calculated masp \
+             transparented value {}",
+            unshielded_transfer_value,
+            reporeted_transparent_value
+        )
+    }
+    res
+}
 
 /// Convert Namada amount and token type to MASP equivalents
 fn convert_amount(
@@ -13,13 +59,7 @@ fn convert_amount(
     token: &Address,
     val: token::Amount,
 ) -> (AssetType, Amount) {
-    // Timestamp the chosen token with the current epoch
-    let token_bytes = (token, epoch.0)
-        .try_to_vec()
-        .expect("token should serialize");
-    // Generate the unique asset identifier from the unique token address
-    let asset_type = AssetType::new(token_bytes.as_ref())
-        .expect("unable to create asset type");
+    let asset_type = asset_type_from_epoched_address(epoch, token);
     // Combine the value and unit into one amount
     let amount = Amount::from_nonnegative(asset_type, u64::from(val))
         .expect("invalid value or asset type for amount");
@@ -55,7 +95,36 @@ fn validate_tx(
         transparent_tx_pool += shielded_tx.value_balance.clone();
 
         // Handle shielding/transparent input
+        // The following boundary conditions must be satisfied
+        // 1. One transparent input
+        // 2. Zero transparent output
+        // 3. Asset type must be properly derived
+        // 4. Value from the input must be the same as the transfer
         if transfer.source != masp() {
+            // Satisfies 1.
+            if shielded_tx.vin.len() != 1 {
+                debug_log!(
+                    "Transparent input to a transaction from the masp must be \
+                     1 but is {}",
+                    shielded_tx.vin.len()
+                );
+                return reject();
+            }
+
+            // Satisfies 2.
+            if shielded_tx.vout.len() != 0 {
+                debug_log!(
+                    "Transparent output to a transaction from the masp must \
+                     be 0 but is {}",
+                    shielded_tx.vin.len()
+                );
+                return reject();
+            }
+
+            // Can not Satisfy 3. nor 4. due to TxIn having
+            // insufficient data
+            let _tx_in: &TxIn = &shielded_tx.vin[0];
+
             // Note that the asset type is timestamped so shields
             // where the shielded value has an incorrect timestamp
             // are automatically rejected
@@ -70,9 +139,50 @@ fn validate_tx(
         }
 
         // Handle unshielding/transparent output
+        // The following boundary conditions must be satisfied
+        // 1. Zero transparent inupt
+        // 2. One transparent output
+        // 3. Asset type must be properly derived
+        // 4. Value from the output must be the same as the containing transfer
+        // 5. Public key must be the hash of the target
         if transfer.target != masp() {
+            // Satisfies 1.
+            if shielded_tx.vin.len() != 0 {
+                debug_log!(
+                    "Transparent input to a transaction to the masp must be 0 \
+                     but is {}",
+                    shielded_tx.vin.len()
+                );
+                return reject();
+            }
+
+            // Satisfies 2.
+            if shielded_tx.vout.len() != 1 {
+                debug_log!(
+                    "Transparent output to a transaction to the masp must be \
+                     1 but is {}",
+                    shielded_tx.vin.len()
+                );
+                return reject();
+            }
+
+            let out: &TxOut = &shielded_tx.vout[0];
+
+            let expected_asset_type: AssetType =
+                asset_type_from_epoched_address(
+                    ctx.get_block_epoch().unwrap(),
+                    &transfer.token,
+                );
+
+            // Satisfies 3. and 4.
+            if !(valid_asset_type(&expected_asset_type, &out.asset_type)
+                && valid_transfer_amount(out.value, u64::from(transfer.amount)))
+            {
+                return reject();
+            }
+
             // Timestamp is derived to allow unshields for older tokens
-            let atype =
+            let atype: &AssetType =
                 shielded_tx.value_balance.components().next().unwrap().0;
 
             let transp_amt =
@@ -81,6 +191,9 @@ fn validate_tx(
 
             // Non-masp destinations subtract from transparent tx pool
             transparent_tx_pool -= transp_amt;
+
+            // Can not Satisfy 5. as TxOut lacks an accompanying
+            // Public key.
         }
 
         match transparent_tx_pool.partial_cmp(&Amount::zero()) {


### PR DESCRIPTION
This PR implements the boundary conditions found in [#56](https://github.com/anoma/namada/issues/56#issuecomment-1400015486).

The following checks are not included

1. If the target address is not the masp, then the public key must be
checked

2. If the source address is not the masp, then the asset type must be
derived

3. If the source address is not the masp, then the value must be
derived

The first one is not satisifed as TxOut lacks a public key to check
against, not only in code but also in the spec

https://github.com/anoma/namada/blob/83e83315a5eaec302d08ed5db242d70625cfe45f/documentation/specs/src/masp/ledger-integration.md#transparent-output-format

The second and third are not satisfied as TxIn in code lacks the
values in the spec that can be used to satisfy them

https://github.com/anoma/namada/blob/83e83315a5eaec302d08ed5db242d70625cfe45f/documentation/specs/src/masp/ledger-integration.md#transparent-input-format


I suggest a followup pr once those values are in.