### PR TITLE
Install protoc to build with the new prost (3/n) 

### DIFF
--- a/.github/workflows/build-and-test-bridge.yml
+++ b/.github/workflows/build-and-test-bridge.yml
@@ -177,6 +177,8 @@ jobs:
           aws-region: eu-west-1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sccache (ubuntu-20.04)
         if: matrix.os == 'ubuntu-20.04'
         env:
@@ -280,6 +282,8 @@ jobs:
           aws-region: eu-west-1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sccache (ubuntu-20.04)
         if: matrix.os == 'ubuntu-20.04'
         env:
@@ -395,6 +399,8 @@ jobs:
           aws-region: eu-west-1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sccache (ubuntu-20.04)
         if: matrix.os == 'ubuntu-20.04'
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -185,6 +185,8 @@ jobs:
           aws-region: eu-west-1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sccache (ubuntu-20.04)
         if: matrix.os == 'ubuntu-20.04'
         env:
@@ -294,6 +296,8 @@ jobs:
           aws-region: eu-west-1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sccache (ubuntu-20.04)
         if: matrix.os == 'ubuntu-20.04'
         env:
@@ -415,6 +419,8 @@ jobs:
           aws-region: eu-west-1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sccache (ubuntu-20.04)
         if: matrix.os == 'ubuntu-20.04'
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -57,6 +57,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup rust toolchain
         uses: oxidecomputer/actions-rs_toolchain@ad3f86084a8a5acf2c09cb691421b31cf8af7a36
         with:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -62,6 +62,8 @@ jobs:
         run: curl https://i.jpillora.com/${{ matrix.make.version }}! | bash
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: ${{ matrix.make.name }}
         working-directory: ./.github/workflows/scripts
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,6 +80,8 @@ jobs:
           aws-region: eu-west-1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sccache (ubuntu-20.04)
         if: matrix.os == 'ubuntu-20.04'
         env:
@@ -172,6 +174,8 @@ jobs:
           aws-region: eu-west-1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sccache (ubuntu-20.04)
         if: matrix.os == 'ubuntu-20.04'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
           aws-region: eu-west-1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install sccache (ubuntu-20.04)
         if: matrix.os == 'ubuntu-20.04'
         env:


### PR DESCRIPTION
follow-up to #1306 

added GITHUB_TOKEN to protoc installation to avoid GH API rate limit as per https://github.com/arduino/setup-protoc/issues/63