### PR TITLE
Allow StorageRead with only refs to Writelog and Storage

### DIFF
--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -20,7 +20,7 @@ pub use merkle_tree::{
 use thiserror::Error;
 pub use traits::{Sha256Hasher, StorageHasher};
 pub use wl_storage::{
-    iter_prefix_post, iter_prefix_pre, PrefixIter, WlStorage,
+    iter_prefix_post, iter_prefix_pre, PrefixIter, WlStorage, WlStorageRef,
 };
 
 #[cfg(feature = "wasm-runtime")]

--- a/core/src/ledger/storage/wl_storage.rs
+++ b/core/src/ledger/storage/wl_storage.rs
@@ -86,11 +86,8 @@ where
     D: DB + for<'iter> DBIter<'iter>,
     H: StorageHasher,
 {
-    fn from(WlStorage{write_log, storage}: &'store WlStorage<D, H>) -> Self {
-        Self {
-            write_log,
-            storage
-        }
+    fn from(WlStorage { write_log, storage }: &'store WlStorage<D, H>) -> Self {
+        Self { write_log, storage }
     }
 }
 
@@ -246,13 +243,19 @@ where
         WlStorageRef::from(self).has_key(key)
     }
 
-    fn iter_prefix<'iter>(&'iter self, prefix: &Key) -> storage_api::Result<Self::PrefixIter<'iter>> {
+    fn iter_prefix<'iter>(
+        &'iter self,
+        prefix: &Key,
+    ) -> storage_api::Result<Self::PrefixIter<'iter>> {
         let (iter, _gas) =
             iter_prefix_post(&self.write_log, &self.storage, prefix);
         Ok(iter)
     }
 
-    fn iter_next<'iter>(&'iter self, iter: &mut Self::PrefixIter<'iter>) -> storage_api::Result<Option<(String, Vec<u8>)>> {
+    fn iter_next<'iter>(
+        &'iter self,
+        iter: &mut Self::PrefixIter<'iter>,
+    ) -> storage_api::Result<Option<(String, Vec<u8>)>> {
         Ok(iter.next().map(|(key, val, _gas)| (key, val)))
     }
 

--- a/shared/src/ledger/native_vp/mod.rs
+++ b/shared/src/ledger/native_vp/mod.rs
@@ -8,6 +8,7 @@ pub mod slash_fund;
 use std::cell::RefCell;
 use std::collections::BTreeSet;
 
+use namada_core::ledger::storage::WlStorageRef;
 pub use namada_core::ledger::vp_env::VpEnv;
 
 use super::storage_api::{self, ResultExt, StorageRead};
@@ -83,6 +84,21 @@ where
     /// To avoid unused parameter without "wasm-runtime" feature
     #[cfg(not(feature = "wasm-runtime"))]
     pub cache_access: std::marker::PhantomData<CA>,
+}
+
+impl<'shell, DB, H, CA> From<&Ctx<'shell, DB, H, CA>>
+    for WlStorageRef<'shell, DB, H>
+where
+    DB: storage::DB + for<'iter> storage::DBIter<'iter>,
+    H: StorageHasher,
+    CA: WasmCacheAccess,
+{
+    fn from(ctx: &Ctx<'shell, DB, H, CA>) -> Self {
+        Self {
+            storage: ctx.storage,
+            write_log: ctx.write_log,
+        }
+    }
 }
 
 /// Read access to the prior storage (state before tx execution) via


### PR DESCRIPTION
In native vps, we want access to the `StorageRead` trait. However, we only have access to `&WriteLog` and `&Storage` from which we cannot construct and object implementing this trait.

This PR adds a `WlStorageRef` struct with fields of these types that implements the `StorageRead` trait.