### PR TITLE
Small logging fixes for slashing

### DIFF
--- a/.changelog/unreleased/bug-fixes/1558-fix-slash-logging.md
+++ b/.changelog/unreleased/bug-fixes/1558-fix-slash-logging.md
@@ -1,0 +1,3 @@
+- Fixes the slash rate output in the query_slashes client
+  command and some redundancy in misbehavior reporting logs.
+  ([#1558](https://github.com/anoma/namada/pull/1558))

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -1512,9 +1512,7 @@ pub async fn query_slashes<C: namada::ledger::queries::Client + Sync>(
                     writeln!(
                         w,
                         "Slash epoch {}, type {}, rate {}",
-                        slash.epoch,
-                        slash.r#type,
-                        slash.r#type.get_slash_rate(&params)
+                        slash.epoch, slash.r#type, slash.rate
                     )
                     .unwrap();
                 }

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -593,11 +593,13 @@ where
                         }
                     };
                 tracing::info!(
-                    "Slashing {} for {} in epoch {}, block height {}",
+                    "Slashing {} for {} in epoch {}, block height {} (current \
+                     epoch = {})",
                     validator,
                     slash_type,
                     evidence_epoch,
-                    evidence_height
+                    evidence_height,
+                    current_epoch
                 );
                 if let Err(err) = slash(
                     &mut self.wl_storage,

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -3003,13 +3003,6 @@ pub fn slash<S>(
 where
     S: StorageRead + StorageWrite,
 {
-    tracing::info!(
-        "Slashing validator {} on new evidence from epoch {} (current epoch = \
-         {})",
-        validator,
-        evidence_epoch,
-        current_epoch
-    );
     let evidence_block_height: u64 = evidence_block_height.into();
     let slash = Slash {
         epoch: evidence_epoch,


### PR DESCRIPTION
Based on v0.17.1.

Fixes the output of the slash rate in `query_slashes`. Cleans up redundant logs when a misbehavior is detected and reported.