### PR TITLE
Sending tokens with same src/dest address does  not do balance accounting correctly

### DIFF
--- a/tx_prelude/src/token.rs
+++ b/tx_prelude/src/token.rs
@@ -37,28 +37,31 @@ pub fn transfer(
             }
             None => token::balance_key(token, dest),
         };
-        let src_bal: Option<Amount> = match src {
-            Address::Internal(InternalAddress::IbcMint) => Some(Amount::max()),
-            Address::Internal(InternalAddress::IbcBurn) => {
-                log_string("invalid transfer from the burn address");
-                unreachable!()
-            }
-            _ => ctx.read(&src_key)?,
-        };
-        let mut src_bal = src_bal.unwrap_or_else(|| {
-            log_string(format!("src {} has no balance", src_key));
-            unreachable!()
-        });
-        src_bal.spend(&amount);
-        let mut dest_bal: Amount = match dest {
-            Address::Internal(InternalAddress::IbcMint) => {
-                log_string("invalid transfer to the mint address");
-                unreachable!()
-            }
-            _ => ctx.read(&dest_key)?.unwrap_or_default(),
-        };
-        dest_bal.receive(&amount);
         if src != dest {
+            let src_bal: Option<Amount> = match src {
+                Address::Internal(InternalAddress::IbcMint) => {
+                    Some(Amount::max())
+                }
+                Address::Internal(InternalAddress::IbcBurn) => {
+                    log_string("invalid transfer from the burn address");
+                    unreachable!()
+                }
+                _ => ctx.read(&src_key)?,
+            };
+            let mut src_bal = src_bal.unwrap_or_else(|| {
+                log_string(format!("src {} has no balance", src_key));
+                unreachable!()
+            });
+            src_bal.spend(&amount);
+            let mut dest_bal: Amount = match dest {
+                Address::Internal(InternalAddress::IbcMint) => {
+                    log_string("invalid transfer to the mint address");
+                    unreachable!()
+                }
+                _ => ctx.read(&dest_key)?.unwrap_or_default(),
+            };
+            dest_bal.receive(&amount);
+
             match src {
                 Address::Internal(InternalAddress::IbcMint) => {
                     ctx.write_temp(&src_key, src_bal)?;


### PR DESCRIPTION
When sending a transfer from address `A -> A` of amount `X`, the tx_transfer wasm does not correctly accumulate the credit/debits with appropriate signs. Instead, the balance of `A` will simply increase by `X` since the debit overwrites the credit in storage. This PR fixes this issue.