### PR TITLE
storage: persist `update_epoch_blocks_delay`

### DIFF
--- a/.changelog/unreleased/bug-fixes/1455-persist-epoch-update-delay.md
+++ b/.changelog/unreleased/bug-fixes/1455-persist-epoch-update-delay.md
@@ -1,0 +1,3 @@
+- Persists a newly added storage field for epoch update blocks delay to be
+  available after node restart when not `None` which may break consensus.
+  ([\#1455](https://github.com/anoma/namada/pull/1455))

--- a/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -537,6 +537,19 @@ impl DB for RocksDB {
                 return Ok(None);
             }
         };
+        let update_epoch_blocks_delay: Option<u32> = match self
+            .0
+            .get_cf(state_cf, "update_epoch_blocks_delay")
+            .map_err(|e| Error::DBError(e.into_string()))?
+        {
+            Some(bytes) => types::decode(bytes).map_err(Error::CodingError)?,
+            None => {
+                tracing::error!(
+                    "Couldn't load epoch update block delay from the DB"
+                );
+                return Ok(None);
+            }
+        };
         let tx_queue: TxQueue = match self
             .0
             .get_cf(state_cf, "tx_queue")
@@ -636,6 +649,7 @@ impl DB for RocksDB {
                     results,
                     next_epoch_min_start_height,
                     next_epoch_min_start_time,
+                    update_epoch_blocks_delay,
                     address_gen,
                     tx_queue,
                 }))
@@ -660,10 +674,11 @@ impl DB for RocksDB {
             height,
             epoch,
             pred_epochs,
-            results,
             next_epoch_min_start_height,
             next_epoch_min_start_time,
+            update_epoch_blocks_delay,
             address_gen,
+            results,
             tx_queue,
         }: BlockStateWrite = state;
 
@@ -704,6 +719,24 @@ impl DB for RocksDB {
             "next_epoch_min_start_time",
             types::encode(&next_epoch_min_start_time),
         );
+        if let Some(current_value) = self
+            .0
+            .get_cf(state_cf, "update_epoch_blocks_delay")
+            .map_err(|e| Error::DBError(e.into_string()))?
+        {
+            // Write the predecessor value for rollback
+            batch.0.put_cf(
+                state_cf,
+                "pred/update_epoch_blocks_delay",
+                current_value,
+            );
+        }
+        batch.0.put_cf(
+            state_cf,
+            "update_epoch_blocks_delay",
+            types::encode(&update_epoch_blocks_delay),
+        );
+
         // Tx queue
         if let Some(pred_tx_queue) = self
             .0
@@ -1412,6 +1445,7 @@ mod test {
         let height = BlockHeight::default();
         let next_epoch_min_start_height = BlockHeight::default();
         let next_epoch_min_start_time = DateTimeUtc::now();
+        let update_epoch_blocks_delay = None;
         let address_gen = EstablishedAddressGen::new("whatever");
         let tx_queue = TxQueue::default();
         let results = BlockResults::default();
@@ -1425,6 +1459,7 @@ mod test {
             pred_epochs: &pred_epochs,
             next_epoch_min_start_height,
             next_epoch_min_start_time,
+            update_epoch_blocks_delay,
             address_gen: &address_gen,
             tx_queue: &tx_queue,
         };

--- a/core/src/ledger/storage/mockdb.rs
+++ b/core/src/ledger/storage/mockdb.rs
@@ -83,6 +83,13 @@ impl DB for MockDB {
                 }
                 None => return Ok(None),
             };
+        let update_epoch_blocks_delay: Option<u32> =
+            match self.0.borrow().get("update_epoch_blocks_delay") {
+                Some(bytes) => {
+                    types::decode(bytes).map_err(Error::CodingError)?
+                }
+                None => return Ok(None),
+            };
         #[cfg(feature = "ferveo-tpke")]
         let tx_queue: TxQueue = match self.0.borrow().get("tx_queue") {
             Some(bytes) => types::decode(bytes).map_err(Error::CodingError)?,
@@ -160,6 +167,7 @@ impl DB for MockDB {
                     pred_epochs,
                     next_epoch_min_start_height,
                     next_epoch_min_start_time,
+                    update_epoch_blocks_delay,
                     address_gen,
                     results,
                     #[cfg(feature = "ferveo-tpke")]
@@ -188,6 +196,7 @@ impl DB for MockDB {
             pred_epochs,
             next_epoch_min_start_height,
             next_epoch_min_start_time,
+            update_epoch_blocks_delay,
             address_gen,
             results,
             #[cfg(feature = "ferveo-tpke")]
@@ -202,6 +211,10 @@ impl DB for MockDB {
         self.0.borrow_mut().insert(
             "next_epoch_min_start_time".into(),
             types::encode(&next_epoch_min_start_time),
+        );
+        self.0.borrow_mut().insert(
+            "update_epoch_blocks_delay".into(),
+            types::encode(&update_epoch_blocks_delay),
         );
         #[cfg(feature = "ferveo-tpke")]
         {

--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -168,6 +168,8 @@ pub struct BlockStateRead {
     pub next_epoch_min_start_height: BlockHeight,
     /// Minimum block time at which the next epoch may start
     pub next_epoch_min_start_time: DateTimeUtc,
+    /// Update epoch delay
+    pub update_epoch_blocks_delay: Option<u32>,
     /// Established address generator
     pub address_gen: EstablishedAddressGen,
     /// Results of applying transactions
@@ -195,6 +197,8 @@ pub struct BlockStateWrite<'a> {
     pub next_epoch_min_start_height: BlockHeight,
     /// Minimum block time at which the next epoch may start
     pub next_epoch_min_start_time: DateTimeUtc,
+    /// Update epoch delay
+    pub update_epoch_blocks_delay: Option<u32>,
     /// Established address generator
     pub address_gen: &'a EstablishedAddressGen,
     /// Results of applying transactions
@@ -390,6 +394,7 @@ where
             pred_epochs,
             next_epoch_min_start_height,
             next_epoch_min_start_time,
+            update_epoch_blocks_delay,
             results,
             address_gen,
             #[cfg(feature = "ferveo-tpke")]
@@ -405,6 +410,7 @@ where
             self.last_epoch = epoch;
             self.next_epoch_min_start_height = next_epoch_min_start_height;
             self.next_epoch_min_start_time = next_epoch_min_start_time;
+            self.update_epoch_blocks_delay = update_epoch_blocks_delay;
             self.address_gen = address_gen;
             // Rebuild Merkle tree
             self.block.tree = MerkleTree::new(merkle_tree_stores)
@@ -462,6 +468,7 @@ where
             pred_epochs: &self.block.pred_epochs,
             next_epoch_min_start_height: self.next_epoch_min_start_height,
             next_epoch_min_start_time: self.next_epoch_min_start_time,
+            update_epoch_blocks_delay: self.update_epoch_blocks_delay,
             address_gen: &self.address_gen,
             #[cfg(feature = "ferveo-tpke")]
             tx_queue: &self.tx_queue,


### PR DESCRIPTION
Persists a newly added storage field for epoch update blocks delay to be available after node restart when not `None`.