### PR TITLE
RocksDB optimization

### DIFF
--- a/apps/src/lib/node/ledger/storage/mod.rs
+++ b/apps/src/lib/node/ledger/storage/mod.rs
@@ -202,7 +202,8 @@ mod tests {
                 .expect("write failed");
             expected.push((key.to_string(), value_bytes));
         }
-        storage.commit_block().expect("commit failed");
+        let batch = PersistentStorage::batch();
+        storage.commit_block(batch).expect("commit failed");
 
         let (iter, gas) = storage.iter_prefix(&prefix);
         assert_eq!(gas, prefix.len() as u64);
@@ -324,7 +325,8 @@ mod tests {
             } else {
                 storage.delete(&key)?;
             }
-            storage.commit_block()?;
+            let batch = PersistentStorage::batch();
+            storage.commit_block(batch)?;
         }
 
         // 2. We try to read from these heights to check that we get back
@@ -407,8 +409,8 @@ mod tests {
         // Update and commit
         let hash = BlockHash::default();
         storage.begin_block(hash, BlockHeight(1))?;
+        let mut batch = PersistentStorage::batch();
         for (height, key, write_type) in blocks_write_type.clone() {
-            let mut batch = PersistentStorage::batch();
             if height != storage.block.height {
                 // to check the root later
                 roots.insert(storage.block.height, storage.merkle_root());
@@ -420,10 +422,11 @@ mod tests {
                         .pred_epochs
                         .new_epoch(storage.block.height, 1000);
                 }
-                storage.commit_block()?;
+                storage.commit_block(batch)?;
                 let hash = BlockHash::default();
                 storage
                     .begin_block(hash, storage.block.height.next_height())?;
+                batch = PersistentStorage::batch();
             }
             match write_type {
                 0 => {
@@ -448,10 +451,9 @@ mod tests {
                     )?;
                 }
             }
-            storage.exec_batch(batch)?;
         }
         roots.insert(storage.block.height, storage.merkle_root());
-        storage.commit_block()?;
+        storage.commit_block(batch)?;
 
         let mut current_state = HashMap::new();
         for i in 0..num_keys {
@@ -508,7 +510,8 @@ mod tests {
 
         storage.block.epoch = storage.block.epoch.next();
         storage.block.pred_epochs.new_epoch(BlockHeight(1), 1000);
-        storage.commit_block().expect("commit failed");
+        let batch = PersistentStorage::batch();
+        storage.commit_block(batch).expect("commit failed");
 
         storage
             .begin_block(BlockHash::default(), BlockHeight(6))
@@ -522,7 +525,8 @@ mod tests {
 
         storage.block.epoch = storage.block.epoch.next();
         storage.block.pred_epochs.new_epoch(BlockHeight(6), 1000);
-        storage.commit_block().expect("commit failed");
+        let batch = PersistentStorage::batch();
+        storage.commit_block(batch).expect("commit failed");
 
         let result = storage.get_merkle_tree(1.into());
         assert!(result.is_ok(), "The tree at Height 1 should be restored");
@@ -532,7 +536,8 @@ mod tests {
             .expect("begin_block failed");
         storage.block.epoch = storage.block.epoch.next();
         storage.block.pred_epochs.new_epoch(BlockHeight(11), 1000);
-        storage.commit_block().expect("commit failed");
+        let batch = PersistentStorage::batch();
+        storage.commit_block(batch).expect("commit failed");
 
         let result = storage.get_merkle_tree(1.into());
         assert!(result.is_err(), "The tree at Height 1 should be pruned");

--- a/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -259,9 +259,12 @@ impl RocksDB {
         historic: bool,
     ) {
         // Find the last block height
+        let state_cf = self
+            .get_column_family(STATE_CF)
+            .expect("State column family should exist");
         let height: BlockHeight = types::decode(
             self.0
-                .get("height")
+                .get_cf(state_cf, "height")
                 .expect("Unable to read DB")
                 .expect("No block height found"),
         )
@@ -292,21 +295,21 @@ impl RocksDB {
             // Diffs
             let cf = self
                 .get_column_family(DIFFS_CF)
-                .expect("ColumnFamily should exist");
+                .expect("Diffs column family should exist");
             let prefix = height.raw();
             self.dump_it(cf, Some(prefix.clone()), &mut file);
 
             // Block
             let cf = self
                 .get_column_family(BLOCK_CF)
-                .expect("ColumnFamily should exist");
+                .expect("Block column family should exist");
             self.dump_it(cf, Some(prefix), &mut file);
         }
 
         // subspace
         let cf = self
             .get_column_family(SUBSPACE_CF)
-            .expect("ColumnFamily should exist");
+            .expect("Subspace column family should exist");
         self.dump_it(cf, None, &mut file);
 
         println!("Done writing to {}", full_path.to_string_lossy());

--- a/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -1,33 +1,34 @@
 //! The persistent storage in RocksDB.
 //!
 //! The current storage tree is:
-//! - `height`: the last committed block height
-//! - `tx_queue`: txs to be decrypted in the next block
-//! - `pred`: predecessor values of the top-level keys of the same name
-//!   - `tx_queue`
-//! - `next_epoch_min_start_height`: minimum block height from which the next
-//!   epoch can start
-//! - `next_epoch_min_start_time`: minimum block time from which the next epoch
-//!   can start
-//! - `pred`: predecessor values of the top-level keys of the same name
-//!   - `next_epoch_min_start_height`
-//!   - `next_epoch_min_start_time`
+//! - `state`: the latest ledger state
+//!   - `height`: the last committed block height
+//!   - `tx_queue`: txs to be decrypted in the next block
+//!   - `pred`: predecessor values of the top-level keys of the same name
+//!     - `tx_queue`
+//!   - `next_epoch_min_start_height`: minimum block height from which the next
+//!     epoch can start
+//!   - `next_epoch_min_start_time`: minimum block time from which the next
+//!     epoch can start
+//!   - `pred`: predecessor values of the top-level keys of the same name
+//!     - `next_epoch_min_start_height`
+//!     - `next_epoch_min_start_time`
 //! - `subspace`: accounts sub-spaces
 //!   - `{address}/{dyn}`: any byte data associated with accounts
-//! - `results`: block results
-//! - `h`: for each block at height `h`:
-//!   - `tree`: merkle tree
-//!     - `root`: root hash
-//!     - `store`: the tree's store
-//!   - `hash`: block hash
-//!   - `epoch`: block epoch
-//!   - `address_gen`: established address generator
-//!   - `diffs`: diffs in account subspaces' key-vals
-//!     - `new/{dyn}`: value set in block height `h`
-//!     - `old/{dyn}`: value from predecessor block height
-//!   - `header`: block's header
+//! - `diffs`: diffs in account subspaces' key-vals
+//!   - `new/{dyn}`: value set in block height `h`
+//!   - `old/{dyn}`: value from predecessor block height
+//! - `block`: block state
+//!   - `results/{dyn}`: block results at height `h`
+//!   - `h`: for each block at height `h`:
+//!     - `tree`: merkle tree
+//!       - `root`: root hash
+//!       - `store`: the tree's store
+//!     - `hash`: block hash
+//!     - `epoch`: block epoch
+//!     - `address_gen`: established address generator
+//!     - `header`: block's header
 
-use std::cmp::Ordering;
 use std::fs::File;
 use std::path::Path;
 use std::str::FromStr;
@@ -48,8 +49,9 @@ use namada::types::storage::{
 use namada::types::time::DateTimeUtc;
 use rayon::prelude::*;
 use rocksdb::{
-    BlockBasedOptions, Direction, FlushOptions, IteratorMode, Options,
-    ReadOptions, SliceTransform, WriteBatch, WriteOptions,
+    BlockBasedOptions, ColumnFamily, ColumnFamilyDescriptor, Direction,
+    FlushOptions, IteratorMode, Options, ReadOptions, SliceTransform,
+    WriteBatch, WriteOptions,
 };
 
 use crate::config::utils::num_of_threads;
@@ -59,6 +61,12 @@ use crate::config::utils::num_of_threads;
 /// Env. var to set a number of Rayon global worker threads
 const ENV_VAR_ROCKSDB_COMPACTION_THREADS: &str =
     "NAMADA_ROCKSDB_COMPACTION_THREADS";
+
+/// Column family names
+const SUBSPACE_CF: &str = "subspace";
+const DIFFS_CF: &str = "diffs";
+const STATE_CF: &str = "state";
+const BLOCK_CF: &str = "block";
 
 /// RocksDB handle
 #[derive(Debug)]
@@ -84,19 +92,18 @@ pub fn open(
         compaction_threads
     );
 
-    let mut cf_opts = Options::default();
-    // ! recommended initial setup https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#other-general-options
-    cf_opts.set_level_compaction_dynamic_level_bytes(true);
+    // DB options
+    let mut db_opts = Options::default();
 
     // This gives `compaction_threads` number to compaction threads and 1 thread
     // for flush background jobs: https://github.com/facebook/rocksdb/blob/17ce1ca48be53ba29138f92dafc9c853d9241377/options/options.cc#L622
-    cf_opts.increase_parallelism(compaction_threads);
+    db_opts.increase_parallelism(compaction_threads);
 
-    cf_opts.set_bytes_per_sync(1048576);
-    set_max_open_files(&mut cf_opts);
+    db_opts.set_bytes_per_sync(1048576);
+    set_max_open_files(&mut db_opts);
 
-    cf_opts.set_compression_type(rocksdb::DBCompressionType::Zstd);
-    cf_opts.set_compression_options(0, 0, 0, 1024 * 1024);
+    db_opts.set_compression_type(rocksdb::DBCompressionType::Zstd);
+    db_opts.set_compression_options(0, 0, 0, 1024 * 1024);
     // TODO the recommended default `options.compaction_pri =
     // kMinOverlappingRatio` doesn't seem to be available in Rust
     let mut table_opts = BlockBasedOptions::default();
@@ -108,47 +115,44 @@ pub fn open(
     }
     // latest format versions https://github.com/facebook/rocksdb/blob/d1c510baecc1aef758f91f786c4fbee3bc847a63/include/rocksdb/table.h#L394
     table_opts.set_format_version(5);
-    cf_opts.set_block_based_table_factory(&table_opts);
+    db_opts.set_block_based_table_factory(&table_opts);
 
-    cf_opts.create_missing_column_families(true);
-    cf_opts.create_if_missing(true);
-    cf_opts.set_atomic_flush(true);
+    db_opts.create_missing_column_families(true);
+    db_opts.create_if_missing(true);
+    db_opts.set_atomic_flush(true);
 
-    cf_opts.set_comparator("key_comparator", key_comparator);
     let extractor = SliceTransform::create_fixed_prefix(20);
-    cf_opts.set_prefix_extractor(extractor);
-    // TODO use column families
+    db_opts.set_prefix_extractor(extractor);
 
-    rocksdb::DB::open_cf_descriptors(&cf_opts, path, vec![])
+    let mut cfs = Vec::new();
+
+    // for subspace (read/update-intensive)
+    let mut subspace_cf_opts = Options::default();
+    // ! recommended initial setup https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#other-general-options
+    subspace_cf_opts.set_level_compaction_dynamic_level_bytes(true);
+    subspace_cf_opts.set_compaction_style(rocksdb::DBCompactionStyle::Level);
+    cfs.push(ColumnFamilyDescriptor::new(SUBSPACE_CF, subspace_cf_opts));
+
+    // for diffs (insert-intensive)
+    let mut diffs_cf_opts = Options::default();
+    diffs_cf_opts.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+    cfs.push(ColumnFamilyDescriptor::new(DIFFS_CF, diffs_cf_opts));
+
+    // for the ledger state (update-intensive)
+    let mut state_cf_opts = Options::default();
+    // ! recommended initial setup https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#other-general-options
+    state_cf_opts.set_level_compaction_dynamic_level_bytes(true);
+    state_cf_opts.set_compaction_style(rocksdb::DBCompactionStyle::Level);
+    cfs.push(ColumnFamilyDescriptor::new(STATE_CF, state_cf_opts));
+
+    // for blocks (insert-intensive)
+    let mut block_cf_opts = Options::default();
+    block_cf_opts.set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+    cfs.push(ColumnFamilyDescriptor::new(BLOCK_CF, block_cf_opts));
+
+    rocksdb::DB::open_cf_descriptors(&db_opts, path, cfs)
         .map(RocksDB)
         .map_err(|e| Error::DBError(e.into_string()))
-}
-
-/// A custom key comparator is used to sort keys by the height. In
-/// lexicographical order, the height aren't ordered. For example, "11" is
-/// before "2".
-fn key_comparator(a: &[u8], b: &[u8]) -> Ordering {
-    let a_str = &String::from_utf8(a.to_vec()).unwrap();
-    let b_str = &String::from_utf8(b.to_vec()).unwrap();
-
-    let a_vec: Vec<&str> = a_str.split('/').collect();
-    let b_vec: Vec<&str> = b_str.split('/').collect();
-
-    let result_a_h = a_vec[0].parse::<u64>();
-    let result_b_h = b_vec[0].parse::<u64>();
-    match (result_a_h, result_b_h) {
-        (Ok(a_h), Ok(b_h)) => {
-            if a_h == b_h {
-                a_vec[1..].cmp(&b_vec[1..])
-            } else {
-                a_h.cmp(&b_h)
-            }
-        }
-        _ => {
-            // the key doesn't include the height
-            a_str.cmp(b_str)
-        }
-    }
 }
 
 impl Drop for RocksDB {
@@ -158,6 +162,12 @@ impl Drop for RocksDB {
 }
 
 impl RocksDB {
+    fn get_column_family(&self, cf_name: &str) -> Result<&ColumnFamily> {
+        self.0
+            .cf_handle(cf_name)
+            .ok_or(Error::DBError("No {cf_name} column family".to_string()))
+    }
+
     fn flush(&self, wait: bool) -> Result<()> {
         let mut flush_opts = FlushOptions::default();
         flush_opts.set_wait(wait);
@@ -169,15 +179,14 @@ impl RocksDB {
     /// Persist the diff of an account subspace key-val under the height where
     /// it was changed.
     fn write_subspace_diff(
-        &mut self,
+        &self,
         height: BlockHeight,
         key: &Key,
         old_value: Option<&[u8]>,
         new_value: Option<&[u8]>,
     ) -> Result<()> {
-        let key_prefix = Key::from(height.to_db_key())
-            .push(&"diffs".to_owned())
-            .map_err(Error::KeyError)?;
+        let cf = self.get_column_family(DIFFS_CF)?;
+        let key_prefix = Key::from(height.to_db_key());
 
         if let Some(old_value) = old_value {
             let old_val_key = key_prefix
@@ -186,7 +195,7 @@ impl RocksDB {
                 .join(key)
                 .to_string();
             self.0
-                .put(old_val_key, old_value)
+                .put_cf(cf, old_val_key, old_value)
                 .map_err(|e| Error::DBError(e.into_string()))?;
         }
 
@@ -197,7 +206,7 @@ impl RocksDB {
                 .join(key)
                 .to_string();
             self.0
-                .put(new_val_key, new_value)
+                .put_cf(cf, new_val_key, new_value)
                 .map_err(|e| Error::DBError(e.into_string()))?;
         }
         Ok(())
@@ -206,15 +215,15 @@ impl RocksDB {
     /// Persist the diff of an account subspace key-val under the height where
     /// it was changed in a batch write.
     fn batch_write_subspace_diff(
+        &self,
         batch: &mut RocksDBWriteBatch,
         height: BlockHeight,
         key: &Key,
         old_value: Option<&[u8]>,
         new_value: Option<&[u8]>,
     ) -> Result<()> {
-        let key_prefix = Key::from(height.to_db_key())
-            .push(&"diffs".to_owned())
-            .map_err(Error::KeyError)?;
+        let cf = self.get_column_family(DIFFS_CF)?;
+        let key_prefix = Key::from(height.to_db_key());
 
         if let Some(old_value) = old_value {
             let old_val_key = key_prefix
@@ -222,7 +231,7 @@ impl RocksDB {
                 .map_err(Error::KeyError)?
                 .join(key)
                 .to_string();
-            batch.0.put(old_val_key, old_value);
+            batch.0.put_cf(cf, old_val_key, old_value);
         }
 
         if let Some(new_value) = new_value {
@@ -231,7 +240,7 @@ impl RocksDB {
                 .map_err(Error::KeyError)?
                 .join(key)
                 .to_string();
-            batch.0.put(new_val_key, new_value);
+            batch.0.put_cf(cf, new_val_key, new_value);
         }
         Ok(())
     }
@@ -249,8 +258,6 @@ impl RocksDB {
         out_file_path: std::path::PathBuf,
         historic: bool,
     ) {
-        use std::io::Write;
-
         // Find the last block height
         let height: BlockHeight = types::decode(
             self.0
@@ -278,42 +285,63 @@ impl RocksDB {
 
         println!("Will write to {} ...", full_path.to_string_lossy());
 
-        let mut dump_it = |prefix: String| {
-            let mut read_opts = ReadOptions::default();
-            read_opts.set_total_order_seek(true);
-
-            let mut upper_prefix = prefix.clone().into_bytes();
-            if let Some(last) = upper_prefix.pop() {
-                upper_prefix.push(last + 1);
-            }
-            read_opts.set_iterate_upper_bound(upper_prefix);
-
-            let iter = self.0.iterator_opt(
-                IteratorMode::From(prefix.as_bytes(), Direction::Forward),
-                read_opts,
-            );
-
-            for (key, raw_val, _gas) in PersistentPrefixIterator(
-                PrefixIterator::new(iter, String::default()),
-                // Empty string to prevent prefix stripping, the prefix is
-                // already in the enclosed iterator
-            ) {
-                let val = HEXLOWER.encode(&raw_val);
-                let bytes = format!("\"{key}\" = \"{val}\"\n");
-                file.write_all(bytes.as_bytes())
-                    .expect("Unable to write to output file");
-            }
-        };
-
         if historic {
             // Dump the keys prepended with the selected block height (includes
             // subspace diff keys)
-            dump_it(height.raw());
+
+            // Diffs
+            let cf = self
+                .get_column_family(DIFFS_CF)
+                .expect("ColumnFamily should exist");
+            let prefix = height.raw();
+            self.dump_it(cf, Some(prefix.clone()), &mut file);
+
+            // Block
+            let cf = self
+                .get_column_family(BLOCK_CF)
+                .expect("ColumnFamily should exist");
+            self.dump_it(cf, Some(prefix), &mut file);
         }
 
-        dump_it("subspace".to_string());
+        // subspace
+        let cf = self
+            .get_column_family(SUBSPACE_CF)
+            .expect("ColumnFamily should exist");
+        self.dump_it(cf, None, &mut file);
 
         println!("Done writing to {}", full_path.to_string_lossy());
+    }
+
+    /// Dump data
+    fn dump_it(
+        &self,
+        cf: &ColumnFamily,
+        prefix: Option<String>,
+        file: &mut File,
+    ) {
+        use std::io::Write;
+
+        let read_opts = make_iter_read_opts(prefix.clone());
+        let iter = if let Some(prefix) = prefix {
+            self.0.iterator_cf_opt(
+                cf,
+                read_opts,
+                IteratorMode::From(prefix.as_bytes(), Direction::Forward),
+            )
+        } else {
+            self.0.iterator_cf_opt(cf, read_opts, IteratorMode::Start)
+        };
+
+        for (key, raw_val, _gas) in PersistentPrefixIterator(
+            PrefixIterator::new(iter, String::default()),
+            // Empty string to prevent prefix stripping, the prefix is
+            // already in the enclosed iterator
+        ) {
+            let val = HEXLOWER.encode(&raw_val);
+            let bytes = format!("\"{key}\" = \"{val}\"\n");
+            file.write_all(bytes.as_bytes())
+                .expect("Unable to write to output file");
+        }
     }
 
     /// Rollback to previous block. Given the inner working of tendermint
@@ -346,12 +374,13 @@ impl RocksDB {
         let previous_height =
             BlockHeight::from(u64::from(last_block.height) - 1);
 
+        let state_cf = self.get_column_family(STATE_CF)?;
         // Revert the non-height-prepended metadata storage keys which get
         // updated with every block. Because of the way we save these
         // three keys in storage we can only perform one rollback before
         // restarting the chain
         tracing::info!("Reverting non-height-prepended metadata keys");
-        batch.put("height", types::encode(&previous_height));
+        batch.put_cf(state_cf, "height", types::encode(&previous_height));
         for metadata_key in [
             "next_epoch_min_start_height",
             "next_epoch_min_start_time",
@@ -364,7 +393,7 @@ impl RocksDB {
                 .map_err(|e| Error::DBError(e.to_string()))?
                 .ok_or(Error::UnknownKey { key: previous_key })?;
 
-            batch.put(metadata_key, previous_value);
+            batch.put_cf(state_cf, metadata_key, previous_value);
             // NOTE: we cannot restore the "pred/" keys themselves since we
             // don't have their predecessors in storage, but there's no need to
             // since we cannot do more than one rollback anyway because of
@@ -373,7 +402,7 @@ impl RocksDB {
 
         // Delete block results for the last block
         tracing::info!("Removing last block results");
-        batch.delete(format!("results/{}", last_block.height));
+        batch.delete_cf(state_cf, format!("results/{}", last_block.height));
 
         // Execute next step in parallel
         let batch = Mutex::new(batch);
@@ -384,51 +413,50 @@ impl RocksDB {
             .try_for_each(|(key, _value, _gas)| -> Result<()> {
                 // Restore previous height diff if present, otherwise delete the
                 // subspace key
-
-                // Add the prefix back since `iter_prefix` has removed it
-                let prefixed_key = format!("subspace/{}", key);
-
+                let subspace_cf = self.get_column_family(SUBSPACE_CF)?;
                 match self.read_subspace_val_with_height(
                     &Key::from(key.to_db_key()),
                     previous_height,
                     last_block.height,
                 )? {
-                    Some(previous_value) => {
-                        batch.lock().unwrap().put(&prefixed_key, previous_value)
-                    }
-                    None => batch.lock().unwrap().delete(&prefixed_key),
+                    Some(previous_value) => batch.lock().unwrap().put_cf(
+                        subspace_cf,
+                        &key,
+                        previous_value,
+                    ),
+                    None => batch.lock().unwrap().delete_cf(subspace_cf, &key),
                 }
 
                 Ok(())
             })?;
 
-        // Delete any height-prepended key, including subspace diff keys
+        tracing::info!("Deleting keys prepended with the last height");
         let mut batch = batch.into_inner().unwrap();
         let prefix = last_block.height.to_string();
-        let mut read_opts = ReadOptions::default();
-        read_opts.set_total_order_seek(true);
-        let mut upper_prefix = prefix.clone().into_bytes();
-        if let Some(last) = upper_prefix.pop() {
-            upper_prefix.push(last + 1);
-        }
-        read_opts.set_iterate_upper_bound(upper_prefix);
-
-        let iter = self.0.iterator_opt(
-            IteratorMode::From(prefix.as_bytes(), Direction::Forward),
-            read_opts,
-        );
-        tracing::info!("Deleting keys prepended with the last height");
-        for (key, _value, _gas) in PersistentPrefixIterator(
-            // Empty prefix string to prevent stripping
-            PrefixIterator::new(iter, String::default()),
-        ) {
-            batch.delete(key);
-        }
+        let mut delete_keys = |cf: &ColumnFamily| {
+            let read_opts = make_iter_read_opts(Some(prefix.clone()));
+            let iter = self.0.iterator_cf_opt(
+                cf,
+                read_opts,
+                IteratorMode::From(prefix.as_bytes(), Direction::Forward),
+            );
+            for (key, _value, _gas) in PersistentPrefixIterator(
+                // Empty prefix string to prevent stripping
+                PrefixIterator::new(iter, String::default()),
+            ) {
+                batch.delete_cf(cf, key);
+            }
+        };
+        // Delete any height-prepended key in subspace diffs
+        let diffs_cf = self.get_column_family(DIFFS_CF)?;
+        delete_keys(diffs_cf);
+        // Delete any height-prepended key in the block
+        let block_cf = self.get_column_family(BLOCK_CF)?;
+        delete_keys(block_cf);
 
         // Write the batch and persist changes to disk
         tracing::info!("Flushing restored state to disk");
-        self.exec_batch(batch)?;
-        self.flush(true)
+        self.exec_batch(batch)
     }
 }
 
@@ -453,9 +481,10 @@ impl DB for RocksDB {
 
     fn read_last_block(&mut self) -> Result<Option<BlockStateRead>> {
         // Block height
+        let state_cf = self.get_column_family(STATE_CF)?;
         let height: BlockHeight = match self
             .0
-            .get("height")
+            .get_cf(state_cf, "height")
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(bytes) => {
@@ -467,10 +496,11 @@ impl DB for RocksDB {
         };
 
         // Block results
+        let block_cf = self.get_column_family(BLOCK_CF)?;
         let results_path = format!("results/{}", height.raw());
         let results: BlockResults = match self
             .0
-            .get(results_path)
+            .get_cf(block_cf, results_path)
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(bytes) => types::decode(bytes).map_err(Error::CodingError)?,
@@ -480,7 +510,7 @@ impl DB for RocksDB {
         // Epoch start height and time
         let next_epoch_min_start_height: BlockHeight = match self
             .0
-            .get("next_epoch_min_start_height")
+            .get_cf(state_cf, "next_epoch_min_start_height")
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(bytes) => types::decode(bytes).map_err(Error::CodingError)?,
@@ -493,7 +523,7 @@ impl DB for RocksDB {
         };
         let next_epoch_min_start_time: DateTimeUtc = match self
             .0
-            .get("next_epoch_min_start_time")
+            .get_cf(state_cf, "next_epoch_min_start_time")
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(bytes) => types::decode(bytes).map_err(Error::CodingError)?,
@@ -506,7 +536,7 @@ impl DB for RocksDB {
         };
         let tx_queue: TxQueue = match self
             .0
-            .get("tx_queue")
+            .get_cf(state_cf, "tx_queue")
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(bytes) => types::decode(bytes).map_err(Error::CodingError)?,
@@ -516,7 +546,7 @@ impl DB for RocksDB {
             }
         };
 
-        // Load data at the height
+        // Load block data at the height
         let prefix = format!("{}/", height.raw());
         let mut read_opts = ReadOptions::default();
         read_opts.set_total_order_seek(false);
@@ -527,9 +557,10 @@ impl DB for RocksDB {
         let mut epoch = None;
         let mut pred_epochs = None;
         let mut address_gen = None;
-        for value in self.0.iterator_opt(
-            IteratorMode::From(prefix.as_bytes(), Direction::Forward),
+        for value in self.0.iterator_cf_opt(
+            block_cf,
             read_opts,
+            IteratorMode::From(prefix.as_bytes(), Direction::Forward),
         ) {
             let (key, bytes) = match value {
                 Ok(data) => data,
@@ -586,9 +617,6 @@ impl DB for RocksDB {
                             types::decode(bytes).map_err(Error::CodingError)?,
                         );
                     }
-                    "diffs" => {
-                        // ignore the diffs
-                    }
                     _ => unknown_key_error(path)?,
                 },
                 None => unknown_key_error(path)?,
@@ -637,42 +665,56 @@ impl DB for RocksDB {
         }: BlockStateWrite = state;
 
         // Epoch start height and time
-        if let Some(current_value) =
-            self.0
-                .get("next_epoch_min_start_height")
-                .map_err(|e| Error::DBError(e.into_string()))?
+        let state_cf = self.get_column_family(STATE_CF)?;
+        if let Some(current_value) = self
+            .0
+            .get_cf(state_cf, "next_epoch_min_start_height")
+            .map_err(|e| Error::DBError(e.into_string()))?
         {
             // Write the predecessor value for rollback
-            batch.put("pred/next_epoch_min_start_height", current_value);
+            batch.0.put_cf(
+                state_cf,
+                "pred/next_epoch_min_start_height",
+                current_value,
+            );
         }
-        batch.put(
+        batch.0.put_cf(
+            state_cf,
             "next_epoch_min_start_height",
             types::encode(&next_epoch_min_start_height),
         );
 
         if let Some(current_value) = self
             .0
-            .get("next_epoch_min_start_time")
+            .get_cf(state_cf, "next_epoch_min_start_time")
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             // Write the predecessor value for rollback
-            batch.put("pred/next_epoch_min_start_time", current_value);
+            batch.0.put_cf(
+                state_cf,
+                "pred/next_epoch_min_start_time",
+                current_value,
+            );
         }
-        batch.put(
+        batch.0.put_cf(
+            state_cf,
             "next_epoch_min_start_time",
             types::encode(&next_epoch_min_start_time),
         );
         // Tx queue
         if let Some(pred_tx_queue) = self
             .0
-            .get("tx_queue")
+            .get_cf(state_cf, "tx_queue")
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             // Write the predecessor value for rollback
-            batch.put("pred/tx_queue", pred_tx_queue);
+            batch.0.put_cf(state_cf, "pred/tx_queue", pred_tx_queue);
         }
-        batch.put("tx_queue", types::encode(&tx_queue));
+        batch
+            .0
+            .put_cf(state_cf, "tx_queue", types::encode(&tx_queue));
 
+        let block_cf = self.get_column_family(BLOCK_CF)?;
         let prefix_key = Key::from(height.to_db_key());
         // Merkle tree
         {
@@ -687,14 +729,16 @@ impl DB for RocksDB {
                     let root_key = prefix_key
                         .push(&"root".to_owned())
                         .map_err(Error::KeyError)?;
-                    batch.put(
+                    batch.0.put_cf(
+                        block_cf,
                         root_key.to_string(),
                         types::encode(merkle_tree_stores.root(st)),
                     );
                     let store_key = prefix_key
                         .push(&"store".to_owned())
                         .map_err(Error::KeyError)?;
-                    batch.put(
+                    batch.0.put_cf(
+                        block_cf,
                         store_key.to_string(),
                         merkle_tree_stores.store(st).encode(),
                     );
@@ -707,7 +751,8 @@ impl DB for RocksDB {
                 let key = prefix_key
                     .push(&"header".to_owned())
                     .map_err(Error::KeyError)?;
-                batch.put(
+                batch.0.put_cf(
+                    block_cf,
                     key.to_string(),
                     h.try_to_vec().expect("serialization failed"),
                 );
@@ -718,49 +763,64 @@ impl DB for RocksDB {
             let key = prefix_key
                 .push(&"hash".to_owned())
                 .map_err(Error::KeyError)?;
-            batch.put(key.to_string(), types::encode(&hash));
+            batch
+                .0
+                .put_cf(block_cf, key.to_string(), types::encode(&hash));
         }
         // Block epoch
         {
             let key = prefix_key
                 .push(&"epoch".to_owned())
                 .map_err(Error::KeyError)?;
-            batch.put(key.to_string(), types::encode(&epoch));
+            batch
+                .0
+                .put_cf(block_cf, key.to_string(), types::encode(&epoch));
         }
         // Block results
         {
             let results_path = format!("results/{}", height.raw());
-            batch.put(results_path, types::encode(&results));
+            batch
+                .0
+                .put_cf(block_cf, results_path, types::encode(&results));
         }
         // Predecessor block epochs
         {
             let key = prefix_key
                 .push(&"pred_epochs".to_owned())
                 .map_err(Error::KeyError)?;
-            batch.put(key.to_string(), types::encode(&pred_epochs));
+            batch.0.put_cf(
+                block_cf,
+                key.to_string(),
+                types::encode(&pred_epochs),
+            );
         }
         // Address gen
         {
             let key = prefix_key
                 .push(&"address_gen".to_owned())
                 .map_err(Error::KeyError)?;
-            batch.put(key.to_string(), types::encode(&address_gen));
+            batch.0.put_cf(
+                block_cf,
+                key.to_string(),
+                types::encode(&address_gen),
+            );
         }
 
         // Block height
-        batch.put("height", types::encode(&height));
+        batch.0.put_cf(state_cf, "height", types::encode(&height));
 
         Ok(())
     }
 
     fn read_block_header(&self, height: BlockHeight) -> Result<Option<Header>> {
+        let block_cf = self.get_column_family(BLOCK_CF)?;
         let prefix_key = Key::from(height.to_db_key());
         let key = prefix_key
             .push(&"header".to_owned())
             .map_err(Error::KeyError)?;
         let value = self
             .0
-            .get(key.to_string())
+            .get_cf(block_cf, key.to_string())
             .map_err(|e| Error::DBError(e.into_string()))?;
         match value {
             Some(v) => Ok(Some(
@@ -776,13 +836,14 @@ impl DB for RocksDB {
         height: BlockHeight,
     ) -> Result<Option<(BlockHeight, MerkleTreeStoresRead)>> {
         // Get the latest height at which the tree stores were written
+        let block_cf = self.get_column_family(BLOCK_CF)?;
         let height_key = Key::from(height.to_db_key());
         let key = height_key
             .push(&"pred_epochs".to_owned())
             .expect("Cannot obtain a storage key");
         let pred_epochs: Epochs = match self
             .0
-            .get(key.to_string())
+            .get_cf(block_cf, key.to_string())
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(b) => types::decode(b).map_err(Error::CodingError)?,
@@ -806,7 +867,7 @@ impl DB for RocksDB {
                 .map_err(Error::KeyError)?;
             let bytes = self
                 .0
-                .get(root_key.to_string())
+                .get_cf(block_cf, root_key.to_string())
                 .map_err(|e| Error::DBError(e.into_string()))?;
             match bytes {
                 Some(b) => {
@@ -821,7 +882,7 @@ impl DB for RocksDB {
                 .map_err(Error::KeyError)?;
             let bytes = self
                 .0
-                .get(store_key.to_string())
+                .get_cf(block_cf, store_key.to_string())
                 .map_err(|e| Error::DBError(e.into_string()))?;
             match bytes {
                 Some(b) => {
@@ -834,10 +895,9 @@ impl DB for RocksDB {
     }
 
     fn read_subspace_val(&self, key: &Key) -> Result<Option<Vec<u8>>> {
-        let subspace_key =
-            Key::parse("subspace").map_err(Error::KeyError)?.join(key);
+        let subspace_cf = self.get_column_family(SUBSPACE_CF)?;
         self.0
-            .get(subspace_key.to_string())
+            .get_cf(subspace_cf, key.to_string())
             .map_err(|e| Error::DBError(e.into_string()))
     }
 
@@ -848,9 +908,8 @@ impl DB for RocksDB {
         last_height: BlockHeight,
     ) -> Result<Option<Vec<u8>>> {
         // Check if the value changed at this height
-        let key_prefix = Key::from(height.to_db_key())
-            .push(&"diffs".to_owned())
-            .map_err(Error::KeyError)?;
+        let diffs_cf = self.get_column_family(DIFFS_CF)?;
+        let key_prefix = Key::from(height.to_db_key());
         let new_val_key = key_prefix
             .push(&"new".to_owned())
             .map_err(Error::KeyError)?
@@ -860,7 +919,7 @@ impl DB for RocksDB {
         // If it has a "new" val, it was written at this height
         match self
             .0
-            .get(new_val_key)
+            .get_cf(diffs_cf, new_val_key)
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(new_val) => {
@@ -873,11 +932,11 @@ impl DB for RocksDB {
                     .join(key)
                     .to_string();
                 // If it has an "old" val, it was deleted at this height
-                if self.0.key_may_exist(old_val_key.clone()) {
+                if self.0.key_may_exist_cf(diffs_cf, old_val_key.clone()) {
                     // check if it actually exists
                     if self
                         .0
-                        .get(old_val_key)
+                        .get_cf(diffs_cf, old_val_key)
                         .map_err(|e| Error::DBError(e.into_string()))?
                         .is_some()
                     {
@@ -892,9 +951,7 @@ impl DB for RocksDB {
         let mut raw_height = height.0 + 1;
         loop {
             // Try to find the next diff on this key
-            let key_prefix = Key::from(BlockHeight(raw_height).to_db_key())
-                .push(&"diffs".to_owned())
-                .map_err(Error::KeyError)?;
+            let key_prefix = Key::from(BlockHeight(raw_height).to_db_key());
             let old_val_key = key_prefix
                 .push(&"old".to_owned())
                 .map_err(Error::KeyError)?
@@ -902,7 +959,7 @@ impl DB for RocksDB {
                 .to_string();
             let old_val = self
                 .0
-                .get(old_val_key)
+                .get_cf(diffs_cf, old_val_key)
                 .map_err(|e| Error::DBError(e.into_string()))?;
             // If it has an "old" val, it's the one we're looking for
             match old_val {
@@ -915,11 +972,11 @@ impl DB for RocksDB {
                         .map_err(Error::KeyError)?
                         .join(key)
                         .to_string();
-                    if self.0.key_may_exist(new_val_key.clone()) {
+                    if self.0.key_may_exist_cf(diffs_cf, new_val_key.clone()) {
                         // check if it actually exists
                         if self
                             .0
-                            .get(new_val_key)
+                            .get_cf(diffs_cf, new_val_key)
                             .map_err(|e| Error::DBError(e.into_string()))?
                             .is_some()
                         {
@@ -944,12 +1001,11 @@ impl DB for RocksDB {
         key: &Key,
         value: impl AsRef<[u8]>,
     ) -> Result<i64> {
+        let subspace_cf = self.get_column_family(SUBSPACE_CF)?;
         let value = value.as_ref();
-        let subspace_key =
-            Key::parse("subspace").map_err(Error::KeyError)?.join(key);
         let size_diff = match self
             .0
-            .get(subspace_key.to_string())
+            .get_cf(subspace_cf, key.to_string())
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(prev_value) => {
@@ -970,7 +1026,7 @@ impl DB for RocksDB {
 
         // Write the new key-val
         self.0
-            .put(subspace_key.to_string(), value)
+            .put_cf(subspace_cf, key.to_string(), value)
             .map_err(|e| Error::DBError(e.into_string()))?;
 
         Ok(size_diff)
@@ -981,13 +1037,12 @@ impl DB for RocksDB {
         height: BlockHeight,
         key: &Key,
     ) -> Result<i64> {
-        let subspace_key =
-            Key::parse("subspace").map_err(Error::KeyError)?.join(key);
+        let subspace_cf = self.get_column_family(SUBSPACE_CF)?;
 
         // Check the length of previous value, if any
         let prev_len = match self
             .0
-            .get(subspace_key.to_string())
+            .get_cf(subspace_cf, key.to_string())
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(prev_value) => {
@@ -1000,7 +1055,7 @@ impl DB for RocksDB {
 
         // Delete the key-val
         self.0
-            .delete(subspace_key.to_string())
+            .delete_cf(subspace_cf, key.to_string())
             .map_err(|e| Error::DBError(e.into_string()))?;
 
         Ok(prev_len)
@@ -1022,17 +1077,16 @@ impl DB for RocksDB {
         value: impl AsRef<[u8]>,
     ) -> Result<i64> {
         let value = value.as_ref();
-        let subspace_key =
-            Key::parse("subspace").map_err(Error::KeyError)?.join(key);
+        let subspace_cf = self.get_column_family(SUBSPACE_CF)?;
         let size_diff = match self
             .0
-            .get(subspace_key.to_string())
+            .get_cf(subspace_cf, key.to_string())
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(old_value) => {
                 let size_diff = value.len() as i64 - old_value.len() as i64;
                 // Persist the previous value
-                Self::batch_write_subspace_diff(
+                self.batch_write_subspace_diff(
                     batch,
                     height,
                     key,
@@ -1042,7 +1096,7 @@ impl DB for RocksDB {
                 size_diff
             }
             None => {
-                Self::batch_write_subspace_diff(
+                self.batch_write_subspace_diff(
                     batch,
                     height,
                     key,
@@ -1054,7 +1108,7 @@ impl DB for RocksDB {
         };
 
         // Write the new key-val
-        batch.put(&subspace_key.to_string(), value);
+        batch.0.put_cf(subspace_cf, key.to_string(), value);
 
         Ok(size_diff)
     }
@@ -1065,19 +1119,18 @@ impl DB for RocksDB {
         height: BlockHeight,
         key: &Key,
     ) -> Result<i64> {
-        let subspace_key =
-            Key::parse("subspace").map_err(Error::KeyError)?.join(key);
+        let subspace_cf = self.get_column_family(SUBSPACE_CF)?;
 
         // Check the length of previous value, if any
         let prev_len = match self
             .0
-            .get(subspace_key.to_string())
+            .get_cf(subspace_cf, key.to_string())
             .map_err(|e| Error::DBError(e.into_string()))?
         {
             Some(prev_value) => {
                 let prev_len = prev_value.len() as i64;
                 // Persist the previous value
-                Self::batch_write_subspace_diff(
+                self.batch_write_subspace_diff(
                     batch,
                     height,
                     key,
@@ -1090,7 +1143,7 @@ impl DB for RocksDB {
         };
 
         // Delete the key-val
-        batch.delete(subspace_key.to_string());
+        batch.0.delete_cf(subspace_cf, key.to_string());
 
         Ok(prev_len)
     }
@@ -1101,6 +1154,7 @@ impl DB for RocksDB {
         epoch: Epoch,
         pred_epochs: &Epochs,
     ) -> Result<()> {
+        let block_cf = self.get_column_family(BLOCK_CF)?;
         match pred_epochs.get_start_height_of_epoch(epoch) {
             Some(height) => {
                 let prefix_key = Key::from(height.to_db_key())
@@ -1114,11 +1168,11 @@ impl DB for RocksDB {
                         let root_key = prefix_key
                             .push(&"root".to_owned())
                             .map_err(Error::KeyError)?;
-                        batch.delete(root_key.to_string());
+                        batch.0.delete_cf(block_cf, root_key.to_string());
                         let store_key = prefix_key
                             .push(&"store".to_owned())
                             .map_err(Error::KeyError)?;
-                        batch.delete(store_key.to_string());
+                        batch.0.delete_cf(block_cf, store_key.to_string());
                     }
                 }
                 Ok(())
@@ -1142,18 +1196,14 @@ impl<'iter> DBIter<'iter> for RocksDB {
         let db_prefix = "results/".to_owned();
         let prefix = "results".to_owned();
 
-        let mut read_opts = ReadOptions::default();
-        // don't use the prefix bloom filter
-        read_opts.set_total_order_seek(true);
-        let mut upper_prefix = prefix.clone().into_bytes();
-        if let Some(last) = upper_prefix.pop() {
-            upper_prefix.push(last + 1);
-        }
-        read_opts.set_iterate_upper_bound(upper_prefix);
-
-        let iter = self.0.iterator_opt(
-            IteratorMode::From(prefix.as_bytes(), Direction::Forward),
+        let block_cf = self
+            .get_column_family(BLOCK_CF)
+            .expect("{BLOCK_CF} column family should exist");
+        let read_opts = make_iter_read_opts(Some(prefix.clone()));
+        let iter = self.0.iterator_cf_opt(
+            block_cf,
             read_opts,
+            IteratorMode::From(prefix.as_bytes(), Direction::Forward),
         );
         PersistentPrefixIterator(PrefixIterator::new(iter, db_prefix))
     }
@@ -1177,9 +1227,11 @@ fn iter_subspace_prefix<'iter>(
     db: &'iter RocksDB,
     prefix: &Key,
 ) -> PersistentPrefixIterator<'iter> {
-    let db_prefix = "subspace/".to_owned();
-    let prefix = format!("{}{}", db_prefix, prefix);
-    iter_prefix(db, db_prefix, prefix)
+    let subspace_cf = db
+        .get_column_family(SUBSPACE_CF)
+        .expect("{SUBSPACE_CF} column family should exist");
+    let db_prefix = "".to_owned();
+    iter_prefix(db, subspace_cf, db_prefix, prefix.to_string())
 }
 
 fn iter_diffs_prefix(
@@ -1187,29 +1239,26 @@ fn iter_diffs_prefix(
     height: BlockHeight,
     is_old: bool,
 ) -> PersistentPrefixIterator {
+    let diffs_cf = db
+        .get_column_family(DIFFS_CF)
+        .expect("{DIFFS_CF} column family should exist");
     let prefix = if is_old { "old" } else { "new" };
-    let db_prefix = format!("{}/diffs/{}/", height.0.raw(), prefix);
+    let db_prefix = format!("{}/{}/", height.0.raw(), prefix);
     // get keys without a prefix
-    iter_prefix(db, db_prefix.clone(), db_prefix)
+    iter_prefix(db, diffs_cf, db_prefix.clone(), db_prefix)
 }
 
-fn iter_prefix(
-    db: &RocksDB,
+fn iter_prefix<'a>(
+    db: &'a RocksDB,
+    cf: &'a ColumnFamily,
     db_prefix: String,
     prefix: String,
-) -> PersistentPrefixIterator {
-    let mut read_opts = ReadOptions::default();
-    // don't use the prefix bloom filter
-    read_opts.set_total_order_seek(true);
-    let mut upper_prefix = prefix.clone().into_bytes();
-    if let Some(last) = upper_prefix.pop() {
-        upper_prefix.push(last + 1);
-    }
-    read_opts.set_iterate_upper_bound(upper_prefix);
-
-    let iter = db.0.iterator_opt(
-        IteratorMode::From(prefix.as_bytes(), Direction::Forward),
+) -> PersistentPrefixIterator<'a> {
+    let read_opts = make_iter_read_opts(Some(prefix.clone()));
+    let iter = db.0.iterator_cf_opt(
+        cf,
         read_opts,
+        IteratorMode::From(prefix.as_bytes(), Direction::Forward),
     );
     PersistentPrefixIterator(PrefixIterator::new(iter, db_prefix))
 }
@@ -1241,6 +1290,23 @@ impl<'a> Iterator for PersistentPrefixIterator<'a> {
             None => None,
         }
     }
+}
+
+/// Make read options for RocksDB iterator with the given prefix
+fn make_iter_read_opts(prefix: Option<String>) -> ReadOptions {
+    let mut read_opts = ReadOptions::default();
+    // don't use the prefix bloom filter
+    read_opts.set_total_order_seek(true);
+
+    if let Some(prefix) = prefix {
+        let mut upper_prefix = prefix.into_bytes();
+        if let Some(last) = upper_prefix.pop() {
+            upper_prefix.push(last + 1);
+        }
+        read_opts.set_iterate_upper_bound(upper_prefix);
+    }
+
+    read_opts
 }
 
 impl DBWriteBatch for RocksDBWriteBatch {

--- a/core/src/ledger/storage/mockdb.rs
+++ b/core/src/ledger/storage/mockdb.rs
@@ -556,21 +556,7 @@ impl Iterator for PrefixIterator<MockIterator> {
     }
 }
 
-impl DBWriteBatch for MockDBWriteBatch {
-    fn put<K, V>(&mut self, _key: K, _value: V)
-    where
-        K: AsRef<[u8]>,
-        V: AsRef<[u8]>,
-    {
-        // Nothing to do - in MockDB, batch writes are committed directly from
-        // `batch_write_subspace_val` and `batch_delete_subspace_val`.
-    }
-
-    fn delete<K: AsRef<[u8]>>(&mut self, _key: K) {
-        // Nothing to do - in MockDB, batch writes are committed directly from
-        // `batch_write_subspace_val` and `batch_delete_subspace_val`.
-    }
-}
+impl DBWriteBatch for MockDBWriteBatch {}
 
 fn unknown_key_error(key: &str) -> Result<()> {
     Err(Error::UnknownKey {

--- a/core/src/ledger/storage/mockdb.rs
+++ b/core/src/ledger/storage/mockdb.rs
@@ -176,6 +176,7 @@ impl DB for MockDB {
     fn write_block(
         &mut self,
         state: BlockStateWrite,
+        _batch: &mut Self::WriteBatch,
         _is_full_commit: bool,
     ) -> Result<()> {
         let BlockStateWrite {
@@ -445,6 +446,7 @@ impl DB for MockDB {
 
     fn prune_merkle_tree_stores(
         &mut self,
+        _batch: &mut Self::WriteBatch,
         epoch: Epoch,
         pred_epochs: &Epochs,
     ) -> Result<()> {

--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -334,17 +334,7 @@ pub trait DBIter<'iter> {
 }
 
 /// Atomic batch write.
-pub trait DBWriteBatch {
-    /// Insert a value into the database under the given key.
-    fn put<K, V>(&mut self, key: K, value: V)
-    where
-        K: AsRef<[u8]>,
-        V: AsRef<[u8]>;
-
-    /// Removes the database entry for key. Does nothing if the key was not
-    /// found.
-    fn delete<K: AsRef<[u8]>>(&mut self, key: K);
-}
+pub trait DBWriteBatch {}
 
 impl<D, H> Storage<D, H>
 where

--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -228,6 +228,7 @@ pub trait DB: std::fmt::Debug {
     fn write_block(
         &mut self,
         state: BlockStateWrite,
+        batch: &mut Self::WriteBatch,
         is_full_commit: bool,
     ) -> Result<()>;
 
@@ -303,6 +304,7 @@ pub trait DB: std::fmt::Debug {
     /// Prune Merkle tree stores at the given epoch
     fn prune_merkle_tree_stores(
         &mut self,
+        batch: &mut Self::WriteBatch,
         pruned_epoch: Epoch,
         pred_epochs: &Epochs,
     ) -> Result<()>;
@@ -456,7 +458,8 @@ where
     }
 
     /// Persist the current block's state to the database
-    pub fn commit_block(&mut self) -> Result<()> {
+    pub fn commit_block(&mut self, batch: D::WriteBatch) -> Result<()> {
+        let mut batch = batch;
         // All states are written only when the first height or a new epoch
         let is_full_commit =
             self.block.height.0 == 1 || self.last_epoch != self.block.epoch;
@@ -474,15 +477,15 @@ where
             #[cfg(feature = "ferveo-tpke")]
             tx_queue: &self.tx_queue,
         };
-        self.db.write_block(state, is_full_commit)?;
+        self.db.write_block(state, &mut batch, is_full_commit)?;
         self.last_height = self.block.height;
         self.last_epoch = self.block.epoch;
         self.header = None;
         if is_full_commit {
             // prune old merkle tree stores
-            self.prune_merkle_tree_stores()?;
+            self.prune_merkle_tree_stores(&mut batch)?;
         }
-        Ok(())
+        self.db.exec_batch(batch)
     }
 
     /// Find the root hash of the merkle tree
@@ -901,7 +904,10 @@ where
 
     // Prune merkle tree stores. Use after updating self.block.height in the
     // commit.
-    fn prune_merkle_tree_stores(&mut self) -> Result<()> {
+    fn prune_merkle_tree_stores(
+        &mut self,
+        batch: &mut D::WriteBatch,
+    ) -> Result<()> {
         if let Some(limit) = self.storage_read_past_height_limit {
             if self.last_height.0 <= limit {
                 return Ok(());
@@ -917,6 +923,7 @@ where
                     // height of the epoch would be used
                     // to restore stores at a height (> min_height) in the epoch
                     self.db.prune_merkle_tree_stores(
+                        batch,
                         epoch.prev(),
                         &self.block.pred_epochs,
                     )?;

--- a/core/src/ledger/storage/wl_storage.rs
+++ b/core/src/ledger/storage/wl_storage.rs
@@ -143,10 +143,11 @@ where
     /// Commit the current block's write log to the storage and commit the block
     /// to DB. Starts a new block write log.
     pub fn commit_block(&mut self) -> storage_api::Result<()> {
+        let mut batch = D::batch();
         self.write_log
-            .commit_block(&mut self.storage)
+            .commit_block(&mut self.storage, &mut batch)
             .into_storage_result()?;
-        self.storage.commit_block().into_storage_result()
+        self.storage.commit_block(batch).into_storage_result()
     }
 
     /// Initialize a new epoch when the current epoch is finished. Returns

--- a/shared/src/ledger/ibc/vp/mod.rs
+++ b/shared/src/ledger/ibc/vp/mod.rs
@@ -355,6 +355,7 @@ mod tests {
     use crate::ibc::tx_msg::Msg;
     use crate::ibc::Height;
     use crate::ibc_proto::cosmos::base::v1beta1::Coin;
+    use crate::ledger::storage::mockdb::MockDBWriteBatch;
     use namada_core::ledger::storage::testing::TestWlStorage;
     use prost::Message;
     use crate::tendermint::time::Time as TmTime;
@@ -457,6 +458,10 @@ mod tests {
         wl_storage.write_log.commit_tx();
 
         wl_storage
+    }
+
+    fn batch() -> MockDBWriteBatch {
+        TestStorage::batch()
     }
 
     fn get_connection_id() -> ConnectionId {
@@ -909,7 +914,7 @@ mod tests {
         let mut wl_storage = insert_init_states();
         wl_storage
             .write_log
-            .commit_block(&mut wl_storage.storage)
+            .commit_block(&mut wl_storage.storage, &mut batch())
             .expect("commit failed");
 
         // prepare data
@@ -1015,7 +1020,7 @@ mod tests {
         wl_storage.write_log.commit_tx();
         wl_storage
             .write_log
-            .commit_block(&mut wl_storage.storage)
+            .commit_block(&mut wl_storage.storage, &mut batch())
             .expect("commit failed");
         // update the connection to Open
         let conn = get_connection(ConnState::Open);
@@ -2096,7 +2101,7 @@ mod tests {
         wl_storage.write_log.commit_tx();
         wl_storage
             .write_log
-            .commit_block(&mut wl_storage.storage)
+            .commit_block(&mut wl_storage.storage, &mut batch())
             .expect("commit failed");
 
         // make a packet and data


### PR DESCRIPTION
- Enable WAL: To avoid lots of small files #1150
- Batch once: To ease write load
- Remove unused key comparator #1149
- Use column families for each write pattern: To be able to set a suitable compaction style for data #1151 
  - Set Universal Compaction style for insert-intensive data (`block` including merkle tree stores, subspace diffs)