### PR TITLE
tendermint_node: Default tendermint dir from config

### DIFF
--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -63,7 +63,9 @@ fn from_env_or_default() -> Result<String> {
             tracing::info!("Using tendermint path from env variable: {}", path);
             Ok(path)
         }
-        Err(std::env::VarError::NotPresent) => Ok(String::from("tendermint")),
+        Err(std::env::VarError::NotPresent) => {
+            Ok(String::from(config::TENDERMINT_DIR))
+        }
         Err(std::env::VarError::NotUnicode(msg)) => {
             Err(Error::TendermintPath(msg))
         }


### PR DESCRIPTION
While rummaging through the code base I found this magic string referring to the default folder for the tendermint binaries.
This folder seems to have a constant `TENDERMINT_DIR` defined for it in `apps/src/lib/config/mod.rs`
