### PR TITLE
test/e2e/invalid_txs: wait for a block after restart

### DIFF
--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -1800,6 +1800,8 @@ fn invalid_transactions() -> Result<()> {
 
     // There should be previous state now
     ledger.exp_string("Last state root hash:")?;
+    // Wait for a block by which time the RPC should be ready
+    ledger.exp_string("Committed block hash")?;
     let _bg_ledger = ledger.background();
 
     // 5. Submit an invalid transactions (invalid token address)


### PR DESCRIPTION
fix for https://github.com/anoma/namada/actions/runs/5347531283/jobs/9696134725 where the client tried to send a tx before the node's RPC was ready