### PR TITLE
Rename `active` to `consensus` validators

### DIFF
--- a/apps/src/bin/namada-relayer/cli.rs
+++ b/apps/src/bin/namada-relayer/cli.rs
@@ -29,7 +29,7 @@ pub async fn main() -> Result<()> {
             }
         },
         cmds::NamadaRelayer::ValidatorSet(sub) => match sub {
-            cmds::ValidatorSet::ActiveValidatorSet(args) => {
+            cmds::ValidatorSet::ConsensusValidatorSet(args) => {
                 validator_set::query_validator_set_args(args).await;
             }
             cmds::ValidatorSet::ValidatorSetProof(args) => {

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1847,11 +1847,11 @@ pub mod cmds {
     /// Used as sub-commands (`SubCmd` instance) in `namadar` binary.
     #[derive(Clone, Debug)]
     pub enum ValidatorSet {
-        /// Query an Ethereum ABI encoding of the active validator
+        /// Query an Ethereum ABI encoding of the consensus validator
         /// set in Namada, at the given epoch, or the latest
         /// one, if none is provided.
-        ActiveValidatorSet(args::ActiveValidatorSet),
-        /// Query an Ethereum ABI encoding of a proof of the active
+        ConsensusValidatorSet(args::ConsensusValidatorSet),
+        /// Query an Ethereum ABI encoding of a proof of the consensus
         /// validator set in Namada, at the given epoch, or the next
         /// one, if none is provided.
         ValidatorSetProof(args::ValidatorSetProof),
@@ -1865,13 +1865,14 @@ pub mod cmds {
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).and_then(|matches| {
-                let active_validator_set = ActiveValidatorSet::parse(matches)
-                    .map(|args| Self::ActiveValidatorSet(args.0));
+                let consensus_validator_set =
+                    ConsensusValidatorSet::parse(matches)
+                        .map(|args| Self::ConsensusValidatorSet(args.0));
                 let validator_set_proof = ValidatorSetProof::parse(matches)
                     .map(|args| Self::ValidatorSetProof(args.0));
                 let relay = ValidatorSetUpdateRelay::parse(matches)
                     .map(|args| Self::ValidatorSetUpdateRelay(args.0));
-                active_validator_set.or(validator_set_proof).or(relay)
+                consensus_validator_set.or(validator_set_proof).or(relay)
             })
         }
 
@@ -1883,32 +1884,32 @@ pub mod cmds {
                      contracts.",
                 )
                 .setting(AppSettings::SubcommandRequiredElseHelp)
-                .subcommand(ActiveValidatorSet::def().display_order(1))
+                .subcommand(ConsensusValidatorSet::def().display_order(1))
                 .subcommand(ValidatorSetProof::def().display_order(1))
                 .subcommand(ValidatorSetUpdateRelay::def().display_order(1))
         }
     }
 
     #[derive(Clone, Debug)]
-    pub struct ActiveValidatorSet(args::ActiveValidatorSet);
+    pub struct ConsensusValidatorSet(args::ConsensusValidatorSet);
 
-    impl SubCmd for ActiveValidatorSet {
-        const CMD: &'static str = "active";
+    impl SubCmd for ConsensusValidatorSet {
+        const CMD: &'static str = "consensus";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches
-                .subcommand_matches(Self::CMD)
-                .map(|matches| Self(args::ActiveValidatorSet::parse(matches)))
+            matches.subcommand_matches(Self::CMD).map(|matches| {
+                Self(args::ConsensusValidatorSet::parse(matches))
+            })
         }
 
         fn def() -> App {
             App::new(Self::CMD)
                 .about(
-                    "Query an Ethereum ABI encoding of the active validator \
-                     set in Namada, at the requested epoch, or the current \
-                     one, if no epoch is provided.",
+                    "Query an Ethereum ABI encoding of the consensus \
+                     validator set in Namada, at the requested epoch, or the \
+                     current one, if no epoch is provided.",
                 )
-                .add_args::<args::ActiveValidatorSet>()
+                .add_args::<args::ConsensusValidatorSet>()
         }
     }
 
@@ -1927,9 +1928,9 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about(
-                    "Query an Ethereum ABI encoding of a proof of the active \
-                     validator set in Namada, at the requested epoch, or the \
-                     next one, if no epoch is provided.",
+                    "Query an Ethereum ABI encoding of a proof of the \
+                     consensus validator set in Namada, at the requested \
+                     epoch, or the next one, if no epoch is provided.",
                 )
                 .add_args::<args::ValidatorSetProof>()
         }
@@ -2521,14 +2522,14 @@ pub mod args {
     }
 
     #[derive(Debug, Clone)]
-    pub struct ActiveValidatorSet {
+    pub struct ConsensusValidatorSet {
         /// The query parameters.
         pub query: Query,
         /// The epoch to query.
         pub epoch: Option<Epoch>,
     }
 
-    impl Args for ActiveValidatorSet {
+    impl Args for ConsensusValidatorSet {
         fn parse(matches: &ArgMatches) -> Self {
             let query = Query::parse(matches);
             let epoch = EPOCH.parse(matches);
@@ -2536,11 +2537,9 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.add_args::<Query>().arg(
-                EPOCH.def().about(
-                    "The epoch of the active set of validators to query.",
-                ),
-            )
+            app.add_args::<Query>().arg(EPOCH.def().about(
+                "The epoch of the consensus set of validators to query.",
+            ))
         }
     }
 

--- a/apps/src/lib/client/eth_bridge/validator_set.rs
+++ b/apps/src/lib/client/eth_bridge/validator_set.rs
@@ -39,7 +39,7 @@ pub async fn query_validator_set_update_proof(args: args::ValidatorSetProof) {
 }
 
 /// Query an ABI encoding of the validator set at a given epoch.
-pub async fn query_validator_set_args(args: args::ActiveValidatorSet) {
+pub async fn query_validator_set_args(args: args::ConsensusValidatorSet) {
     let client = HttpClient::new(args.query.ledger_address).unwrap();
 
     let epoch = if let Some(epoch) = args.epoch {
@@ -51,7 +51,7 @@ pub async fn query_validator_set_args(args: args::ActiveValidatorSet) {
     let encoded_validator_set_args = RPC
         .shell()
         .eth_bridge()
-        .read_active_valset(&client, &epoch)
+        .read_consensus_valset(&client, &epoch)
         .await
         .unwrap();
 
@@ -244,7 +244,7 @@ where
     let bridge_current_epoch = Epoch(epoch_to_relay.0.saturating_sub(2));
     let shell = RPC.shell().eth_bridge();
     let encoded_validator_set_args_fut =
-        shell.read_active_valset(nam_client, &bridge_current_epoch);
+        shell.read_consensus_valset(nam_client, &bridge_current_epoch);
 
     let shell = RPC.shell().eth_bridge();
     let governance_address_fut = shell.read_governance_contract(nam_client);
@@ -262,7 +262,7 @@ where
         [u8; 32],
         Vec<Signature>,
     ) = abi_decode_struct(encoded_proof);
-    let active_set: ValidatorSetArgs =
+    let consensus_set: ValidatorSetArgs =
         abi_decode_struct(encoded_validator_set_args);
 
     let eth_client =
@@ -270,7 +270,7 @@ where
     let governance = Governance::new(governance_contract.address, eth_client);
 
     let mut relay_op = governance.update_validators_set(
-        active_set,
+        consensus_set,
         bridge_hash,
         gov_hash,
         signatures,

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -203,7 +203,7 @@ where
                 let voting_powers = self
                     .wl_storage
                     .ethbridge_queries()
-                    .get_active_eth_addresses(Some(next_epoch))
+                    .get_consensus_eth_addresses(Some(next_epoch))
                     .iter()
                     .map(|(eth_addr_book, _, voting_power)| {
                         (eth_addr_book, voting_power)
@@ -232,10 +232,10 @@ where
     ///
     /// This checks that the vote extension:
     /// * Correctly deserializes.
-    /// * The Ethereum events vote extension within was correctly signed by an
-    ///   active validator.
+    /// * The Ethereum events vote extension within was correctly signed by a
+    ///   consensus validator.
     /// * The validator set update vote extension within was correctly signed by
-    ///   an active validator, in case it could have been sent at the current
+    ///   a consensus validator, in case it could have been sent at the current
     ///   block height.
     /// * The Ethereum events vote extension block height signed over is correct
     ///   (for replay protection).

--- a/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/bridge_pool_vext.rs
@@ -24,7 +24,7 @@ where
     /// pool root and nonce.
     ///
     /// Checks that at epoch of the provided height:
-    ///  * The inner Namada address corresponds to an active validator.
+    ///  * The inner Namada address corresponds to a consensus validator.
     ///  * Check that the root and nonce are correct.
     ///  * The validator correctly signed the extension.
     ///  * The validator signed over the correct height inside of the extension.

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -28,7 +28,7 @@ where
     /// block height.
     ///
     /// Checks that at epoch of the provided height:
-    ///  * The Tendermint address corresponds to an active validator.
+    ///  * The inner Namada address corresponds to a consensus validator.
     ///  * The validator correctly signed the extension.
     ///  * The validator signed over the correct height inside of the extension.
     ///  * There are no duplicate Ethereum events in this vote extension, and

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -28,7 +28,8 @@ where
     /// To validate a [`validator_set_update::SignedVext`], Namada nodes
     /// check if:
     ///
-    ///  * The signing validator is active during `signing_epoch`.
+    ///  * The signing validator is a consensus validator during
+    ///    `signing_epoch`.
     ///  * The validator correctly signed the extension, with its Ethereum hot
     ///    key.
     ///  * The validator signed over the epoch inside of the extension, whose
@@ -93,7 +94,7 @@ where
         for (eth_addr_book, namada_addr, namada_power) in self
             .wl_storage
             .ethbridge_queries()
-            .get_active_eth_addresses(Some(signing_epoch.next()))
+            .get_consensus_eth_addresses(Some(signing_epoch.next()))
             .iter()
         {
             let &ext_power = match ext.data.voting_powers.get(&eth_addr_book) {
@@ -357,7 +358,7 @@ mod test_vote_extensions {
             shell
                 .wl_storage
                 .ethbridge_queries()
-                .get_active_eth_addresses(Some(next_epoch))
+                .get_consensus_eth_addresses(Some(next_epoch))
                 .iter()
                 .map(|(eth_addr_book, _, voting_power)| {
                     (eth_addr_book, voting_power)
@@ -444,7 +445,7 @@ mod test_vote_extensions {
             shell
                 .wl_storage
                 .ethbridge_queries()
-                .get_active_eth_addresses(Some(next_epoch))
+                .get_consensus_eth_addresses(Some(next_epoch))
                 .iter()
                 .map(|(eth_addr_book, _, voting_power)| {
                     (eth_addr_book, voting_power)
@@ -534,7 +535,7 @@ mod test_vote_extensions {
             shell
                 .wl_storage
                 .ethbridge_queries()
-                .get_active_eth_addresses(Some(next_epoch))
+                .get_consensus_eth_addresses(Some(next_epoch))
                 .iter()
                 .map(|(eth_addr_book, _, voting_power)| {
                     (eth_addr_book, voting_power)
@@ -624,7 +625,7 @@ mod test_vote_extensions {
                 shell
                     .wl_storage
                     .ethbridge_queries()
-                    .get_active_eth_addresses(Some(next_epoch))
+                    .get_consensus_eth_addresses(Some(next_epoch))
                     .iter()
                     .map(|(eth_addr_book, _, voting_power)| {
                         (eth_addr_book, voting_power)
@@ -702,10 +703,10 @@ mod test_vote_extensions {
     }
 
     /// Test if a [`validator_set_update::Vext`] is signed with a secp key
-    /// that belongs to an active validator of some previous epoch
+    /// that belongs to a consensus validator of some previous epoch
     #[test]
     #[ignore]
-    fn test_secp_key_belongs_to_active_validator() {
+    fn test_secp_key_belongs_to_consensus_validator() {
         // TODO: we need to prove ownership of validator keys
         // https://github.com/anoma/namada/issues/106
     }

--- a/core/src/types/vote_extensions/ethereum_events.rs
+++ b/core/src/types/vote_extensions/ethereum_events.rs
@@ -18,12 +18,11 @@ pub type Vext = EthereumEventsVext;
 /// a Namada protocol key.
 pub type SignedVext = Signed<Vext>;
 
-/// Represents a set of [`EthereumEvent`] instances
-/// seen by some validator.
+/// Represents a set of [`EthereumEvent`] instances seen by some validator.
 ///
-/// This struct will be created and signed over by each
-/// active validator, to be included as a vote extension at the end of a
-/// Tendermint PreCommit phase.
+/// This struct will be created and signed over by each consensus validator,
+/// to be included as a vote extension at the end of a Tendermint PreCommit
+/// phase.
 #[derive(
     Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema,
 )]

--- a/core/src/types/vote_extensions/validator_set_update.rs
+++ b/core/src/types/vote_extensions/validator_set_update.rs
@@ -32,7 +32,7 @@ pub type VextDigest = ValidatorSetUpdateVextDigest;
     Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, BorshSchema,
 )]
 pub struct ValidatorSetUpdateVextDigest {
-    /// A mapping from an active validator address to a [`Signature`].
+    /// A mapping from a consensus validator address to a [`Signature`].
     pub signatures: HashMap<Address, Signature>,
     /// The addresses of the validators in the new [`Epoch`],
     /// and their respective voting power.
@@ -309,7 +309,8 @@ pub struct ValidatorSetArgs {
     pub validators: Vec<EthAddress>,
     /// The voting powers of the validators.
     pub voting_powers: Vec<EthBridgeVotingPower>,
-    /// The epoch when the validators were active.
+    /// The epoch when the validators were part of
+    /// the consensus set of validators.
     ///
     /// Serves as a nonce.
     pub epoch: Epoch,

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -38,9 +38,9 @@ impl utils::GetVoters for HashSet<EthMsgUpdate> {
 }
 
 /// Applies derived state changes to storage, based on Ethereum `events` which
-/// were newly seen by some active validator(s). For `events`
-/// which have been seen by enough voting power ( > 2/3 ), extra state changes
-/// may take place, such as minting of wrapped ERC20s.
+/// were newly seen by some consensus validator(s). For `events` which have
+/// been seen by enough voting power (`>= 2/3`), extra state changes may take
+/// place, such as minting of wrapped ERC20s.
 ///
 /// This function is deterministic based on some existing blockchain state and
 /// the passed `events`.

--- a/ethereum_bridge/src/test_utils.rs
+++ b/ethereum_bridge/src/test_utils.rs
@@ -121,11 +121,11 @@ pub fn stored_keys_count(wl_storage: &TestWlStorage) -> usize {
 /// Set up a [`TestWlStorage`] initialized at genesis with the given
 /// validators.
 pub fn setup_storage_with_validators(
-    active_validators: HashMap<Address, token::Amount>,
+    consensus_validators: HashMap<Address, token::Amount>,
 ) -> (TestWlStorage, HashMap<Address, TestValidatorKeys>) {
     let mut wl_storage = TestWlStorage::default();
     let all_keys =
-        init_storage_with_validators(&mut wl_storage, active_validators);
+        init_storage_with_validators(&mut wl_storage, consensus_validators);
     (wl_storage, all_keys)
 }
 
@@ -133,29 +133,30 @@ pub fn setup_storage_with_validators(
 /// validators.
 pub fn init_storage_with_validators(
     wl_storage: &mut TestWlStorage,
-    active_validators: HashMap<Address, token::Amount>,
+    consensus_validators: HashMap<Address, token::Amount>,
 ) -> HashMap<Address, TestValidatorKeys> {
     // set last height to a reasonable value;
     // it should allow vote extensions to be cast
     wl_storage.storage.last_height = 3.into();
 
     let mut all_keys = HashMap::new();
-    let validators = active_validators.into_iter().map(|(address, tokens)| {
-        let keys = TestValidatorKeys::generate();
-        let consensus_key = keys.consensus.ref_to();
-        let eth_cold_key = keys.eth_gov.ref_to();
-        let eth_hot_key = keys.eth_bridge.ref_to();
-        all_keys.insert(address.clone(), keys);
-        GenesisValidator {
-            address,
-            tokens,
-            consensus_key,
-            eth_cold_key,
-            eth_hot_key,
-            commission_rate: dec!(0.05),
-            max_commission_rate_change: dec!(0.01),
-        }
-    });
+    let validators =
+        consensus_validators.into_iter().map(|(address, tokens)| {
+            let keys = TestValidatorKeys::generate();
+            let consensus_key = keys.consensus.ref_to();
+            let eth_cold_key = keys.eth_gov.ref_to();
+            let eth_hot_key = keys.eth_bridge.ref_to();
+            all_keys.insert(address.clone(), keys);
+            GenesisValidator {
+                address,
+                tokens,
+                consensus_key,
+                eth_cold_key,
+                eth_hot_key,
+                commission_rate: dec!(0.05),
+                max_commission_rate_change: dec!(0.01),
+            }
+        });
 
     namada_proof_of_stake::init_genesis(
         wl_storage,


### PR DESCRIPTION
This should make our validator set naming schemes consistent with `main`.