### PR TITLE
Gijs/makefile e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,12 +118,24 @@ test-unit-coverage:
 		-Z unstable-options \
 		-- --skip e2e -Z unstable-options --report-time
 
+# NOTE: `TEST_FILTER` is prepended with `e2e::`. Since filters in `cargo test`
+# work with a substring search, TEST_FILTER only works if it contains a string
+# that directly follows `e2e::`, e.g. `TEST_FILTER=multitoken_tests` would run
+# all tests that start with `e2e::multitoken_tests`.
 test-e2e:
-	RUST_BACKTRACE=1 $(cargo) test e2e \
-		-Z unstable-options \
-		-- \
-		--test-threads=1 \
-		-Z unstable-options --report-time
+ifdef NAMADA_E2E_USE_PREBUILT_BINARIES
+	NAMADA_E2E_USE_PREBUILT_BINARIES=true RUST_BACKTRACE=1 $(cargo) +$(nightly) test e2e::$(TEST_FILTER) \
+	-Z unstable-options \
+	-- \
+	--test-threads=1 \
+	-Z unstable-options --report-time
+else
+	RUST_BACKTRACE=1 $(cargo) +$(nightly) test e2e::$(TEST_FILTER) \
+	-Z unstable-options \
+	-- \
+	--test-threads=1 \
+	-Z unstable-options --report-time
+endif
 
 test-unit-abcipp:
 	$(cargo) test \

--- a/Makefile
+++ b/Makefile
@@ -123,14 +123,14 @@ test-unit-coverage:
 # that directly follows `e2e::`, e.g. `TEST_FILTER=multitoken_tests` would run
 # all tests that start with `e2e::multitoken_tests`.
 test-e2e:
-ifdef NAMADA_E2E_USE_PREBUILT_BINARIES
-	NAMADA_E2E_USE_PREBUILT_BINARIES=true RUST_BACKTRACE=1 $(cargo) +$(nightly) test e2e::$(TEST_FILTER) \
+ifdef NAMADA_E2E_NO_PREBUILT_BINARIES
+	RUST_BACKTRACE=1 $(cargo) +$(nightly) test e2e::$(TEST_FILTER) \
 	-Z unstable-options \
 	-- \
 	--test-threads=1 \
 	-Z unstable-options --report-time
 else
-	RUST_BACKTRACE=1 $(cargo) +$(nightly) test e2e::$(TEST_FILTER) \
+	NAMADA_E2E_USE_PREBUILT_BINARIES=true RUST_BACKTRACE=1 $(cargo) +$(nightly) test e2e::$(TEST_FILTER) \
 	-Z unstable-options \
 	-- \
 	--test-threads=1 \


### PR DESCRIPTION
This PR fixes the `test-e2e`-target in the makefile by using the nightly.

It also uses the `NAMADA_E2E_USE_PREBUILT_BINARIES=true` variable by default for a ~50x speed improvement on e2e-tests. The default behavior can be suppressed by using passing the `NAMADA_E2E_NO_PREBUILT_BINARIES` argument to `make`. If the argument is there, it will build the binaries between every e2e test.