### PR TITLE
Ethereum related signing changes

### DIFF
--- a/core/src/types/key/mod.rs
+++ b/core/src/types/key/mod.rs
@@ -265,13 +265,16 @@ pub trait SigScheme: Eq + Ord + Debug + Serialize + Default {
     type Hasher: 'static + StorageHasher;
     /// The scheme type of this implementation
     const TYPE: SchemeType;
+
     /// Generate a keypair.
     #[cfg(feature = "rand")]
     fn generate<R>(csprng: &mut R) -> Self::SecretKey
     where
         R: CryptoRng + RngCore;
+
     /// Instantiate a secret key from the bytes.
     fn from_bytes(bytes: [u8; 32]) -> Self::SecretKey;
+
     /// Sign the data with a key.
     fn sign(
         keypair: &Self::SecretKey,

--- a/core/src/types/vote_extensions/validator_set_update.rs
+++ b/core/src/types/vote_extensions/validator_set_update.rs
@@ -362,6 +362,7 @@ mod tag {
     use super::{
         epoch_to_token, Vext, VotingPowersMapExt, GOVERNANCE_CONTRACT_VERSION,
     };
+    use crate::ledger::storage::KeccakHasher;
     use crate::proto::Signable;
     use crate::types::eth_abi::{AbiEncode, Encode, Token};
     use crate::types::keccak::KeccakHash;
@@ -372,6 +373,7 @@ mod tag {
     pub struct SerializeWithAbiEncode;
 
     impl Signable<Vext> for SerializeWithAbiEncode {
+        type Hasher = KeccakHasher;
         type Output = KeccakHash;
 
         fn as_signable(ext: &Vext) -> Self::Output {


### PR DESCRIPTION
Hash data to be signed with SHA256 by default, unless we specifically choose another hashing algorithm.