### PR TITLE
fix optional prefix iter

### DIFF
--- a/.changelog/unreleased/bug-fixes/1615-fix-optional-prefix-iter.md
+++ b/.changelog/unreleased/bug-fixes/1615-fix-optional-prefix-iter.md
@@ -1,0 +1,2 @@
+- Storage: Fix iterator without a prefix.
+  ([\#1615](https://github.com/anoma/namada/pull/1615))

--- a/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -1364,8 +1364,8 @@ fn make_iter_read_opts(prefix: Option<String>) -> ReadOptions {
         let mut upper_prefix = prefix.into_bytes();
         if let Some(last) = upper_prefix.pop() {
             upper_prefix.push(last + 1);
+            read_opts.set_iterate_upper_bound(upper_prefix);
         }
-        read_opts.set_iterate_upper_bound(upper_prefix);
     }
 
     read_opts


### PR DESCRIPTION
Based on v0.17.4

The optional prefix iter did nothing when given `None` for prefix as shown by the test added in [3bf41d5](https://github.com/anoma/namada/pull/1615/commits/3bf41d54c213e3d5ea493a6755e5044fccdc818a). The problem was with the upper bound set on the iterator that should only be set when there is a non empty prefix - fixed in [82a07d8](https://github.com/anoma/namada/pull/1615/commits/82a07d8e731eb1cc8bb376a97d919d1a2165d11e). The same issue was already present before changes from #1478 on prefix iter with an empty key (i.e. `Key::default()`).

This affects the rollback command that relies on the iterator with no prefix.