### PR TITLE
Refactor Bridge pool VP

### DIFF
--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -84,9 +84,9 @@ where
         }
     }
 
-    /// Check that the correct amount of wrapper erc20s were
-    /// sent from the correct account into escrow
-    fn check_werc20s_escrowed(
+    /// Check that the correct amount of erc20 assets were
+    /// sent from the correct account into escrow.
+    fn check_erc20s_escrowed(
         &self,
         keys_changed: &BTreeSet<Key>,
         transfer: &PendingTransfer,
@@ -363,7 +363,7 @@ where
                     ok
                 })
         } else {
-            self.check_werc20s_escrowed(keys_changed, &transfer)
+            self.check_erc20s_escrowed(keys_changed, &transfer)
         }
     }
 }


### PR DESCRIPTION
Fix a bug in the Bridge pool's `escrow_check` method(*) and refactor the VP code a bit, for clarity.

(*) The code path of the bug was not being triggered. The logic of this method was faulty nonetheless.