### PR TITLE
apps: add namadac utils default-base-dir

### DIFF
--- a/.changelog/unreleased/improvements/1491-utils-base-dir.md
+++ b/.changelog/unreleased/improvements/1491-utils-base-dir.md
@@ -1,0 +1,4 @@
+- Add a command, `namadac utils default-base-dir`, to
+  print the default base directory the command
+  line would use were one not provided by the user.
+  ([#1491](https://github.com/anoma/namada/pull/1491))

--- a/apps/src/bin/namada-client/cli.rs
+++ b/apps/src/bin/namada-client/cli.rs
@@ -319,6 +319,9 @@ pub async fn main() -> Result<()> {
             Utils::PkToTmAddress(PkToTmAddress(args)) => {
                 utils::pk_to_tm_address(global_args, args)
             }
+            Utils::DefaultBaseDir(DefaultBaseDir(args)) => {
+                utils::default_base_dir(global_args, args)
+            }
         },
     }
     Ok(())

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1506,6 +1506,7 @@ pub mod cmds {
         InitNetwork(InitNetwork),
         InitGenesisValidator(InitGenesisValidator),
         PkToTmAddress(PkToTmAddress),
+        DefaultBaseDir(DefaultBaseDir),
     }
 
     impl SubCmd for Utils {
@@ -1522,11 +1523,14 @@ pub mod cmds {
                     SubCmd::parse(matches).map(Self::InitGenesisValidator);
                 let pk_to_tm_address =
                     SubCmd::parse(matches).map(Self::PkToTmAddress);
+                let default_base_dir =
+                    SubCmd::parse(matches).map(Self::DefaultBaseDir);
                 join_network
                     .or(fetch_wasms)
                     .or(init_network)
                     .or(init_genesis)
                     .or(pk_to_tm_address)
+                    .or(default_base_dir)
             })
         }
 
@@ -1538,6 +1542,7 @@ pub mod cmds {
                 .subcommand(InitNetwork::def())
                 .subcommand(InitGenesisValidator::def())
                 .subcommand(PkToTmAddress::def())
+                .subcommand(DefaultBaseDir::def())
                 .setting(AppSettings::SubcommandRequiredElseHelp)
         }
     }
@@ -1641,6 +1646,29 @@ pub mod cmds {
                      Tendermint address.",
                 )
                 .add_args::<args::PkToTmAddress>()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct DefaultBaseDir(pub args::DefaultBaseDir);
+
+    impl SubCmd for DefaultBaseDir {
+        const CMD: &'static str = "default-base-dir";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches
+                .subcommand_matches(Self::CMD)
+                .map(|matches| Self(args::DefaultBaseDir::parse(matches)))
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about(
+                    "Print the default base directory that would be used if \
+                     --base-dir or NAMADA_BASE_DIR were not used to set the \
+                     base directory.",
+                )
+                .add_args::<args::DefaultBaseDir>()
         }
     }
 }
@@ -3643,6 +3671,19 @@ pub mod args {
                 "The consensus public key to be converted to Tendermint \
                  address.",
             ))
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct DefaultBaseDir {}
+
+    impl Args for DefaultBaseDir {
+        fn parse(_matches: &ArgMatches) -> Self {
+            Self {}
+        }
+
+        fn def(app: App) -> App {
+            app
         }
     }
 

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -27,7 +27,7 @@ use crate::config::genesis::genesis_config::{
     self, GenesisConfig, HexString, ValidatorPreGenesisConfig,
 };
 use crate::config::global::GlobalConfig;
-use crate::config::{self, Config, TendermintMode};
+use crate::config::{self, get_default_namada_folder, Config, TendermintMode};
 use crate::facade::tendermint::node::Id as TendermintNodeId;
 use crate::facade::tendermint_config::net::Address as TendermintAddress;
 use crate::node::ledger::tendermint_node;
@@ -899,6 +899,18 @@ pub fn pk_to_tm_address(
 ) {
     let tm_addr = tm_consensus_key_raw_hash(&public_key);
     println!("{tm_addr}");
+}
+
+pub fn default_base_dir(
+    _global_args: args::Global,
+    _args: args::DefaultBaseDir,
+) {
+    println!(
+        "{}",
+        get_default_namada_folder().to_str().expect(
+            "expected a default namada folder to be possible to determine"
+        )
+    );
 }
 
 /// Initialize genesis validator's address, consensus key and validator account


### PR DESCRIPTION
Add a utility command to print the default base directory that would be
used by the Namada command line if a base directory were not provided
on the command line or in the environment.
