### PR TITLE
Write Merkle tree stores only when a new epoch

### DIFF
--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -772,7 +772,9 @@ mod test_utils {
     use namada::types::chain::ChainId;
     use namada::types::hash::Hash;
     use namada::types::key::*;
-    use namada::types::storage::{BlockHash, BlockResults, Epoch, Header};
+    use namada::types::storage::{
+        BlockHash, BlockResults, Epoch, Epochs, Header,
+    };
     use namada::types::transaction::{Fee, WrapperTx};
     use tempfile::tempdir;
     use tokio::sync::mpsc::UnboundedReceiver;
@@ -1015,24 +1017,28 @@ mod test_utils {
         let merkle_tree = MerkleTree::<Sha256Hasher>::default();
         let stores = merkle_tree.stores();
         let hash = BlockHash([0; 32]);
-        let pred_epochs = Default::default();
+        let mut pred_epochs: Epochs = Default::default();
+        pred_epochs.new_epoch(BlockHeight(1), 1000);
         let address_gen = EstablishedAddressGen::new("test");
         shell
             .storage
             .db
-            .write_block(BlockStateWrite {
-                merkle_tree_stores: stores,
-                header: None,
-                hash: &hash,
-                height: BlockHeight(1),
-                epoch: Epoch(0),
-                pred_epochs: &pred_epochs,
-                next_epoch_min_start_height: BlockHeight(3),
-                next_epoch_min_start_time: DateTimeUtc::now(),
-                address_gen: &address_gen,
-                results: &BlockResults::default(),
-                tx_queue: &shell.storage.tx_queue,
-            })
+            .write_block(
+                BlockStateWrite {
+                    merkle_tree_stores: stores,
+                    header: None,
+                    hash: &hash,
+                    height: BlockHeight(1),
+                    epoch: Epoch(1),
+                    pred_epochs: &pred_epochs,
+                    next_epoch_min_start_height: BlockHeight(3),
+                    next_epoch_min_start_time: DateTimeUtc::now(),
+                    address_gen: &address_gen,
+                    results: &BlockResults::default(),
+                    tx_queue: &shell.storage.tx_queue,
+                },
+                true,
+            )
             .expect("Test failed");
 
         // Drop the shell

--- a/core/src/ledger/storage/merkle_tree.rs
+++ b/core/src/ledger/storage/merkle_tree.rs
@@ -248,16 +248,38 @@ impl<H: StorageHasher + Default> core::fmt::Debug for MerkleTree<H> {
 
 impl<H: StorageHasher + Default> MerkleTree<H> {
     /// Restore the tree from the stores
-    pub fn new(stores: MerkleTreeStoresRead) -> Self {
+    pub fn new(stores: MerkleTreeStoresRead) -> Result<Self> {
         let base = Smt::new(stores.base.0.into(), stores.base.1);
         let account = Smt::new(stores.account.0.into(), stores.account.1);
         let ibc = Amt::new(stores.ibc.0.into(), stores.ibc.1);
         let pos = Smt::new(stores.pos.0.into(), stores.pos.1);
-        Self {
+        let tree = Self {
             base,
             account,
             ibc,
             pos,
+        };
+
+        // validate
+        let account_key = H::hash(StoreType::Account.to_string());
+        let account_root = tree.base.get(&account_key.into())?;
+        let ibc_key = H::hash(StoreType::Ibc.to_string());
+        let ibc_root = tree.base.get(&ibc_key.into())?;
+        let pos_key = H::hash(StoreType::PoS.to_string());
+        let pos_root = tree.base.get(&pos_key.into())?;
+        if (tree.base.root().is_zero()
+            && tree.account.root().is_zero()
+            && tree.ibc.root().is_zero()
+            && tree.pos.root().is_zero())
+            || (account_root == tree.account.root().into()
+                && ibc_root == tree.ibc.root().into()
+                && pos_root == tree.pos.root().into())
+        {
+            Ok(tree)
+        } else {
+            Err(Error::MerkleTree(
+                "Invalid MerkleTreeStoresRead".to_string(),
+            ))
         }
     }
 
@@ -696,7 +718,8 @@ mod test {
             stores_read.set_root(st, stores_write.root(st).clone());
             stores_read.set_store(stores_write.store(st).to_owned());
         }
-        let restored_tree = MerkleTree::<Sha256Hasher>::new(stores_read);
+        let restored_tree =
+            MerkleTree::<Sha256Hasher>::new(stores_read).unwrap();
         assert!(restored_tree.has_key(&ibc_key).unwrap());
         assert!(restored_tree.has_key(&pos_key).unwrap());
     }

--- a/core/src/ledger/storage/mockdb.rs
+++ b/core/src/ledger/storage/mockdb.rs
@@ -172,7 +172,11 @@ impl DB for MockDB {
         }
     }
 
-    fn write_block(&mut self, state: BlockStateWrite) -> Result<()> {
+    fn write_block(
+        &mut self,
+        state: BlockStateWrite,
+        _is_full_commit: bool,
+    ) -> Result<()> {
         let BlockStateWrite {
             merkle_tree_stores,
             header,
@@ -310,7 +314,7 @@ impl DB for MockDB {
     fn read_merkle_tree_stores(
         &self,
         height: BlockHeight,
-    ) -> Result<Option<MerkleTreeStoresRead>> {
+    ) -> Result<Option<(BlockHeight, MerkleTreeStoresRead)>> {
         let mut merkle_tree_stores = MerkleTreeStoresRead::default();
         let height_key = Key::from(height.to_db_key());
         let tree_key = height_key
@@ -342,7 +346,7 @@ impl DB for MockDB {
                 None => return Ok(None),
             }
         }
-        Ok(Some(merkle_tree_stores))
+        Ok(Some((height, merkle_tree_stores)))
     }
 
     fn read_subspace_val(&self, key: &Key) -> Result<Option<Vec<u8>>> {
@@ -454,6 +458,16 @@ impl<'iter> DBIter<'iter> for MockDB {
         let prefix = "results".to_owned();
         let iter = self.0.borrow().clone().into_iter();
         MockPrefixIterator::new(MockIterator { prefix, iter }, db_prefix)
+    }
+
+    fn iter_old_diffs(&self, _height: BlockHeight) -> MockPrefixIterator {
+        // Mock DB can read only the latest value for now
+        unimplemented!()
+    }
+
+    fn iter_new_diffs(&self, _height: BlockHeight) -> MockPrefixIterator {
+        // Mock DB can read only the latest value for now
+        unimplemented!()
     }
 }
 

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1079,6 +1079,19 @@ impl Epochs {
         }
         None
     }
+
+    /// Look-up the starting block height of an epoch before a given height.
+    pub fn get_epoch_start_height(
+        &self,
+        height: BlockHeight,
+    ) -> Option<BlockHeight> {
+        for start_height in self.first_block_heights.iter().rev() {
+            if *start_height <= height {
+                return Some(*start_height);
+            }
+        }
+        None
+    }
 }
 
 /// A value of a storage prefix iterator.
@@ -1180,10 +1193,30 @@ mod tests {
         epochs.new_epoch(BlockHeight(10), max_age_num_blocks);
         println!("epochs {:#?}", epochs);
         assert_eq!(epochs.get_epoch(BlockHeight(0)), Some(Epoch(0)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(0)),
+            Some(BlockHeight(0))
+        );
         assert_eq!(epochs.get_epoch(BlockHeight(9)), Some(Epoch(0)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(9)),
+            Some(BlockHeight(0))
+        );
         assert_eq!(epochs.get_epoch(BlockHeight(10)), Some(Epoch(1)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(10)),
+            Some(BlockHeight(10))
+        );
         assert_eq!(epochs.get_epoch(BlockHeight(11)), Some(Epoch(1)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(11)),
+            Some(BlockHeight(10))
+        );
         assert_eq!(epochs.get_epoch(BlockHeight(100)), Some(Epoch(1)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(100)),
+            Some(BlockHeight(10))
+        );
 
         // epoch 2
         epochs.new_epoch(BlockHeight(20), max_age_num_blocks);
@@ -1192,8 +1225,20 @@ mod tests {
         assert_eq!(epochs.get_epoch(BlockHeight(9)), Some(Epoch(0)));
         assert_eq!(epochs.get_epoch(BlockHeight(10)), Some(Epoch(1)));
         assert_eq!(epochs.get_epoch(BlockHeight(11)), Some(Epoch(1)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(11)),
+            Some(BlockHeight(10))
+        );
         assert_eq!(epochs.get_epoch(BlockHeight(20)), Some(Epoch(2)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(20)),
+            Some(BlockHeight(20))
+        );
         assert_eq!(epochs.get_epoch(BlockHeight(100)), Some(Epoch(2)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(100)),
+            Some(BlockHeight(20))
+        );
 
         // epoch 3, epoch 0 and 1 should be trimmed
         epochs.new_epoch(BlockHeight(200), max_age_num_blocks);
@@ -1204,7 +1249,15 @@ mod tests {
         assert_eq!(epochs.get_epoch(BlockHeight(11)), None);
         assert_eq!(epochs.get_epoch(BlockHeight(20)), Some(Epoch(2)));
         assert_eq!(epochs.get_epoch(BlockHeight(100)), Some(Epoch(2)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(100)),
+            Some(BlockHeight(20))
+        );
         assert_eq!(epochs.get_epoch(BlockHeight(200)), Some(Epoch(3)));
+        assert_eq!(
+            epochs.get_epoch_start_height(BlockHeight(200)),
+            Some(BlockHeight(200))
+        );
 
         // increase the limit
         max_age_num_blocks = 200;


### PR DESCRIPTION
- Write Merkle tree roots and stores only when a new epoch
- Rebuild the tree with the latest saved stores and subspace diffs if needed