### PR TITLE
PoS: delay slash validator set update when next epoch is done in TM

### DIFF
--- a/.changelog/unreleased/bug-fixes/1582-slash-validator-delay-set-update.md
+++ b/.changelog/unreleased/bug-fixes/1582-slash-validator-delay-set-update.md
@@ -1,0 +1,3 @@
+- PoS: Ensure that when a validator is slashed, it gets removed from
+  validator set in the same epoch in Namada state as in CometBFT's state.
+  ([\#1582](https://github.com/anoma/namada/pull/1582))

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -107,8 +107,10 @@ where
         }
 
         // Invariant: This has to be applied after
-        // `copy_validator_sets_and_positions` if we're starting a new epoch
+        // `copy_validator_sets_and_positions` and before `self.update_epoch`.
         self.record_slashes_from_evidence();
+        // Invariant: This has to be applied after
+        // `copy_validator_sets_and_positions` if we're starting a new epoch
         if new_epoch {
             self.process_slashes();
         }

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -2974,6 +2974,7 @@ where
 /// Record a slash for a misbehavior that has been received from Tendermint and
 /// then jail the validator, removing it from the validator set. The slash rate
 /// will be computed at a later epoch.
+#[allow(clippy::too_many_arguments)]
 pub fn slash<S>(
     storage: &mut S,
     params: &PosParams,
@@ -2982,6 +2983,7 @@ pub fn slash<S>(
     evidence_block_height: impl Into<u64>,
     slash_type: SlashType,
     validator: &Address,
+    validator_set_update_epoch: Epoch,
 ) -> storage_api::Result<()>
 where
     S: StorageRead + StorageWrite,
@@ -3017,7 +3019,7 @@ where
     // Remove the validator from the set starting at the next epoch and up thru
     // the pipeline epoch.
     for epoch in
-        Epoch::iter_bounds_inclusive(current_epoch.next(), pipeline_epoch)
+        Epoch::iter_bounds_inclusive(validator_set_update_epoch, pipeline_epoch)
     {
         let prev_state = validator_state_handle(validator)
             .get(storage, epoch, params)?

--- a/proof_of_stake/src/tests.rs
+++ b/proof_of_stake/src/tests.rs
@@ -941,6 +941,7 @@ fn test_slashes_with_unbonding_aux(
         evidence_block_height,
         slash_0_type,
         val_addr,
+        current_epoch.next(),
     )
     .unwrap();
 
@@ -978,6 +979,7 @@ fn test_slashes_with_unbonding_aux(
         evidence_block_height,
         slash_1_type,
         val_addr,
+        current_epoch.next(),
     )
     .unwrap();
 

--- a/proof_of_stake/src/tests/state_machine.rs
+++ b/proof_of_stake/src/tests/state_machine.rs
@@ -421,6 +421,7 @@ impl StateMachineTest for ConcretePosState {
                     height,
                     slash_type,
                     &address,
+                    current_epoch.next(),
                 )
                 .unwrap();
 


### PR DESCRIPTION
Based on v0.17.4.

As caught by e.g. https://github.com/anoma/namada/actions/runs/5280174696/jobs/9551903699?pr=1569

When the epoch change conditions are met, we send validator set update to TM, which takes 2 blocks before the change applies. To stay in sync with TM, we delay epoch update by 2 blocks as well. However, when we receive slashable evidence and the validator set update has already been applied but we're not yet on the new epoch, we have to queue up slashed validator removal from validator set by another epoch.
