### PR TITLE
Update help text to properly display the url

### DIFF
--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -3260,7 +3260,8 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(CHAIN_ID.def().about("The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-config repository."))
+            app.arg(CHAIN_ID.def().about("The chain ID. The chain must be known in the repository: \
+                                          https://github.com/heliaxdev/anoma-network-config"))
                 .arg(GENESIS_VALIDATOR.def().about("The alias of the genesis validator that you want to set up as, if any."))
                 .arg(PRE_GENESIS_PATH.def().about("The path to the pre-genesis directory for genesis validator, if any. Defaults to \"{base-dir}/pre-genesis/{genesis-validator}\"."))
             .arg(DONT_PREFETCH_WASM.def().about(


### PR DESCRIPTION
As it currently stands the help text renders like

```bash
namadac utils join-network --help
...
OPTIONS:
        --chain-id <chain-id>
            The chain ID. The chain must be known in the https://github.com/heliaxdev/anoma-network-
            config repository.

```

which causes issues as upon a quick glance or click the url is `https://github.com/heliaxdev/anoma-network-`. I have changed the text so it's properly kept in tact

```bash
 % namadac utils join-network  --help
...
OPTIONS:
        --chain-id <chain-id>
            The chain ID. The chain must be known in the repository:
            https://github.com/heliaxdev/anoma-network-config
```

now the link can properly be clicked from the terminal and people at a click glance won't confuse the url