### PR TITLE
Updates RocksDB dump

### DIFF
--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1631,6 +1631,7 @@ pub mod args {
         arg_default_from_ctx("gas-token", DefaultFn(|| "NAM".into()));
     const GENESIS_PATH: Arg<PathBuf> = arg("genesis-path");
     const GENESIS_VALIDATOR: ArgOpt<String> = arg("genesis-validator").opt();
+    const HISTORIC: ArgFlag = flag("historic");
     const LEDGER_ADDRESS_ABOUT: &str =
         "Address of a ledger node as \"{scheme}://{host}:{port}\". If the \
          scheme is not supplied, it is assumed to be TCP.";
@@ -1769,6 +1770,7 @@ pub mod args {
         // TODO: allow to specify height
         // pub block_height: Option<BlockHeight>,
         pub out_file_path: PathBuf,
+        pub historic: bool,
     }
 
     impl Args for LedgerDumpDb {
@@ -1777,9 +1779,12 @@ pub mod args {
             let out_file_path = OUT_FILE_PATH_OPT
                 .parse(matches)
                 .unwrap_or_else(|| PathBuf::from("db_dump".to_string()));
+            let historic = HISTORIC.parse(matches);
+
             Self {
                 // block_height,
                 out_file_path,
+                historic,
             }
         }
 
@@ -1792,6 +1797,9 @@ pub mod args {
                     "Path for the output file (omitting file extension). \
                      Defaults to \"db_dump.{block_height}.toml\" in the \
                      current working directory.",
+                ))
+                .arg(HISTORIC.def().about(
+                    "If provided, dump also the diff of the last height",
                 ))
         }
     }

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -206,6 +206,7 @@ pub fn dump_db(
     args::LedgerDumpDb {
         // block_height,
         out_file_path,
+        historic,
     }: args::LedgerDumpDb,
 ) {
     use namada::ledger::storage::DB;
@@ -214,7 +215,7 @@ pub fn dump_db(
     let db_path = config.shell.db_dir(&chain_id);
 
     let db = storage::PersistentDB::open(db_path, None);
-    db.dump_last_block(out_file_path);
+    db.dump_last_block(out_file_path, historic);
 }
 
 /// Runs and monitors a few concurrent tasks.

--- a/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -242,10 +242,14 @@ impl RocksDB {
     }
 
     /// Dump last known block
-    pub fn dump_last_block(&self, out_file_path: std::path::PathBuf) {
+    pub fn dump_last_block(
+        &self,
+        out_file_path: std::path::PathBuf,
+        historic: bool,
+    ) {
         use std::io::Write;
 
-        // Fine the last block height
+        // Find the last block height
         let height: BlockHeight = types::decode(
             self.0
                 .get("height")
@@ -295,10 +299,15 @@ impl RocksDB {
             }
         };
 
-        // Dump accounts subspace and block height data
-        dump_it("subspace".to_string());
-        let block_prefix = format!("{}/", height.raw());
-        dump_it(block_prefix);
+        let prefix = if historic {
+            // Dump subspace and diffs from last block height
+            height.raw()
+        } else {
+            // Dump only accounts subspace
+            "subspace".to_string()
+        };
+
+        dump_it(prefix);
 
         println!("Done writing to {}", full_path.to_string_lossy());
     }


### PR DESCRIPTION
Improves the `ledger dump-db` command. RocksDB iterator doesn't actually recognize the provided prefix correctly leading to duplicated keys in the dump file.

This PR solves the duplicated keys issue and adds an `historic` flag: if the flag is set it will dump the `subspace` keys and the diff of the last height, otherwise it will only dump the `subspace` subways.