### PR TITLE
fix storage rollback

### DIFF
--- a/.changelog/unreleased/bug-fixes/1615-fix-optional-prefix-iter.md
+++ b/.changelog/unreleased/bug-fixes/1615-fix-optional-prefix-iter.md
@@ -1,0 +1,2 @@
+- Storage: Fix iterator without a prefix.
+  ([\#1615](https://github.com/anoma/namada/pull/1615))

--- a/.changelog/unreleased/bug-fixes/1616-fix-rollback.md
+++ b/.changelog/unreleased/bug-fixes/1616-fix-rollback.md
@@ -1,0 +1,2 @@
+- Fixed the rollback command to restore deleted keys.
+  ([\#1616](https://github.com/anoma/namada/pull/1616))

--- a/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -1364,8 +1364,8 @@ fn make_iter_read_opts(prefix: Option<String>) -> ReadOptions {
         let mut upper_prefix = prefix.into_bytes();
         if let Some(last) = upper_prefix.pop() {
             upper_prefix.push(last + 1);
+            read_opts.set_iterate_upper_bound(upper_prefix);
         }
-        read_opts.set_iterate_upper_bound(upper_prefix);
     }
 
     read_opts


### PR DESCRIPTION
depends on #1615

The issue fixed in #1615 was affecting rollback because the iterator without prefix didn't find anything. There's another issue in rollback itself - a key-val that's deleted is not being restored as shown in [5ca18bc](https://github.com/anoma/namada/pull/1616/commits/5ca18bc344e1d1f3dbe220c760b2ee26a0b65cb4).