### PR TITLE
Add bp relaying functionality to Namadar

### DIFF
--- a/apps/src/bin/namada-relayer/cli.rs
+++ b/apps/src/bin/namada-relayer/cli.rs
@@ -9,8 +9,14 @@ pub async fn main() -> Result<()> {
     let (cmd, _) = cli::namada_relayer_cli()?;
     match cmd {
         cmds::NamadaRelayer::EthBridgePool(sub) => match sub {
+            cmds::EthBridgePool::RecommendBatch(args) => {
+                bridge_pool::recommend_batch(args).await;
+            }
             cmds::EthBridgePool::ConstructProof(args) => {
-                bridge_pool::construct_bridge_pool_proof(args).await;
+                bridge_pool::construct_proof(args).await;
+            }
+            cmds::EthBridgePool::RelayProof(args) => {
+                bridge_pool::relay_bridge_pool_proof(args).await;
             }
             cmds::EthBridgePool::QueryPool(query) => {
                 bridge_pool::query_bridge_pool(query).await;

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2007,7 +2007,7 @@ pub mod args {
     const MAX_COMMISSION_RATE_CHANGE: Arg<Decimal> =
         arg("max-commission-rate-change");
     const MODE: ArgOpt<String> = arg_opt("mode");
-    const NAM_TO_ETH: Arg<f64> = arg("nam-to-eth");
+    const NAM_PER_ETH: Arg<f64> = arg("nam-per-eth");
     const NET_ADDRESS: Arg<SocketAddr> = arg("net-address");
     const NO_CONVERSIONS: ArgFlag = flag("no-conversions");
     const OWNER: ArgOpt<WalletAddress> = arg_opt("owner");
@@ -2215,7 +2215,7 @@ pub mod args {
         /// gas the relayer is willing to pay.
         pub gas: Option<u64>,
         /// Estimate of amount of NAM a single ETH is worth.
-        pub nam_to_eth: f64,
+        pub nam_per_eth: f64,
     }
 
     impl Args for RecommendBatch {
@@ -2223,12 +2223,12 @@ pub mod args {
             let query = Query::parse(matches);
             let max_gas = MAX_ETH_GAS.parse(matches);
             let gas = ETH_GAS.parse(matches);
-            let nam_to_eth = NAM_TO_ETH.parse(matches);
+            let nam_to_eth = NAM_PER_ETH.parse(matches);
             Self {
                 query,
                 max_gas,
                 gas,
-                nam_to_eth,
+                nam_per_eth: nam_to_eth,
             }
         }
 
@@ -2242,11 +2242,12 @@ pub mod args {
                     "Under ideal conditions, relaying transfers will yield a \
                      net profit. If that is not possible, setting this \
                      optional value will result in a batch transfer that \
-                     costs as close to the value as possible without \
+                     costs as close to the given value as possible without \
                      exceeding it.",
                 ))
-                .arg(NAM_TO_ETH.def().about(
-                    "The amount of NAM that one ETH is worth, represented as a decimal number.",
+                .arg(NAM_PER_ETH.def().about(
+                    "The amount of NAM that one ETH is worth, represented as \
+                     a decimal number.",
                 ))
         }
     }

--- a/apps/src/lib/client/eth_bridge/bridge_pool.rs
+++ b/apps/src/lib/client/eth_bridge/bridge_pool.rs
@@ -1,17 +1,26 @@
 use std::collections::HashMap;
+use std::io::Write;
+use std::sync::Arc;
 
 use borsh::BorshSerialize;
+use ethbridge_bridge_contract::Bridge;
+use namada::eth_bridge::ethers::abi::AbiDecode;
+use namada::eth_bridge::ethers::prelude::{Http, Provider};
+use namada::eth_bridge::structs::RelayProof;
 use namada::ledger::queries::RPC;
 use namada::proto::Tx;
+use namada::types::address::Address;
 use namada::types::eth_abi::Encode;
 use namada::types::eth_bridge_pool::{
     GasFee, PendingTransfer, TransferToEthereum,
 };
+use namada::types::keccak::KeccakHash;
+use namada::types::token::Amount;
 use serde::{Deserialize, Serialize};
 
 use super::super::signing::TxSigningKey;
 use super::super::tx::process_tx;
-use crate::cli::{args, Context};
+use crate::cli::{args, safe_exit, Context};
 use crate::facade::tendermint_rpc::HttpClient;
 
 const ADD_TRANSFER_WASM: &str = "tx_bridge_pool.wasm";
@@ -47,35 +56,6 @@ pub async fn add_to_eth_bridge_pool(
     let transfer_tx = Tx::new(tx_code, Some(data));
     // this should not initialize any new addresses, so we ignore the result.
     process_tx(ctx, tx, transfer_tx, TxSigningKey::None).await;
-}
-
-#[derive(Serialize, Deserialize)]
-struct AbiBridgePoolProof {
-    proof: Vec<u8>,
-}
-
-/// Construct a proof that a set of transfers are in the bridge pool.
-pub async fn construct_bridge_pool_proof(args: args::BridgePoolProof) {
-    let client = HttpClient::new(args.query.ledger_address).unwrap();
-    let data = (args.transfers, args.relayer).try_to_vec().unwrap();
-    let response = RPC
-        .shell()
-        .eth_bridge()
-        .generate_bridge_pool_proof(&client, Some(data), None, false)
-        .await;
-
-    match response {
-        Ok(response) => {
-            let abi_encoded_proof = AbiBridgePoolProof {
-                proof: response.data,
-            };
-            println!(
-                "Ethereum ABI-encoded proof:\n {}",
-                serde_json::to_string(&abi_encoded_proof).unwrap()
-            );
-        }
-        Err(e) => println!("Encountered error: {}", e),
-    }
 }
 
 /// A json serializable representation of the Ethereum
@@ -148,4 +128,167 @@ pub async fn query_relay_progress(args: args::Query) {
         .await
         .unwrap();
     println!("{}", serde_json::to_string_pretty(&resp).unwrap());
+}
+
+/// Recommend the most economical batch of transfers to relay based
+/// on a conversion rate estimates from NAM to ETH and gas usage
+/// heuristics.
+pub async fn recommend_batch(args: args::RecommendBatch) {}
+
+/// Internal methdod to construct a proof that a set of transfers are in the
+/// bridge pool.
+async fn construct_bridge_pool_proof(
+    client: &HttpClient,
+    transfers: &[KeccakHash],
+    relayer: Address,
+) -> Vec<u8> {
+    let in_progress = RPC
+        .shell()
+        .eth_bridge()
+        .transfer_to_ethereum_progress(client)
+        .await
+        .unwrap();
+
+    let warnings: Vec<_> = in_progress
+        .keys()
+        .filter_map(|k| {
+            let hash = PendingTransfer::from(k).keccak256();
+            transfers.contains(&hash).then_some(hash)
+        })
+        .collect();
+
+    if !warnings.is_empty() {
+        println!(
+            "\x1b[93mWarning: The following hashes correspond to transfers \
+             \nthat have been relayed but do not yet have a quorum of \
+             \nvalidator signatures; thus they are still in the bridge \
+             pool:\n\x1b[0m{:?}",
+            warnings
+        );
+        print!("\nDo you wish to proceed? (y/n): ");
+        std::io::stdout().flush().unwrap();
+        loop {
+            let mut buffer = String::new();
+            let stdin = std::io::stdin();
+            stdin.read_line(&mut buffer).unwrap_or_else(|e| {
+                println!("Encountered error reading from STDIN: {:?}", e);
+                safe_exit(1)
+            });
+            match buffer.trim() {
+                "y" => break,
+                "n" => safe_exit(0),
+                _ => {
+                    print!("Expected 'y' or 'n'. Please try again: ");
+                    std::io::stdout().flush().unwrap();
+                },
+            }
+        }
+    }
+
+    let data = (transfers, relayer).try_to_vec().unwrap();
+    let response = RPC
+        .shell()
+        .eth_bridge()
+        .generate_bridge_pool_proof(client, Some(data), None, false)
+        .await;
+
+    match response {
+        Ok(response) => response.data,
+        Err(e) => {
+            println!("Encountered error constructing proof:\n{:?}", e);
+            safe_exit(1)
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct BridgePoolProofResponse {
+    hashes: Vec<KeccakHash>,
+    relayer_address: Address,
+    total_fees: Amount,
+    abi_encoded_proof: Vec<u8>,
+}
+
+/// Construct a merkle proof of a batch of transfers in
+/// the bridge pool and return it to the user (as opposed
+/// to relaying it to ethereum).
+pub async fn construct_proof(args: args::BridgePoolProof) {
+    let client = HttpClient::new(args.query.ledger_address).unwrap();
+    let bp_proof_bytes = construct_bridge_pool_proof(
+        &client,
+        &args.transfers,
+        args.relayer.clone(),
+    )
+    .await;
+    let bp_proof: RelayProof = match AbiDecode::decode(&bp_proof_bytes) {
+        Ok(proof) => proof,
+        Err(error) => {
+            println!("Unable to decode the generated proof: {:?}", error);
+            safe_exit(1)
+        }
+    };
+    let resp = BridgePoolProofResponse {
+        hashes: args.transfers,
+        relayer_address: args.relayer,
+        total_fees: bp_proof
+            .transfers
+            .iter()
+            .map(|t| t.fee.as_u64())
+            .sum::<u64>()
+            .into(),
+        abi_encoded_proof: bp_proof_bytes,
+    };
+    println!("{}", serde_json::to_string(&resp).unwrap());
+}
+
+/// Relay a validator set update, signed off for a given epoch.
+pub async fn relay_bridge_pool_proof(args: args::RelayBridgePoolProof) {
+    let nam_client = HttpClient::new(args.query.ledger_address).unwrap();
+    let bp_proof =
+        construct_bridge_pool_proof(&nam_client, &args.transfers, args.relayer)
+            .await;
+    let eth_client =
+        Arc::new(Provider::<Http>::try_from(&args.eth_rpc_endpoint).unwrap());
+    let bridge = match RPC
+        .shell()
+        .eth_bridge()
+        .read_bridge_contract(&nam_client)
+        .await
+    {
+        Ok(address) => Bridge::new(address.address, eth_client),
+        error => {
+            println!(
+                "Failed to retreive the Ethereum Bridge smart contract \
+                 address from storage with reason:\n{:?}\n\nPerhaps the \
+                 Ethereum bridge is not active.",
+                error
+            );
+            safe_exit(1)
+        }
+    };
+    let bp_proof = match AbiDecode::decode(&bp_proof) {
+        Ok(proof) => proof,
+        Err(error) => {
+            println!("Unable to decode the generated proof: {:?}", error);
+            safe_exit(1)
+        }
+    };
+    let mut relay_op = bridge.transfer_to_erc(bp_proof);
+    if let Some(gas) = args.gas {
+        relay_op.tx.set_gas(gas);
+    }
+    if let Some(gas_price) = args.gas_price {
+        relay_op.tx.set_gas_price(gas_price);
+    }
+    if let Some(eth_addr) = args.eth_addr {
+        relay_op.tx.set_from(eth_addr.into());
+    }
+
+    let pending_tx = relay_op.send().await.unwrap();
+    let transf_result = pending_tx
+        .confirmations(args.confirmations as usize)
+        .await
+        .unwrap();
+
+    println!("{transf_result:?}");
 }

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -807,7 +807,8 @@ where
                 );
                 return;
             };
-            let start_block = self.storage.ethereum_height.clone().unwrap_or_default();
+            let start_block =
+                self.storage.ethereum_height.clone().unwrap_or_default();
             tracing::info!(
                 ?start_block,
                 "Found Ethereum height from which the Ethereum oracle should \

--- a/core/src/types/ethereum_structs.rs
+++ b/core/src/types/ethereum_structs.rs
@@ -1,11 +1,10 @@
 //! Ethereum bridge struct re-exports and types to do with ethereum.
-pub use ethbridge_structs::*;
-
 use std::fmt;
 use std::num::NonZeroU64;
 use std::ops::{Add, AddAssign, Deref};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+pub use ethbridge_structs::*;
 use num256::Uint256;
 
 /// This type must be able to represent any valid Ethereum block height. It must

--- a/core/src/types/keccak.rs
+++ b/core/src/types/keccak.rs
@@ -7,6 +7,7 @@ use std::fmt::Display;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use data_encoding::HEXUPPER;
 use ethabi::Token;
+use serde::{Serialize, Serializer};
 use thiserror::Error;
 pub use tiny_keccak::{Hasher, Keccak};
 
@@ -96,6 +97,15 @@ impl TryFrom<&str> for KeccakHash {
 impl AsRef<[u8]> for KeccakHash {
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl Serialize for KeccakHash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -180,6 +180,14 @@ impl From<BlockHeight> for u64 {
     }
 }
 
+impl FromStr for BlockHeight {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(Self(s.parse::<u64>()?))
+    }
+}
+
 /// Hash of a block as fixed-size byte array
 #[derive(
     Clone,

--- a/ethereum_bridge/src/oracle/config.rs
+++ b/ethereum_bridge/src/oracle/config.rs
@@ -1,8 +1,8 @@
 //! Configuration for an oracle.
 use std::num::NonZeroU64;
 
-use namada_core::types::ethereum_structs;
 use namada_core::types::ethereum_events::EthAddress;
+use namada_core::types::ethereum_structs;
 
 /// Configuration for an oracle.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]

--- a/tests/src/e2e/eth_bridge_tests.rs
+++ b/tests/src/e2e/eth_bridge_tests.rs
@@ -295,7 +295,7 @@ fn test_add_to_bridge_pool() {
     let mut namadar =
         run!(test, Bin::Relayer, proof_args, Some(QUERY_TIMEOUT_SECONDS),)
             .unwrap();
-    namadar.exp_string("Ethereum ABI-encoded proof:").unwrap();
+    namadar.exp_string(r#"{"hashes":["#).unwrap();
 }
 
 /// Tests transfers of wNAM ERC20s from Ethereum are treated differently to


### PR DESCRIPTION
This PR adds more cli commands to `namadar` relating to the bridge pool.

* Constructing a proof manually returns more data about the batch
* Batches can now be relayed to the smart contracts directly with a new cli command
* A recommendation for a batch to be relayed can be generated.