### PR TITLE
apps/client/utils/init-network: avoid adding tokens to wallet twice

### DIFF
--- a/.changelog/unreleased/improvements/1362-init-network-dup-tokens.md
+++ b/.changelog/unreleased/improvements/1362-init-network-dup-tokens.md
@@ -1,0 +1,2 @@
+- Client/utils: Avoid adding token addresses twice in wallets created for new
+  networks. ([\#1362](https://github.com/anoma/namada/pull/1362))

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -601,11 +601,10 @@ pub fn init_network(
         })
     }
 
-    config.token.iter_mut().for_each(|(name, config)| {
+    config.token.iter_mut().for_each(|(_name, config)| {
         if config.address.is_none() {
             let address = address::gen_established_address("token");
             config.address = Some(address.to_string());
-            wallet.add_address(name.clone(), address);
         }
         if config.vp.is_none() {
             config.vp = Some("vp_token".to_string());


### PR DESCRIPTION
follow-up to https://github.com/anoma/namada/pull/1081 - the token addresses are being added twice into the wallet when running `init-network`. In here it's a no-op but with #1350 changes it triggers a replace prompt which is unwanted