### PR TITLE
client: stop waiting for catch-up when max tries are reached

### DIFF
--- a/.changelog/unreleased/bug-fixes/1456-fix-max-wait-tries.md
+++ b/.changelog/unreleased/bug-fixes/1456-fix-max-wait-tries.md
@@ -1,0 +1,2 @@
+- Client: Fixed an off-by-one error to stop waiting for start or catch-up when
+  max tries are reached. ([\#1456](https://github.com/anoma/namada/pull/1456))

--- a/apps/src/bin/namada-client/cli.rs
+++ b/apps/src/bin/namada-client/cli.rs
@@ -179,7 +179,7 @@ async fn wait_until_node_is_synched(ledger_address: &TendermintAddress) {
                 if is_at_least_height_one && !is_catching_up {
                     return;
                 } else {
-                    if try_count > MAX_TRIES {
+                    if try_count == MAX_TRIES {
                         println!(
                             "Node is still catching up, wait for it to finish \
                              synching."


### PR DESCRIPTION
Based on #1258.

Fix off-by-one error. Stop waiting for start or catch-up when max tries are reached.