### PR TITLE
Increment the bridge pool's batch nonce

### DIFF
--- a/core/src/ledger/eth_bridge/storage/bridge_pool.rs
+++ b/core/src/ledger/eth_bridge/storage/bridge_pool.rs
@@ -7,12 +7,13 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use ethabi::Token;
 use eyre::eyre;
 
-use crate::types::address::{Address, InternalAddress};
+use crate::types::address::{nam, Address, InternalAddress};
 use crate::types::eth_abi::Encode;
 use crate::types::eth_bridge_pool::PendingTransfer;
 use crate::types::hash::Hash;
 use crate::types::keccak::{keccak_hash, KeccakHash};
 use crate::types::storage::{BlockHeight, DbKeySeg, Key, KeySeg};
+use crate::types::token;
 
 /// The main address of the Ethereum bridge pool
 pub const BRIDGE_POOL_ADDRESS: Address =
@@ -73,6 +74,12 @@ pub fn is_pending_transfer_key(key: &Key) -> bool {
     is_bridge_pool_key(key)
         && *key != get_signed_root_key()
         && *key != get_nonce_key()
+}
+
+/// Check if the bridge pool's NAM escrow was updated.
+pub fn was_escrow_updated(changed_keys: &BTreeSet<Key>) -> bool {
+    let pool_balance_key = token::balance_key(&nam(), &BRIDGE_POOL_ADDRESS);
+    changed_keys.iter().any(|key| key == &pool_balance_key)
 }
 
 /// A simple Merkle tree for the Ethereum bridge pool

--- a/core/src/ledger/eth_bridge/storage/bridge_pool.rs
+++ b/core/src/ledger/eth_bridge/storage/bridge_pool.rs
@@ -7,13 +7,12 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use ethabi::Token;
 use eyre::eyre;
 
-use crate::types::address::{nam, Address, InternalAddress};
+use crate::types::address::{Address, InternalAddress};
 use crate::types::eth_abi::Encode;
 use crate::types::eth_bridge_pool::PendingTransfer;
 use crate::types::hash::Hash;
 use crate::types::keccak::{keccak_hash, KeccakHash};
 use crate::types::storage::{BlockHeight, DbKeySeg, Key, KeySeg};
-use crate::types::token;
 
 /// The main address of the Ethereum bridge pool
 pub const BRIDGE_POOL_ADDRESS: Address =
@@ -74,12 +73,6 @@ pub fn is_pending_transfer_key(key: &Key) -> bool {
     is_bridge_pool_key(key)
         && *key != get_signed_root_key()
         && *key != get_nonce_key()
-}
-
-/// Check if the bridge pool's NAM escrow was updated.
-pub fn was_escrow_updated(changed_keys: &BTreeSet<Key>) -> bool {
-    let pool_balance_key = token::balance_key(&nam(), &BRIDGE_POOL_ADDRESS);
-    changed_keys.iter().any(|key| key == &pool_balance_key)
 }
 
 /// A simple Merkle tree for the Ethereum bridge pool

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -43,6 +43,12 @@ impl Uint {
         ethUint::from(self).to_little_endian(&mut bytes);
         bytes
     }
+
+    /// Try to increment this [`Uint`], whilst checking
+    /// for overflows.
+    pub fn checked_increment(self) -> Option<Self> {
+        ethUint::from(self).checked_add(1.into()).map(Self::from)
+    }
 }
 
 impl Display for Uint {

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -7,7 +7,8 @@ use borsh::BorshDeserialize;
 use eyre::{Result, WrapErr};
 use namada_core::hints::likely;
 use namada_core::ledger::eth_bridge::storage::bridge_pool::{
-    get_pending_key, is_pending_transfer_key, BRIDGE_POOL_ADDRESS,
+    get_nonce_key, get_pending_key, is_pending_transfer_key,
+    BRIDGE_POOL_ADDRESS,
 };
 use namada_core::ledger::eth_bridge::storage::{
     self as bridge_storage, wrapped_erc20s,
@@ -30,6 +31,7 @@ use namada_core::types::token::{
 
 use crate::parameters::read_native_erc20_address;
 use crate::protocol::transactions::update;
+use crate::storage::eth_bridge_queries::EthBridgeQueries;
 
 /// Updates storage based on the given confirmed `event`. For example, for a
 /// confirmed [`EthereumEvent::TransfersToNamada`], mint the corresponding
@@ -240,6 +242,9 @@ where
         _ = changed_keys.insert(key);
     }
     if !transfers.is_empty() {
+        let nonce_key = get_nonce_key();
+        increment_bp_nonce(&nonce_key, wl_storage)?;
+        changed_keys.insert(nonce_key);
         changed_keys.insert(relayer_rewards_key);
         changed_keys.insert(pool_balance_key);
     }
@@ -270,6 +275,23 @@ where
     }
 
     Ok(changed_keys)
+}
+
+fn increment_bp_nonce<D, H>(
+    nonce_key: &Key,
+    wl_storage: &mut WlStorage<D, H>,
+) -> Result<()>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    let next_nonce = wl_storage
+        .ethbridge_queries()
+        .get_bridge_pool_nonce()
+        .checked_increment()
+        .expect("Bridge pool nonce has overflowed");
+    wl_storage.write(nonce_key, next_nonce)?;
+    Ok(())
 }
 
 fn refund_transfer<D, H>(


### PR DESCRIPTION
If we detect that a transfer to ethereum event was newly confirmed, we increment the bridge pool's batch nonce.