### PR TITLE
Add IBC event queries

### DIFF
--- a/.changelog/unreleased/improvements/1404-ibc-event-query.md
+++ b/.changelog/unreleased/improvements/1404-ibc-event-query.md
@@ -1,0 +1,2 @@
+- Added query endpoint for IBC events replacing Tendermint index.
+  ([\#1404](https://github.com/anoma/namada/pull/1404))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4188,6 +4188,7 @@ dependencies = [
  "namada_test_utils",
  "namada_tx_prelude",
  "namada_vp_prelude",
+ "once_cell",
  "pretty_assertions",
  "proptest",
  "prost",

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -364,7 +364,9 @@ where
                         }
                         for ibc_event in &result.ibc_events {
                             // Add the IBC event besides the tx_event
-                            let event = Event::from(ibc_event.clone());
+                            let mut event = Event::from(ibc_event.clone());
+                            // Add the height for IBC event query
+                            event["height"] = height.to_string();
                             response.events.push(event);
                         }
                         match serde_json::to_string(

--- a/shared/src/ledger/events.rs
+++ b/shared/src/ledger/events.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{self, Display};
 use std::ops::{Index, IndexMut};
+use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use thiserror::Error;
@@ -60,6 +61,25 @@ impl Display for EventType {
             EventType::Proposal => write!(f, "proposal"),
         }?;
         Ok(())
+    }
+}
+
+impl FromStr for EventType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "accepted" => Ok(EventType::Accepted),
+            "applied" => Ok(EventType::Applied),
+            "proposal" => Ok(EventType::Proposal),
+            // IBC
+            "update_client" => Ok(EventType::Ibc("update_client".to_string())),
+            "send_packet" => Ok(EventType::Ibc("send_packet".to_string())),
+            "write_acknowledgement" => {
+                Ok(EventType::Ibc("write_acknowledgement".to_string()))
+            }
+            _ => Err(Error::InvalidEventType),
+        }
     }
 }
 
@@ -199,6 +219,9 @@ impl Attributes {
 /// Errors to do with emitting events.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Error when parsing an event type
+    #[error("Invalid event type")]
+    InvalidEventType,
     /// Error when parsing attributes from an event JSON.
     #[error("Json missing `attributes` field")]
     MissingAttributes,

--- a/shared/src/ledger/events/log/dumb_queries.rs
+++ b/shared/src/ledger/events/log/dumb_queries.rs
@@ -31,15 +31,12 @@ impl QueryMatcher {
             return false;
         }
 
-        for attr in &self.attributes {
-            if let Some(value) = event.attributes.get(attr.0) {
-                if value != attr.1 {
-                    return false;
-                }
+        self.attributes.iter().all(|(key, value)| {
+            match event.attributes.get(key) {
+                Some(v) => v == value,
+                None => false,
             }
-        }
-
-        true
+        })
     }
 
     /// Returns a query matching the given accepted transaction hash.

--- a/shared/src/ledger/events/log/dumb_queries.rs
+++ b/shared/src/ledger/events/log/dumb_queries.rs
@@ -6,51 +6,98 @@
 //! tm.event='NewBlock' AND <accepted|applied>.<$attr>='<$value>'
 //! ```
 
+use std::collections::HashMap;
+
+use crate::ibc::core::ics04_channel::packet::Sequence;
+use crate::ibc::core::ics24_host::identifier::{ChannelId, ClientId, PortId};
 use crate::ledger::events::{Event, EventType};
 use crate::types::hash::Hash;
+use crate::types::storage::BlockHeight;
 
 /// A [`QueryMatcher`] verifies if a Namada event matches a
 /// given Tendermint query.
 #[derive(Debug, Clone)]
 pub struct QueryMatcher {
     event_type: EventType,
-    attr: String,
-    value: Hash,
+    attributes: HashMap<String, String>,
 }
 
 impl QueryMatcher {
     /// Checks if this [`QueryMatcher`] validates the
     /// given [`Event`].
     pub fn matches(&self, event: &Event) -> bool {
-        event.event_type == self.event_type
-            && event
-                .attributes
-                .get(&self.attr)
-                .and_then(|value| {
-                    value
-                        .as_str()
-                        .try_into()
-                        .map(|v: Hash| v == self.value)
-                        .ok()
-                })
-                .unwrap_or_default()
+        if event.event_type != self.event_type {
+            return false;
+        }
+
+        for attr in &self.attributes {
+            if let Some(value) = event.attributes.get(attr.0) {
+                if value != attr.1 {
+                    return false;
+                }
+            }
+        }
+
+        true
     }
 
     /// Returns a query matching the given accepted transaction hash.
     pub fn accepted(tx_hash: Hash) -> Self {
+        let mut attributes = HashMap::new();
+        attributes.insert("hash".to_string(), tx_hash.to_string());
         Self {
             event_type: EventType::Accepted,
-            attr: "hash".to_string(),
-            value: tx_hash,
+            attributes,
         }
     }
 
     /// Returns a query matching the given applied transaction hash.
     pub fn applied(tx_hash: Hash) -> Self {
+        let mut attributes = HashMap::new();
+        attributes.insert("hash".to_string(), tx_hash.to_string());
         Self {
             event_type: EventType::Applied,
-            attr: "hash".to_string(),
-            value: tx_hash,
+            attributes,
+        }
+    }
+
+    /// Returns a query matching the given IBC UpdateClient parameters
+    pub fn ibc_update_client(
+        client_id: ClientId,
+        consensus_height: BlockHeight,
+    ) -> Self {
+        let mut attributes = HashMap::new();
+        attributes.insert("client_id".to_string(), client_id.to_string());
+        attributes.insert(
+            "consensus_height".to_string(),
+            format!("0-{}", consensus_height),
+        );
+        Self {
+            event_type: EventType::Ibc("update_client".to_string()),
+            attributes,
+        }
+    }
+
+    /// Returns a query matching the given IBC packet parameters
+    pub fn ibc_packet(
+        event_type: EventType,
+        source_port: PortId,
+        source_channel: ChannelId,
+        destination_port: PortId,
+        destination_channel: ChannelId,
+        sequence: Sequence,
+    ) -> Self {
+        let mut attributes = HashMap::new();
+        attributes.insert("src_port".to_string(), source_port.to_string());
+        attributes
+            .insert("src_channel".to_string(), source_channel.to_string());
+        attributes.insert("dst_port".to_string(), destination_port.to_string());
+        attributes
+            .insert("dst_channel".to_string(), destination_channel.to_string());
+        attributes.insert("sequence".to_string(), sequence.to_string());
+        Self {
+            event_type,
+            attributes,
         }
     }
 }
@@ -66,10 +113,11 @@ mod tests {
         const HASH: &str =
             "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF";
 
+        let mut attributes = HashMap::new();
+        attributes.insert("hash".to_string(), HASH.to_string());
         let matcher = QueryMatcher {
             event_type: EventType::Accepted,
-            attr: "hash".to_string(),
-            value: HASH.try_into().unwrap(),
+            attributes,
         };
 
         let tests = {

--- a/shared/src/ledger/queries/mod.rs
+++ b/shared/src/ledger/queries/mod.rs
@@ -7,7 +7,8 @@ use shell::SHELL;
 #[cfg(any(test, feature = "async-client"))]
 pub use types::Client;
 pub use types::{
-    EncodedResponseQuery, RequestCtx, RequestQuery, ResponseQuery, Router,
+    EncodedResponseQuery, Error, RequestCtx, RequestQuery, ResponseQuery,
+    Router,
 };
 use vp::VP;
 // Re-export to show in rustdoc!

--- a/shared/src/ledger/queries/mod.rs
+++ b/shared/src/ledger/queries/mod.rs
@@ -16,7 +16,6 @@ pub use vp::{Pos, Vp};
 
 use super::storage::{DBIter, StorageHasher, DB};
 use super::storage_api;
-use crate::tendermint_rpc::error::Error as RpcError;
 use crate::types::storage::BlockHeight;
 
 #[macro_use]
@@ -102,6 +101,7 @@ mod testing {
     use super::*;
     use crate::ledger::events::log::EventLog;
     use crate::ledger::storage::testing::TestWlStorage;
+    use crate::tendermint_rpc::error::Error as RpcError;
     use crate::types::storage::BlockHeight;
     use crate::vm::wasm::{self, TxCache, VpCache};
     use crate::vm::WasmCacheRoAccess;

--- a/shared/src/ledger/queries/shell.rs
+++ b/shared/src/ledger/queries/shell.rs
@@ -6,15 +6,17 @@ use namada_core::types::address::Address;
 use namada_core::types::hash::Hash;
 use namada_core::types::storage::{BlockResults, KeySeg};
 
+use crate::ibc::core::ics04_channel::packet::Sequence;
+use crate::ibc::core::ics24_host::identifier::{ChannelId, ClientId, PortId};
 use crate::ledger::events::log::dumb_queries;
-use crate::ledger::events::Event;
+use crate::ledger::events::{Event, EventType};
 use crate::ledger::queries::types::{RequestCtx, RequestQuery};
 use crate::ledger::queries::{require_latest_height, EncodedResponseQuery};
 use crate::ledger::storage::traits::StorageHasher;
 use crate::ledger::storage::{DBIter, DB};
 use crate::ledger::storage_api::{self, ResultExt, StorageRead};
 use crate::tendermint::merkle::proof::Proof;
-use crate::types::storage::{self, Epoch, PrefixValue};
+use crate::types::storage::{self, BlockHeight, Epoch, PrefixValue};
 #[cfg(any(test, feature = "async-client"))]
 use crate::types::transaction::TxResult;
 
@@ -56,6 +58,11 @@ router! {SHELL,
     // was the transaction applied?
     ( "applied" / [tx_hash: Hash] ) -> Option<Event> = applied,
 
+    // IBC UpdateClient event
+    ( "ibc_client_update" / [client_id: ClientId] / [consensus_height: BlockHeight] ) -> Option<Event> = ibc_client_update,
+
+    // IBC packet event
+    ( "ibc_packet" / [event_type: EventType] / [source_port: PortId] / [source_channel: ChannelId] / [destination_port: PortId] / [destination_channel: ChannelId] / [sequence: Sequence]) -> Option<Event> = ibc_packet,
 }
 
 // Handlers:
@@ -334,6 +341,56 @@ where
     H: 'static + StorageHasher + Sync,
 {
     let matcher = dumb_queries::QueryMatcher::applied(tx_hash);
+    Ok(ctx
+        .event_log
+        .iter_with_matcher(matcher)
+        .by_ref()
+        .next()
+        .cloned())
+}
+
+fn ibc_client_update<D, H>(
+    ctx: RequestCtx<'_, D, H>,
+    client_id: ClientId,
+    consensus_height: BlockHeight,
+) -> storage_api::Result<Option<Event>>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    let matcher = dumb_queries::QueryMatcher::ibc_update_client(
+        client_id,
+        consensus_height,
+    );
+    Ok(ctx
+        .event_log
+        .iter_with_matcher(matcher)
+        .by_ref()
+        .next()
+        .cloned())
+}
+
+fn ibc_packet<D, H>(
+    ctx: RequestCtx<'_, D, H>,
+    event_type: EventType,
+    source_port: PortId,
+    source_channel: ChannelId,
+    destination_port: PortId,
+    destination_channel: ChannelId,
+    sequence: Sequence,
+) -> storage_api::Result<Option<Event>>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    let matcher = dumb_queries::QueryMatcher::ibc_packet(
+        event_type,
+        source_port,
+        source_channel,
+        destination_port,
+        destination_channel,
+        sequence,
+    );
     Ok(ctx
         .event_log
         .iter_with_matcher(matcher)

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -60,6 +60,7 @@ eyre = "0.6.5"
 file-serve = "0.2.0"
 fs_extra = "1.2.0"
 itertools = "0.10.0"
+once_cell = "1.8.0"
 pretty_assertions = "0.7.2"
 # A fork with state machine testing
 proptest = {git = "https://github.com/heliaxdev/proptest", rev = "8f1b4abe7ebd35c0781bf9a00a4ee59833ffa2a1"}

--- a/tests/src/e2e/ibc_tests.rs
+++ b/tests/src/e2e/ibc_tests.rs
@@ -67,6 +67,7 @@ use namada::ledger::events::EventType;
 use namada::ledger::ibc::storage::*;
 use namada::ledger::parameters::{storage as param_storage, EpochDuration};
 use namada::ledger::pos::{self, PosParams};
+use namada::ledger::queries::RPC;
 use namada::ledger::storage::ics23_specs::ibc_proof_specs;
 use namada::ledger::storage::Sha256Hasher;
 use namada::types::address::{Address, InternalAddress};
@@ -74,8 +75,7 @@ use namada::types::key::PublicKey;
 use namada::types::storage::{BlockHeight, Key, RESERVED_ADDRESS_PREFIX};
 use namada::types::token::Amount;
 use namada_apps::client::rpc::{
-    query_ibc_client_update_event, query_ibc_packet_event, query_storage_value,
-    query_storage_value_bytes,
+    query_storage_value, query_storage_value_bytes,
 };
 use namada_apps::client::utils::id_from_pk;
 use namada_apps::config::genesis::genesis_config::GenesisConfig;
@@ -1175,10 +1175,10 @@ fn check_ibc_update_query(
     let client = HttpClient::new(ledger_address).unwrap();
     match Runtime::new()
         .unwrap()
-        .block_on(query_ibc_client_update_event(
+        .block_on(RPC.shell().ibc_client_update(
             &client,
             &client_id.as_str().parse().unwrap(),
-            consensus_height,
+            &consensus_height,
         )) {
         Ok(Some(event)) => {
             println!("Found the update event: {:?}", event);
@@ -1197,14 +1197,14 @@ fn check_ibc_packet_query(
     let rpc = get_actor_rpc(test, &Who::Validator(0));
     let ledger_address = TendermintAddress::from_str(&rpc).unwrap();
     let client = HttpClient::new(ledger_address).unwrap();
-    match Runtime::new().unwrap().block_on(query_ibc_packet_event(
+    match Runtime::new().unwrap().block_on(RPC.shell().ibc_packet(
         &client,
         event_type,
         &packet.source_port.as_str().parse().unwrap(),
         &packet.source_channel.as_str().parse().unwrap(),
         &packet.destination_port.as_str().parse().unwrap(),
         &packet.destination_channel.as_str().parse().unwrap(),
-        packet.sequence.to_string().parse().unwrap(),
+        &packet.sequence.to_string().parse().unwrap(),
     )) {
         Ok(Some(event)) => {
             println!("Found the packet event: {:?}", event);

--- a/tests/src/e2e/ibc_tests.rs
+++ b/tests/src/e2e/ibc_tests.rs
@@ -99,7 +99,7 @@ fn run_ledger_ibc() -> Result<()> {
         test_a,
         Who::Validator(0),
         Bin::Node,
-        &["ledger", "run", "--tx-index"],
+        &["ledger", "run"],
         Some(40)
     )?;
     ledger_a.exp_string("Namada ledger node started")?;
@@ -108,7 +108,7 @@ fn run_ledger_ibc() -> Result<()> {
         test_b,
         Who::Validator(0),
         Bin::Node,
-        &["ledger", "run", "--tx-index"],
+        &["ledger", "run"],
         Some(40)
     )?;
     ledger_b.exp_string("Namada ledger node started")?;

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -3851,6 +3851,7 @@ fn test_genesis_validators() -> Result<()> {
         test_dir,
         net,
         genesis,
+        async_runtime: Default::default(),
     };
 
     // Host the network archive to make it available for `join-network` commands

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -23,6 +23,7 @@ use namada::types::chain::ChainId;
 use namada_apps::client::utils;
 use namada_apps::config::genesis::genesis_config::{self, GenesisConfig};
 use namada_apps::{config, wallet};
+use once_cell::sync::Lazy;
 use rand::Rng;
 use serde_json;
 use tempfile::{tempdir, TempDir};
@@ -202,6 +203,7 @@ pub fn network(
         test_dir,
         net,
         genesis,
+        async_runtime: Default::default(),
     })
 }
 
@@ -222,6 +224,7 @@ pub struct Test {
     pub test_dir: TestDir,
     pub net: Network,
     pub genesis: GenesisConfig,
+    pub async_runtime: LazyAsyncRuntime,
 }
 
 #[derive(Debug)]
@@ -274,6 +277,15 @@ impl Drop for Test {
                 path.to_string_lossy()
             );
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct LazyAsyncRuntime(Lazy<tokio::runtime::Runtime>);
+
+impl Default for LazyAsyncRuntime {
+    fn default() -> Self {
+        Self(Lazy::new(|| tokio::runtime::Runtime::new().unwrap()))
     }
 }
 
@@ -411,6 +423,11 @@ impl Test {
                 .join(format!("validator-{}", index))
                 .join(config::DEFAULT_BASE_DIR),
         }
+    }
+
+    /// Get an async runtime.
+    pub fn async_runtime(&self) -> &tokio::runtime::Runtime {
+        Lazy::force(&self.async_runtime.0)
     }
 }
 


### PR DESCRIPTION
closes #1358

To get IBC "update_client", "send_packet" and "write_acknowledgement" events for an IBC relayer without Tendermint index because Tendermint index is disabled by default.