### PR TITLE
Custom height db dump

### DIFF
--- a/.changelog/unreleased/improvements/1468-custom-height-db-dump.md
+++ b/.changelog/unreleased/improvements/1468-custom-height-db-dump.md
@@ -1,0 +1,2 @@
+- Adds the possibility to dump the state of the db at a custom height.
+  ([\#1468](https://github.com/anoma/namada/pull/1468))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2341,7 +2341,7 @@ pub mod args {
         }),
     );
     pub const BLOCK_HEIGHT: Arg<BlockHeight> = arg("block-height");
-    // pub const BLOCK_HEIGHT_OPT: ArgOpt<BlockHeight> = arg_opt("height");
+    pub const BLOCK_HEIGHT_OPT: ArgOpt<BlockHeight> = arg_opt("height");
     pub const BROADCAST_ONLY: ArgFlag = flag("broadcast-only");
     pub const CHAIN_ID: Arg<ChainId> = arg("chain-id");
     pub const CHAIN_ID_OPT: ArgOpt<ChainId> = CHAIN_ID.opt();
@@ -2608,41 +2608,41 @@ pub mod args {
     #[derive(Clone, Debug)]
     pub struct LedgerDumpDb {
         // TODO: allow to specify height
-        // pub block_height: Option<BlockHeight>,
+        pub block_height: Option<BlockHeight>,
         pub out_file_path: PathBuf,
         pub historic: bool,
     }
 
     impl Args for LedgerDumpDb {
         fn parse(matches: &ArgMatches) -> Self {
-            // let block_height = BLOCK_HEIGHT_OPT.parse(matches);
+            let block_height = BLOCK_HEIGHT_OPT.parse(matches);
             let out_file_path = OUT_FILE_PATH_OPT
                 .parse(matches)
                 .unwrap_or_else(|| PathBuf::from("db_dump".to_string()));
             let historic = HISTORIC.parse(matches);
 
             Self {
-                // block_height,
+                block_height,
                 out_file_path,
                 historic,
             }
         }
 
         fn def(app: App) -> App {
-            app
-                // .arg(BLOCK_HEIGHT_OPT.def().help(
-                //     "The block height to dump. Defaults to latest committed
-                // block.", ))
-                .arg(OUT_FILE_PATH_OPT.def().help(
-                    "Path for the output file (omitting file extension). \
-                     Defaults to \"db_dump.{block_height}.toml\" in the \
-                     current working directory.",
-                ))
-                .arg(
-                    HISTORIC.def().help(
-                        "If provided, dump also the diff of the last height",
-                    ),
-                )
+            app.arg(BLOCK_HEIGHT_OPT.def().help(
+                "The block height to dump. Defaults to latest committed
+                block.",
+            ))
+            .arg(OUT_FILE_PATH_OPT.def().help(
+                "Path for the output file (omitting file extension). Defaults \
+                 to \"db_dump.{block_height}.toml\" in the current working \
+                 directory.",
+            ))
+            .arg(
+                HISTORIC
+                    .def()
+                    .help("If provided, dump also the diff of the last height"),
+            )
         }
     }
 

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -215,7 +215,7 @@ pub fn reset(config: config::Ledger) -> Result<(), shell::Error> {
 pub fn dump_db(
     config: config::Ledger,
     args::LedgerDumpDb {
-        // block_height,
+        block_height,
         out_file_path,
         historic,
     }: args::LedgerDumpDb,
@@ -226,7 +226,7 @@ pub fn dump_db(
     let db_path = config.shell.db_dir(&chain_id);
 
     let db = storage::PersistentDB::open(db_path, None);
-    db.dump_last_block(out_file_path, historic);
+    db.dump_block(out_file_path, historic, &mut block_height.clone());
 }
 
 /// Roll Namada state back to the previous height

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -226,7 +226,7 @@ pub fn dump_db(
     let db_path = config.shell.db_dir(&chain_id);
 
     let db = storage::PersistentDB::open(db_path, None);
-    db.dump_block(out_file_path, historic, &mut block_height.clone());
+    db.dump_block(out_file_path, historic, block_height);
 }
 
 /// Roll Namada state back to the previous height


### PR DESCRIPTION
## Describe your changes

Closes #1192.

Accepts an optional `height` parameter for the `dump-db` command to allow dumping the state at a specific block height.
Also buffers the write to the resulting file.

## Indicate on which release or other PRs this topic is based on

v0.20.1

## Checklist before merging to draft

- [x] I have added a changelog
- [x] Git history is in acceptable state