### PR TITLE
release: bump supported cargo-release version to 0.24.4

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# depends on cargo-release 0.21.4, git 2.24.0 or later, unclog 0.5.0
+# depends on cargo-release 0.24.4, git 2.24.0 or later, unclog 0.5.0
 set -e
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
It looks like no config file changes are required here.