### PR TITLE
Timeout unresponsive oracle

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
@@ -504,7 +504,7 @@ mod test_oracle {
                 last_processed_block: last_processed_block_sender,
                 // backoff should be short for tests so that they run faster
                 backoff: Duration::from_millis(5),
-                ceiling: Duration::from_secs(60),
+                ceiling: DEFAULT_CEILING,
                 control: control_receiver,
             },
             admin_channel,

--- a/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
@@ -24,7 +24,7 @@ use super::test_tools::mock_web3_client::Web3;
 use crate::timeouts::TimeoutStrategy;
 
 /// The default amount of time the oracle will wait between processing blocks
-const DEFAULT_BACKOFF: Duration = std::time::Duration::from_secs(1);
+const DEFAULT_BACKOFF: Duration = std::time::Duration::from_millis(500);
 const DEFAULT_CEILING: Duration = std::time::Duration::from_secs(30);
 
 #[derive(Error, Debug)]

--- a/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
@@ -259,7 +259,9 @@ async fn run_oracle_aux(mut oracle: Oracle) {
                     ControlFlow::Break(Err(eyre!("Shutting down.")))
                 }
             }
-        }).await;
+        })
+        .await
+        .expect("Oracle timed out while trying to communicate with the Ethereum fullnode.");
 
         if res.is_err() {
             break;
@@ -502,7 +504,7 @@ mod test_oracle {
                 last_processed_block: last_processed_block_sender,
                 // backoff should be short for tests so that they run faster
                 backoff: Duration::from_millis(5),
-                ceiling: Duration::from_secs(2),
+                ceiling: Duration::from_secs(60),
                 control: control_receiver,
             },
             admin_channel,
@@ -834,7 +836,7 @@ mod test_oracle {
         // check that the oracle indeed processes the confirmed blocks
         for height in 0u64..confirmed_block_height + 1 {
             let block_processed =
-                timeout(Duration::from_secs(3), blocks_processed_recv.recv())
+                timeout(Duration::from_secs(5), blocks_processed_recv.recv())
                     .await
                     .expect("Timed out waiting for block to be checked")
                     .unwrap();

--- a/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/oracle/mod.rs
@@ -25,7 +25,7 @@ use crate::timeouts::TimeoutStrategy;
 
 /// The default amount of time the oracle will wait between processing blocks
 const DEFAULT_BACKOFF: Duration = std::time::Duration::from_secs(1);
-const DEFAULT_CEILING: Duration = std::time::Duration::from_secs(20);
+const DEFAULT_CEILING: Duration = std::time::Duration::from_secs(30);
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/apps/src/lib/node/ledger/ethereum_node/test_tools/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_node/test_tools/mod.rs
@@ -14,6 +14,7 @@ pub mod mock_web3_client {
 
     use super::super::events::signatures::*;
     use super::super::{Error, Result};
+    use crate::node::ledger::ethereum_node::oracle::SyncStatus;
 
     /// Commands we can send to the mock client
     #[derive(Debug)]
@@ -120,6 +121,16 @@ pub mod mock_web3_client {
         pub async fn eth_block_number(&self) -> Result<Uint256> {
             self.check_cmd_channel();
             Ok(self.0.borrow().latest_block_height.clone())
+        }
+
+        pub async fn syncing(
+            &self,
+        ) -> std::result::Result<SyncStatus, super::super::oracle::Error>
+        {
+            self.eth_block_number()
+                .await
+                .map(SyncStatus::AtHeight)
+                .map_err(|_| super::super::oracle::Error::FallenBehind)
         }
 
         /// Gets the events (for the appropriate signature) that

--- a/core/src/types/ethereum_structs.rs
+++ b/core/src/types/ethereum_structs.rs
@@ -50,6 +50,12 @@ impl From<BlockHeight> for Uint256 {
     }
 }
 
+impl<'a> From<&'a BlockHeight> for &'a Uint256 {
+    fn from(height: &'a BlockHeight) -> Self {
+        &height.inner
+    }
+}
+
 impl Add for BlockHeight {
     type Output = BlockHeight;
 


### PR DESCRIPTION
The oracle correctly ensures whether or not it is syncning with the fullnode. A heartbeat is implemented to check responsiveness of the fullnode with a timeout in place. Exceeding the timeout shuts down the ledger.