### PR TITLE
Handle Ethereum event nonces

### DIFF
--- a/apps/src/lib/node/ledger/ethereum_oracle/events.rs
+++ b/apps/src/lib/node/ledger/ethereum_oracle/events.rs
@@ -518,7 +518,7 @@ pub mod eth_events {
                     2
                 ],
                 valid_map: vec![true; 2],
-                nonce: 1u64.into(),
+                nonce: 0u64.into(),
                 confirmations: 0u64.into(),
             };
             let eth_transfers = TransferToErcFilter {
@@ -534,16 +534,16 @@ pub mod eth_events {
                     2
                 ],
                 valid_map: vec![true; 2],
-                nonce: 1u64.into(),
+                nonce: 0u64.into(),
                 relayer_address: address,
             };
             let update = ValidatorSetUpdateFilter {
-                validator_set_nonce: 1u64.into(),
+                validator_set_nonce: 0u64.into(),
                 bridge_validator_set_hash: [1; 32],
                 governance_validator_set_hash: [2; 32],
             };
             let whitelist = UpdateBridgeWhitelistFilter {
-                nonce: 1u64.into(),
+                nonce: 0u64.into(),
                 tokens: vec![H160([0; 20]); 2],
                 token_cap: vec![0u64.into(); 2],
             };

--- a/apps/src/lib/node/ledger/ethereum_oracle/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_oracle/mod.rs
@@ -669,7 +669,7 @@ mod test_oracle {
             .expect("Test failed");
 
         let new_event = TransferToNamadaFilter {
-            nonce: 1337.into(),
+            nonce: 0.into(),
             transfers: vec![],
             valid_map: vec![],
             confirmations: 100.into(),
@@ -725,7 +725,7 @@ mod test_oracle {
             .expect("Test failed");
         // send a new event to the oracle
         let new_event = TransferToNamadaFilter {
-            nonce: 1337.into(),
+            nonce: 0.into(),
             transfers: vec![],
             valid_map: vec![],
             confirmations: 100.into(),
@@ -786,7 +786,7 @@ mod test_oracle {
 
         // confirmed after 100 blocks
         let first_event = TransferToNamadaFilter {
-            nonce: 1337.into(),
+            nonce: 0.into(),
             transfers: vec![],
             valid_map: vec![],
             confirmations: 100.into(),
@@ -806,7 +806,7 @@ mod test_oracle {
             }],
             valid_map: vec![true],
             relayer_address: gas_payer.to_string(),
-            nonce: 1.into(),
+            nonce: 0.into(),
         }
         .encode();
 
@@ -843,7 +843,7 @@ mod test_oracle {
             valid_transfers_map: valid_map,
         } = event
         {
-            assert_eq!(nonce, 1337.into());
+            assert_eq!(nonce, 0.into());
             assert!(transfers.is_empty());
             assert!(valid_map.is_empty());
         } else {

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -1194,7 +1194,7 @@ mod test_finalize_block {
                 transfer
             };
             let ethereum_event = EthereumEvent::TransfersToEthereum {
-                nonce: 1u64.into(),
+                nonce: 0u64.into(),
                 transfers: vec![transfer],
                 valid_transfers_map: vec![true],
                 relayer: bertha,

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -511,11 +511,12 @@ mod test_finalize_block {
     use std::num::NonZeroU64;
     use std::str::FromStr;
 
+    use namada::core::ledger::eth_bridge::storage::wrapped_erc20s;
     use namada::eth_bridge::storage::bridge_pool::{
-        get_key_from_hash, get_nonce_key, get_signed_root_key,
+        self, get_key_from_hash, get_nonce_key, get_signed_root_key,
     };
     use namada::eth_bridge::storage::min_confirmations_key;
-    use namada::ledger::eth_bridge::{EthBridgeQueries, MinimumConfirmations};
+    use namada::ledger::eth_bridge::MinimumConfirmations;
     use namada::ledger::gas::VpGasMeter;
     use namada::ledger::native_vp::parameters::ParametersVp;
     use namada::ledger::native_vp::NativeVp;
@@ -523,7 +524,9 @@ mod test_finalize_block {
     use namada::ledger::pos::PosQueries;
     use namada::ledger::storage_api;
     use namada::ledger::storage_api::StorageWrite;
-    use namada::types::ethereum_events::{EthAddress, Uint};
+    use namada::types::ethereum_events::{
+        EthAddress, TransferToEthereum, Uint,
+    };
     use namada::types::governance::ProposalVote;
     use namada::types::keccak::KeccakHash;
     use namada::types::storage::Epoch;
@@ -533,7 +536,6 @@ mod test_finalize_block {
     };
     use namada::types::transaction::{EncryptionKey, Fee, WrapperTx, MIN_FEE};
     use namada::types::vote_extensions::ethereum_events;
-    use namada::types::vote_extensions::ethereum_events::MultiSignedEthEvent;
 
     use super::*;
     use crate::node::ledger::oracle::control::Command;
@@ -1057,11 +1059,19 @@ mod test_finalize_block {
         assert!(shell.new_ethereum_events().is_empty());
     }
 
+    /// Actions to perform in [`test_bp`].
+    enum TestBpAction {
+        /// The tested unit correctly signed over the bridge pool root.
+        VerifySignedRoot,
+        /// The tested unit correctly incremented the bridge pool's nonce.
+        CheckNonceIncremented,
+    }
+
     /// Helper function for testing the relevant protocol tx
     /// for signing bridge pool roots and nonces
-    fn test_bp_roots<F>(craft_tx: F)
+    fn test_bp<F>(craft_tx: F)
     where
-        F: FnOnce(&TestShell) -> Tx,
+        F: FnOnce(&mut TestShell) -> (Tx, TestBpAction),
     {
         let (mut shell, _, _, _) = setup_at_height(3u64);
         namada::eth_bridge::test_utils::commit_bridge_pool_root_at_height(
@@ -1085,7 +1095,7 @@ mod test_finalize_block {
                 Uint::from(1).try_to_vec().expect("Test failed"),
             )
             .expect("Test failed");
-        let tx = craft_tx(&shell);
+        let (tx, action) = craft_tx(&mut shell);
         let processed_tx = ProcessedTx {
             tx: tx.to_bytes(),
             result: TxResult {
@@ -1103,23 +1113,119 @@ mod test_finalize_block {
             .expect("Reading signed Bridge pool root shouldn't fail.");
         assert!(root.is_none());
         _ = shell.finalize_block(req).expect("Test failed");
-        let (root, _) = shell
-            .wl_storage
-            .ethbridge_queries()
-            .get_signed_bridge_pool_root()
-            .expect("Test failed");
-        assert_eq!(root.data.0, KeccakHash([1; 32]));
-        assert_eq!(root.data.1, Uint::from(1));
+        shell.wl_storage.commit_block().unwrap();
+        match action {
+            TestBpAction::VerifySignedRoot => {
+                let (root, _) = shell
+                    .wl_storage
+                    .ethbridge_queries()
+                    .get_signed_bridge_pool_root()
+                    .expect("Test failed");
+                assert_eq!(root.data.0, KeccakHash([1; 32]));
+                assert_eq!(root.data.1, Uint::from(1));
+            }
+            TestBpAction::CheckNonceIncremented => {
+                let nonce = shell
+                    .wl_storage
+                    .ethbridge_queries()
+                    .get_bridge_pool_nonce();
+                assert_eq!(nonce, Uint::from(2));
+            }
+        }
+    }
+
+    #[test]
+    /// Test that adding a new erc20 transfer to the bridge pool
+    /// increments the pool's nonce.
+    fn test_bp_nonce_is_incremented() {
+        test_bp(|shell: &mut TestShell| {
+            let asset = EthAddress([0xff; 20]);
+            let receiver = EthAddress([0xaa; 20]);
+            let bertha = crate::wallet::defaults::bertha_address();
+            // add `asset` to bertha's balance
+            {
+                let asset_key = wrapped_erc20s::Keys::from(&asset);
+                let owner_key = asset_key.balance(&bertha);
+                let amt: Amount = 999_999_u64.into();
+                shell
+                    .wl_storage
+                    .write(&owner_key, amt)
+                    .expect("Test failed");
+            }
+            // add NAM to bertha's balance
+            {
+                let amt: Amount = 999_999_u64.into();
+                let owner_key =
+                    token::balance_key(&namada::types::address::nam(), &bertha);
+                shell
+                    .wl_storage
+                    .write(&owner_key, amt)
+                    .expect("Test failed");
+            }
+            // add some tokens to the pool
+            {
+                use crate::node::ledger::shell::address::nam;
+                let amt: Amount = 999_999_u64.into();
+                let pool_balance_key = token::balance_key(
+                    &nam(),
+                    &bridge_pool::BRIDGE_POOL_ADDRESS,
+                );
+                shell
+                    .wl_storage
+                    .write(&pool_balance_key, amt)
+                    .expect("Test failed");
+            }
+            // write transfer to storage
+            let transfer = {
+                use namada::core::types::eth_bridge_pool::PendingTransfer;
+                let transfer = TransferToEthereum {
+                    amount: 10u64.into(),
+                    asset,
+                    receiver,
+                    gas_amount: 10u64.into(),
+                    sender: bertha.clone(),
+                    gas_payer: bertha.clone(),
+                };
+                let pending = PendingTransfer::from(&transfer);
+                shell
+                    .wl_storage
+                    .write(&bridge_pool::get_pending_key(&pending), pending)
+                    .expect("Test failed");
+                transfer
+            };
+            let ethereum_event = EthereumEvent::TransfersToEthereum {
+                nonce: 1u64.into(),
+                transfers: vec![transfer],
+                valid_transfers_map: vec![true],
+                relayer: bertha,
+            };
+            let (protocol_key, _, _) =
+                crate::wallet::defaults::validator_keys();
+            let validator_addr = crate::wallet::defaults::validator_address();
+            let ext = {
+                let ext = ethereum_events::Vext {
+                    validator_addr,
+                    block_height: shell.wl_storage.storage.last_height,
+                    ethereum_events: vec![ethereum_event],
+                }
+                .sign(&protocol_key);
+                assert!(ext.verify(&protocol_key.ref_to()).is_ok());
+                ext
+            };
+            let tx = ProtocolTxType::EthEventsVext(ext).sign(&protocol_key);
+            (tx, TestBpAction::CheckNonceIncremented)
+        });
     }
 
     #[test]
     /// Test that the generated protocol tx passes Finalize Block
     /// and effects the expected storage changes.
     fn test_bp_roots_protocol_tx() {
-        test_bp_roots(|shell: &TestShell| {
+        test_bp(|shell: &mut TestShell| {
             let vext = shell.extend_vote_with_bp_roots().expect("Test failed");
-            ProtocolTxType::BridgePoolVext(vext)
-                .sign(shell.mode.get_protocol_key().expect("Test failed"))
+            let tx = ProtocolTxType::BridgePoolVext(vext)
+                .sign(shell.mode.get_protocol_key().expect("Test failed"));
+            (tx, TestBpAction::VerifySignedRoot)
         });
     }
 

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1584,6 +1584,7 @@ mod test_utils {
                     .storage
                     .ethereum_height
                     .as_ref(),
+                eth_events_queue: &shell.wl_storage.storage.eth_events_queue,
             })
             .expect("Test failed");
 

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1647,7 +1647,7 @@ mod mempool_tests {
             .clone();
         let protocol_key = shell.mode.get_protocol_key().expect("Test failed");
         let ethereum_event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };
@@ -1746,7 +1746,7 @@ mod mempool_tests {
         let validator_addr = wallet::defaults::validator_address();
 
         let ethereum_event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -634,7 +634,7 @@ mod test_prepare_proposal {
         let validator_addr = wallet::defaults::validator_address();
 
         let ethereum_event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };
@@ -729,7 +729,7 @@ mod test_prepare_proposal {
         let validator_addr = wallet::defaults::validator_address();
 
         let ethereum_event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };
@@ -871,7 +871,7 @@ mod test_prepare_proposal {
         let validator_addr = wallet::defaults::validator_address();
 
         let ethereum_event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -930,7 +930,7 @@ mod test_process_proposal {
         let protocol_key = shell.mode.get_protocol_key().expect("Test failed");
         let addr = shell.mode.get_validator_address().expect("Test failed");
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };
@@ -1057,7 +1057,7 @@ mod test_process_proposal {
         ];
 
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };
@@ -1160,7 +1160,7 @@ mod test_process_proposal {
         let (protocol_key, _, _) = wallet::defaults::validator_keys();
         let addr = wallet::defaults::validator_address();
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };
@@ -1225,7 +1225,7 @@ mod test_process_proposal {
         let (protocol_key, _, _) = wallet::defaults::validator_keys();
         let addr = wallet::defaults::validator_address();
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };
@@ -1282,7 +1282,7 @@ mod test_process_proposal {
             (bertha_addr, bertha_key)
         };
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1u64.into(),
+            nonce: 0u64.into(),
             transfers: vec![],
             valid_transfers_map: vec![],
         };

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -61,8 +61,6 @@ pub enum VoteExtensionError {
          not active"
     )]
     EthereumBridgeInactive,
-    #[error("A vote extension for the Ethereum bridge is missing")]
-    MissingBridgeVext,
 }
 
 impl<D, H> Shell<D, H>

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -28,8 +28,10 @@ const VALIDATOR_EXPECT_MSG: &str = "Only validators receive this method call.";
 /// The error yielded from validating faulty vote extensions in the shell
 #[derive(Error, Debug)]
 pub enum VoteExtensionError {
-    #[error("The bridge pool nonce in the vote extension is outdated")]
-    OutdatedBpNonce,
+    #[error("The bridge pool nonce in the vote extension is invalid")]
+    InvalidBpNonce,
+    #[error("The transfer to Namada nonce in the vote extension is invalid")]
+    InvalidNamNonce,
     #[error("The vote extension was issued for an unexpected block height")]
     UnexpectedBlockHeight,
     #[error("The vote extension was issued for an unexpected epoch")]

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -28,6 +28,8 @@ const VALIDATOR_EXPECT_MSG: &str = "Only validators receive this method call.";
 /// The error yielded from validating faulty vote extensions in the shell
 #[derive(Error, Debug)]
 pub enum VoteExtensionError {
+    #[error("The length of the transfers and their validity map differ")]
+    TransfersLenMismatch,
     #[error("The bridge pool nonce in the vote extension is invalid")]
     InvalidBpNonce,
     #[error("The transfer to Namada nonce in the vote extension is invalid")]

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -28,6 +28,8 @@ const VALIDATOR_EXPECT_MSG: &str = "Only validators receive this method call.";
 /// The error yielded from validating faulty vote extensions in the shell
 #[derive(Error, Debug)]
 pub enum VoteExtensionError {
+    #[error("The bridge pool nonce in the vote extension is outdated")]
+    OutdatedBpNonce,
     #[error("The vote extension was issued for an unexpected block height")]
     UnexpectedBlockHeight,
     #[error("The vote extension was issued for an unexpected epoch")]

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -199,8 +199,8 @@ where
     /// ## Transfers to Namada
     ///
     /// For a transfers to Namada event to be considered valid,
-    /// much like a transfers to Ethereum, the nonce of this
-    /// kind of event must match the one stored in Namada.
+    /// the nonce of this kind of event must not be lower than
+    /// the one stored in Namada.
     ///
     /// In this case, the length of the transfers array and their
     /// respective validity map must also match.
@@ -208,9 +208,8 @@ where
     /// ## Whitelist updates
     ///
     /// For any of these events to be considered valid, the
-    /// whitelist update nonce in storage must match the nonce
-    /// in the event.
-    // TODO: change transfers to namada checking docstr
+    /// whitelist update nonce in storage must be greater
+    /// than or equal to the nonce in the event.
     pub fn validate_eth_event(
         &self,
         event: &EthereumEvent,

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -142,6 +142,10 @@ where
 
     /// Validate a batch of Ethereum events contained in
     /// an [`ethereum_events::Vext`].
+    ///
+    /// A detailed description of the validation applied
+    /// to each event kind can be found in the docstring
+    /// of [`Shell::validate_eth_event`].
     pub fn validate_eth_events(
         &self,
         ext: &ethereum_events::Vext,
@@ -168,7 +172,22 @@ where
             .try_for_each(|event| self.validate_eth_event(event))
     }
 
-    /// Valdidate an [`EthereumEvent`].
+    /// Valdidate an [`EthereumEvent`] against the current state
+    /// of the ledger.
+    ///
+    /// # Event kinds
+    ///
+    /// In this section, we shall describe the checks perform for
+    /// each kind of relevant Ethereum event.
+    ///
+    /// ## Transfers to Ethereum
+    ///
+    /// We need to check if the nonce in the event corresponds to
+    /// the most recent bridge pool nonce. Unless the nonces match,
+    /// no state updates derived from the event should be applied.
+    /// In case the nonces are different, we reject the event, and
+    /// thus the inclusion of its container Ethereum events vote
+    /// extension.
     pub fn validate_eth_event(
         &self,
         event: &EthereumEvent,

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -210,6 +210,7 @@ where
     /// For any of these events to be considered valid, the
     /// whitelist update nonce in storage must match the nonce
     /// in the event.
+    // TODO: change transfers to namada checking docstr
     pub fn validate_eth_event(
         &self,
         event: &EthereumEvent,
@@ -264,12 +265,11 @@ where
                     .wl_storage
                     .ethbridge_queries()
                     .get_namada_transfers_nonce();
-                if &current_nam_nonce != ext_nonce {
+                if &current_nam_nonce > ext_nonce {
                     tracing::debug!(
+                        ?event,
                         %current_nam_nonce,
-                        %ext_nonce,
-                        "The Ethereum events vote extension's transfer to \
-                         Namada nonce is invalid"
+                        "Attempt to replay a transfer to Namada event"
                     );
                     return Err(VoteExtensionError::InvalidNamNonce);
                 }

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -464,8 +464,6 @@ mod test_vote_extensions {
     use namada::types::address::testing::gen_established_address;
     #[cfg(feature = "abcipp")]
     use namada::types::eth_abi::Encode;
-    #[cfg(feature = "abcipp")]
-    use namada::types::ethereum_events::Uint;
     use namada::types::ethereum_events::{
         EthAddress, EthereumEvent, TransferToEthereum, Uint,
     };

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -204,15 +204,18 @@ where
                 if &current_bp_nonce != ext_nonce {
                     return Err(VoteExtensionError::OutdatedBpNonce);
                 }
-
-                // TODO: check if token is not whitelisted
+                // TODO: maybe perform additional checks:
+                // - some token asset is not whitelisted
+                // - do we have enough balance for the transfer
             }
             EthereumEvent::TransfersToNamada { .. } => {
-                // TODO: check if token is not whitelisted
-
                 // TODO: check nonce of transfers to namada;
                 // for this, we need to store the nonce of
                 // these transfers somewhere
+
+                // TODO: maybe perform additional checks:
+                // - some token asset is not whitelisted
+                // - do we have enough balance for the transfer
             }
             EthereumEvent::UpdateBridgeWhitelist { .. } => {
                 // TODO: check nonce of whitelist update;

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -713,7 +713,7 @@ mod test_vote_extensions {
             shell.wl_storage.pos_queries().get_current_decision_height();
         let vote_ext = ethereum_events::Vext {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
-                nonce: 1.into(),
+                nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
                     amount: 100.into(),
                     sender: gen_established_address(),

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -149,7 +149,7 @@ where
     /// A detailed description of the validation applied
     /// to each event kind can be found in the docstring
     /// of [`Shell::validate_eth_event`].
-    pub fn validate_eth_events(
+    fn validate_eth_events(
         &self,
         ext: &ethereum_events::Vext,
     ) -> std::result::Result<(), VoteExtensionError> {
@@ -210,7 +210,7 @@ where
     /// For any of these events to be considered valid, the
     /// whitelist update nonce in storage must be greater
     /// than or equal to the nonce in the event.
-    pub fn validate_eth_event(
+    fn validate_eth_event(
         &self,
         event: &EthereumEvent,
     ) -> std::result::Result<(), VoteExtensionError> {

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -191,6 +191,25 @@ where
     /// In case the nonces are different, we reject the event, and
     /// thus the inclusion of its container Ethereum events vote
     /// extension.
+    ///
+    /// Additionally, the length of the transfers array and their
+    /// respective validity map must match, for the event to be
+    /// considered valid.
+    ///
+    /// ## Transfers to Namada
+    ///
+    /// For a transfers to Namada event to be considered valid,
+    /// much like a transfers to Ethereum, the nonce of this
+    /// kind of event must match the one stored in Namada.
+    ///
+    /// In this case, the length of the transfers array and their
+    /// respective validity map must also match.
+    ///
+    /// ## Whitelist updates
+    ///
+    /// For any of these events to be considered valid, the
+    /// whitelist update nonce in storage must match the nonce
+    /// in the event.
     pub fn validate_eth_event(
         &self,
         event: &EthereumEvent,

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -214,6 +214,12 @@ where
         &self,
         event: &EthereumEvent,
     ) -> std::result::Result<(), VoteExtensionError> {
+        // TODO: on the transfer events, maybe perform additional checks:
+        // - some token asset is not whitelisted
+        // - do we have enough balance for the transfer
+        // in practice, some events may have a variable degree of garbage
+        // data in them; we can simply rely on quorum decisions to filter
+        // out such events, which will time out in storage
         match event {
             EthereumEvent::TransfersToEthereum {
                 nonce: ext_nonce,
@@ -241,9 +247,6 @@ where
                     );
                     return Err(VoteExtensionError::InvalidBpNonce);
                 }
-                // TODO: maybe perform additional checks:
-                // - some token asset is not whitelisted
-                // - do we have enough balance for the transfer
             }
             EthereumEvent::TransfersToNamada {
                 nonce: ext_nonce,
@@ -272,9 +275,6 @@ where
                     );
                     return Err(VoteExtensionError::InvalidNamNonce);
                 }
-                // TODO: maybe perform additional checks:
-                // - some token asset is not whitelisted
-                // - do we have enough balance for the transfer
             }
             EthereumEvent::UpdateBridgeWhitelist { .. } => {
                 // TODO: check nonce of whitelist update;

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -206,11 +206,15 @@ where
             }
             EthereumEvent::TransfersToNamada { .. } => {
                 // TODO: check if token is not whitelisted
+
+                // TODO: check nonce of transfers to namada;
+                // for this, we need to store the nonce of
+                // these transfers somewhere
             }
-            EthereumEvent::ValidatorSetUpdate { .. } => {
-                // no validation required. this is only here
-                // to stop clippy from complaining about not
-                // using the `if-let` destructuring pattern
+            EthereumEvent::UpdateBridgeWhitelist { .. } => {
+                // TODO: check nonce of whitelist update;
+                // for this, we need to store the nonce of
+                // whitelist updates somewhere
             }
             // consider other ethereum event kinds valid
             _ => {}

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -596,7 +596,7 @@ mod test_vote_extensions {
     fn test_get_eth_events() {
         let (mut shell, _, oracle, _) = setup();
         let event_1 = EthereumEvent::TransfersToEthereum {
-            nonce: 1.into(),
+            nonce: 0.into(),
             transfers: vec![TransferToEthereum {
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
@@ -609,7 +609,7 @@ mod test_vote_extensions {
             relayer: gen_established_address(),
         };
         let event_2 = EthereumEvent::TransfersToEthereum {
-            nonce: 2.into(),
+            nonce: 1.into(),
             transfers: vec![TransferToEthereum {
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
@@ -660,7 +660,7 @@ mod test_vote_extensions {
             .expect("Test failed")
             .clone();
         let event_1 = EthereumEvent::TransfersToEthereum {
-            nonce: 1.into(),
+            nonce: 0.into(),
             transfers: vec![TransferToEthereum {
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
@@ -722,7 +722,7 @@ mod test_vote_extensions {
         #[allow(clippy::redundant_clone)]
         let ethereum_events = ethereum_events::Vext {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
-                nonce: 1.into(),
+                nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
                     amount: 100.into(),
                     sender: gen_established_address(),
@@ -895,7 +895,7 @@ mod test_vote_extensions {
         #[allow(clippy::redundant_clone)]
         let mut ethereum_events = ethereum_events::Vext {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
-                nonce: 1.into(),
+                nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
                     amount: 100.into(),
                     sender: gen_established_address(),
@@ -973,7 +973,7 @@ mod test_vote_extensions {
         #[allow(clippy::redundant_clone)]
         let vote_ext = ethereum_events::Vext {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
-                nonce: 1.into(),
+                nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
                     amount: 100.into(),
                     sender: gen_established_address(),

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -143,6 +143,9 @@ where
     /// Validate a batch of Ethereum events contained in
     /// an [`ethereum_events::Vext`].
     ///
+    /// The supplied Ethereum events must be ordered in
+    /// ascending ordering, and must not contain any dupes.
+    ///
     /// A detailed description of the validation applied
     /// to each event kind can be found in the docstring
     /// of [`Shell::validate_eth_event`].

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -202,17 +202,34 @@ where
                 let current_bp_nonce =
                     self.wl_storage.ethbridge_queries().get_bridge_pool_nonce();
                 if &current_bp_nonce != ext_nonce {
-                    return Err(VoteExtensionError::OutdatedBpNonce);
+                    tracing::debug!(
+                        %current_bp_nonce,
+                        %ext_nonce,
+                        "The Ethereum events vote extension's BP nonce is \
+                         invalid"
+                    );
+                    return Err(VoteExtensionError::InvalidBpNonce);
                 }
                 // TODO: maybe perform additional checks:
                 // - some token asset is not whitelisted
                 // - do we have enough balance for the transfer
             }
-            EthereumEvent::TransfersToNamada { .. } => {
-                // TODO: check nonce of transfers to namada;
-                // for this, we need to store the nonce of
-                // these transfers somewhere
-
+            EthereumEvent::TransfersToNamada {
+                nonce: ext_nonce, ..
+            } => {
+                let current_nam_nonce = self
+                    .wl_storage
+                    .ethbridge_queries()
+                    .get_namada_transfers_nonce();
+                if &current_nam_nonce != ext_nonce {
+                    tracing::debug!(
+                        %current_nam_nonce,
+                        %ext_nonce,
+                        "The Ethereum events vote extension's transfer to \
+                         Namada nonce is invalid"
+                    );
+                    return Err(VoteExtensionError::InvalidNamNonce);
+                }
                 // TODO: maybe perform additional checks:
                 // - some token asset is not whitelisted
                 // - do we have enough balance for the transfer

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -201,6 +201,11 @@ where
                 if &current_bp_nonce != ext_nonce {
                     return Err(VoteExtensionError::OutdatedBpNonce);
                 }
+
+                // TODO: check if token is not whitelisted
+            }
+            EthereumEvent::TransfersToNamada { .. } => {
+                // TODO: check if token is not whitelisted
             }
             EthereumEvent::ValidatorSetUpdate { .. } => {
                 // no validation required. this is only here

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -501,15 +501,7 @@ mod test_vote_extensions {
             .write(&bridge_pool::get_nonce_key(), nonce.try_to_vec().unwrap())
             .expect("Test failed");
 
-        // write nam nonce to storage
-        shell
-            .wl_storage
-            .storage
-            .write(
-                &bridge_pool::get_namada_transfers_nonce_key(),
-                nonce.try_to_vec().unwrap(),
-            )
-            .expect("Test failed");
+        // TODO: write nam nonce to storage
 
         // eth transfers with the same nonce as the bp nonce in storage are
         // valid

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -197,8 +197,20 @@ where
     ) -> std::result::Result<(), VoteExtensionError> {
         match event {
             EthereumEvent::TransfersToEthereum {
-                nonce: ext_nonce, ..
+                nonce: ext_nonce,
+                transfers,
+                valid_transfers_map,
+                ..
             } => {
+                if transfers.len() != valid_transfers_map.len() {
+                    tracing::debug!(
+                        transfers_len = transfers.len(),
+                        valid_transfers_map_len = valid_transfers_map.len(),
+                        "{}",
+                        VoteExtensionError::TransfersLenMismatch
+                    );
+                    return Err(VoteExtensionError::TransfersLenMismatch);
+                }
                 let current_bp_nonce =
                     self.wl_storage.ethbridge_queries().get_bridge_pool_nonce();
                 if &current_bp_nonce != ext_nonce {
@@ -215,8 +227,20 @@ where
                 // - do we have enough balance for the transfer
             }
             EthereumEvent::TransfersToNamada {
-                nonce: ext_nonce, ..
+                nonce: ext_nonce,
+                transfers,
+                valid_transfers_map,
+                ..
             } => {
+                if transfers.len() != valid_transfers_map.len() {
+                    tracing::debug!(
+                        transfers_len = transfers.len(),
+                        valid_transfers_map_len = valid_transfers_map.len(),
+                        "{}",
+                        VoteExtensionError::TransfersLenMismatch
+                    );
+                    return Err(VoteExtensionError::TransfersLenMismatch);
+                }
                 let current_nam_nonce = self
                     .wl_storage
                     .ethbridge_queries()

--- a/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -2,15 +2,18 @@
 //!
 //! The current storage tree is:
 //! - `chain_id`
+//! - `ethereum_height`: the height of the last eth block processed by the
+//!   oracle
+//! - `eth_events_queue`: a queue of confirmed ethereum events to be processed
+//!   in order
 //! - `height`: the last committed block height
 //! - `tx_queue`: txs to be decrypted in the next block
-//! - `pred`: predecessor values of the top-level keys of the same name
-//!   - `tx_queue`
 //! - `next_epoch_min_start_height`: minimum block height from which the next
 //!   epoch can start
 //! - `next_epoch_min_start_time`: minimum block time from which the next epoch
 //!   can start
 //! - `pred`: predecessor values of the top-level keys of the same name
+//!   - `tx_queue`
 //!   - `next_epoch_min_start_height`
 //!   - `next_epoch_min_start_time`
 //! - `subspace`: accounts sub-spaces

--- a/core/src/ledger/eth_bridge/storage/bridge_pool.rs
+++ b/core/src/ledger/eth_bridge/storage/bridge_pool.rs
@@ -20,6 +20,7 @@ pub const BRIDGE_POOL_ADDRESS: Address =
 /// Sub-segment for getting the latest signed
 const SIGNED_ROOT_SEG: &str = "signed_root";
 const NONCE: &str = "bridge_pool_nonce";
+const TRANSFERS_TO_NAMADA_NONCE: &str = "transfers_to_namada_nonce";
 
 #[derive(thiserror::Error, Debug)]
 #[error(transparent)]
@@ -59,6 +60,20 @@ pub fn get_nonce_key() -> Key {
         segments: vec![
             DbKeySeg::AddressSeg(BRIDGE_POOL_ADDRESS),
             DbKeySeg::StringSeg(NONCE.into()),
+        ],
+    }
+}
+
+/// Get the storage key of the nonce emitted by the
+/// Ethereum bridge smart contract for transfers to
+/// Namada.
+///
+/// This nonce is used for replay protection.
+pub fn get_namada_transfers_nonce_key() -> Key {
+    Key {
+        segments: vec![
+            DbKeySeg::AddressSeg(BRIDGE_POOL_ADDRESS),
+            DbKeySeg::StringSeg(TRANSFERS_TO_NAMADA_NONCE.into()),
         ],
     }
 }

--- a/core/src/ledger/eth_bridge/storage/bridge_pool.rs
+++ b/core/src/ledger/eth_bridge/storage/bridge_pool.rs
@@ -24,7 +24,6 @@ pub const BRIDGE_POOL_ADDRESS: Address =
 struct Segments {
     signed_root: &'static str,
     bridge_pool_nonce: &'static str,
-    transfers_to_namada_nonce: &'static str,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -65,22 +64,6 @@ pub fn get_nonce_key() -> Key {
         segments: vec![
             DbKeySeg::AddressSeg(BRIDGE_POOL_ADDRESS),
             DbKeySeg::StringSeg(Segments::VALUES.bridge_pool_nonce.into()),
-        ],
-    }
-}
-
-/// Get the storage key of the nonce emitted by the
-/// Ethereum bridge smart contract for transfers to
-/// Namada.
-///
-/// This nonce is used for replay protection.
-pub fn get_namada_transfers_nonce_key() -> Key {
-    Key {
-        segments: vec![
-            DbKeySeg::AddressSeg(BRIDGE_POOL_ADDRESS),
-            DbKeySeg::StringSeg(
-                Segments::VALUES.transfers_to_namada_nonce.into(),
-            ),
         ],
     }
 }

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -510,7 +510,7 @@ pub mod testing {
     }
 
     pub fn arbitrary_nonce() -> Uint {
-        123.into()
+        0.into()
     }
 
     pub fn arbitrary_keccak_hash() -> KeccakHash {

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -198,6 +198,45 @@ impl KeySeg for EthAddress {
     }
 }
 
+/// Event transferring batches of ether or Ethereum based ERC20 tokens
+/// from Ethereum to wrapped assets on Namada
+#[derive(
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Hash,
+    Ord,
+    Clone,
+    Debug,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+)]
+pub struct TransfersToNamada {
+    /// Monotonically increasing nonce
+    pub nonce: Uint,
+    /// The batch of transfers
+    pub transfers: Vec<TransferToNamada>,
+    /// The indices of the transfers which succeeded or failed
+    pub valid_transfers_map: Vec<bool>,
+}
+
+impl From<TransfersToNamada> for EthereumEvent {
+    #[inline]
+    fn from(event: TransfersToNamada) -> Self {
+        let TransfersToNamada {
+            nonce,
+            transfers,
+            valid_transfers_map,
+        } = event;
+        Self::TransfersToNamada {
+            nonce,
+            transfers,
+            valid_transfers_map,
+        }
+    }
+}
+
 /// An Ethereum event to be processed by the Namada ledger
 #[derive(
     PartialEq,

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -198,6 +198,12 @@ impl KeySeg for EthAddress {
     }
 }
 
+/// Nonces of Ethereum events.
+pub trait GetEventNonce {
+    /// Returns the nonce of an Ethereum event.
+    fn get_event_nonce(&self) -> Uint;
+}
+
 /// Event transferring batches of ether or Ethereum based ERC20 tokens
 /// from Ethereum to wrapped assets on Namada
 #[derive(
@@ -219,6 +225,13 @@ pub struct TransfersToNamada {
     pub transfers: Vec<TransferToNamada>,
     /// The indices of the transfers which succeeded or failed
     pub valid_transfers_map: Vec<bool>,
+}
+
+impl GetEventNonce for TransfersToNamada {
+    #[inline]
+    fn get_event_nonce(&self) -> Uint {
+        self.nonce
+    }
 }
 
 impl From<TransfersToNamada> for EthereumEvent {

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -2,7 +2,7 @@
 
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
-use std::ops::Add;
+use std::ops::{Add, Sub};
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
@@ -106,6 +106,14 @@ impl Add<u64> for Uint {
 
     fn add(self, rhs: u64) -> Self::Output {
         (ethUint(self.0) + rhs).into()
+    }
+}
+
+impl Sub<u64> for Uint {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        (ethUint(self.0) - rhs).into()
     }
 }
 

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -57,6 +57,12 @@ impl Uint {
         ethUint(self.0).to_little_endian(&mut bytes);
         bytes
     }
+
+    /// Try to increment this [`Uint`], whilst checking
+    /// for overflows.
+    pub fn checked_increment(self) -> Option<Self> {
+        ethUint::from(self).checked_add(1.into()).map(Self::from)
+    }
 }
 
 impl Display for Uint {

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1185,11 +1185,14 @@ impl<E: GetEventNonce> InnerEthEventsQueue<E> {
         &mut self,
         current_nonce: Uint,
         latest_event: E,
-    ) -> Option<E> {
+    ) -> Option<E>
+    where
+        E: std::fmt::Debug,
+    {
         let event_nonce = latest_event.get_event_nonce();
         assert!(
             current_nonce <= event_nonce,
-            "Attempted to replay an Ethereum event"
+            "Attempted to replay an Ethereum event: {latest_event:#?}"
         );
 
         // check if we can process the next event in the queue

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1161,7 +1161,7 @@ pub struct EthEventsQueue {
     // TODO: add queue of update whitelist events
 }
 
-/// A queue of Ethereum events to be processed in order.
+/// A queue of confirmed Ethereum events to be processed in order.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct InnerEthEventsQueue<E> {
     inner: VecDeque<E>,

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::bytes::ByteBuf;
+use crate::hints;
 use crate::ledger::eth_bridge::storage::bridge_pool::BridgePoolProof;
 use crate::types::address::{self, Address};
 use crate::types::ethereum_events::{GetEventNonce, TransfersToNamada, Uint};
@@ -1265,6 +1266,7 @@ impl<E: GetEventNonce> InnerEthEventsQueue<E> {
                 // the event is already present in the queue... this is
                 // certainly a protocol error
                 |_| {
+                    hints::cold();
                     unreachable!(
                         "An event with an identical nonce was already present \
                          in the EthEventsQueue"

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1372,10 +1372,10 @@ mod tests {
         let mut queue = EthEventsQueue::default();
         queue.transfers_to_namada.next_nonce_to_process = 1u64.into();
 
-        let new_event_4 = TransfersToNamada {
+        let new_event_1 = TransfersToNamada {
             valid_transfers_map: vec![],
             transfers: vec![],
-            nonce: 4u64.into(),
+            nonce: 1u64.into(),
         };
         let new_event_2 = TransfersToNamada {
             valid_transfers_map: vec![],
@@ -1387,10 +1387,15 @@ mod tests {
             transfers: vec![],
             nonce: 3u64.into(),
         };
-        let new_event_1 = TransfersToNamada {
+        let new_event_4 = TransfersToNamada {
             valid_transfers_map: vec![],
             transfers: vec![],
-            nonce: 1u64.into(),
+            nonce: 4u64.into(),
+        };
+        let new_event_7 = TransfersToNamada {
+            valid_transfers_map: vec![],
+            transfers: vec![],
+            nonce: 7u64.into(),
         };
 
         // enqueue events
@@ -1415,12 +1420,20 @@ mod tests {
                 .next()
                 .is_none()
         );
+        assert!(
+            queue
+                .transfers_to_namada
+                .get_next_events(new_event_7.clone())
+                .next()
+                .is_none()
+        );
         assert_eq!(
             &queue.transfers_to_namada.inner,
             &[
                 new_event_2.clone(),
                 new_event_3.clone(),
-                new_event_4.clone()
+                new_event_4.clone(),
+                new_event_7.clone()
             ]
         );
 
@@ -1432,10 +1445,16 @@ mod tests {
                 .get_next_events(new_event_1)
                 .collect::<Vec<_>>()
         );
-        assert!(queue.transfers_to_namada.pop_event().is_none());
 
         // check the next nonce to process
         assert_eq!(queue.transfers_to_namada.get_event_nonce(), 5u64.into());
+
+        // one remaining event with nonce 7
+        assert_eq!(
+            queue.transfers_to_namada.pop_event().expect("Test failed"),
+            new_event_7
+        );
+        assert!(queue.transfers_to_namada.pop_event().is_none());
     }
 
     #[test]

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1256,14 +1256,20 @@ impl<E: GetEventNonce> InnerEthEventsQueue<E> {
 
     /// Push a new transfer to Namada event to the queue.
     #[inline]
-    fn push_event(&mut self, new_event: E) {
+    fn push_event(&mut self, new_event: E)
+    where
+        E: std::fmt::Debug,
+    {
         self.inner
             .binary_search_by_key(
                 &new_event.get_event_nonce(),
                 |event_in_queue| event_in_queue.get_event_nonce(),
             )
             .map_or_else(
-                |insert_at| self.inner.insert(insert_at, new_event),
+                |insert_at| {
+                    tracing::debug!(?new_event, "Queueing Ethereum event");
+                    self.inner.insert(insert_at, new_event)
+                },
                 // the event is already present in the queue... this is
                 // certainly a protocol error
                 |_| {

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1238,11 +1238,9 @@ impl<E: GetEventNonce> Iterator for EthEventsQueueIter<'_, E> {
 }
 
 impl<E: GetEventNonce> InnerEthEventsQueue<E> {
-    /// Retrieve the next events to be processed, if any.
-    ///
-    /// This decision is based on the nonce of the next event to be
-    /// processed by the ledger, and the nonce of the event that was just
-    /// confirmed (i.e. achieved a quorum of votes behind it).
+    /// Push a new Ethereum event of type `E` into the queue,
+    /// and return a draining iterator over the next events to
+    /// be processed, if any.
     pub fn get_next_events(
         &mut self,
         latest_event: E,

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1168,6 +1168,16 @@ pub struct InnerEthEventsQueue<E> {
     inner: VecDeque<E>,
 }
 
+impl<E: GetEventNonce> InnerEthEventsQueue<E> {
+    /// Return an Ethereum events queue starting at the specified nonce.
+    pub fn new_at(next_nonce_to_process: Uint) -> Self {
+        Self {
+            next_nonce_to_process,
+            ..Default::default()
+        }
+    }
+}
+
 impl<E: GetEventNonce> Default for InnerEthEventsQueue<E> {
     fn default() -> Self {
         Self {

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1151,6 +1151,14 @@ pub struct PrefixValue {
     pub value: Vec<u8>,
 }
 
+/// A queue of Ethereum events to be processed
+/// in order.
+#[derive(Default, Debug, BorshSerialize, BorshDeserialize, BorshSchema)]
+pub struct EthEventsQueue {
+    // TODO: change this field to an actual queue
+    inner: (),
+}
+
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1323,7 +1323,7 @@ mod tests {
     #[test]
     fn test_eth_events_queue_enqueue() {
         let mut queue = EthEventsQueue::default();
-        let mut nam_nonce = 1u64.into();
+        let nam_nonce = 1u64.into();
 
         let new_event_4 = TransfersToNamada {
             valid_transfers_map: vec![],
@@ -1379,23 +1379,10 @@ mod tests {
             Some(new_event_1.clone()),
             queue.transfers_to_namada.get_next(nam_nonce, new_event_1)
         );
-        nam_nonce = nam_nonce + 1;
-        assert_eq!(
-            Some(new_event_2.clone()),
-            queue.transfers_to_namada.get_next(nam_nonce, new_event_2)
-        );
-        nam_nonce = nam_nonce + 1;
-        assert_eq!(
-            Some(new_event_3.clone()),
-            queue.transfers_to_namada.get_next(nam_nonce, new_event_3)
-        );
-        nam_nonce = nam_nonce + 1;
-        assert_eq!(
-            Some(new_event_4.clone()),
-            queue.transfers_to_namada.get_next(nam_nonce, new_event_4)
-        );
-
-        assert!(queue.transfers_to_namada.inner.is_empty());
+        assert_eq!(Some(new_event_2), queue.transfers_to_namada.pop_event());
+        assert_eq!(Some(new_event_3), queue.transfers_to_namada.pop_event());
+        assert_eq!(Some(new_event_4), queue.transfers_to_namada.pop_event());
+        assert!(queue.transfers_to_namada.pop_event().is_none());
     }
 
     #[test]

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1210,8 +1210,14 @@ impl EthEventsQueue {
                 |insert_at| {
                     self.transfers_to_namada.insert(insert_at, new_event)
                 },
-                // the event is already in the queue, so we drop it
-                |_| {},
+                // the event is already present in the queue... this is
+                // certainly a protocol error
+                |_| {
+                    unreachable!(
+                        "An event with an identical nonce was already present \
+                         in the EthEventsQueue"
+                    )
+                },
             )
     }
 

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1293,7 +1293,7 @@ mod tests {
             transfers: vec![],
             nonce: 2u64.into(),
         };
-        queue.get_next_nam_transfer(nam_nonce, new_event.clone());
+        queue.get_next_nam_transfer(nam_nonce, new_event);
     }
 
     /// Test enqueueing transfer to Namada events to

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1241,7 +1241,7 @@ impl<E: GetEventNonce> InnerEthEventsQueue<E> {
     /// Push a new Ethereum event of type `E` into the queue,
     /// and return a draining iterator over the next events to
     /// be processed, if any.
-    pub fn get_next_events(
+    pub fn push_and_iter(
         &mut self,
         latest_event: E,
     ) -> EthEventsQueueIter<'_, E>
@@ -1368,7 +1368,7 @@ mod tests {
         };
         let next_event = queue
             .transfers_to_namada
-            .get_next_events(new_event.clone())
+            .push_and_iter(new_event.clone())
             .next();
         assert_eq!(next_event, Some(new_event));
     }
@@ -1386,7 +1386,7 @@ mod tests {
             transfers: vec![],
             nonce: 2u64.into(),
         };
-        _ = queue.transfers_to_namada.get_next_events(new_event);
+        _ = queue.transfers_to_namada.push_and_iter(new_event);
     }
 
     /// Test enqueueing transfer to Namada events to
@@ -1426,28 +1426,28 @@ mod tests {
         assert!(
             queue
                 .transfers_to_namada
-                .get_next_events(new_event_4.clone())
+                .push_and_iter(new_event_4.clone())
                 .next()
                 .is_none()
         );
         assert!(
             queue
                 .transfers_to_namada
-                .get_next_events(new_event_2.clone())
+                .push_and_iter(new_event_2.clone())
                 .next()
                 .is_none()
         );
         assert!(
             queue
                 .transfers_to_namada
-                .get_next_events(new_event_3.clone())
+                .push_and_iter(new_event_3.clone())
                 .next()
                 .is_none()
         );
         assert!(
             queue
                 .transfers_to_namada
-                .get_next_events(new_event_7.clone())
+                .push_and_iter(new_event_7.clone())
                 .next()
                 .is_none()
         );
@@ -1466,7 +1466,7 @@ mod tests {
             vec![new_event_1.clone(), new_event_2, new_event_3, new_event_4],
             queue
                 .transfers_to_namada
-                .get_next_events(new_event_1)
+                .push_and_iter(new_event_1)
                 .collect::<Vec<_>>()
         );
 

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1234,10 +1234,11 @@ impl<E: GetEventNonce> InnerEthEventsQueue<E> {
         E: std::fmt::Debug,
     {
         let event_nonce = latest_event.get_event_nonce();
-        assert!(
-            self.next_nonce_to_process <= event_nonce,
-            "Attempted to replay an Ethereum event: {latest_event:#?}"
-        );
+        if hints::unlikely(self.next_nonce_to_process > event_nonce) {
+            unreachable!(
+                "Attempted to replay an Ethereum event: {latest_event:#?}"
+            );
+        }
 
         self.push_event(latest_event);
 

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1240,7 +1240,7 @@ impl<E: GetEventNonce> InnerEthEventsQueue<E> {
             );
         }
 
-        self.push_event(latest_event);
+        self.try_push_event(latest_event);
 
         EthEventsQueueIter {
             current_nonce: self.next_nonce_to_process,
@@ -1254,9 +1254,12 @@ impl<E: GetEventNonce> InnerEthEventsQueue<E> {
         self.inner.front().map(GetEventNonce::get_event_nonce)
     }
 
-    /// Push a new transfer to Namada event to the queue.
+    /// Attempt to push a new Ethereum event to the queue.
+    ///
+    /// This operation may panic if a confirmed event is
+    /// already present in the queue.
     #[inline]
-    fn push_event(&mut self, new_event: E)
+    fn try_push_event(&mut self, new_event: E)
     where
         E: std::fmt::Debug,
     {

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1222,7 +1222,7 @@ impl<E: GetEventNonce> Iterator for EthEventsQueueIter<'_, E> {
 impl<E: GetEventNonce> InnerEthEventsQueue<E> {
     /// Retrieve the next events to be processed, if any.
     ///
-    /// This decision is based on the nonce of the last event that has been
+    /// This decision is based on the nonce of the next event to be
     /// processed by the ledger, and the nonce of the event that was just
     /// confirmed (i.e. achieved a quorum of votes behind it).
     pub fn get_next_events(

--- a/ethereum_bridge/src/bridge_pool_vp.rs
+++ b/ethereum_bridge/src/bridge_pool_vp.rs
@@ -1,5 +1,5 @@
 use namada_core::ledger::eth_bridge::storage::bridge_pool::{
-    get_namada_transfers_nonce_key, get_nonce_key, BRIDGE_POOL_ADDRESS,
+    get_nonce_key, BRIDGE_POOL_ADDRESS,
 };
 use namada_core::ledger::storage::{DBIter, StorageHasher, WlStorage, DB};
 use namada_core::ledger::storage_api::StorageWrite;
@@ -23,7 +23,4 @@ where
     wl_storage
         .write(&get_nonce_key(), Uint::from(0))
         .expect("Initializing the Bridge pool nonce shouldn't fail.");
-    wl_storage
-        .write(&get_namada_transfers_nonce_key(), Uint::from(0))
-        .expect("Initializing the Namada transfers nonce shouldn't fail.");
 }

--- a/ethereum_bridge/src/bridge_pool_vp.rs
+++ b/ethereum_bridge/src/bridge_pool_vp.rs
@@ -1,6 +1,5 @@
-use borsh::BorshSerialize;
 use namada_core::ledger::eth_bridge::storage::bridge_pool::{
-    get_nonce_key, BRIDGE_POOL_ADDRESS,
+    get_namada_transfers_nonce_key, get_nonce_key, BRIDGE_POOL_ADDRESS,
 };
 use namada_core::ledger::storage::{DBIter, StorageHasher, WlStorage, DB};
 use namada_core::ledger::storage_api::StorageWrite;
@@ -18,23 +17,13 @@ where
     H: StorageHasher,
 {
     let escrow_key = balance_key(&nam(), &BRIDGE_POOL_ADDRESS);
+    wl_storage.write(&escrow_key, Amount::default()).expect(
+        "Initializing the escrow balance of the Bridge pool VP shouldn't fail.",
+    );
     wl_storage
-        .write_bytes(
-            &escrow_key,
-            Amount::default()
-                .try_to_vec()
-                .expect("Serializing an amount shouldn't fail."),
-        )
-        .expect(
-            "Initializing the escrow balance of the Bridge pool VP shouldn't \
-             fail.",
-        );
-    wl_storage
-        .write_bytes(
-            &get_nonce_key(),
-            Uint::from(0)
-                .try_to_vec()
-                .expect("Serializing a Uint should not fail."),
-        )
+        .write(&get_nonce_key(), Uint::from(0))
         .expect("Initializing the Bridge pool nonce shouldn't fail.");
+    wl_storage
+        .write(&get_namada_transfers_nonce_key(), Uint::from(0))
+        .expect("Initializing the Namada transfers nonce shouldn't fail.");
 }

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -92,7 +92,7 @@ where
         .storage
         .eth_events_queue
         .transfers_to_namada
-        .get_next_events(transfer_event)
+        .push_and_iter(transfer_event)
         .collect();
     for TransfersToNamada {
         transfers,

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -137,15 +137,14 @@ where
     H: 'static + StorageHasher + Sync,
 {
     let eth_msg_keys = vote_tallies::Keys::from(&update.body);
-    let exists_in_storage = 'exists: {
-        let Some(seen) = votes::storage::maybe_read_seen(wl_storage, &eth_msg_keys)? else {
-            break 'exists false;
-        };
+    let exists_in_storage =  if let Some(seen) = votes::storage::maybe_read_seen(wl_storage, &eth_msg_keys)? {
         if seen {
             tracing::debug!(?update, "Ethereum event is already seen");
             return Ok((ChangedKeys::default(), false));
         }
         true
+    } else {
+        false
     };
 
     let (vote_tracking, changed, confirmed, already_present) =

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -68,7 +68,7 @@ where
 
     let mut changed_keys = apply_updates(wl_storage, updates, voting_powers)?;
 
-    changed_keys.extend(timeout_events(wl_storage)?);
+    changed_keys.append(&mut timeout_events(wl_storage)?);
 
     Ok(TxResult {
         changed_keys,

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -137,7 +137,9 @@ where
     H: 'static + StorageHasher + Sync,
 {
     let eth_msg_keys = vote_tallies::Keys::from(&update.body);
-    let exists_in_storage =  if let Some(seen) = votes::storage::maybe_read_seen(wl_storage, &eth_msg_keys)? {
+    let exists_in_storage = if let Some(seen) =
+        votes::storage::maybe_read_seen(wl_storage, &eth_msg_keys)?
+    {
         if seen {
             tracing::debug!(?update, "Ethereum event is already seen");
             return Ok((ChangedKeys::default(), false));

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -116,7 +116,7 @@ where
 
     // Right now, the order in which events are acted on does not matter.
     // For `TransfersToNamada` events, they can happen in any order.
-    for event in &confirmed {
+    for event in confirmed {
         let mut changed = events::act_on(wl_storage, event)?;
         changed_keys.append(&mut changed);
     }

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -383,7 +383,7 @@ mod tests {
         let receiver = address::testing::established_address_1();
 
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1.into(),
+            nonce: 0.into(),
             valid_transfers_map: vec![true],
             transfers: vec![TransferToNamada {
                 amount: Amount::from(100),
@@ -446,7 +446,7 @@ mod tests {
         let receiver = address::testing::established_address_1();
 
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1.into(),
+            nonce: 0.into(),
             valid_transfers_map: vec![true],
             transfers: vec![TransferToNamada {
                 amount: Amount::from(100),
@@ -498,7 +498,7 @@ mod tests {
         );
 
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1.into(),
+            nonce: 0.into(),
             valid_transfers_map: vec![true],
             transfers: vec![TransferToNamada {
                 amount: Amount::from(100),
@@ -621,7 +621,7 @@ mod tests {
         let receiver = address::testing::established_address_1();
 
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1.into(),
+            nonce: 0.into(),
             valid_transfers_map: vec![true],
             transfers: vec![TransferToNamada {
                 amount: Amount::from(100),
@@ -652,7 +652,7 @@ mod tests {
         wl_storage.storage.block.epoch = wl_storage.storage.last_epoch + 1_u64;
 
         let new_event = EthereumEvent::TransfersToNamada {
-            nonce: 2.into(),
+            nonce: 1.into(),
             valid_transfers_map: vec![true],
             transfers: vec![TransferToNamada {
                 amount: Amount::from(100),

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -7,7 +7,7 @@ use namada_core::ledger::storage;
 use namada_core::ledger::storage::{StoreType, WlStorage};
 use namada_core::ledger::storage_api::StorageRead;
 use namada_core::types::address::Address;
-use namada_core::types::ethereum_events::{EthAddress, Uint};
+use namada_core::types::ethereum_events::{EthAddress, GetEventNonce, Uint};
 use namada_core::types::keccak::KeccakHash;
 use namada_core::types::storage::{BlockHeight, Epoch};
 use namada_core::types::token;
@@ -142,9 +142,13 @@ where
         }
     }
 
-    /// Get the latest transfers to Namada nonce.
-    pub fn get_namada_transfers_nonce(self) -> Uint {
-        todo!()
+    /// Get the nonce of the next transfers to Namada event to be processed.
+    pub fn get_next_nam_transfers_nonce(self) -> Uint {
+        self.wl_storage
+            .storage
+            .eth_events_queue
+            .transfers_to_namada
+            .get_event_nonce()
     }
 
     /// Get the latest nonce for the Ethereum bridge

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -1,7 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use namada_core::ledger::eth_bridge::storage::active_key;
 use namada_core::ledger::eth_bridge::storage::bridge_pool::{
-    get_namada_transfers_nonce_key, get_nonce_key, get_signed_root_key,
+    get_nonce_key, get_signed_root_key,
 };
 use namada_core::ledger::storage;
 use namada_core::ledger::storage::{StoreType, WlStorage};
@@ -144,16 +144,7 @@ where
 
     /// Get the latest transfers to Namada nonce.
     pub fn get_namada_transfers_nonce(self) -> Uint {
-        Uint::try_from_slice(
-            &self
-                .wl_storage
-                .storage
-                .read(&get_namada_transfers_nonce_key())
-                .expect("Reading the Namada transfers nonce shouldn't fail.")
-                .0
-                .expect("Reading the Namada transfers nonce shouldn't fail."),
-        )
-        .expect("Deserializing the nonce from storage should not fail.")
+        todo!()
     }
 
     /// Get the latest nonce for the Ethereum bridge

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -1,7 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use namada_core::ledger::eth_bridge::storage::active_key;
 use namada_core::ledger::eth_bridge::storage::bridge_pool::{
-    get_nonce_key, get_signed_root_key,
+    get_namada_transfers_nonce_key, get_nonce_key, get_signed_root_key,
 };
 use namada_core::ledger::storage;
 use namada_core::ledger::storage::{StoreType, WlStorage};
@@ -140,6 +140,20 @@ where
                 enabled_epoch,
             )) => queried_epoch >= enabled_epoch,
         }
+    }
+
+    /// Get the latest transfers to Namada nonce.
+    pub fn get_namada_transfers_nonce(self) -> Uint {
+        Uint::try_from_slice(
+            &self
+                .wl_storage
+                .storage
+                .read(&get_namada_transfers_nonce_key())
+                .expect("Reading the Namada transfers nonce shouldn't fail.")
+                .0
+                .expect("Reading the Namada transfers nonce shouldn't fail."),
+        )
+        .expect("Deserializing the nonce from storage should not fail.")
     }
 
     /// Get the latest nonce for the Ethereum bridge

--- a/ethereum_bridge/src/storage/vote_tallies.rs
+++ b/ethereum_bridge/src/storage/vote_tallies.rs
@@ -239,11 +239,11 @@ mod test {
         pub(super) fn arbitrary_event_with_hash() -> (EthereumEvent, String) {
             (
                 EthereumEvent::TransfersToNamada {
-                    nonce: 1.into(),
+                    nonce: 0.into(),
                     transfers: vec![],
                     valid_transfers_map: vec![],
                 },
-                "EF11F4E55D73918490B7AB11A9A4E461BBC255BB480E94BA95F959D7147CDE64"
+                "9E1736C43D19118E6CE4302118AF337109491ECC52757DFB949BAD6A7940B0C2"
                     .to_owned(),
             )
         }

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -681,7 +681,7 @@ mod tests {
             ]),
         );
         let event = EthereumEvent::TransfersToNamada {
-            nonce: 1.into(),
+            nonce: 0.into(),
             transfers: vec![TransferToNamada {
                 amount: Amount::from(100),
                 asset: DAI_ERC20_ETH_ADDRESS,

--- a/tests/src/e2e/eth_bridge_tests.rs
+++ b/tests/src/e2e/eth_bridge_tests.rs
@@ -552,7 +552,8 @@ async fn test_dai_transfer_implicit() -> Result<()> {
         receiver: albert_addr.to_owned(),
     };
     let _bg_ledger =
-        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+        send_transfer_to_namada_event(bg_ledger, dai_transfer, 0.into())
+            .await?;
 
     let albert_wdai_balance = find_wrapped_erc20_balance(
         &test,
@@ -590,7 +591,8 @@ async fn test_dai_transfer_established() -> Result<()> {
         receiver: established_addr.to_owned(),
     };
     let _bg_ledger =
-        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+        send_transfer_to_namada_event(bg_ledger, dai_transfer, 0.into())
+            .await?;
 
     let established_wdai_balance = find_wrapped_erc20_balance(
         &test,
@@ -619,7 +621,8 @@ async fn test_wdai_transfer_implicit_unauthorized() -> Result<()> {
         receiver: albert_addr.to_owned(),
     };
     let _bg_ledger =
-        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+        send_transfer_to_namada_event(bg_ledger, dai_transfer, 0.into())
+            .await?;
 
     let albert_wdai_balance = find_wrapped_erc20_balance(
         &test,
@@ -685,7 +688,8 @@ async fn test_wdai_transfer_established_unauthorized() -> Result<()> {
         receiver: albert_established_addr.to_owned(),
     };
     let _bg_ledger =
-        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+        send_transfer_to_namada_event(bg_ledger, dai_transfer, 0.into())
+            .await?;
 
     let albert_wdai_balance = find_wrapped_erc20_balance(
         &test,
@@ -739,7 +743,8 @@ async fn test_wdai_transfer_implicit_to_implicit() -> Result<()> {
         receiver: albert_addr.to_owned(),
     };
     let _bg_ledger =
-        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+        send_transfer_to_namada_event(bg_ledger, dai_transfer, 0.into())
+            .await?;
 
     let albert_wdai_balance = find_wrapped_erc20_balance(
         &test,
@@ -801,7 +806,8 @@ async fn test_wdai_transfer_implicit_to_established() -> Result<()> {
         receiver: albert_addr.to_owned(),
     };
     let _bg_ledger =
-        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+        send_transfer_to_namada_event(bg_ledger, dai_transfer, 0.into())
+            .await?;
 
     let albert_wdai_balance = find_wrapped_erc20_balance(
         &test,
@@ -886,7 +892,8 @@ async fn test_wdai_transfer_established_to_implicit() -> Result<()> {
         receiver: albert_established_addr.to_owned(),
     };
     let _bg_ledger =
-        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+        send_transfer_to_namada_event(bg_ledger, dai_transfer, 0.into())
+            .await?;
 
     let albert_established_wdai_balance = find_wrapped_erc20_balance(
         &test,
@@ -962,7 +969,8 @@ async fn test_wdai_transfer_established_to_established() -> Result<()> {
         receiver: albert_established_addr.to_owned(),
     };
     let _bg_ledger =
-        send_transfer_to_namada_event(bg_ledger, dai_transfer).await?;
+        send_transfer_to_namada_event(bg_ledger, dai_transfer, 0.into())
+            .await?;
 
     let albert_established_wdai_balance = find_wrapped_erc20_balance(
         &test,

--- a/tests/src/e2e/eth_bridge_tests.rs
+++ b/tests/src/e2e/eth_bridge_tests.rs
@@ -436,7 +436,7 @@ async fn test_wnam_transfer() -> Result<()> {
         receiver: address::testing::established_address_1(),
     };
     let transfers = EthereumEvent::TransfersToNamada {
-        nonce: 1.into(),
+        nonce: 0.into(),
         transfers: vec![wnam_transfer.clone()],
         valid_transfers_map: vec![true],
     };

--- a/tests/src/e2e/eth_bridge_tests/helpers.rs
+++ b/tests/src/e2e/eth_bridge_tests/helpers.rs
@@ -12,12 +12,11 @@ use namada::ledger::eth_bridge::{
     MinimumConfirmations, UpgradeableContract,
 };
 use namada::types::address::{wnam, Address};
-use namada::types::ethereum_events::EthAddress;
+use namada::types::ethereum_events::{EthAddress, Uint};
 use namada_apps::config::ethereum_bridge;
 use namada_core::ledger::eth_bridge;
 use namada_core::types::ethereum_events::{EthereumEvent, TransferToNamada};
 use namada_core::types::token;
-use rand::Rng;
 
 use crate::e2e::helpers::{get_actor_rpc, strip_trailing_newline};
 use crate::e2e::setup::{
@@ -133,11 +132,10 @@ pub fn setup_single_validator_test() -> Result<(Test, NamadaBgCmd)> {
 pub async fn send_transfer_to_namada_event(
     bg_ledger: NamadaBgCmd,
     transfer: TransferToNamada,
+    nonce: Uint,
 ) -> Result<NamadaBgCmd> {
-    let mut rng = rand::thread_rng();
-    let nonce: u64 = rng.gen();
     let transfers = EthereumEvent::TransfersToNamada {
-        nonce: nonce.into(),
+        nonce,
         transfers: vec![transfer.clone()],
         valid_transfers_map: vec![true],
     };

--- a/tests/src/e2e/eth_bridge_tests/helpers.rs
+++ b/tests/src/e2e/eth_bridge_tests/helpers.rs
@@ -114,7 +114,7 @@ pub fn setup_single_validator_test() -> Result<(Test, NamadaBgCmd)> {
         &test.net.chain_id,
         &Who::Validator(0),
         ethereum_bridge::ledger::Mode::SelfHostedEndpoint,
-        None,
+        Some(DEFAULT_ETHEREUM_EVENTS_LISTEN_ADDR),
     );
     let mut ledger =
         run_as!(test, Who::Validator(0), Bin::Node, vec!["ledger"], Some(40))?;


### PR DESCRIPTION
* Increment the nonce of the Bridge pool when we process `TransfersToEthereum` Ethereum events
* Increment the nonce of `TransfersToNamada` Ethereum events
* Reject Ethereum events with invalid nonces in `CheckTx` and `ProcessProposal`
* Process `TransfersToNamada` Ethereum events in order

**TODO:** Handle nonces derived from updates to the token whitelist