### PR TITLE
Polish vote extension code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4727,7 +4727,6 @@ dependencies = [
  "flate2",
  "futures 0.3.25",
  "git2",
- "index-set",
  "itertools",
  "libc",
  "libloading",

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -106,7 +106,6 @@ eyre = "0.6.5"
 flate2 = "1.0.22"
 file-lock = "2.0.2"
 futures = "0.3"
-index-set = {git = "https://github.com/heliaxdev/index-set", tag = "v0.7.1"}
 itertools = "0.10.1"
 libc = "0.2.97"
 libloading = "0.7.2"

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -807,7 +807,7 @@ where
                 );
                 return;
             }
-            if !self.wl_storage.ethbridge_queries().is_bridge_active() {
+            if !self.wl_storage.ethbridge_queries().is_bridge_active(None) {
                 tracing::info!(
                     "Not starting oracle as the Ethereum bridge is disabled"
                 );

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1602,3 +1602,55 @@ mod test_utils {
         assert!(!shell.wl_storage.storage.tx_queue.is_empty());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    /// Test that we do not include protocol txs voting on ethereum
+    /// events or signing bridge pool roots + nonces if the bridge
+    /// is inactive.
+    #[test]
+    #[cfg(not(feature = "abcipp"))]
+    fn test_mempool_filter_protocol_txs_bridge_inactive() {
+        let (mut shell, _, _, _) = setup_at_height(3);
+        deactivate_bridge(&mut shell);
+        let address = shell
+            .mode
+            .get_validator_address()
+            .expect("Test failed")
+            .clone();
+        let protocol_key = shell.mode.get_protocol_key().expect("Test failed");
+        let ethereum_event = EthereumEvent::TransfersToNamada {
+            nonce: 1u64.into(),
+            transfers: vec![],
+        };
+        let eth_vext = ProtocolTxType::EthEventsVext(
+            ethereum_events::Vext {
+                validator_addr: address.clone(),
+                block_height: shell.wl_storage.storage.last_height,
+                ethereum_events: vec![ethereum_event],
+            }
+            .sign(protocol_key),
+        )
+        .sign(protocol_key)
+        .to_bytes();
+
+        let to_sign = get_bp_bytes_to_sign();
+        let hot_key = shell.mode.get_eth_bridge_keypair().expect("Test failed");
+        let sig = Signed::<_, SignableEthMessage>::new(hot_key, to_sign).sig;
+        let bp_vext = ProtocolTxType::BridgePoolVext(
+            bridge_pool_roots::Vext {
+                block_height: shell.wl_storage.storage.last_height,
+                validator_addr: address,
+                sig,
+            }
+            .sign(protocol_key),
+        )
+        .sign(protocol_key)
+        .to_bytes();
+        let rsp = shell.prepare_proposal(RequestPrepareProposal {
+            txs: vec![eth_vext, bp_vext],
+            ..Default::default()
+        });
+        assert!(rsp.txs.is_empty());
+    }
+}

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1743,8 +1743,8 @@ mod mempool_tests {
         assert_eq!(rsp.code, 1);
     }
 
-    /// Test if Ethereum events validation and inclusion in a block
-    /// behaves as expected, considering honest validators.
+    /// Test if Ethereum events validation behaves as expected,
+    /// considering honest validators.
     #[test]
     fn test_mempool_eth_events_vext_normal_op() {
         const LAST_HEIGHT: BlockHeight = BlockHeight(3);

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1710,7 +1710,7 @@ mod mempool_tests {
     /// Test that if an error is encountered while trying to process a tx,
     /// it is prohibited from making its way onto the mempool.
     #[test]
-    fn test_error_in_processing_tx() {
+    fn test_mempool_error_in_processing_tx() {
         let (shell, _recv, _, _) = test_utils::setup_at_height(3u64);
         let keypair = test_utils::gen_keypair();
         let tx = Tx::new(

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -807,7 +807,7 @@ where
                 );
                 return;
             }
-            if !self.wl_storage.ethbridge_queries().is_bridge_active(None) {
+            if !self.wl_storage.ethbridge_queries().is_bridge_active() {
                 tracing::info!(
                     "Not starting oracle as the Ethereum bridge is disabled"
                 );

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1605,6 +1605,16 @@ mod test_utils {
 
 #[cfg(test)]
 mod tests {
+    use namada::proto::{SignableEthMessage, Signed};
+    use namada::types::ethereum_events::EthereumEvent;
+    use namada::types::transaction::protocol::ProtocolTxType;
+    use namada::types::vote_extensions::{bridge_pool_roots, ethereum_events};
+
+    use crate::facade::tendermint_proto::abci::RequestPrepareProposal;
+    use crate::node::ledger::shell::test_utils::{
+        deactivate_bridge, get_bp_bytes_to_sign, setup_at_height,
+    };
+
     /// Test that we do not include protocol txs voting on ethereum
     /// events or signing bridge pool roots + nonces if the bridge
     /// is inactive.

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1604,7 +1604,7 @@ mod test_utils {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "abcipp")))]
 mod tests {
     use namada::proto::{SignableEthMessage, Signed};
     use namada::types::ethereum_events::EthereumEvent;
@@ -1619,7 +1619,6 @@ mod tests {
     /// voting on ethereum events or signing bridge pool roots
     /// and nonces if the bridge is inactive.
     #[test]
-    #[cfg(not(feature = "abcipp"))]
     fn test_mempool_filter_protocol_txs_bridge_inactive() {
         let (mut shell, _, _, _) = setup_at_height(3);
         deactivate_bridge(&mut shell);

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1439,6 +1439,7 @@ mod test_utils {
     /// Get the only validator's voting power.
     #[inline]
     #[cfg(not(feature = "abcipp"))]
+    #[allow(dead_code)]
     pub fn get_validator_bonded_stake() -> namada::types::token::Amount {
         200_000_000_000.into()
     }

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -868,8 +868,8 @@ where
     /// Validate a transaction request. On success, the transaction will
     /// included in the mempool and propagated to peers, otherwise it will be
     /// rejected.
-    // TODO: move this to another file after 0.11 merges,
-    // since this method has become fairly large at this point
+    // TODO: move this to another file, since this method has become fairly
+    // large at this point
     pub fn mempool_validate(
         &self,
         tx_bytes: &[u8],
@@ -1615,9 +1615,9 @@ mod tests {
         deactivate_bridge, get_bp_bytes_to_sign, setup_at_height,
     };
 
-    /// Test that we do not include protocol txs voting on ethereum
-    /// events or signing bridge pool roots + nonces if the bridge
-    /// is inactive.
+    /// Test that we do not include protocol txs in the mempool,
+    /// voting on ethereum events or signing bridge pool roots
+    /// and nonces if the bridge is inactive.
     #[test]
     #[cfg(not(feature = "abcipp"))]
     fn test_mempool_filter_protocol_txs_bridge_inactive() {

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -402,6 +402,8 @@ mod test_prepare_proposal {
     };
     use namada::ledger::pos::PosQueries;
     use namada::proof_of_stake::consensus_validator_set_handle;
+    #[cfg(feature = "abcipp")]
+    use namada::proto::SignableEthMessage;
     use namada::proto::{Signed, SignedTxData};
     use namada::types::ethereum_events::EthereumEvent;
     #[cfg(feature = "abcipp")]
@@ -423,6 +425,10 @@ mod test_prepare_proposal {
     };
     #[cfg(feature = "abcipp")]
     use crate::node::ledger::shell::test_utils::deactivate_bridge;
+    #[cfg(feature = "abcipp")]
+    use crate::node::ledger::shell::test_utils::get_bp_bytes_to_sign;
+    #[cfg(feature = "abcipp")]
+    use crate::node::ledger::shell::test_utils::setup_at_height;
     use crate::node::ledger::shell::test_utils::{
         self, gen_keypair, TestShell,
     };

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -572,7 +572,7 @@ mod test_prepare_proposal {
                 ext
             };
 
-            check_eth_events_filtering(&shell, signed_vote_extension);
+            check_eth_events_filtering(shell, signed_vote_extension);
         }
 
         let (shell, _recv, _, _) = test_utils::setup_at_height(LAST_HEIGHT);

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -512,37 +512,6 @@ mod test_prepare_proposal {
         })
     }
 
-    /// Test that if a tx from the mempool is not a
-    /// WrapperTx type, it is not included in the
-    /// proposed block.
-    // TODO: remove this test after CheckTx implements
-    // filtering of invalid txs; otherwise, we would have
-    // needed to return invalid txs from PrepareProposal,
-    // for these to get removed from a node's mempool.
-    // not returning invalid txs from PrepareProposal is
-    // a DoS vector, because the mempool will slowly fill
-    // up with garbage. luckily, Tendermint implements a
-    // mempool eviction policy, but honest client's txs
-    // may get lost in the process
-    #[test]
-    fn test_prepare_proposal_rejects_non_wrapper_tx() {
-        let (shell, _recv, _, _) = test_utils::setup_at_height(3u64);
-        let non_wrapper_tx = Tx::new(
-            "wasm_code".as_bytes().to_owned(),
-            Some("transaction_data".as_bytes().to_owned()),
-        );
-        let req = RequestPrepareProposal {
-            #[cfg(feature = "abcipp")]
-            local_last_commit: get_local_last_commit(&shell),
-            txs: vec![non_wrapper_tx.to_bytes()],
-            ..Default::default()
-        };
-        #[cfg(feature = "abcipp")]
-        assert_eq!(shell.prepare_proposal(req).txs.len(), 2);
-        #[cfg(not(feature = "abcipp"))]
-        assert_eq!(shell.prepare_proposal(req).txs.len(), 0);
-    }
-
     /// Check if we are filtering out an invalid vote extension `vext`
     fn check_eth_events_filtering(
         shell: &mut TestShell,

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -402,7 +402,7 @@ mod test_prepare_proposal {
     };
     use namada::ledger::pos::PosQueries;
     use namada::proof_of_stake::consensus_validator_set_handle;
-    use namada::proto::{SignableEthMessage, Signed, SignedTxData};
+    use namada::proto::{Signed, SignedTxData};
     use namada::types::ethereum_events::EthereumEvent;
     #[cfg(feature = "abcipp")]
     use namada::types::key::common;
@@ -411,17 +411,20 @@ mod test_prepare_proposal {
     use namada::types::transaction::protocol::ProtocolTxType;
     use namada::types::transaction::{Fee, TxType, WrapperTx};
     #[cfg(feature = "abcipp")]
+    use namada::types::vote_extensions::bridge_pool_roots;
+    use namada::types::vote_extensions::ethereum_events;
+    #[cfg(feature = "abcipp")]
     use namada::types::vote_extensions::VoteExtension;
-    use namada::types::vote_extensions::{bridge_pool_roots, ethereum_events};
 
     use super::*;
     #[cfg(feature = "abcipp")]
     use crate::facade::tendermint_proto::abci::{
         ExtendedCommitInfo, ExtendedVoteInfo,
     };
+    #[cfg(feature = "abcipp")]
+    use crate::node::ledger::shell::test_utils::deactivate_bridge;
     use crate::node::ledger::shell::test_utils::{
-        self, deactivate_bridge, gen_keypair, get_bp_bytes_to_sign,
-        setup_at_height, TestShell,
+        self, gen_keypair, TestShell,
     };
     use crate::node::ledger::shims::abcipp_shim_types::shim::request::FinalizeBlock;
     use crate::wallet;

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -453,76 +453,42 @@ where
                     .into(),
             },
             TxType::Protocol(protocol_tx) => match protocol_tx.tx {
-                ProtocolTxType::EthEventsVext(ext) => {
-                    if !self
-                        .wl_storage
-                        .ethbridge_queries()
-                        .is_bridge_active(None)
-                    {
-                        TxResult {
-                            code: ErrorCodes::InvalidVoteExtension.into(),
-                            info: "Process proposal rejected this proposal \
-                                   because an Ethereum events vote extensions \
-                                   was included but the bridge is not active."
-                                .into(),
-                        }
-                    } else {
-                        self.validate_eth_events_vext_and_get_it_back(
-                            ext,
-                            self.wl_storage.storage.last_height,
-                        )
-                        .map(|_| TxResult {
-                            code: ErrorCodes::Ok.into(),
-                            info: "Process Proposal accepted this transaction"
-                                .into(),
-                        })
-                        .unwrap_or_else(|err| {
-                            TxResult {
-                                code: ErrorCodes::InvalidVoteExtension.into(),
-                                info: format!(
-                                    "Process proposal rejected this proposal \
-                                     because one of the included Ethereum \
-                                     events vote extensions was invalid: {err}"
-                                ),
-                            }
-                        })
-                    }
-                }
-                ProtocolTxType::BridgePoolVext(ext) => {
-                    if !self
-                        .wl_storage
-                        .ethbridge_queries()
-                        .is_bridge_active(None)
-                    {
-                        TxResult {
-                            code: ErrorCodes::InvalidVoteExtension.into(),
-                            info: "Process proposal rejected this proposal \
-                                   because an Brige pool root vote extensions \
-                                   was included but the bridge is not active."
-                                .into(),
-                        }
-                    } else {
-                        self.validate_bp_roots_vext_and_get_it_back(
-                            ext,
-                            self.wl_storage.storage.last_height,
-                        )
-                        .map(|_| TxResult {
-                            code: ErrorCodes::Ok.into(),
-                            info: "Process Proposal accepted this transaction"
-                                .into(),
-                        })
-                        .unwrap_or_else(|err| {
-                            TxResult {
-                                code: ErrorCodes::InvalidVoteExtension.into(),
-                                info: format!(
-                                    "Process proposal rejected this proposal \
-                                     because one of the included Bridge pool \
-                                     root's vote extensions was invalid: {err}"
-                                ),
-                            }
-                        })
-                    }
-                }
+                ProtocolTxType::EthEventsVext(ext) => self
+                    .validate_eth_events_vext_and_get_it_back(
+                        ext,
+                        self.wl_storage.storage.last_height,
+                    )
+                    .map(|_| TxResult {
+                        code: ErrorCodes::Ok.into(),
+                        info: "Process Proposal accepted this transaction"
+                            .into(),
+                    })
+                    .unwrap_or_else(|err| TxResult {
+                        code: ErrorCodes::InvalidVoteExtension.into(),
+                        info: format!(
+                            "Process proposal rejected this proposal because \
+                             one of the included Ethereum events vote \
+                             extensions was invalid: {err}"
+                        ),
+                    }),
+                ProtocolTxType::BridgePoolVext(ext) => self
+                    .validate_bp_roots_vext_and_get_it_back(
+                        ext,
+                        self.wl_storage.storage.last_height,
+                    )
+                    .map(|_| TxResult {
+                        code: ErrorCodes::Ok.into(),
+                        info: "Process Proposal accepted this transaction"
+                            .into(),
+                    })
+                    .unwrap_or_else(|err| TxResult {
+                        code: ErrorCodes::InvalidVoteExtension.into(),
+                        info: format!(
+                            "Process proposal rejected this proposal because \
+                             one of the included Bridge pool root's vote \
+                             extensions was invalid: {err}"
+                        ),
+                    }),
                 ProtocolTxType::ValSetUpdateVext(ext) => self
                     .validate_valset_upd_vext_and_get_it_back(
                         ext,

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -454,7 +454,11 @@ where
             },
             TxType::Protocol(protocol_tx) => match protocol_tx.tx {
                 ProtocolTxType::EthEventsVext(ext) => {
-                    if !self.wl_storage.ethbridge_queries().is_bridge_active() {
+                    if !self
+                        .wl_storage
+                        .ethbridge_queries()
+                        .is_bridge_active(None)
+                    {
                         TxResult {
                             code: ErrorCodes::InvalidVoteExtension.into(),
                             info: "Process proposal rejected this proposal \
@@ -485,7 +489,11 @@ where
                     }
                 }
                 ProtocolTxType::BridgePoolVext(ext) => {
-                    if !self.wl_storage.ethbridge_queries().is_bridge_active() {
+                    if !self
+                        .wl_storage
+                        .ethbridge_queries()
+                        .is_bridge_active(None)
+                    {
                         TxResult {
                             code: ErrorCodes::InvalidVoteExtension.into(),
                             info: "Process proposal rejected this proposal \
@@ -729,7 +737,7 @@ where
     /// vote extensions in [`DigestCounters`].
     #[cfg(feature = "abcipp")]
     fn has_proper_eth_events_num(&self, meta: &ValidationMeta) -> bool {
-        if self.wl_storage.ethbridge_queries().is_bridge_active() {
+        if self.wl_storage.ethbridge_queries().is_bridge_active(None) {
             meta.digests.eth_ev_digest_num
                 == usize::from(self.wl_storage.storage.last_height.0 != 0)
         } else {
@@ -741,7 +749,7 @@ where
     /// root vote extensions in [`DigestCounters`].
     #[cfg(feature = "abcipp")]
     fn has_proper_bp_roots_num(&self, meta: &ValidationMeta) -> bool {
-        if self.wl_storage.ethbridge_queries().is_bridge_active() {
+        if self.wl_storage.ethbridge_queries().is_bridge_active(None) {
             meta.digests.bridge_pool_roots
                 == usize::from(self.wl_storage.storage.last_height.0 != 0)
         } else {

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -250,8 +250,6 @@ where
 
         let will_reject_proposal = invalid_txs || has_remaining_decrypted_txs;
 
-        // TODO: check if tx queue still has txs left in it
-
         let status = if will_reject_proposal {
             ProposalStatus::Reject
         } else {
@@ -1107,8 +1105,14 @@ mod test_process_proposal {
             shell.process_proposal(request)
         {
             if let [resp1, resp2] = resp.as_slice() {
-                assert_eq!(resp1.result.code, u32::from(ErrorCodes::Ok));
-                assert_eq!(resp2.result.code, u32::from(ErrorCodes::Ok));
+                assert_eq!(
+                    resp1.result.code,
+                    u32::from(ErrorCodes::InvalidVoteExtension)
+                );
+                assert_eq!(
+                    resp2.result.code,
+                    u32::from(ErrorCodes::InvalidVoteExtension)
+                );
             } else {
                 panic!("Test failed")
             }

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -727,6 +727,7 @@ where
     /// vote extensions in [`DigestCounters`].
     #[cfg(feature = "abcipp")]
     fn has_proper_valset_upd_num(&self, meta: &ValidationMeta) -> bool {
+        // TODO: check if this logic is correct for ABCI++
         self.wl_storage
             .ethbridge_queries()
             .is_bridge_active()

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -745,7 +745,7 @@ where
                     true
                 }
             })
-            .unwrap_or_else(|| meta.digests.valset_upd_digest_num == 0)
+            .unwrap_or(meta.digests.valset_upd_digest_num == 0)
     }
 
     /// Checks if it is not possible to include encrypted txs at the current

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -100,7 +100,7 @@ where
     pub fn extend_vote_with_ethereum_events(
         &mut self,
     ) -> Option<Signed<ethereum_events::Vext>> {
-        if !self.wl_storage.ethbridge_queries().is_bridge_active() {
+        if !self.wl_storage.ethbridge_queries().is_bridge_active(None) {
             return None;
         }
         let validator_addr = self
@@ -141,7 +141,7 @@ where
     pub fn extend_vote_with_bp_roots(
         &self,
     ) -> Option<Signed<bridge_pool_roots::Vext>> {
-        if !self.wl_storage.ethbridge_queries().is_bridge_active() {
+        if !self.wl_storage.ethbridge_queries().is_bridge_active(None) {
             return None;
         }
         let validator_addr = self
@@ -282,7 +282,7 @@ where
         req: &request::VerifyVoteExtension,
         ext: Option<Signed<ethereum_events::Vext>>,
     ) -> bool {
-        if !self.wl_storage.ethbridge_queries().is_bridge_active() {
+        if !self.wl_storage.ethbridge_queries().is_bridge_active(None) {
             ext.is_none()
         } else if let Some(ext) = ext {
             self.validate_eth_events_vext(
@@ -311,7 +311,7 @@ where
         req: &request::VerifyVoteExtension,
         ext: Option<bridge_pool_roots::SignedVext>,
     ) -> bool {
-        if self.wl_storage.ethbridge_queries().is_bridge_active() {
+        if self.wl_storage.ethbridge_queries().is_bridge_active(None) {
             if let Some(ext) = ext {
                 self.validate_bp_roots_vext(
                     ext,
@@ -424,7 +424,7 @@ where
                     protocol_tx_indices.insert(index);
                     self.wl_storage
                         .ethbridge_queries()
-                        .is_bridge_active()
+                        .is_bridge_active(None)
                         .then_some(tx_bytes.clone())
                 }
                 TxType::Protocol(ProtocolTx {
@@ -469,7 +469,7 @@ where
         let mut bp_roots = vec![];
         let mut valset_upds = vec![];
         let bridge_active =
-            self.wl_storage.ethbridge_queries().is_bridge_active();
+            self.wl_storage.ethbridge_queries().is_bridge_active(None);
 
         for ext in deserialize_vote_extensions(vote_extensions) {
             if let Some(validator_set_update) = ext.validator_set_update {

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -30,28 +30,30 @@ const VALIDATOR_EXPECT_MSG: &str = "Only validators receive this method call.";
 /// The error yielded from validating faulty vote extensions in the shell
 #[derive(Error, Debug)]
 pub enum VoteExtensionError {
-    #[error("The vote extension was issued for an unexpected block height.")]
+    #[error("The Ethereum bridge is currently deactivated")]
+    BridgeDeactivated,
+    #[error("The vote extension was issued for an unexpected block height")]
     UnexpectedBlockHeight,
-    #[error("The vote extension was issued for an unexpected epoch.")]
+    #[error("The vote extension was issued for an unexpected epoch")]
     UnexpectedEpoch,
     #[error(
-        "The vote extension contains duplicate or non-sorted Ethereum events."
+        "The vote extension contains duplicate or non-sorted Ethereum events"
     )]
     HaveDupesOrNonSorted,
     #[error(
         "The public key of the vote extension's associated validator could \
-         not be found in storage."
+         not be found in storage"
     )]
     PubKeyNotInStorage,
-    #[error("The vote extension's signature is invalid.")]
+    #[error("The vote extension's signature is invalid")]
     VerifySigFailed,
     #[error(
-        "Validator is missing from an expected field in the vote extension."
+        "Validator is missing from an expected field in the vote extension"
     )]
     ValidatorMissingFromExtension,
     #[error(
         "Found value for a field in the vote extension diverging from the \
-         equivalent field in storage."
+         equivalent field in storage"
     )]
     DivergesFromStorage,
     #[error("The signature of the Bridge pool root is invalid")]
@@ -61,7 +63,7 @@ pub enum VoteExtensionError {
          not active"
     )]
     EthereumBridgeInactive,
-    #[error("A vote extension for the Ethereum bridge is missing.")]
+    #[error("A vote extension for the Ethereum bridge is missing")]
     MissingBridgeVext,
 }
 

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -30,8 +30,6 @@ const VALIDATOR_EXPECT_MSG: &str = "Only validators receive this method call.";
 /// The error yielded from validating faulty vote extensions in the shell
 #[derive(Error, Debug)]
 pub enum VoteExtensionError {
-    #[error("The Ethereum bridge is currently deactivated")]
-    BridgeDeactivated,
     #[error("The vote extension was issued for an unexpected block height")]
     UnexpectedBlockHeight,
     #[error("The vote extension was issued for an unexpected epoch")]

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -71,7 +71,7 @@ where
             );
             return Err(VoteExtensionError::UnexpectedBlockHeight);
         }
-        if last_height.0 == 0 {
+        if ext.data.block_height.0 == 0 {
             tracing::debug!("Dropping vote extension issued at genesis");
             return Err(VoteExtensionError::UnexpectedBlockHeight);
         }

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -53,7 +53,7 @@ where
     > {
         #[cfg(feature = "abcipp")]
         if ext.data.block_height != last_height {
-            tracing::error!(
+            tracing::debug!(
                 ext_height = ?ext.data.block_height,
                 ?last_height,
                 "Bridge pool root's vote extension issued for a block height \
@@ -63,7 +63,7 @@ where
         }
         #[cfg(not(feature = "abcipp"))]
         if ext.data.block_height > last_height {
-            tracing::error!(
+            tracing::debug!(
                 ext_height = ?ext.data.block_height,
                 ?last_height,
                 "Bridge pool root's vote extension issued for a block height \
@@ -72,7 +72,7 @@ where
             return Err(VoteExtensionError::UnexpectedBlockHeight);
         }
         if last_height.0 == 0 {
-            tracing::error!("Dropping vote extension issued at genesis");
+            tracing::debug!("Dropping vote extension issued at genesis");
             return Err(VoteExtensionError::UnexpectedBlockHeight);
         }
 
@@ -85,7 +85,7 @@ where
         {
             Some(epoch) => epoch,
             _ => {
-                tracing::error!(
+                tracing::debug!(
                     block_height = ?ext.data.block_height,
                     "The epoch of the Bridge pool root's vote extension's \
                      block height should always be known",
@@ -98,7 +98,7 @@ where
             .ethbridge_queries()
             .is_bridge_active_at(ext_height_epoch)
         {
-            tracing::error!(
+            tracing::debug!(
                 vext_epoch = ?ext_height_epoch,
                 "The Ethereum bridge was not enabled when the pool
                  root's vote extension was cast",
@@ -113,7 +113,7 @@ where
             .pos_queries()
             .get_validator_from_address(validator, Some(ext_height_epoch))
             .map_err(|err| {
-                tracing::error!(
+                tracing::debug!(
                     ?err,
                     %validator,
                     "Could not get public key from Storage for some validator, \
@@ -123,7 +123,7 @@ where
             })?;
         // verify the signature of the vote extension
         ext.verify(&pk).map_err(|err| {
-            tracing::error!(
+            tracing::debug!(
                 ?err,
                 ?ext.sig,
                 ?pk,
@@ -159,7 +159,7 @@ where
         signed
             .verify(&pk)
             .map_err(|err| {
-                tracing::error!(
+                tracing::debug!(
                     ?err,
                     ?signed.sig,
                     ?pk,

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -51,31 +51,6 @@ where
         (token::Amount, Signed<bridge_pool_roots::Vext>),
         VoteExtensionError,
     > {
-        #[cfg(feature = "abcipp")]
-        if ext.data.block_height != last_height {
-            tracing::debug!(
-                ext_height = ?ext.data.block_height,
-                ?last_height,
-                "Bridge pool root's vote extension issued for a block height \
-                 different from the expected last height."
-            );
-            return Err(VoteExtensionError::UnexpectedBlockHeight);
-        }
-        #[cfg(not(feature = "abcipp"))]
-        if ext.data.block_height > last_height {
-            tracing::debug!(
-                ext_height = ?ext.data.block_height,
-                ?last_height,
-                "Bridge pool root's vote extension issued for a block height \
-                 higher than the chain's last height."
-            );
-            return Err(VoteExtensionError::UnexpectedBlockHeight);
-        }
-        if ext.data.block_height.0 == 0 {
-            tracing::debug!("Dropping vote extension issued at genesis");
-            return Err(VoteExtensionError::UnexpectedBlockHeight);
-        }
-
         // NOTE(not(feature = "abciplus")): for ABCI++, we should pass
         // `last_height` here, instead of `ext.data.block_height`
         let ext_height_epoch = match self
@@ -104,6 +79,31 @@ where
                  root's vote extension was cast",
             );
             return Err(VoteExtensionError::EthereumBridgeInactive);
+        }
+
+        #[cfg(feature = "abcipp")]
+        if ext.data.block_height != last_height {
+            tracing::debug!(
+                ext_height = ?ext.data.block_height,
+                ?last_height,
+                "Bridge pool root's vote extension issued for a block height \
+                 different from the expected last height."
+            );
+            return Err(VoteExtensionError::UnexpectedBlockHeight);
+        }
+        #[cfg(not(feature = "abcipp"))]
+        if ext.data.block_height > last_height {
+            tracing::debug!(
+                ext_height = ?ext.data.block_height,
+                ?last_height,
+                "Bridge pool root's vote extension issued for a block height \
+                 higher than the chain's last height."
+            );
+            return Err(VoteExtensionError::UnexpectedBlockHeight);
+        }
+        if ext.data.block_height.0 == 0 {
+            tracing::debug!("Dropping vote extension issued at genesis");
+            return Err(VoteExtensionError::UnexpectedBlockHeight);
         }
 
         // get the public key associated with this validator

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -54,30 +54,6 @@ where
         (token::Amount, Signed<ethereum_events::Vext>),
         VoteExtensionError,
     > {
-        #[cfg(feature = "abcipp")]
-        if ext.data.block_height != last_height {
-            tracing::debug!(
-                ext_height = ?ext.data.block_height,
-                ?last_height,
-                "Ethereum events vote extension issued for a block height \
-                 different from the expected last height."
-            );
-            return Err(VoteExtensionError::UnexpectedBlockHeight);
-        }
-        #[cfg(not(feature = "abcipp"))]
-        if ext.data.block_height > last_height {
-            tracing::debug!(
-                ext_height = ?ext.data.block_height,
-                ?last_height,
-                "Ethereum events vote extension issued for a block height \
-                 higher than the chain's last height."
-            );
-            return Err(VoteExtensionError::UnexpectedBlockHeight);
-        }
-        if ext.data.block_height.0 == 0 {
-            tracing::debug!("Dropping vote extension issued at genesis");
-            return Err(VoteExtensionError::UnexpectedBlockHeight);
-        }
         // NOTE(not(feature = "abciplus")): for ABCI++, we should pass
         // `last_height` here, instead of `ext.data.block_height`
         let ext_height_epoch = match self
@@ -106,6 +82,30 @@ where
                  events' vote extension was cast",
             );
             return Err(VoteExtensionError::EthereumBridgeInactive);
+        }
+        #[cfg(feature = "abcipp")]
+        if ext.data.block_height != last_height {
+            tracing::debug!(
+                ext_height = ?ext.data.block_height,
+                ?last_height,
+                "Ethereum events vote extension issued for a block height \
+                 different from the expected last height."
+            );
+            return Err(VoteExtensionError::UnexpectedBlockHeight);
+        }
+        #[cfg(not(feature = "abcipp"))]
+        if ext.data.block_height > last_height {
+            tracing::debug!(
+                ext_height = ?ext.data.block_height,
+                ?last_height,
+                "Ethereum events vote extension issued for a block height \
+                 higher than the chain's last height."
+            );
+            return Err(VoteExtensionError::UnexpectedBlockHeight);
+        }
+        if ext.data.block_height.0 == 0 {
+            tracing::debug!("Dropping vote extension issued at genesis");
+            return Err(VoteExtensionError::UnexpectedBlockHeight);
         }
         // verify if we have any duplicate Ethereum events,
         // and if these are sorted in ascending order

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -56,7 +56,7 @@ where
     > {
         #[cfg(feature = "abcipp")]
         if ext.data.block_height != last_height {
-            tracing::error!(
+            tracing::debug!(
                 ext_height = ?ext.data.block_height,
                 ?last_height,
                 "Ethereum events vote extension issued for a block height \
@@ -66,7 +66,7 @@ where
         }
         #[cfg(not(feature = "abcipp"))]
         if ext.data.block_height > last_height {
-            tracing::error!(
+            tracing::debug!(
                 ext_height = ?ext.data.block_height,
                 ?last_height,
                 "Ethereum events vote extension issued for a block height \
@@ -75,7 +75,7 @@ where
             return Err(VoteExtensionError::UnexpectedBlockHeight);
         }
         if last_height.0 == 0 {
-            tracing::error!("Dropping vote extension issued at genesis");
+            tracing::debug!("Dropping vote extension issued at genesis");
             return Err(VoteExtensionError::UnexpectedBlockHeight);
         }
         // NOTE(not(feature = "abciplus")): for ABCI++, we should pass
@@ -87,7 +87,7 @@ where
         {
             Some(epoch) => epoch,
             _ => {
-                tracing::error!(
+                tracing::debug!(
                     block_height = ?ext.data.block_height,
                     "The epoch of the Ethereum events vote extension's \
                      block height should always be known",
@@ -100,7 +100,7 @@ where
             .ethbridge_queries()
             .is_bridge_active_at(ext_height_epoch)
         {
-            tracing::error!(
+            tracing::debug!(
                 vext_epoch = ?ext_height_epoch,
                 "The Ethereum bridge was not enabled when the Ethereum
                  events' vote extension was cast",
@@ -118,7 +118,7 @@ where
         };
         let validator = &ext.data.validator_addr;
         if have_dupes_or_non_sorted {
-            tracing::error!(
+            tracing::debug!(
                 %validator,
                 "Found duplicate or non-sorted Ethereum events in a vote extension from \
                  some validator"
@@ -131,7 +131,7 @@ where
             .pos_queries()
             .get_validator_from_address(validator, Some(ext_height_epoch))
             .map_err(|err| {
-                tracing::error!(
+                tracing::debug!(
                     ?err,
                     %validator,
                     "Could not get public key from Storage for some validator, \
@@ -142,7 +142,7 @@ where
         // verify the signature of the vote extension
         ext.verify(&pk)
             .map_err(|err| {
-                tracing::error!(
+                tracing::debug!(
                     ?err,
                     ?ext.sig,
                     ?pk,

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -74,7 +74,7 @@ where
             );
             return Err(VoteExtensionError::UnexpectedBlockHeight);
         }
-        if last_height.0 == 0 {
+        if ext.data.block_height.0 == 0 {
             tracing::debug!("Dropping vote extension issued at genesis");
             return Err(VoteExtensionError::UnexpectedBlockHeight);
         }

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -59,6 +59,19 @@ where
         (token::Amount, validator_set_update::SignedVext),
         VoteExtensionError,
     > {
+        if !self
+            .wl_storage
+            .ethbridge_queries()
+            .is_bridge_active_at(ext.data.signing_epoch.next())
+        {
+            let next_epoch = ext.data.signing_epoch.next();
+            tracing::debug!(
+                ?next_epoch,
+                "The Ethereum bridge was not enabled when the valset
+                 upd's vote extension was cast",
+            );
+            return Err(VoteExtensionError::EthereumBridgeInactive);
+        }
         if self.wl_storage.storage.last_height.0 == 0 {
             tracing::debug!(
                 "Dropping validator set update vote extension issued at \
@@ -74,19 +87,6 @@ where
                  different from the expected one.",
             );
             return Err(VoteExtensionError::UnexpectedEpoch);
-        }
-        if !self
-            .wl_storage
-            .ethbridge_queries()
-            .is_bridge_active_at(signing_epoch.next())
-        {
-            let next_epoch = signing_epoch.next();
-            tracing::debug!(
-                ?next_epoch,
-                "The Ethereum bridge was not enabled when the valset
-                 upd's vote extension was cast",
-            );
-            return Err(VoteExtensionError::EthereumBridgeInactive);
         }
         // verify if the new epoch validators' voting powers in storage match
         // the voting powers in the vote extension

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -60,14 +60,14 @@ where
         VoteExtensionError,
     > {
         if self.wl_storage.storage.last_height.0 == 0 {
-            tracing::error!(
+            tracing::debug!(
                 "Dropping validator set update vote extension issued at \
                  genesis"
             );
             return Err(VoteExtensionError::UnexpectedBlockHeight);
         }
         if ext.data.signing_epoch != signing_epoch {
-            tracing::error!(
+            tracing::debug!(
                 vext_epoch = ?ext.data.signing_epoch,
                 expected_epoch = ?signing_epoch,
                 "Validator set update vote extension issued for an epoch \
@@ -81,7 +81,7 @@ where
             .is_bridge_active_at(signing_epoch.next())
         {
             let next_epoch = signing_epoch.next();
-            tracing::error!(
+            tracing::debug!(
                 ?next_epoch,
                 "The Ethereum bridge was not enabled when the valset
                  upd's vote extension was cast",
@@ -99,7 +99,7 @@ where
             let &ext_power = match ext.data.voting_powers.get(&eth_addr_book) {
                 Some(voting_power) => voting_power,
                 _ => {
-                    tracing::error!(
+                    tracing::debug!(
                         ?eth_addr_book,
                         "Could not find expected Ethereum addresses in valset \
                          upd vote extension",
@@ -110,7 +110,7 @@ where
                 }
             };
             if namada_power != ext_power {
-                tracing::error!(
+                tracing::debug!(
                     validator = %namada_addr,
                     expected = ?namada_power,
                     got = ?ext_power,
@@ -126,7 +126,7 @@ where
             .pos_queries()
             .get_validator_from_address(validator, Some(signing_epoch))
             .map_err(|err| {
-                tracing::error!(
+                tracing::debug!(
                     ?err,
                     %validator,
                     "Could not get public key from Storage for some validator, \
@@ -142,7 +142,7 @@ where
         // verify the signature of the vote extension
         ext.verify(&pk)
             .map_err(|err| {
-                tracing::error!(
+                tracing::debug!(
                     ?err,
                     ?ext.sig,
                     ?pk,

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -75,6 +75,19 @@ where
             );
             return Err(VoteExtensionError::UnexpectedEpoch);
         }
+        if !self
+            .wl_storage
+            .ethbridge_queries()
+            .is_bridge_active_at(signing_epoch.next())
+        {
+            let next_epoch = signing_epoch.next();
+            tracing::error!(
+                ?next_epoch,
+                "The Ethereum bridge was not enabled when the valset
+                 upd's vote extension was cast",
+            );
+            return Err(VoteExtensionError::EthereumBridgeInactive);
+        }
         // verify if the new epoch validators' voting powers in storage match
         // the voting powers in the vote extension
         for (eth_addr_book, namada_addr, namada_power) in self

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -174,6 +174,14 @@ impl Add<u64> for BlockHeight {
     }
 }
 
+impl Sub<u64> for BlockHeight {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
 impl AddAssign for BlockHeight {
     fn add_assign(&mut self, other: Self) {
         self.0 += other.0;

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -128,8 +128,22 @@ where
     /// Returns a boolean indicating whether the bridge is currently active,
     /// or if it will be active within the provided epoch offset
     /// (i.e. `current_epoch + in_num_of_epochs`).
+    #[inline]
     pub fn is_bridge_active(
         self,
+        in_num_of_epochs: Option<NonZeroU64>,
+    ) -> bool {
+        self.is_bridge_active_at(
+            self.wl_storage.storage.get_current_epoch().0,
+            in_num_of_epochs,
+        )
+    }
+
+    /// Behaves exactly like [`Self::is_bridge_active`], but performs
+    /// the check at the given [`Epoch`].
+    pub fn is_bridge_active_at(
+        self,
+        epoch: Epoch,
         in_num_of_epochs: Option<NonZeroU64>,
     ) -> bool {
         match self.check_bridge_status() {
@@ -138,10 +152,9 @@ where
             EthBridgeStatus::Enabled(EthBridgeEnabled::AtEpoch(
                 enabled_epoch,
             )) => {
-                let current_epoch =
-                    self.wl_storage.storage.get_current_epoch().0;
                 let offset = in_num_of_epochs.map(NonZeroU64::get).unwrap_or(0);
-                current_epoch + offset >= enabled_epoch
+                let queried_epoch = epoch + offset;
+                queried_epoch >= enabled_epoch
             }
         }
     }


### PR DESCRIPTION
* Only start proposing validator set updates an epoch before the bridge is enabled through governance, or while the bridge is active.
* Reject all current vote extension protocol transactions from the mempool, if the bridge is not active.
* Change `tracing::error!()` log lines to `tracing::debug!()` log lines, so node logs aren't spammed with validation logic.
* Remove the `index-set` crate from `apps`, as that was only required by the remaining txs allocator (now defunct).
* Convert PrepareProposal into CheckTx mempool tests.