### PR TITLE
Broadcast validator set update protocol txs from `namadac`

### DIFF
--- a/apps/src/bin/namada-client/cli.rs
+++ b/apps/src/bin/namada-client/cli.rs
@@ -3,7 +3,7 @@
 use color_eyre::eyre::Result;
 use namada_apps::cli;
 use namada_apps::cli::cmds::*;
-use namada_apps::client::eth_bridge::bridge_pool;
+use namada_apps::client::eth_bridge::{bridge_pool, validator_set};
 use namada_apps::client::{rpc, tx, utils};
 
 pub async fn main() -> Result<()> {
@@ -49,9 +49,14 @@ pub async fn main() -> Result<()> {
                 Sub::Withdraw(Withdraw(args)) => {
                     tx::submit_withdraw(ctx, args).await;
                 }
-                // Eth bridge pool
+                // Eth bridge
                 Sub::AddToEthBridgePool(args) => {
                     bridge_pool::add_to_eth_bridge_pool(ctx, args.0).await;
+                }
+                Sub::SubmitValidatorSetUpdate(SubmitValidatorSetUpdate(
+                    args,
+                )) => {
+                    validator_set::submit_validator_set_update(ctx, args).await;
                 }
                 // Ledger queries
                 Sub::QueryEpoch(QueryEpoch(args)) => {

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2364,8 +2364,6 @@ pub mod args {
     pub struct SubmitValidatorSetUpdate {
         /// The query parameters.
         pub query: Query,
-        /// The transaction arguments.
-        pub tx: Tx,
         /// The signing epoch of the validator set update.
         pub signing_epoch: Option<Epoch>,
     }
@@ -2374,16 +2372,14 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let signing_epoch = EPOCH.parse(matches);
             let query = Query::parse(matches);
-            let tx = Tx::parse(matches);
             Self {
                 signing_epoch,
-                tx,
                 query,
             }
         }
 
         fn def(app: App) -> App {
-            app.add_args::<Tx>().add_args::<Query>().arg(
+            app.add_args::<Query>().arg(
                 EPOCH
                     .def()
                     .about("The signing epoch of the validator set update."),

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1735,7 +1735,6 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about("Submit a validator set update protocol tx.")
-                .setting(AppSettings::ArgRequiredElseHelp)
                 .add_args::<args::SubmitValidatorSetUpdate>()
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2364,25 +2364,22 @@ pub mod args {
     pub struct SubmitValidatorSetUpdate {
         /// The query parameters.
         pub query: Query,
-        /// The signing epoch of the validator set update.
-        pub signing_epoch: Option<Epoch>,
+        /// The epoch of the validator set to relay.
+        pub epoch: Option<Epoch>,
     }
 
     impl Args for SubmitValidatorSetUpdate {
         fn parse(matches: &ArgMatches) -> Self {
-            let signing_epoch = EPOCH.parse(matches);
+            let epoch = EPOCH.parse(matches);
             let query = Query::parse(matches);
-            Self {
-                signing_epoch,
-                query,
-            }
+            Self { epoch, query }
         }
 
         fn def(app: App) -> App {
             app.add_args::<Query>().arg(
                 EPOCH
                     .def()
-                    .about("The signing epoch of the validator set update."),
+                    .about("The epoch of the validator set to relay."),
             )
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1724,7 +1724,7 @@ pub mod cmds {
     pub struct SubmitValidatorSetUpdate(pub args::SubmitValidatorSetUpdate);
 
     impl SubCmd for SubmitValidatorSetUpdate {
-        const CMD: &'static str = "submit-validator-set-update";
+        const CMD: &'static str = "validator-set-update";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).map(|matches| {

--- a/apps/src/lib/client/eth_bridge/bridge_pool.rs
+++ b/apps/src/lib/client/eth_bridge/bridge_pool.rs
@@ -396,7 +396,7 @@ mod recommendations {
         let voting_powers = RPC
             .shell()
             .eth_bridge()
-            .eth_voting_powers(&client, &height)
+            .voting_powers_at_height(&client, &height)
             .await
             .unwrap();
         let valset_size = voting_powers.len() as u64;

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -441,7 +441,7 @@ where
                         .unwrap(),
                     );
                     wallet
-                        .take_validator_data()
+                        .into_validator_data()
                         .map(|data| ShellMode::Validator {
                             data,
                             broadcast_sender,

--- a/apps/src/lib/wallet/mod.rs
+++ b/apps/src/lib/wallet/mod.rs
@@ -41,6 +41,8 @@ pub enum FindKeyError {
     KeyNotFound,
     #[error("{0}")]
     KeyDecryptionError(keys::DecryptionError),
+    #[error("Expected a Secp256k1 key, but found another key kind")]
+    NotSecp256k1Error,
 }
 
 impl Wallet {
@@ -168,6 +170,12 @@ impl Wallet {
         protocol_pk: Option<common::PublicKey>,
         protocol_key_scheme: SchemeType,
     ) -> Result<ValidatorKeys, FindKeyError> {
+        match &eth_bridge_pk {
+            Some(common::PublicKey::Secp256k1(_)) | None => {}
+            _ => {
+                return Err(FindKeyError::NotSecp256k1Error);
+            }
+        }
         let protocol_keypair = self
             .find_secret_key(protocol_pk, |data| data.keys.protocol_keypair)?;
         let eth_bridge_keypair = self

--- a/apps/src/lib/wallet/mod.rs
+++ b/apps/src/lib/wallet/mod.rs
@@ -223,14 +223,19 @@ impl Wallet {
         self.store.add_validator_data(address, keys);
     }
 
-    /// Returns the validator data, if it exists.
+    /// Returns a reference to the validator data, if it exists.
     pub fn get_validator_data(&self) -> Option<&ValidatorData> {
         self.store.get_validator_data()
     }
 
+    /// Take the validator data, if it exists.
+    pub fn take_validator_data(&mut self) -> Option<ValidatorData> {
+        self.store.validator_data.take()
+    }
+
     /// Returns the validator data, if it exists.
     /// [`Wallet::save`] cannot be called after using this
-    /// method as it involves a partial move
+    /// method as it involves a partial move.
     pub fn into_validator_data(self) -> Option<ValidatorData> {
         self.store.validator_data()
     }

--- a/apps/src/lib/wallet/mod.rs
+++ b/apps/src/lib/wallet/mod.rs
@@ -231,7 +231,7 @@ impl Wallet {
     /// Returns the validator data, if it exists.
     /// [`Wallet::save`] cannot be called after using this
     /// method as it involves a partial move
-    pub fn take_validator_data(self) -> Option<ValidatorData> {
+    pub fn into_validator_data(self) -> Option<ValidatorData> {
         self.store.validator_data()
     }
 


### PR DESCRIPTION
Closes https://github.com/anoma/namada/issues/1291

---

**TODO:** write e2e test that deletes a proof from storage, and uses the new `namadac` sub-command to generate the missing proof. on-going effort here: <https://p.sicp.me/nHvwQ>