### PR TITLE
[feat]: Dont' persist storage changes at genesis

### DIFF
--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -360,10 +360,6 @@ where
             response.validators.push(abci_validator);
         }
 
-        self.wl_storage
-            .commit_genesis()
-            .expect("Must be able to commit genesis state");
-
         Ok(response)
     }
 }


### PR DESCRIPTION
Persisting storage at genesis (init chain) can cause database corruption if a node restarts before reaching blockheight 1. The persistence of state should only occur at the time that tendermint is informed of the next block height. Thus we remove the db write call in init chain and defer persisting until the first commit block call.