### PR TITLE
Accept validator set updates from previous epochs

### DIFF
--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -180,26 +180,19 @@ where
     pub fn extend_vote_with_valset_update(
         &mut self,
     ) -> Option<validator_set_update::SignedVext> {
-        let next_epoch = self.wl_storage.storage.get_current_epoch().0.next();
-
-        if !self
-            .wl_storage
-            .ethbridge_queries()
-            .is_bridge_active_at(next_epoch)
-        {
-            return None;
-        }
-
-        let validator_addr = self
-            .mode
-            .get_validator_address()
-            .expect(VALIDATOR_EXPECT_MSG)
-            .to_owned();
-
         self.wl_storage
             .ethbridge_queries()
             .must_send_valset_upd(SendValsetUpd::Now)
             .then(|| {
+                let next_epoch =
+                    self.wl_storage.storage.get_current_epoch().0.next();
+
+                let validator_addr = self
+                    .mode
+                    .get_validator_address()
+                    .expect(VALIDATOR_EXPECT_MSG)
+                    .to_owned();
+
                 let voting_powers = self
                     .wl_storage
                     .ethbridge_queries()

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -28,7 +28,7 @@ where
     /// To validate a [`validator_set_update::SignedVext`], Namada nodes
     /// check if:
     ///
-    ///  * The signing validator is a consensus validator during the value of
+    ///  * The signing validator is a consensus validator during the epoch
     ///    `signing_epoch` inside the extension.
     ///  * A validator set update proof is not available yet for
     ///    `signing_epoch`.

--- a/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/val_set_update.rs
@@ -60,19 +60,6 @@ where
         (token::Amount, validator_set_update::SignedVext),
         VoteExtensionError,
     > {
-        if !self
-            .wl_storage
-            .ethbridge_queries()
-            .is_bridge_active_at(ext.data.signing_epoch.next())
-        {
-            let next_epoch = ext.data.signing_epoch.next();
-            tracing::debug!(
-                ?next_epoch,
-                "The Ethereum bridge was not enabled when the valset
-                 upd's vote extension was cast",
-            );
-            return Err(VoteExtensionError::EthereumBridgeInactive);
-        }
         if self.wl_storage.storage.last_height.0 == 0 {
             tracing::debug!(
                 "Dropping validator set update vote extension issued at \

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -634,12 +634,6 @@ mod tests {
                 name: "bridge".to_string(),
                 address: arbitrary_eth_address(),
             },
-            EthereumEvent::TransfersToEthereum {
-                nonce: arbitrary_nonce(),
-                transfers: vec![],
-                valid_transfers_map: vec![],
-                relayer: gen_implicit_address(),
-            },
             EthereumEvent::UpdateBridgeWhitelist {
                 nonce: arbitrary_nonce(),
                 whitelist: vec![],
@@ -813,6 +807,8 @@ mod tests {
     /// we act on a TransfersToEthereum
     fn test_act_on_timeout_for_transfers_to_eth() {
         let mut wl_storage = TestWlStorage::default();
+        test_utils::bootstrap_ethereum_bridge(&mut wl_storage);
+        wl_storage.commit_block().expect("Test failed");
         init_storage(&mut wl_storage);
         // Height 0
         let pending_transfers = init_bridge_pool(&mut wl_storage);
@@ -857,7 +853,9 @@ mod tests {
                 .iter_prefix(&prefix)
                 .expect("Test failed")
                 .count(),
-            1
+            // NOTE: we should have two writes -- one of them being
+            // the bridge pool nonce update
+            2
         );
 
         // Check the gas fee

--- a/shared/src/ledger/queries/shell/eth_bridge.rs
+++ b/shared/src/ledger/queries/shell/eth_bridge.rs
@@ -426,11 +426,7 @@ where
         )));
     }
 
-    let valset_upd_keys = vote_tallies::Keys::from(&epoch);
-
-    let seen = StorageRead::read(ctx.wl_storage, &valset_upd_keys.seen())?
-        .unwrap_or(false);
-    if !seen {
+    if !ctx.wl_storage.ethbridge_queries().valset_upd_seen(epoch) {
         return Err(storage_api::Error::Custom(CustomError(
             format!(
                 "Validator set update proof is not yet available for the \
@@ -440,6 +436,7 @@ where
         )));
     }
 
+    let valset_upd_keys = vote_tallies::Keys::from(&epoch);
     let proof: EthereumProof<VotingPowersMap> =
         StorageRead::read(ctx.wl_storage, &valset_upd_keys.body())?.expect(
             "EthereumProof is seen in storage, therefore it must exist",


### PR DESCRIPTION
Based on #1302

Partially solve #1291

Allows validator set updates that haven't reached the `seen` state in storage to be accepted into the mempool. This is crucial for the liveness of the Ethereum bridge.

This PR doesn't address creating a CLI command to craft validator set updates to be sent to validators.