### PR TITLE
Ensure wrapped ERC20 transfers are correctly authorized and add end-to-end tests for them

### DIFF
--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -73,7 +73,13 @@ where
     } in transfers
     {
         let mut changed = if asset != &wrapped_native_erc20 {
-            mint_wrapped_erc20s(storage, asset, receiver, amount)?
+            let changed =
+                mint_wrapped_erc20s(storage, asset, receiver, amount)?;
+            tracing::info!(
+                "Minted wrapped ERC20s - (receiver - {receiver}, amount - \
+                 {amount})",
+            );
+            changed
         } else {
             redeem_native_token(storage, receiver, amount)?
         };

--- a/shared/src/ledger/native_vp/ethereum_bridge/authorize.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/authorize.rs
@@ -10,8 +10,9 @@ use namada_core::types::address::Address;
 pub(super) fn is_authorized(
     verifiers: &BTreeSet<Address>,
     sender: &Address,
+    receiver: &Address,
 ) -> bool {
-    verifiers.contains(sender)
+    verifiers.contains(sender) && verifiers.contains(receiver)
 }
 
 #[cfg(test)]
@@ -21,22 +22,34 @@ mod tests {
 
     #[test]
     fn test_is_authorized_passes() {
-        let owner = address::testing::established_address_1();
-        let verifiers = BTreeSet::from([owner.clone()]);
-        assert!(verifiers.contains(&owner));
+        let sender = address::testing::established_address_1();
+        let receiver = address::testing::established_address_2();
+        let verifiers = BTreeSet::from([sender.clone(), receiver.clone()]);
 
-        let authorized = is_authorized(&verifiers, &owner);
+        let authorized = is_authorized(&verifiers, &sender, &receiver);
 
         assert!(authorized);
     }
 
     #[test]
     fn test_is_authorized_fails() {
-        let owner = address::testing::established_address_1();
+        let sender = address::testing::established_address_1();
+        let receiver = address::testing::established_address_2();
         let verifiers = BTreeSet::default();
-        assert!(!verifiers.contains(&owner));
 
-        let authorized = is_authorized(&verifiers, &owner);
+        let authorized = is_authorized(&verifiers, &sender, &receiver);
+
+        assert!(!authorized);
+
+        let verifiers = BTreeSet::from([sender.clone()]);
+
+        let authorized = is_authorized(&verifiers, &sender, &receiver);
+
+        assert!(!authorized);
+
+        let verifiers = BTreeSet::from([receiver.clone()]);
+
+        let authorized = is_authorized(&verifiers, &sender, &receiver);
 
         assert!(!authorized);
     }

--- a/shared/src/ledger/native_vp/ethereum_bridge/authorize.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/authorize.rs
@@ -1,37 +1,43 @@
 //! Functionality to do with checking whether a transaction is authorized by the
 //! "owner" of some key under this account
-use eyre::Result;
+use std::collections::BTreeSet;
+
 use namada_core::types::address::Address;
 
-use crate::ledger::native_vp::StorageReader;
-
+/// For wrapped ERC20 transfers, checks that `verifiers` contains the `sender`'s
+/// address - we delegate to the sender's VP to authorize the transfer (for
+/// regular Namada accounts, this will be `vp_implicit` or `vp_user`).
 pub(super) fn is_authorized(
-    _reader: impl StorageReader,
-    _tx_data: &[u8],
-    _owner: &Address,
-) -> Result<bool> {
-    tracing::warn!(
-        "authorize::is_authorized is not implemented, so all transfers are \
-         authorized"
-    );
-    Ok(true)
+    verifiers: &BTreeSet<Address>,
+    sender: &Address,
+) -> bool {
+    verifiers.contains(sender)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ledger::native_vp;
     use crate::types::address;
 
     #[test]
-    fn test_is_authorized_established_address() -> Result<()> {
-        let reader = native_vp::testing::FakeStorageReader::default();
-        let tx_data = vec![];
+    fn test_is_authorized_passes() {
         let owner = address::testing::established_address_1();
+        let verifiers = BTreeSet::from([owner.clone()]);
+        assert!(verifiers.contains(&owner));
 
-        let authorized = is_authorized(reader, &tx_data, &owner)?;
+        let authorized = is_authorized(&verifiers, &owner);
 
         assert!(authorized);
-        Ok(())
+    }
+
+    #[test]
+    fn test_is_authorized_fails() {
+        let owner = address::testing::established_address_1();
+        let verifiers = BTreeSet::default();
+        assert!(!verifiers.contains(&owner));
+
+        let authorized = is_authorized(&verifiers, &owner);
+
+        assert!(!authorized);
     }
 }

--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -182,8 +182,12 @@ where
 }
 
 /// Check if a delta matches the delta given by a transfer
-fn check_delta(delta: &(Address, Amount), transfer: &PendingTransfer) -> bool {
-    delta.0 == transfer.transfer.sender && delta.1 == transfer.transfer.amount
+fn check_delta(
+    sender: &Address,
+    amount: &Amount,
+    transfer: &PendingTransfer,
+) -> bool {
+    *sender == transfer.transfer.sender && *amount == transfer.transfer.amount
 }
 
 /// Helper struct for handling the different escrow
@@ -319,7 +323,8 @@ where
                 (&escrow_key).try_into().expect("This should not fail"),
                 (&owner_key).try_into().expect("This should not fail"),
             ) {
-                Ok(Some(delta)) if check_delta(&delta, &transfer) => {}
+                Ok(Some((sender, _, amount)))
+                    if check_delta(&sender, &amount, &transfer) => {}
                 other => {
                     tracing::debug!(
                         "The assets of the transfer were not properly \

--- a/shared/src/ledger/native_vp/ethereum_bridge/vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/vp.rs
@@ -147,7 +147,7 @@ where
             Some(sender) => sender,
             None => return Ok(false),
         };
-        let authed = authorize::is_authorized(&self.ctx, tx_data, &sender)?;
+        let authed = authorize::is_authorized(verifiers, &sender);
         Ok(authed)
     }
 }

--- a/shared/src/ledger/native_vp/ethereum_bridge/vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/vp.rs
@@ -142,15 +142,16 @@ where
             Some(CheckType::Escrow) => return self.check_escrow(verifiers),
             None => return Ok(false),
         };
-        let (sender, _) = match check_balance_changes(&self.ctx, key_a, key_b)?
-        {
-            Some(sender) => sender,
-            None => return Ok(false),
-        };
-        if authorize::is_authorized(verifiers, &sender) {
+        let (sender, receiver, _) =
+            match check_balance_changes(&self.ctx, key_a, key_b)? {
+                Some(sender) => sender,
+                None => return Ok(false),
+            };
+        if authorize::is_authorized(verifiers, &sender, &receiver) {
             tracing::info!(
                 ?verifiers,
                 ?sender,
+                ?receiver,
                 "Ethereum Bridge VP authorized transfer"
             );
             Ok(true)
@@ -158,6 +159,7 @@ where
             tracing::info!(
                 ?verifiers,
                 ?sender,
+                ?receiver,
                 "Ethereum Bridge VP rejected unauthorized transfer"
             );
             Ok(false)
@@ -243,14 +245,18 @@ fn determine_check_type(
 /// Checks that the balances at both `key_a` and `key_b` have changed by some
 /// amount, and that the changes balance each other out. If the balance changes
 /// are invalid, the reason is logged and a `None` is returned. Otherwise,
-/// return the `Address` of the owner of the balance which is decreasing,
-/// and by how much it decreased, which should be authorizing the balance
-/// change.
+/// return:
+/// - the `Address` of the sender i.e. the owner of the balance which is
+///   decreasing
+/// - the `Address` of the receiver i.e. the owner of the balance which is
+///   increasing
+/// - the `Amount` of the transfer i.e. by how much the sender's balance
+///   decreased, or equivalently by how much the receiver's balance increased
 pub(super) fn check_balance_changes(
     reader: impl StorageReader,
     key_a: wrapped_erc20s::Key,
     key_b: wrapped_erc20s::Key,
-) -> Result<Option<(Address, Amount)>> {
+) -> Result<Option<(Address, Address, Amount)>> {
     let (balance_a, balance_b) =
         match (key_a.suffix.clone(), key_b.suffix.clone()) {
             (
@@ -355,9 +361,13 @@ pub(super) fn check_balance_changes(
     }
 
     if balance_a_delta < 0 {
-        if let wrapped_erc20s::KeyType::Balance { owner } = key_a.suffix {
+        if let wrapped_erc20s::KeyType::Balance { owner: sender } = key_a.suffix
+        {
+            let wrapped_erc20s::KeyType::Balance { owner: receiver } =
+                key_b.suffix else { unreachable!() };
             Ok(Some((
-                owner,
+                sender,
+                receiver,
                 Amount::from(
                     u64::try_from(balance_b_delta)
                         .expect("This should not fail"),
@@ -368,9 +378,13 @@ pub(super) fn check_balance_changes(
         }
     } else {
         assert!(balance_b_delta < 0);
-        if let wrapped_erc20s::KeyType::Balance { owner } = key_b.suffix {
+        if let wrapped_erc20s::KeyType::Balance { owner: sender } = key_b.suffix
+        {
+            let wrapped_erc20s::KeyType::Balance { owner: receiver } =
+                key_a.suffix else { unreachable!() };
             Ok(Some((
-                owner,
+                sender,
+                receiver,
                 Amount::from(
                     u64::try_from(balance_a_delta)
                         .expect("This should not fail"),

--- a/shared/src/ledger/native_vp/ethereum_bridge/vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/vp.rs
@@ -147,8 +147,21 @@ where
             Some(sender) => sender,
             None => return Ok(false),
         };
-        let authed = authorize::is_authorized(verifiers, &sender);
-        Ok(authed)
+        if authorize::is_authorized(verifiers, &sender) {
+            tracing::info!(
+                ?verifiers,
+                ?sender,
+                "Ethereum Bridge VP authorized transfer"
+            );
+            Ok(true)
+        } else {
+            tracing::info!(
+                ?verifiers,
+                ?sender,
+                "Ethereum Bridge VP rejected unauthorized transfer"
+            );
+            Ok(false)
+        }
     }
 }
 

--- a/tests/src/e2e/eth_bridge_tests.rs
+++ b/tests/src/e2e/eth_bridge_tests.rs
@@ -8,20 +8,27 @@ use namada::ledger::eth_bridge::{
     UpgradeableContract,
 };
 use namada::types::address::wnam;
+use namada::types::ethereum_events::testing::DAI_ERC20_ETH_ADDRESS;
 use namada::types::ethereum_events::EthAddress;
 use namada::types::{address, token};
 use namada_apps::config::ethereum_bridge;
 use namada_core::ledger::eth_bridge::ADDRESS as BRIDGE_ADDRESS;
 use namada_core::types::address::Address;
-use namada_core::types::ethereum_events::EthereumEvent;
-use namada_tx_prelude::ethereum_events::TransferToNamada;
+use namada_core::types::ethereum_events::{EthereumEvent, TransferToNamada};
 
 use super::setup::set_ethereum_bridge_mode;
-use crate::e2e::eth_bridge_tests::helpers::EventsEndpointClient;
-use crate::e2e::helpers::{find_balance, get_actor_rpc};
+use crate::e2e::eth_bridge_tests::helpers::{
+    attempt_wrapped_erc20_transfer, find_wrapped_erc20_balance,
+    send_transfer_to_namada_event, setup_single_validator_test,
+    EventsEndpointClient,
+};
+use crate::e2e::helpers::{
+    find_address, find_balance, get_actor_rpc, init_established_account,
+};
 use crate::e2e::setup;
 use crate::e2e::setup::constants::{
-    wasm_abs_path, ALBERT, BERTHA, NAM, TX_WRITE_STORAGE_KEY_WASM,
+    wasm_abs_path, ALBERT, ALBERT_KEY, BERTHA, BERTHA_KEY, NAM,
+    TX_WRITE_STORAGE_KEY_WASM,
 };
 use crate::e2e::setup::{Bin, Who};
 use crate::{run, run_as};
@@ -393,6 +400,488 @@ async fn test_wnam_transfer() -> Result<()> {
         token::Amount::from(BRIDGE_INITIAL_NAM_BALANCE * 1_000_000)
             - wnam_transfer.amount
     );
+
+    Ok(())
+}
+
+/// Test we can transfer some DAI to an implicit address on Namada.
+#[tokio::test]
+async fn test_dai_transfer_implicit() -> Result<()> {
+    let (test, bg_ledger) = setup_single_validator_test()?;
+
+    let transfer_amount = token::Amount::from(10_000_000);
+    // [`ALBERT`] is a pre-existing implicit address in our wallet
+    let albert_addr = find_address(&test, ALBERT)?;
+
+    let dai_transfer = TransferToNamada {
+        amount: transfer_amount.to_owned(),
+        asset: DAI_ERC20_ETH_ADDRESS,
+        receiver: albert_addr.to_owned(),
+    };
+    let _bg_ledger =
+        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+
+    let albert_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr,
+    )?;
+    assert_eq!(albert_wdai_balance, transfer_amount);
+
+    Ok(())
+}
+
+/// Test we can transfer some DAI to an established address on Namada.
+#[tokio::test]
+async fn test_dai_transfer_established() -> Result<()> {
+    let (test, bg_ledger) = setup_single_validator_test()?;
+
+    // create an established account that Albert controls
+    let established_alias = "albert-established";
+    init_established_account(
+        &test,
+        &Who::Validator(0),
+        ALBERT,
+        ALBERT_KEY,
+        established_alias,
+    )?;
+    let established_addr = find_address(&test, established_alias)?;
+
+    let transfer_amount = token::Amount::from(10_000_000);
+
+    let dai_transfer = TransferToNamada {
+        amount: transfer_amount.to_owned(),
+        asset: DAI_ERC20_ETH_ADDRESS,
+        receiver: established_addr.to_owned(),
+    };
+    let _bg_ledger =
+        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+
+    let established_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &established_addr,
+    )?;
+    assert_eq!(established_wdai_balance, transfer_amount);
+
+    Ok(())
+}
+
+/// Test attempting to transfer some wDAI from an implicit address on Namada is
+/// not authorized if the transaction is not signed by the key that controls the
+/// implicit address.
+#[tokio::test]
+async fn test_wdai_transfer_implicit_unauthorized() -> Result<()> {
+    let (test, bg_ledger) = setup_single_validator_test()?;
+
+    let initial_transfer_amount = token::Amount::from(10_000_000);
+    let albert_addr = find_address(&test, ALBERT)?;
+
+    let dai_transfer = TransferToNamada {
+        amount: initial_transfer_amount.to_owned(),
+        asset: DAI_ERC20_ETH_ADDRESS,
+        receiver: albert_addr.to_owned(),
+    };
+    let _bg_ledger =
+        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+
+    let albert_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr,
+    )?;
+    assert_eq!(albert_wdai_balance, initial_transfer_amount);
+
+    let bertha_addr = find_address(&test, BERTHA)?;
+
+    // attempt a transfer from Albert to Bertha that should fail, as it's not
+    // signed with Albert's key
+    let mut cmd = attempt_wrapped_erc20_transfer(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr.to_string(),
+        &bertha_addr.to_string(),
+        &bertha_addr.to_string(),
+        &token::Amount::from(10_000),
+    )?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.exp_string("Transaction is invalid.")?;
+    cmd.assert_success();
+
+    // check balances are unchanged after an unsuccessful transfer
+    let albert_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr,
+    )?;
+    assert_eq!(albert_wdai_balance, initial_transfer_amount);
+
+    Ok(())
+}
+
+/// Test attempting to transfer some wDAI from an implicit address on Namada is
+/// not authorized if the transaction is not signed by the key that controls the
+/// implicit address.
+#[tokio::test]
+async fn test_wdai_transfer_established_unauthorized() -> Result<()> {
+    let (test, bg_ledger) = setup_single_validator_test()?;
+
+    let initial_transfer_amount = token::Amount::from(10_000_000);
+    // create an established account that Albert controls
+    let albert_established_alias = "albert-established";
+    init_established_account(
+        &test,
+        &Who::Validator(0),
+        ALBERT,
+        ALBERT_KEY,
+        albert_established_alias,
+    )?;
+    let albert_established_addr =
+        find_address(&test, albert_established_alias)?;
+
+    let dai_transfer = TransferToNamada {
+        amount: initial_transfer_amount.to_owned(),
+        asset: DAI_ERC20_ETH_ADDRESS,
+        receiver: albert_established_addr.to_owned(),
+    };
+    let _bg_ledger =
+        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+
+    let albert_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_established_addr,
+    )?;
+    assert_eq!(albert_wdai_balance, initial_transfer_amount);
+
+    let bertha_addr = find_address(&test, BERTHA)?;
+
+    // attempt a transfer from Albert to Bertha that should fail, as it's not
+    // signed with Albert's key
+    let mut cmd = attempt_wrapped_erc20_transfer(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_established_addr.to_string(),
+        &bertha_addr.to_string(),
+        &bertha_addr.to_string(),
+        &token::Amount::from(10_000),
+    )?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.exp_string("Transaction is invalid.")?;
+    cmd.assert_success();
+
+    // check balances are unchanged after an unsuccessful transfer
+    let albert_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_established_addr,
+    )?;
+    assert_eq!(albert_wdai_balance, initial_transfer_amount);
+
+    Ok(())
+}
+
+/// Test transferring some wDAI from an implicit address on Namada to another
+/// implicit address of Namada.
+#[tokio::test]
+async fn test_wdai_transfer_implicit_to_implicit() -> Result<()> {
+    let (test, bg_ledger) = setup_single_validator_test()?;
+
+    let initial_transfer_amount = token::Amount::from(10_000_000);
+    let albert_addr = find_address(&test, ALBERT)?;
+
+    let dai_transfer = TransferToNamada {
+        amount: initial_transfer_amount.to_owned(),
+        asset: DAI_ERC20_ETH_ADDRESS,
+        receiver: albert_addr.to_owned(),
+    };
+    let _bg_ledger =
+        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+
+    let albert_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr,
+    )?;
+    assert_eq!(albert_wdai_balance, initial_transfer_amount);
+
+    // attempt a transfer from Albert to Bertha that should succeed, as it's
+    // signed with Albert's key
+    let bertha_addr = find_address(&test, BERTHA)?;
+    let second_transfer_amount = token::Amount::from(10_000);
+    let mut cmd = attempt_wrapped_erc20_transfer(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr.to_string(),
+        &bertha_addr.to_string(),
+        &albert_addr.to_string(),
+        &second_transfer_amount,
+    )?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.assert_success();
+
+    let albert_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr,
+    )?;
+    assert_eq!(
+        albert_wdai_balance,
+        initial_transfer_amount - second_transfer_amount
+    );
+
+    let bertha_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &bertha_addr,
+    )?;
+    assert_eq!(bertha_wdai_balance, second_transfer_amount);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_wdai_transfer_implicit_to_established() -> Result<()> {
+    let (test, bg_ledger) = setup_single_validator_test()?;
+
+    let initial_transfer_amount = token::Amount::from(10_000_000);
+    let albert_addr = find_address(&test, ALBERT)?;
+
+    let dai_transfer = TransferToNamada {
+        amount: initial_transfer_amount.to_owned(),
+        asset: DAI_ERC20_ETH_ADDRESS,
+        receiver: albert_addr.to_owned(),
+    };
+    let _bg_ledger =
+        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+
+    let albert_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr,
+    )?;
+    assert_eq!(albert_wdai_balance, initial_transfer_amount);
+
+    // create an established account that Bertha controls
+    let bertha_established_alias = "bertha-established";
+    init_established_account(
+        &test,
+        &Who::Validator(0),
+        BERTHA,
+        BERTHA_KEY,
+        bertha_established_alias,
+    )?;
+    let bertha_established_addr =
+        find_address(&test, bertha_established_alias)?;
+
+    // attempt a transfer from Albert to Bertha that should succeed, as it's
+    // signed with Albert's key
+    let second_transfer_amount = token::Amount::from(10_000);
+    let mut cmd = attempt_wrapped_erc20_transfer(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr.to_string(),
+        &bertha_established_addr.to_string(),
+        &albert_addr.to_string(),
+        &second_transfer_amount,
+    )?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.assert_success();
+
+    let albert_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_addr,
+    )?;
+    assert_eq!(
+        albert_wdai_balance,
+        initial_transfer_amount - second_transfer_amount
+    );
+
+    let bertha_established_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &bertha_established_addr,
+    )?;
+    assert_eq!(bertha_established_wdai_balance, second_transfer_amount);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_wdai_transfer_established_to_implicit() -> Result<()> {
+    let (test, bg_ledger) = setup_single_validator_test()?;
+
+    // create an established account that Albert controls
+    let albert_established_alias = "albert-established";
+    init_established_account(
+        &test,
+        &Who::Validator(0),
+        ALBERT,
+        ALBERT_KEY,
+        albert_established_alias,
+    )?;
+    let albert_established_addr =
+        find_address(&test, albert_established_alias)?;
+
+    let initial_transfer_amount = token::Amount::from(10_000_000);
+    let dai_transfer = TransferToNamada {
+        amount: initial_transfer_amount.to_owned(),
+        asset: DAI_ERC20_ETH_ADDRESS,
+        receiver: albert_established_addr.to_owned(),
+    };
+    let _bg_ledger =
+        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+
+    let albert_established_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_established_addr,
+    )?;
+    assert_eq!(albert_established_wdai_balance, initial_transfer_amount);
+
+    let bertha_addr = find_address(&test, BERTHA)?;
+
+    // attempt a transfer from Albert to Bertha that should succeed, as it's
+    // signed with Albert's key
+    let second_transfer_amount = token::Amount::from(10_000);
+    let mut cmd = attempt_wrapped_erc20_transfer(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_established_addr.to_string(),
+        &bertha_addr.to_string(),
+        &albert_established_addr.to_string(),
+        &second_transfer_amount,
+    )?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.assert_success();
+
+    let albert_established_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_established_addr,
+    )?;
+    assert_eq!(
+        albert_established_wdai_balance,
+        initial_transfer_amount - second_transfer_amount
+    );
+
+    let bertha_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &bertha_addr,
+    )?;
+    assert_eq!(bertha_wdai_balance, second_transfer_amount);
+
+    // TODO: invalid transfer
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_wdai_transfer_established_to_established() -> Result<()> {
+    let (test, bg_ledger) = setup_single_validator_test()?;
+
+    // create an established account that Albert controls
+    let albert_established_alias = "albert-established";
+    init_established_account(
+        &test,
+        &Who::Validator(0),
+        ALBERT,
+        ALBERT_KEY,
+        albert_established_alias,
+    )?;
+    let albert_established_addr =
+        find_address(&test, albert_established_alias)?;
+
+    let initial_transfer_amount = token::Amount::from(10_000_000);
+    let dai_transfer = TransferToNamada {
+        amount: initial_transfer_amount.to_owned(),
+        asset: DAI_ERC20_ETH_ADDRESS,
+        receiver: albert_established_addr.to_owned(),
+    };
+    let _bg_ledger =
+        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+
+    let albert_established_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_established_addr,
+    )?;
+    assert_eq!(albert_established_wdai_balance, initial_transfer_amount);
+
+    // create an established account that Bertha controls
+    let bertha_established_alias = "bertha-established";
+    init_established_account(
+        &test,
+        &Who::Validator(0),
+        BERTHA,
+        BERTHA_KEY,
+        bertha_established_alias,
+    )?;
+    let bertha_established_addr =
+        find_address(&test, bertha_established_alias)?;
+
+    // attempt a transfer from Albert to Bertha that should succeed, as it's
+    // signed with Albert's key
+    let second_transfer_amount = token::Amount::from(10_000);
+    let mut cmd = attempt_wrapped_erc20_transfer(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_established_addr.to_string(),
+        &bertha_established_addr.to_string(),
+        &albert_established_addr.to_string(),
+        &second_transfer_amount,
+    )?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.exp_string("Transaction is valid.")?;
+    cmd.assert_success();
+
+    let albert_established_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &albert_established_addr,
+    )?;
+    assert_eq!(
+        albert_established_wdai_balance,
+        initial_transfer_amount - second_transfer_amount
+    );
+
+    let bertha_established_wdai_balance = find_wrapped_erc20_balance(
+        &test,
+        &Who::Validator(0),
+        &DAI_ERC20_ETH_ADDRESS,
+        &bertha_established_addr,
+    )?;
+    assert_eq!(bertha_established_wdai_balance, second_transfer_amount);
+
+    // TODO: invalid transfer
 
     Ok(())
 }

--- a/tests/src/e2e/eth_bridge_tests/helpers.rs
+++ b/tests/src/e2e/eth_bridge_tests/helpers.rs
@@ -1,10 +1,29 @@
 //! Helper functionality for use in tests to do with the Ethereum bridge.
 
-use borsh::BorshSerialize;
+use std::num::NonZeroU64;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use data_encoding::HEXLOWER;
 use eyre::{eyre, Context, Result};
 use hyper::client::HttpConnector;
 use hyper::{Body, Client, Method, Request, StatusCode};
-use namada_core::types::ethereum_events::EthereumEvent;
+use namada::ledger::eth_bridge::{
+    wrapped_erc20s, ContractVersion, Contracts, EthereumBridgeConfig,
+    MinimumConfirmations, UpgradeableContract,
+};
+use namada::types::address::{wnam, Address};
+use namada::types::ethereum_events::EthAddress;
+use namada_apps::config::ethereum_bridge;
+use namada_core::ledger::eth_bridge;
+use namada_core::types::ethereum_events::{EthereumEvent, TransferToNamada};
+use namada_core::types::token;
+use rand::Rng;
+
+use crate::e2e::helpers::{get_actor_rpc, strip_trailing_newline};
+use crate::e2e::setup::{
+    self, set_ethereum_bridge_mode, Bin, NamadaBgCmd, NamadaCmd, Test, Who,
+};
+use crate::{run, run_as};
 
 /// Simple client for submitting fake Ethereum events to a Namada node.
 pub struct EventsEndpointClient {
@@ -44,4 +63,166 @@ impl EventsEndpointClient {
         }
         Ok(())
     }
+}
+
+/// Sets up the necessary environment for a test involving a single Namada
+/// validator that is exposing an endpoint for submission of fake Ethereum
+/// events.
+pub fn setup_single_validator_test() -> Result<(Test, NamadaBgCmd)> {
+    let ethereum_bridge_params = EthereumBridgeConfig {
+        min_confirmations: MinimumConfirmations::from(unsafe {
+            // SAFETY: The only way the API contract of `NonZeroU64` can
+            // be violated is if we construct values
+            // of this type using 0 as argument.
+            NonZeroU64::new_unchecked(10)
+        }),
+        contracts: Contracts {
+            native_erc20: wnam(),
+            bridge: UpgradeableContract {
+                address: EthAddress([2; 20]),
+                version: ContractVersion::default(),
+            },
+            governance: UpgradeableContract {
+                address: EthAddress([3; 20]),
+                version: ContractVersion::default(),
+            },
+        },
+    };
+
+    // use a network-config.toml with eth bridge parameters in it
+    let test = setup::network(
+        |mut genesis| {
+            genesis.ethereum_bridge_params = Some(ethereum_bridge_params);
+            genesis
+        },
+        None,
+    )?;
+
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        &Who::Validator(0),
+        ethereum_bridge::ledger::Mode::EventsEndpoint,
+    );
+    let mut ledger =
+        run_as!(test, Who::Validator(0), Bin::Node, vec!["ledger"], Some(40))?;
+
+    ledger.exp_string("Namada ledger node started")?;
+    ledger.exp_string("This node is a validator")?;
+    ledger.exp_regex(r"Committed block hash.*, height: [0-9]+")?;
+
+    let bg_ledger = ledger.background();
+
+    Ok((test, bg_ledger))
+}
+
+/// Sends a fake Ethereum event to a Namada node representing a transfer of
+/// wrapped ERC20s.
+pub async fn send_transfer_to_namada_event(
+    bg_ledger: NamadaBgCmd,
+    transfer: TransferToNamada,
+) -> Result<NamadaBgCmd> {
+    let mut rng = rand::thread_rng();
+    let nonce: u64 = rng.gen();
+    let transfers = EthereumEvent::TransfersToNamada {
+        nonce: nonce.into(),
+        transfers: vec![transfer.clone()],
+    };
+
+    // TODO(namada#1055): right now, we use a hardcoded Ethereum events endpoint
+    // address that would only work for e2e tests involving a single
+    // validator node - this should become an attribute of the validator under
+    // test once the linked issue is implemented
+    const ETHEREUM_EVENTS_ENDPOINT: &str = "http://0.0.0.0:3030/eth_events";
+    let mut client =
+        EventsEndpointClient::new(ETHEREUM_EVENTS_ENDPOINT.to_string());
+    client.send(&transfers).await?;
+
+    // wait until the transfer is definitely processed
+    let mut ledger = bg_ledger.foreground();
+    let TransferToNamada {
+        receiver, amount, ..
+    } = transfer;
+    ledger.exp_string(&format!(
+        "Minted wrapped ERC20s - (receiver - {receiver}, amount - {amount})",
+    ))?;
+    ledger.exp_string("Committed block hash")?;
+    Ok(ledger.background())
+}
+
+/// Attempt to transfer some wrapped ERC20 from one Namada address to another.
+/// This will fail if the keys for `signer` are not in the local wallet.
+pub fn attempt_wrapped_erc20_transfer(
+    test: &Test,
+    node: &Who,
+    asset: &EthAddress,
+    from: &str,
+    to: &str,
+    signer: &str,
+    amount: &token::Amount,
+) -> Result<NamadaCmd> {
+    let ledger_address = get_actor_rpc(test, node);
+
+    let eth_bridge_addr = eth_bridge::ADDRESS.to_string();
+    let sub_prefix = wrapped_erc20s::sub_prefix(asset).to_string();
+
+    let amount = amount.to_string();
+    let transfer_args = vec![
+        "transfer",
+        "--token",
+        &eth_bridge_addr,
+        "--sub-prefix",
+        &sub_prefix,
+        "--source",
+        from,
+        "--target",
+        to,
+        "--signer",
+        signer,
+        "--amount",
+        &amount,
+        "--ledger-address",
+        &ledger_address,
+    ];
+    run!(test, Bin::Client, transfer_args, Some(40))
+}
+
+/// Find the balance of specific wrapped ERC20 for an account. This function
+/// will error if an account doesn't have an explicit balance (i.e. has never
+/// been involved in a wrapped ERC20 transfer of any kind).
+pub fn find_wrapped_erc20_balance(
+    test: &Test,
+    node: &Who,
+    asset: &EthAddress,
+    owner: &Address,
+) -> Result<token::Amount> {
+    let ledger_address = get_actor_rpc(test, node);
+
+    let sub_prefix = wrapped_erc20s::sub_prefix(asset);
+    let prefix =
+        token::multitoken_balance_prefix(&eth_bridge::ADDRESS, &sub_prefix);
+    let balance_key = token::multitoken_balance_key(&prefix, owner);
+    let mut bytes = run!(
+        test,
+        Bin::Client,
+        &[
+            "query-bytes",
+            "--storage-key",
+            &balance_key.to_string(),
+            "--ledger-address",
+            &ledger_address,
+        ],
+        Some(10)
+    )?;
+    let (_, matched) = bytes.exp_regex("Found data: 0x.*")?;
+    let data_str = strip_trailing_newline(&matched)
+        .trim()
+        .rsplit_once(' ')
+        .unwrap()
+        .1[2..]
+        .to_string();
+    let amount =
+        token::Amount::try_from_slice(&HEXLOWER.decode(data_str.as_bytes())?)?;
+    bytes.assert_success();
+    Ok(amount)
 }

--- a/tests/src/e2e/helpers.rs
+++ b/tests/src/e2e/helpers.rs
@@ -23,6 +23,35 @@ use super::setup::{sleep, Test, ENV_VAR_DEBUG, ENV_VAR_USE_PREBUILT_BINARIES};
 use crate::e2e::setup::{Bin, Who, APPS_PACKAGE};
 use crate::run;
 
+/// Initialize an established account.
+pub fn init_established_account(
+    test: &Test,
+    node: &Who,
+    source_alias: &str,
+    key_alias: &str,
+    established_alias: &str,
+) -> Result<()> {
+    let ledger_address = get_actor_rpc(test, node);
+
+    let init_account_args = vec![
+        "init-account",
+        "--source",
+        source_alias,
+        "--public-key",
+        key_alias,
+        "--alias",
+        established_alias,
+        "--ledger-address",
+        &ledger_address,
+    ];
+    let mut client_init_account =
+        run!(test, Bin::Client, init_account_args, Some(40))?;
+    client_init_account.exp_string("Transaction is valid.")?;
+    client_init_account.exp_string("Transaction applied")?;
+    client_init_account.assert_success();
+    Ok(())
+}
+
 /// Find the address of an account by its alias from the wallet
 pub fn find_address(test: &Test, alias: impl AsRef<str>) -> Result<Address> {
     let mut find = run!(
@@ -328,7 +357,7 @@ pub fn generate_bin_command(bin_name: &str, manifest_path: &Path) -> Command {
     }
 }
 
-fn strip_trailing_newline(input: &str) -> &str {
+pub(crate) fn strip_trailing_newline(input: &str) -> &str {
     input
         .strip_suffix("\r\n")
         .or_else(|| input.strip_suffix('\n'))


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/432 and relates to https://github.com/anoma/namada/issues/508

This PR
- ensures we check the relevant VPs are being executed for wrapped ERC20 transfers
- adds end-to-end tests covering
  - transfers of DAI from Ethereum to implicit and established Namada accounts
  - authorized transfers of wrapped DAI between implicit <-> established accounts once on Namada
  - rejecting transactions that attempt to transfer wrapped DAI from implicit/established accounts, if the transactions aren't signed by the key which controls the sending account

NB: some helper fns added/used in this PR are also in https://github.com/anoma/namada/pull/886/files#diff-b26bbd416d9d500f8f12aee8f7b3182f35b5cacb748898d9c07fe2cdd41e69b8