### PR TITLE
ci: run with maint-* target branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - maint-*
       - "!eth-bridge-integration"
   # Run in PRs with conflicts (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)
   pull_request_target:
     branches:
       - main
+      - maint-*
       - "!eth-bridge-integration"
     types: [opened, synchronize, reopened]
   workflow_dispatch:


### PR DESCRIPTION
We want CIs to start if the target branch is `main` or `maint-*`.