### PR TITLE
Once an epoch, the ethereum oracle configuration gets updated

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_oracle/control.rs
+++ b/apps/src/lib/node/ledger/ethereum_oracle/control.rs
@@ -11,15 +11,14 @@ pub type Receiver = mpsc::Receiver<Command>;
 /// Returns two sides of a [`mpsc`] channel that can be used for controlling an
 /// oracle.
 pub fn channel() -> (Sender, Receiver) {
-    mpsc::channel(1)
+    mpsc::channel(5)
 }
 
 /// Commands used to configure and control an `Oracle`.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Command {
-    /// Sends an initial configuration to the oracle for it to use. The oracle
-    /// will not do anything until this command has been sent.
-    /// [`Command::Start`] should be the first command sent, and at most
-    /// once.
-    Start { initial: Config },
+    /// Update the config if it changes in storage.
+    /// Also used to send an initial configuration to the oracle for it to use.
+    /// The oracle will not do anything until this command has been sent.
+    UpdateConfig(Config),
 }

--- a/apps/src/lib/node/ledger/ethereum_oracle/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_oracle/mod.rs
@@ -12,6 +12,7 @@ use namada::eth_bridge::oracle::config::Config;
 use namada::types::ethereum_events::EthereumEvent;
 use num256::Uint256;
 use thiserror::Error;
+use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::Sender as BoundedSender;
 use tokio::task::LocalSet;
 use tokio::time::Instant;
@@ -24,6 +25,7 @@ use self::events::{signatures, PendingEvent};
 #[cfg(test)]
 use self::test_tools::mock_web3_client::Web3;
 use super::abortable::AbortableSpawner;
+use crate::node::ledger::oracle::control::Command;
 use crate::timeouts::TimeoutStrategy;
 
 /// The default amount of time the oracle will wait between processing blocks
@@ -150,6 +152,17 @@ impl Oracle {
         }
         true
     }
+
+    /// Check if a new config has been sent from teh Shell.
+    fn update_config(&mut self) -> Option<Config> {
+        match self.control.try_recv() {
+            Ok(Command::UpdateConfig(config)) => Some(config),
+            Err(TryRecvError::Disconnected) => panic!(
+                "The Ethereum oracle command channel has unexpectedly hung up."
+            ),
+            _ => None,
+        }
+    }
 }
 
 /// Block until an initial configuration is received via the command channel.
@@ -159,10 +172,8 @@ async fn await_initial_configuration(
     receiver: &mut control::Receiver,
 ) -> Option<Config> {
     match receiver.recv().await {
-        Some(cmd) => match cmd {
-            control::Command::Start { initial: config } => Some(config),
-        },
-        None => None,
+        Some(Command::UpdateConfig(config)) => Some(config),
+        _ => None,
     }
 }
 
@@ -218,27 +229,27 @@ pub fn run_oracle(
 /// is reached, an event is forwarded to the ledger process
 async fn run_oracle_aux(mut oracle: Oracle) {
     tracing::info!("Oracle is awaiting initial configuration");
-    let config = match await_initial_configuration(&mut oracle.control).await {
-        Some(config) => {
-            tracing::info!(
-                "Oracle received initial configuration - {:?}",
+    let mut config =
+        match await_initial_configuration(&mut oracle.control).await {
+            Some(config) => {
+                tracing::info!(
+                    "Oracle received initial configuration - {:?}",
+                    config
+                );
                 config
-            );
-            config
-        }
-        None => {
-            tracing::debug!(
-                "Oracle control channel was closed before the oracle could be \
-                 configured"
-            );
-            return;
-        }
-    };
+            }
+            None => {
+                tracing::debug!(
+                    "Oracle control channel was closed before the oracle \
+                     could be configured"
+                );
+                return;
+            }
+        };
 
     let mut next_block_to_process = config.start_block.clone();
 
     loop {
-        let next_block = next_block_to_process.clone();
         tracing::info!(
             ?next_block_to_process,
             "Checking Ethereum block for bridge events"
@@ -246,7 +257,7 @@ async fn run_oracle_aux(mut oracle: Oracle) {
         let deadline = Instant::now() + oracle.ceiling;
         let res = TimeoutStrategy::Constant(oracle.backoff).timeout(deadline, || async {
             tokio::select! {
-                result = process(&oracle, &config, next_block.clone()) => {
+                result = process(&oracle, &config, next_block_to_process.clone()) => {
                     match result {
                         Ok(()) => {
                             ControlFlow::Break(Ok(()))
@@ -279,6 +290,10 @@ async fn run_oracle_aux(mut oracle: Oracle) {
             oracle
                 .last_processed_block
                 .send_replace(Some(next_block_to_process.clone()));
+            // check if a new config has been sent.
+            if let Some(new_config) = oracle.update_config() {
+                config = new_config;
+            }
             next_block_to_process += 1.into();
         }
     }
@@ -481,7 +496,7 @@ mod test_oracle {
     /// for tests.
     async fn start_with_default_config(
         oracle: Oracle,
-        control_sender: control::Sender,
+        control_sender: &mut control::Sender,
         config: Config,
     ) -> tokio::task::JoinHandle<()> {
         let handle = tokio::task::spawn_blocking(move || {
@@ -495,7 +510,7 @@ mod test_oracle {
             });
         });
         control_sender
-            .send(control::Command::Start { initial: config })
+            .send(control::Command::UpdateConfig(config))
             .await
             .unwrap();
         handle
@@ -532,12 +547,12 @@ mod test_oracle {
             oracle,
             eth_recv,
             admin_channel,
-            control_sender,
+            mut control_sender,
             ..
         } = setup();
         let oracle = start_with_default_config(
             oracle,
-            control_sender,
+            &mut control_sender,
             Config::default(),
         )
         .await;
@@ -557,12 +572,11 @@ mod test_oracle {
             mut eth_recv,
             admin_channel,
             blocks_processed_recv: _processed,
-            control_sender,
-            ..
+            mut control_sender,
         } = setup();
         let oracle = start_with_default_config(
             oracle,
-            control_sender,
+            &mut control_sender,
             Config::default(),
         )
         .await;
@@ -589,8 +603,7 @@ mod test_oracle {
             mut eth_recv,
             admin_channel,
             blocks_processed_recv: _processed,
-            control_sender,
-            ..
+            mut control_sender,
         } = setup();
         let min_confirmations = 100;
         let config = Config {
@@ -599,7 +612,8 @@ mod test_oracle {
             ..Config::default()
         };
         let oracle =
-            start_with_default_config(oracle, control_sender, config).await;
+            start_with_default_config(oracle, &mut control_sender, config)
+                .await;
         // Increase height above the configured minimum confirmations
         admin_channel
             .send(TestCmd::NewHeight(min_confirmations.into()))
@@ -638,8 +652,7 @@ mod test_oracle {
             eth_recv,
             admin_channel,
             blocks_processed_recv: _processed,
-            control_sender,
-            ..
+            mut control_sender,
         } = setup();
         let min_confirmations = 100;
         let config = Config {
@@ -648,7 +661,8 @@ mod test_oracle {
             ..Config::default()
         };
         let oracle =
-            start_with_default_config(oracle, control_sender, config).await;
+            start_with_default_config(oracle, &mut control_sender, config)
+                .await;
         // Increase height above the configured minimum confirmations
         admin_channel
             .send(TestCmd::NewHeight(min_confirmations.into()))
@@ -701,8 +715,7 @@ mod test_oracle {
             mut eth_recv,
             admin_channel,
             blocks_processed_recv: _processed,
-            control_sender,
-            ..
+            mut control_sender,
         } = setup();
         let min_confirmations = 100;
         let config = Config {
@@ -711,7 +724,8 @@ mod test_oracle {
             ..Config::default()
         };
         let oracle =
-            start_with_default_config(oracle, control_sender, config).await;
+            start_with_default_config(oracle, &mut control_sender, config)
+                .await;
         // Increase height above the configured minimum confirmations
         admin_channel
             .send(TestCmd::NewHeight(min_confirmations.into()))
@@ -825,13 +839,15 @@ mod test_oracle {
             eth_recv,
             admin_channel,
             mut blocks_processed_recv,
-            control_sender,
-            ..
+            mut control_sender,
         } = setup();
         let config = Config::default();
-        let oracle =
-            start_with_default_config(oracle, control_sender, config.clone())
-                .await;
+        let oracle = start_with_default_config(
+            oracle,
+            &mut control_sender,
+            config.clone(),
+        )
+        .await;
 
         // set the height of the chain such that there are some blocks deep
         // enough to be considered confirmed by the oracle
@@ -890,13 +906,15 @@ mod test_oracle {
             eth_recv,
             admin_channel,
             mut blocks_processed_recv,
-            control_sender,
-            ..
+            mut control_sender,
         } = setup();
         let config = Config::default();
-        let oracle =
-            start_with_default_config(oracle, control_sender, config.clone())
-                .await;
+        let oracle = start_with_default_config(
+            oracle,
+            &mut control_sender,
+            config.clone(),
+        )
+        .await;
 
         let confirmed_block_height = 9; // all blocks up to and including this block have enough confirmations
         let synced_block_height =

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -402,6 +402,9 @@ where
 
         if new_epoch {
             self.update_epoch(&mut response);
+            // send the latest oracle configs. These may have changed due to
+            // governance.
+            self.update_eth_oracle();
         }
 
         let _ = self
@@ -497,9 +500,6 @@ where
                 },
             )
             .expect("Must be able to update validator sets");
-        // send the latest oracle configs. These may have changed due to
-        // governance.
-        self.update_eth_oracle();
     }
 }
 

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -455,7 +455,7 @@ where
 
     /// If a new epoch begins, we update the response to include
     /// changes to the validator sets and consensus parameters
-    fn update_epoch(&self, response: &mut shim::response::FinalizeBlock) {
+    fn update_epoch(&mut self, response: &mut shim::response::FinalizeBlock) {
         // Apply validator set update
         let (current_epoch, _gas) = self.wl_storage.storage.get_current_epoch();
         let pos_params =
@@ -497,6 +497,9 @@ where
                 },
             )
             .expect("Must be able to update validator sets");
+        // send the latest oracle configs. These may have changed due to
+        // governance.
+        self.update_eth_oracle();
     }
 }
 
@@ -505,14 +508,21 @@ where
 #[cfg(test)]
 mod test_finalize_block {
     use std::collections::BTreeMap;
+    use std::num::NonZeroU64;
     use std::str::FromStr;
 
     use namada::eth_bridge::storage::bridge_pool::{
         get_key_from_hash, get_nonce_key, get_signed_root_key,
     };
-    use namada::ledger::eth_bridge::EthBridgeQueries;
+    use namada::eth_bridge::storage::min_confirmations_key;
+    use namada::ledger::eth_bridge::{EthBridgeQueries, MinimumConfirmations};
+    use namada::ledger::gas::VpGasMeter;
+    use namada::ledger::native_vp::parameters::ParametersVp;
+    use namada::ledger::native_vp::NativeVp;
     use namada::ledger::parameters::EpochDuration;
+    use namada::ledger::pos::PosQueries;
     use namada::ledger::storage_api;
+    use namada::ledger::storage_api::StorageWrite;
     use namada::types::ethereum_events::{EthAddress, Uint};
     use namada::types::governance::ProposalVote;
     use namada::types::keccak::KeccakHash;
@@ -526,6 +536,7 @@ mod test_finalize_block {
     use namada::types::vote_extensions::ethereum_events::MultiSignedEthEvent;
 
     use super::*;
+    use crate::node::ledger::oracle::control::Command;
     use crate::node::ledger::shell::test_utils::*;
     use crate::node::ledger::shims::abcipp_shim_types::shim::request::{
         FinalizeBlock, ProcessedTx,
@@ -1116,7 +1127,7 @@ mod test_finalize_block {
     /// the DB.
     #[test]
     fn test_finalize_doesnt_commit_db() {
-        let (mut shell, _broadcaster, _, _) = setup();
+        let (mut shell, _broadcaster, _, _eth_control) = setup();
 
         // Update epoch duration to make sure we go through couple epochs
         let epoch_duration = EpochDuration {
@@ -1201,5 +1212,64 @@ mod test_finalize_block {
             // Store the state after commit for the next iteration
             last_storage_state = store_block_state(&shell);
         }
+    }
+
+    /// Test that updating the ethereum bridge params via governance works.
+    #[tokio::test]
+    async fn test_eth_bridge_param_updates() {
+        use namada::ledger::governance::storage as gov_storage;
+        let (mut shell, _broadcaster, _, mut control_receiver) =
+            setup_at_height(3u64);
+        let proposal_execution_key = gov_storage::get_proposal_execution_key(0);
+        shell
+            .wl_storage
+            .write(&proposal_execution_key, ())
+            .expect("Test failed.");
+        let tx = Tx::new(vec![], None);
+        let new_min_confirmations = MinimumConfirmations::from(unsafe {
+            NonZeroU64::new_unchecked(42)
+        });
+        shell
+            .wl_storage
+            .write(&min_confirmations_key(), new_min_confirmations)
+            .expect("Test failed");
+        let gas_meter = VpGasMeter::new(0);
+        let keys_changed = BTreeSet::from([min_confirmations_key()]);
+        let verifiers = BTreeSet::default();
+        let ctx = namada::ledger::native_vp::Ctx::new(
+            shell.mode.get_validator_address().expect("Test failed"),
+            &shell.wl_storage.storage,
+            &shell.wl_storage.write_log,
+            &tx,
+            &TxIndex(0),
+            gas_meter,
+            &keys_changed,
+            &verifiers,
+            shell.vp_wasm_cache.clone(),
+        );
+        let parameters = ParametersVp { ctx };
+        let result = parameters
+            .validate_tx(
+                0u64.try_to_vec().expect("Test failed").as_slice(),
+                &keys_changed,
+                &verifiers,
+            )
+            .expect("Test failed");
+        assert!(result);
+
+        // we advance forward to the next epoch
+        let mut req = FinalizeBlock::default();
+        req.header.time = namada::types::time::DateTimeUtc::now();
+        shell.wl_storage.storage.last_height =
+            shell.wl_storage.pos_queries().get_current_decision_height() + 11;
+        shell.finalize_block(req).expect("Test failed");
+        shell.commit();
+        let _ = control_receiver.recv().await.expect("Test failed");
+        let mut req = FinalizeBlock::default();
+        req.header.time = namada::types::time::DateTimeUtc::now();
+        shell.finalize_block(req).expect("Test failed");
+        let Command::UpdateConfig(cmd) =
+            control_receiver.recv().await.expect("Test failed");
+        assert_eq!(u64::from(cmd.min_confirmations), 42);
     }
 }

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -157,7 +157,7 @@ where
         if let Some(config) = genesis.ethereum_bridge_params {
             tracing::debug!("Initializing Ethereum bridge storage.");
             config.init_storage(&mut self.wl_storage);
-            self.start_ethereum_oracle_if_necessary();
+            self.update_eth_oracle();
         } else {
             self.wl_storage
                 .write_bytes(

--- a/core/src/ledger/eth_bridge/storage/mod.rs
+++ b/core/src/ledger/eth_bridge/storage/mod.rs
@@ -3,6 +3,7 @@ pub mod bridge_pool;
 pub mod wrapped_erc20s;
 
 use super::ADDRESS;
+use crate::ledger::parameters::ADDRESS as PARAM_ADDRESS;
 use crate::types::address::nam;
 use crate::types::storage::{DbKeySeg, Key, KeySeg};
 use crate::types::token::balance_key;
@@ -39,7 +40,7 @@ pub fn is_eth_bridge_key(key: &Key) -> bool {
 pub fn active_key() -> Key {
     Key {
         segments: vec![
-            DbKeySeg::AddressSeg(ADDRESS),
+            DbKeySeg::AddressSeg(PARAM_ADDRESS),
             DbKeySeg::StringSeg(ACTIVE_SUBKEY.into()),
         ],
     }
@@ -49,7 +50,7 @@ pub fn active_key() -> Key {
 pub fn min_confirmations_key() -> Key {
     Key {
         segments: vec![
-            DbKeySeg::AddressSeg(ADDRESS),
+            DbKeySeg::AddressSeg(PARAM_ADDRESS),
             DbKeySeg::StringSeg(MIN_CONFIRMATIONS_SUBKEY.into()),
         ],
     }
@@ -59,7 +60,7 @@ pub fn min_confirmations_key() -> Key {
 pub fn native_erc20_key() -> Key {
     Key {
         segments: vec![
-            DbKeySeg::AddressSeg(ADDRESS),
+            DbKeySeg::AddressSeg(PARAM_ADDRESS),
             DbKeySeg::StringSeg(NATIVE_ERC20_SUBKEY.into()),
         ],
     }
@@ -69,7 +70,7 @@ pub fn native_erc20_key() -> Key {
 pub fn bridge_contract_key() -> Key {
     Key {
         segments: vec![
-            DbKeySeg::AddressSeg(ADDRESS),
+            DbKeySeg::AddressSeg(PARAM_ADDRESS),
             DbKeySeg::StringSeg(BRIDGE_CONTRACT_SUBKEY.into()),
         ],
     }
@@ -79,7 +80,7 @@ pub fn bridge_contract_key() -> Key {
 pub fn governance_contract_key() -> Key {
     Key {
         segments: vec![
-            DbKeySeg::AddressSeg(ADDRESS),
+            DbKeySeg::AddressSeg(PARAM_ADDRESS),
             DbKeySeg::StringSeg(GOVERNANCE_CONTRACT_SUBKEY.into()),
         ],
     }

--- a/core/src/ledger/parameters/mod.rs
+++ b/core/src/ledger/parameters/mod.rs
@@ -14,7 +14,9 @@ use crate::types::storage::Key;
 use crate::types::time::DurationSecs;
 use crate::types::token;
 
-const ADDRESS: Address = Address::Internal(InternalAddress::Parameters);
+/// The internal address for storage keys representing parameters than
+/// can be changed via governance.
+pub const ADDRESS: Address = Address::Internal(InternalAddress::Parameters);
 
 /// Protocol parameters
 #[derive(

--- a/core/src/ledger/parameters/storage.rs
+++ b/core/src/ledger/parameters/storage.rs
@@ -12,6 +12,7 @@ struct Keys {
     epochs_per_year: &'static str,
     implicit_vp: &'static str,
     max_expected_time_per_block: &'static str,
+    min_confirmations: &'static str,
     pos_gain_d: &'static str,
     pos_gain_p: &'static str,
     pos_inflation_amount: &'static str,


### PR DESCRIPTION
This PR resolves issue #1080.

 * Oracle storage has been moved under the control of the `Parameters` vp. This allows it to be changed by storage.
 * Once an epoch, the shell sends the config in storage to the oracle.
 * Since the oracle has no notion of epochs, after processing every ethereum blocks, checks if a new config has been sent.