### PR TITLE
shared/masp: add missing await on async load and save calls

### DIFF
--- a/.changelog/unreleased/bug-fixes/1588-fix-masp-missing-await.md
+++ b/.changelog/unreleased/bug-fixes/1588-fix-masp-missing-await.md
@@ -1,0 +1,2 @@
+- Fix missing async awaits in MASP load and save calls.
+  ([\#1588](https://github.com/anoma/namada/pull/1588))

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -107,7 +107,7 @@ pub async fn query_transfers<
         || Either::Right(wallet.get_addresses().into_values().collect()),
         Either::Left,
     );
-    let _ = shielded.load();
+    let _ = shielded.load().await;
     // Obtain the effects of all shielded and transparent transactions
     let transfers = shielded
         .query_tx_deltas(
@@ -368,7 +368,7 @@ pub async fn query_pinned_balance<
         .values()
         .map(|fvk| ExtendedFullViewingKey::from(*fvk).fvk.vk)
         .collect();
-    let _ = shielded.load();
+    let _ = shielded.load().await;
     // Print the token balances by payment address
     for owner in owners {
         let mut balance = Err(PinnedBalanceError::InvalidViewingKey);
@@ -693,14 +693,14 @@ pub async fn query_shielded_balance<
         Some(viewing_key) => vec![viewing_key],
         None => wallet.get_viewing_keys().values().copied().collect(),
     };
-    let _ = shielded.load();
+    let _ = shielded.load().await;
     let fvks: Vec<_> = viewing_keys
         .iter()
         .map(|fvk| ExtendedFullViewingKey::from(*fvk).fvk.vk)
         .collect();
     shielded.fetch(client, &[], &fvks).await;
     // Save the update state so that future fetches can be short-circuited
-    let _ = shielded.save();
+    let _ = shielded.save().await;
     // The epoch is required to identify timestamped tokens
     let epoch = query_and_print_epoch(client).await;
     // Map addresses to token names

--- a/shared/src/ledger/masp.rs
+++ b/shared/src/ledger/masp.rs
@@ -1103,10 +1103,10 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
         let spending_key = spending_key.map(|x| x.into());
         let spending_keys: Vec<_> = spending_key.into_iter().collect();
         // Load the current shielded context given the spending key we possess
-        let _ = self.load();
+        let _ = self.load().await;
         self.fetch(client, &spending_keys, &[]).await;
         // Save the update state so that future fetches can be short-circuited
-        let _ = self.save();
+        let _ = self.save().await;
         // Determine epoch in which to submit potential shielded transaction
         let epoch = rpc::query_epoch(client).await;
         // Context required for storing which notes are in the source's
@@ -1298,7 +1298,7 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
         (Epoch, TransferDelta, TransactionDelta),
     > {
         const TXS_PER_PAGE: u8 = 100;
-        let _ = self.load();
+        let _ = self.load().await;
         let vks = viewing_keys;
         let fvks: Vec<_> = vks
             .values()
@@ -1306,7 +1306,7 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
             .collect();
         self.fetch(client, &[], &fvks).await;
         // Save the update state so that future fetches can be short-circuited
-        let _ = self.save();
+        let _ = self.save().await;
         // Required for filtering out rejected transactions from Tendermint
         // responses
         let block_results = rpc::query_results(client).await;


### PR DESCRIPTION
based on #1238 that introduced the change, fixes a missing `.await` as caught in #1586 by a new clippy version