### PR TITLE
Amend the `Ord` implementation of `Uint`

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_oracle/events.rs
+++ b/apps/src/lib/node/ledger/ethereum_oracle/events.rs
@@ -488,7 +488,7 @@ pub mod eth_events {
             let test_case = U256::from(confs);
             assert_eq!(test_case.parse_u32().expect("Test failed"), confs);
 
-            let test_case = U256::from(uint.clone());
+            let test_case = U256(uint.0);
             assert_eq!(test_case.parse_uint256().expect("Test failed"), uint);
 
             let test_case = boolean;

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -20,6 +20,7 @@ use crate::types::token::Amount;
 
 /// Namada native type to replace the ethabi::Uint type
 #[derive(
+    Copy,
     Clone,
     Debug,
     Default,

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -1,12 +1,13 @@
 //! Types representing data intended for Namada via Ethereum events
 
+use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
-use ethabi::ethereum_types::H160;
-use ethabi::{Token, Uint as ethUint};
+use ethabi::ethereum_types::{H160, U256 as ethUint};
+use ethabi::Token;
 use eyre::{eyre, Context};
 use serde::{Deserialize, Serialize};
 
@@ -25,8 +26,6 @@ use crate::types::token::Amount;
     Hash,
     PartialEq,
     Eq,
-    PartialOrd,
-    Ord,
     Serialize,
     Deserialize,
     BorshSerialize,
@@ -34,6 +33,20 @@ use crate::types::token::Amount;
     BorshSchema,
 )]
 pub struct Uint(pub [u64; 4]);
+
+impl PartialOrd for Uint {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        ethUint(self.0).partial_cmp(&ethUint(other.0))
+    }
+}
+
+impl Ord for Uint {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        ethUint(self.0).cmp(&ethUint(other.0))
+    }
+}
 
 impl Uint {
     /// Convert to a little endian byte representation of

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -53,14 +53,14 @@ impl Uint {
     /// a uint256.
     pub fn to_bytes(self) -> [u8; 32] {
         let mut bytes = [0; 32];
-        ethUint::from(self).to_little_endian(&mut bytes);
+        ethUint(self.0).to_little_endian(&mut bytes);
         bytes
     }
 }
 
 impl Display for Uint {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        ethUint::from(self).fmt(f)
+        ethUint(self.0).fmt(f)
     }
 }
 
@@ -98,7 +98,7 @@ impl Add<u64> for Uint {
     type Output = Self;
 
     fn add(self, rhs: u64) -> Self::Output {
-        (ethUint::from(self) + rhs).into()
+        (ethUint(self.0) + rhs).into()
     }
 }
 

--- a/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
+++ b/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
@@ -268,7 +268,7 @@ mod test_apply_bp_roots_to_storage {
         } = setup();
         let root = wl_storage.ethbridge_queries().get_bridge_pool_root();
         let nonce = wl_storage.ethbridge_queries().get_bridge_pool_nonce();
-        let to_sign = keccak_hash([root.0, nonce.clone().to_bytes()].concat());
+        let to_sign = keccak_hash([root.0, nonce.to_bytes()].concat());
         let hot_key = &keys[&validators[0]].eth_bridge;
         let vext = bridge_pool_roots::Vext {
             validator_addr: validators[0].clone(),
@@ -317,7 +317,7 @@ mod test_apply_bp_roots_to_storage {
         } = setup();
         let root = wl_storage.ethbridge_queries().get_bridge_pool_root();
         let nonce = wl_storage.ethbridge_queries().get_bridge_pool_nonce();
-        let to_sign = keccak_hash([root.0, nonce.clone().to_bytes()].concat());
+        let to_sign = keccak_hash([root.0, nonce.to_bytes()].concat());
         let hot_key = &keys[&validators[0]].eth_bridge;
         let mut vexts: MultiSignedVext = bridge_pool_roots::Vext {
             validator_addr: validators[0].clone(),
@@ -358,7 +358,7 @@ mod test_apply_bp_roots_to_storage {
         } = setup();
         let root = wl_storage.ethbridge_queries().get_bridge_pool_root();
         let nonce = wl_storage.ethbridge_queries().get_bridge_pool_nonce();
-        let to_sign = keccak_hash([root.0, nonce.clone().to_bytes()].concat());
+        let to_sign = keccak_hash([root.0, nonce.to_bytes()].concat());
         let hot_key = &keys[&validators[0]].eth_bridge;
         let vext = bridge_pool_roots::Vext {
             validator_addr: validators[0].clone(),
@@ -404,7 +404,7 @@ mod test_apply_bp_roots_to_storage {
         } = setup();
         let root = wl_storage.ethbridge_queries().get_bridge_pool_root();
         let nonce = wl_storage.ethbridge_queries().get_bridge_pool_nonce();
-        let to_sign = keccak_hash([root.0, nonce.clone().to_bytes()].concat());
+        let to_sign = keccak_hash([root.0, nonce.to_bytes()].concat());
         let bp_root_key = vote_tallies::Keys::from(BridgePoolRoot(
             BridgePoolRootProof::new((root, nonce)),
         ));
@@ -459,7 +459,7 @@ mod test_apply_bp_roots_to_storage {
         } = setup();
         let root = wl_storage.ethbridge_queries().get_bridge_pool_root();
         let nonce = wl_storage.ethbridge_queries().get_bridge_pool_nonce();
-        let to_sign = keccak_hash([root.0, nonce.clone().to_bytes()].concat());
+        let to_sign = keccak_hash([root.0, nonce.to_bytes()].concat());
         let hot_key = &keys[&validators[0]].eth_bridge;
 
         let bp_root_key = vote_tallies::Keys::from(BridgePoolRoot(
@@ -517,7 +517,7 @@ mod test_apply_bp_roots_to_storage {
         } = setup();
         let root = wl_storage.ethbridge_queries().get_bridge_pool_root();
         let nonce = wl_storage.ethbridge_queries().get_bridge_pool_nonce();
-        let to_sign = keccak_hash([root.0, nonce.clone().to_bytes()].concat());
+        let to_sign = keccak_hash([root.0, nonce.to_bytes()].concat());
         let hot_key = &keys[&validators[0]].eth_bridge;
 
         let bp_root_key = vote_tallies::Keys::from(BridgePoolRoot(
@@ -580,7 +580,7 @@ mod test_apply_bp_roots_to_storage {
         } = setup();
         let root = wl_storage.ethbridge_queries().get_bridge_pool_root();
         let nonce = wl_storage.ethbridge_queries().get_bridge_pool_nonce();
-        let to_sign = keccak_hash([root.0, nonce.clone().to_bytes()].concat());
+        let to_sign = keccak_hash([root.0, nonce.to_bytes()].concat());
         let hot_key = &keys[&validators[0]].eth_bridge;
         let mut expected =
             BridgePoolRoot(BridgePoolRootProof::new((root, nonce)));
@@ -628,7 +628,7 @@ mod test_apply_bp_roots_to_storage {
         } = setup();
         let root = wl_storage.ethbridge_queries().get_bridge_pool_root();
         let nonce = wl_storage.ethbridge_queries().get_bridge_pool_nonce();
-        let to_sign = keccak_hash([root.0, nonce.clone().to_bytes()].concat());
+        let to_sign = keccak_hash([root.0, nonce.to_bytes()].concat());
 
         assert!(
             wl_storage

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -740,7 +740,7 @@ mod tests {
             &root,
             100.into(),
         );
-        let to_sign = keccak_hash([root.0, nonce.clone().to_bytes()].concat());
+        let to_sign = keccak_hash([root.0, nonce.to_bytes()].concat());
         let signing_key = key::testing::keypair_1();
         let hot_key =
             &keys[&address::testing::established_address_2()].eth_bridge;


### PR DESCRIPTION
* Fix the `Ord` and `PartialOrd` implementation of Namada's `Uint` type.
  + Deriving `Ord` on `Uint` makes us compare the inner array, which has a little-endian representation. Some comparisons will be faulty, because of this, e.g. type `(1300).to_bytes(4, 'little') > (1236).to_bytes(4, 'little')` into a python repl.
* Implement `Copy` on `Uint`, for convenience.