### PR TITLE
Stateful replay protection

### DIFF
--- a/.changelog/unreleased/bug-fixes/1405-bugfix-replay-prepare.md
+++ b/.changelog/unreleased/bug-fixes/1405-bugfix-replay-prepare.md
@@ -1,0 +1,3 @@
+- Fixed a bug in `prepare_proposal` causing the creation
+  of blocks containing already applied transactions.
+  ([#1405](https://github.com/anoma/namada/pull/1405))

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -22,6 +22,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use namada::core::types::hash::Hash;
 use namada::ledger::events::log::EventLog;
 use namada::ledger::events::Event;
 use namada::ledger::gas::BlockGasMeter;
@@ -30,9 +31,9 @@ use namada::ledger::pos::namada_proof_of_stake::types::{
 };
 use namada::ledger::storage::write_log::WriteLog;
 use namada::ledger::storage::{
-    DBIter, Sha256Hasher, Storage, StorageHasher, WlStorage, DB,
+    DBIter, Sha256Hasher, Storage, StorageHasher, TempWlStorage, WlStorage, DB,
 };
-use namada::ledger::storage_api::{self, StorageRead};
+use namada::ledger::storage_api::{self, StorageRead, StorageWrite};
 use namada::ledger::{ibc, pos, protocol, replay_protection};
 use namada::proof_of_stake::{self, read_pos_params, slash};
 use namada::proto::{self, Tx};
@@ -47,7 +48,7 @@ use namada::types::token::{self};
 use namada::types::transaction::MIN_FEE;
 use namada::types::transaction::{
     hash_tx, process_tx, verify_decrypted_correctly, AffineCurve, DecryptedTx,
-    EllipticCurve, PairingEngine, TxType,
+    EllipticCurve, PairingEngine, TxType, WrapperTx,
 };
 use namada::types::{address, hash};
 use namada::vm::wasm::{TxCache, VpCache};
@@ -112,6 +113,8 @@ pub enum Error {
     LoadingWasm(String),
     #[error("Error reading from or writing to storage: {0}")]
     StorageApi(#[from] storage_api::Error),
+    #[error("Transaction replay attempt: {0}")]
+    ReplayAttempt(String),
 }
 
 impl From<Error> for TxResult {
@@ -644,6 +647,55 @@ where
         );
         response.data = root.0;
         response
+    }
+
+    /// Checks that neither the wrapper nor the inner transaction have already
+    /// been applied. Requires a [`TempWlStorage`] to perform the check during
+    /// block construction and validation
+    pub fn replay_protection_checks(
+        &self,
+        wrapper: &WrapperTx,
+        tx_bytes: &[u8],
+        temp_wl_storage: &mut TempWlStorage<D, H>,
+    ) -> Result<()> {
+        let inner_hash_key =
+            replay_protection::get_tx_hash_key(&wrapper.tx_hash);
+        if temp_wl_storage
+            .has_key(&inner_hash_key)
+            .expect("Error while checking inner tx hash key in storage")
+        {
+            return Err(Error::ReplayAttempt(format!(
+                "Inner transaction hash {} already in storage",
+                &wrapper.tx_hash
+            )));
+        }
+
+        // Write inner hash to WAL
+        temp_wl_storage
+            .write(&inner_hash_key, ())
+            .expect("Couldn't write inner transaction hash to write log");
+
+        let tx =
+            Tx::try_from(tx_bytes).expect("Deserialization shouldn't fail");
+        let wrapper_hash = Hash(tx.unsigned_hash());
+        let wrapper_hash_key =
+            replay_protection::get_tx_hash_key(&wrapper_hash);
+        if temp_wl_storage
+            .has_key(&wrapper_hash_key)
+            .expect("Error while checking wrapper tx hash key in storage")
+        {
+            return Err(Error::ReplayAttempt(format!(
+                "Wrapper transaction hash {} already in storage",
+                wrapper_hash
+            )));
+        }
+
+        // Write wrapper hash to WAL
+        temp_wl_storage
+            .write(&wrapper_hash_key, ())
+            .expect("Couldn't write wrapper tx hash to write log");
+
+        Ok(())
     }
 
     /// Validate a transaction request. On success, the transaction will

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -4,7 +4,6 @@
 use data_encoding::HEXUPPER;
 use namada::core::hints;
 use namada::core::ledger::storage::WlStorage;
-use namada::core::types::hash::Hash;
 use namada::ledger::storage::TempWlStorage;
 use namada::proof_of_stake::pos_queries::PosQueries;
 use namada::types::internal::WrapperTxInQueue;
@@ -429,53 +428,16 @@ where
                     }
                 } else {
                     // Replay protection checks
-                    let inner_hash_key =
-                        replay_protection::get_tx_hash_key(&wrapper.tx_hash);
-                    if temp_wl_storage.has_key(&inner_hash_key).expect(
-                        "Error while checking inner tx hash key in storage",
+                    if let Err(e) = self.replay_protection_checks(
+                        &wrapper,
+                        tx_bytes,
+                        temp_wl_storage,
                     ) {
                         return TxResult {
                             code: ErrorCodes::ReplayTx.into(),
-                            info: format!(
-                                "Inner transaction hash {} already in \
-                                 storage, replay attempt",
-                                &wrapper.tx_hash
-                            ),
+                            info: e.to_string(),
                         };
                     }
-
-                    // Write inner hash to WAL
-                    temp_wl_storage
-                        .write_log
-                        .write(&inner_hash_key, vec![])
-                        .expect(
-                            "Couldn't write inner transaction hash to write \
-                             log",
-                        );
-
-                    let tx = Tx::try_from(tx_bytes)
-                        .expect("Deserialization shouldn't fail");
-                    let wrapper_hash = Hash(tx.unsigned_hash());
-                    let wrapper_hash_key =
-                        replay_protection::get_tx_hash_key(&wrapper_hash);
-                    if temp_wl_storage.has_key(&wrapper_hash_key).expect(
-                        "Error while checking wrapper tx hash key in storage",
-                    ) {
-                        return TxResult {
-                            code: ErrorCodes::ReplayTx.into(),
-                            info: format!(
-                                "Wrapper transaction hash {} already in \
-                                 storage, replay attempt",
-                                wrapper_hash
-                            ),
-                        };
-                    }
-
-                    // Write wrapper hash to WAL
-                    temp_wl_storage
-                        .write_log
-                        .write(&wrapper_hash_key, vec![])
-                        .expect("Couldn't write wrapper tx hash to write log");
 
                     // If the public key corresponds to the MASP sentinel
                     // transaction key, then the fee payer is effectively
@@ -1168,8 +1130,8 @@ mod test_process_proposal {
                 assert_eq!(
                     response[0].result.info,
                     format!(
-                        "Wrapper transaction hash {} already in storage, \
-                         replay attempt",
+                        "Transaction replay attempt: Wrapper transaction hash \
+                         {} already in storage",
                         wrapper_unsigned_hash
                     )
                 );
@@ -1236,8 +1198,8 @@ mod test_process_proposal {
                 assert_eq!(
                     response[1].result.info,
                     format!(
-                        "Inner transaction hash {} already in storage, replay \
-                         attempt",
+                        "Transaction replay attempt: Inner transaction hash \
+                         {} already in storage",
                         wrapper.tx_hash
                     )
                 );
@@ -1299,8 +1261,8 @@ mod test_process_proposal {
                 assert_eq!(
                     response[0].result.info,
                     format!(
-                        "Inner transaction hash {} already in storage, replay \
-                         attempt",
+                        "Transaction replay attempt: Inner transaction hash \
+                         {} already in storage",
                         inner_unsigned_hash
                     )
                 );
@@ -1395,8 +1357,8 @@ mod test_process_proposal {
                 assert_eq!(
                     response[1].result.info,
                     format!(
-                        "Inner transaction hash {} already in storage, replay \
-                         attempt",
+                        "Transaction replay attempt: Inner transaction hash \
+                         {} already in storage",
                         inner_unsigned_hash
                     )
                 );


### PR DESCRIPTION
Implements stateful replay protection in `prepare_proposal` to avoid adding the same transaction more than once in a block