### PR TITLE
Removed unused associated type from ShieldedUtils

### DIFF
--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -60,7 +60,7 @@ use crate::wallet::CliWalletUtils;
 ///
 /// If a response is not delivered until `deadline`, we exit the cli with an
 /// error.
-pub async fn query_tx_status<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_tx_status<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     status: namada::ledger::rpc::TxEventQuery<'_>,
     deadline: Duration,
@@ -70,7 +70,7 @@ pub async fn query_tx_status<C: namada::ledger::queries::Client + Sync>(
 
 /// Query and print the epoch of the last committed block
 pub async fn query_and_print_epoch<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
 ) -> Epoch {
@@ -80,7 +80,7 @@ pub async fn query_and_print_epoch<
 }
 
 /// Query the last committed block
-pub async fn query_block<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_block<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
 ) {
     let block = namada::ledger::rpc::query_block(client).await;
@@ -98,7 +98,7 @@ pub async fn query_block<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query the results of the last committed block
-pub async fn query_results<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_results<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     _args: args::Query,
 ) -> Vec<BlockResults> {
@@ -109,8 +109,8 @@ pub async fn query_results<C: namada::ledger::queries::Client + Sync>(
 
 /// Query the specified accepted transfers from the ledger
 pub async fn query_transfers<
-    C: namada::ledger::queries::Client + Sync,
-    U: ShieldedUtils<C = C>,
+    C: namada::ledger::queries::Client + Send + Sync,
+    U: ShieldedUtils,
 >(
     client: &C,
     wallet: &mut Wallet<CliWalletUtils>,
@@ -243,7 +243,7 @@ pub async fn query_transfers<
 }
 
 /// Query the raw bytes of given storage key
-pub async fn query_raw_bytes<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_raw_bytes<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     args: args::QueryRawBytes,
 ) {
@@ -261,8 +261,8 @@ pub async fn query_raw_bytes<C: namada::ledger::queries::Client + Sync>(
 
 /// Query token balance(s)
 pub async fn query_balance<
-    C: namada::ledger::queries::Client + Sync,
-    U: ShieldedUtils<C = C>,
+    C: namada::ledger::queries::Client + Send + Sync,
+    U: ShieldedUtils,
 >(
     client: &C,
     wallet: &mut Wallet<CliWalletUtils>,
@@ -295,7 +295,7 @@ pub async fn query_balance<
 
 /// Query token balance(s)
 pub async fn query_transparent_balance<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     wallet: &mut Wallet<CliWalletUtils>,
@@ -395,8 +395,8 @@ pub async fn query_transparent_balance<
 
 /// Query the token pinned balance(s)
 pub async fn query_pinned_balance<
-    C: namada::ledger::queries::Client + Sync,
-    U: ShieldedUtils<C = C>,
+    C: namada::ledger::queries::Client + Send + Sync,
+    U: ShieldedUtils,
 >(
     client: &C,
     wallet: &mut Wallet<CliWalletUtils>,
@@ -626,11 +626,11 @@ async fn print_balances<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query Proposals
-pub async fn query_proposal<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_proposal<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     args: args::QueryProposal,
 ) {
-    async fn print_proposal<C: namada::ledger::queries::Client + Sync>(
+    async fn print_proposal<C: namada::ledger::queries::Client + Send + Sync>(
         client: &C,
         id: u64,
         current_epoch: Epoch,
@@ -759,8 +759,8 @@ pub async fn query_proposal<C: namada::ledger::queries::Client + Sync>(
 
 /// Query token shielded balance(s)
 pub async fn query_shielded_balance<
-    C: namada::ledger::queries::Client + Sync,
-    U: ShieldedUtils<C = C>,
+    C: namada::ledger::queries::Client + Send + Sync,
+    U: ShieldedUtils,
 >(
     client: &C,
     wallet: &mut Wallet<CliWalletUtils>,
@@ -1093,7 +1093,7 @@ pub async fn print_decoded_balance_with_epoch<
 }
 
 /// Query token amount of owner.
-pub async fn get_token_balance<C: namada::ledger::queries::Client + Sync>(
+pub async fn get_token_balance<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     token: &Address,
     owner: &Address,
@@ -1102,7 +1102,7 @@ pub async fn get_token_balance<C: namada::ledger::queries::Client + Sync>(
 }
 
 pub async fn query_proposal_result<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     args: args::QueryProposalResult,
@@ -1274,7 +1274,7 @@ pub async fn query_proposal_result<
 }
 
 pub async fn query_protocol_parameters<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     _args: args::QueryProtocolParameters,
@@ -1344,7 +1344,7 @@ pub async fn query_protocol_parameters<
     println!("{:4}Votes per token: {}", "", pos_params.tm_votes_per_token);
 }
 
-pub async fn query_bond<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_bond<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     source: &Address,
     validator: &Address,
@@ -1356,7 +1356,7 @@ pub async fn query_bond<C: namada::ledger::queries::Client + Sync>(
 }
 
 pub async fn query_unbond_with_slashing<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     source: &Address,
@@ -1371,7 +1371,7 @@ pub async fn query_unbond_with_slashing<
 }
 
 pub async fn query_and_print_unbonds<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     source: &Address,
@@ -1409,7 +1409,7 @@ pub async fn query_and_print_unbonds<
 }
 
 pub async fn query_withdrawable_tokens<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     bond_source: &Address,
@@ -1425,7 +1425,7 @@ pub async fn query_withdrawable_tokens<
 }
 
 /// Query PoS bond(s) and unbond(s)
-pub async fn query_bonds<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_bonds<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     _wallet: &mut Wallet<CliWalletUtils>,
     args: args::QueryBonds,
@@ -1534,7 +1534,7 @@ pub async fn query_bonds<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query PoS bonded stake
-pub async fn query_bonded_stake<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_bonded_stake<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     args: args::QueryBondedStake,
 ) {
@@ -1617,7 +1617,7 @@ pub async fn query_bonded_stake<C: namada::ledger::queries::Client + Sync>(
 /// Query and return validator's commission rate and max commission rate change
 /// per epoch
 pub async fn query_commission_rate<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     validator: &Address,
@@ -1633,7 +1633,7 @@ pub async fn query_commission_rate<
 
 /// Query PoS validator's commission rate information
 pub async fn query_and_print_commission_rate<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     _wallet: &mut Wallet<CliWalletUtils>,
@@ -1666,7 +1666,7 @@ pub async fn query_and_print_commission_rate<
 }
 
 /// Query PoS slashes
-pub async fn query_slashes<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_slashes<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     _wallet: &mut Wallet<CliWalletUtils>,
     args: args::QuerySlashes,
@@ -1729,7 +1729,7 @@ pub async fn query_slashes<C: namada::ledger::queries::Client + Sync>(
     }
 }
 
-pub async fn query_delegations<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_delegations<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     _wallet: &mut Wallet<CliWalletUtils>,
     args: args::QueryDelegations,
@@ -1748,7 +1748,7 @@ pub async fn query_delegations<C: namada::ledger::queries::Client + Sync>(
     }
 }
 
-pub async fn query_find_validator<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_find_validator<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     args: args::QueryFindValidator,
 ) {
@@ -1773,7 +1773,7 @@ pub async fn query_find_validator<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Dry run a transaction
-pub async fn dry_run_tx<C: namada::ledger::queries::Client + Sync>(
+pub async fn dry_run_tx<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     tx_bytes: Vec<u8>,
 ) {
@@ -1784,7 +1784,7 @@ pub async fn dry_run_tx<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Get account's public key stored in its storage sub-space
-pub async fn get_public_key<C: namada::ledger::queries::Client + Sync>(
+pub async fn get_public_key<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     address: &Address,
 ) -> Option<common::PublicKey> {
@@ -1792,7 +1792,7 @@ pub async fn get_public_key<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Check if the given address is a known validator.
-pub async fn is_validator<C: namada::ledger::queries::Client + Sync>(
+pub async fn is_validator<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     address: &Address,
 ) -> bool {
@@ -1800,14 +1800,14 @@ pub async fn is_validator<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Check if a given address is a known delegator
-pub async fn is_delegator<C: namada::ledger::queries::Client + Sync>(
+pub async fn is_delegator<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     address: &Address,
 ) -> bool {
     namada::ledger::rpc::is_delegator(client, address).await
 }
 
-pub async fn is_delegator_at<C: namada::ledger::queries::Client + Sync>(
+pub async fn is_delegator_at<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     address: &Address,
     epoch: Epoch,
@@ -1818,7 +1818,7 @@ pub async fn is_delegator_at<C: namada::ledger::queries::Client + Sync>(
 /// Check if the address exists on chain. Established address exists if it has a
 /// stored validity predicate. Implicit and internal addresses always return
 /// true.
-pub async fn known_address<C: namada::ledger::queries::Client + Sync>(
+pub async fn known_address<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     address: &Address,
 ) -> bool {
@@ -1826,7 +1826,7 @@ pub async fn known_address<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query for all conversions.
-pub async fn query_conversions<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_conversions<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     wallet: &mut Wallet<CliWalletUtils>,
     args: args::QueryConversions,
@@ -1892,7 +1892,7 @@ pub async fn query_conversions<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query a conversion.
-pub async fn query_conversion<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_conversion<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     asset_type: AssetType,
 ) -> Option<(
@@ -1907,7 +1907,7 @@ pub async fn query_conversion<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query a wasm code hash
-pub async fn query_wasm_code_hash<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_wasm_code_hash<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     code_path: impl AsRef<str>,
 ) -> Option<Hash> {
@@ -1915,7 +1915,7 @@ pub async fn query_wasm_code_hash<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query a storage value and decode it with [`BorshDeserialize`].
-pub async fn query_storage_value<C: namada::ledger::queries::Client + Sync, T>(
+pub async fn query_storage_value<C: namada::ledger::queries::Client + Send + Sync, T>(
     client: &C,
     key: &storage::Key,
 ) -> Option<T>
@@ -1927,7 +1927,7 @@ where
 
 /// Query a storage value and the proof without decoding.
 pub async fn query_storage_value_bytes<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     key: &storage::Key,
@@ -1942,7 +1942,7 @@ pub async fn query_storage_value_bytes<
 /// [`BorshDeserialize`]. Returns an iterator of the storage keys paired with
 /// their associated values.
 pub async fn query_storage_prefix<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
     T,
 >(
     client: &C,
@@ -1956,7 +1956,7 @@ where
 
 /// Query to check if the given storage key exists.
 pub async fn query_has_storage_key<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     key: &storage::Key,
@@ -1966,7 +1966,7 @@ pub async fn query_has_storage_key<
 
 /// Call the corresponding `tx_event_query` RPC method, to fetch
 /// the current status of a transation.
-pub async fn query_tx_events<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_tx_events<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     tx_event_query: namada::ledger::rpc::TxEventQuery<'_>,
 ) -> std::result::Result<
@@ -1978,7 +1978,7 @@ pub async fn query_tx_events<C: namada::ledger::queries::Client + Sync>(
 
 /// Lookup the full response accompanying the specified transaction event
 // TODO: maybe remove this in favor of `query_tx_status`
-pub async fn query_tx_response<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_tx_response<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     tx_query: namada::ledger::rpc::TxEventQuery<'_>,
 ) -> Result<TxResponse, TError> {
@@ -1987,7 +1987,7 @@ pub async fn query_tx_response<C: namada::ledger::queries::Client + Sync>(
 
 /// Lookup the results of applying the specified transaction to the
 /// blockchain.
-pub async fn query_result<C: namada::ledger::queries::Client + Sync>(
+pub async fn query_result<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     args: args::QueryResult,
 ) {
@@ -2026,7 +2026,7 @@ pub async fn query_result<C: namada::ledger::queries::Client + Sync>(
     }
 }
 
-pub async fn get_proposal_votes<C: namada::ledger::queries::Client + Sync>(
+pub async fn get_proposal_votes<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     epoch: Epoch,
     proposal_id: u64,
@@ -2035,7 +2035,7 @@ pub async fn get_proposal_votes<C: namada::ledger::queries::Client + Sync>(
 }
 
 pub async fn get_proposal_offline_votes<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     proposal: OfflineProposal,
@@ -2219,7 +2219,7 @@ pub async fn get_proposal_offline_votes<
     }
 }
 
-pub async fn get_bond_amount_at<C: namada::ledger::queries::Client + Sync>(
+pub async fn get_bond_amount_at<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     delegator: &Address,
     validator: &Address,
@@ -2235,7 +2235,7 @@ pub async fn get_bond_amount_at<C: namada::ledger::queries::Client + Sync>(
     Some(total_active)
 }
 
-pub async fn get_all_validators<C: namada::ledger::queries::Client + Sync>(
+pub async fn get_all_validators<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     epoch: Epoch,
 ) -> HashSet<Address> {
@@ -2243,7 +2243,7 @@ pub async fn get_all_validators<C: namada::ledger::queries::Client + Sync>(
 }
 
 pub async fn get_total_staked_tokens<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     epoch: Epoch,
@@ -2255,7 +2255,7 @@ pub async fn get_total_staked_tokens<
 /// sum of validator's self-bonds and delegations to their address.
 /// Returns `None` when the given address is not a validator address. For a
 /// validator with `0` stake, this returns `Ok(token::Amount::zero())`.
-async fn get_validator_stake<C: namada::ledger::queries::Client + Sync>(
+async fn get_validator_stake<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     epoch: Epoch,
     validator: &Address,
@@ -2269,7 +2269,7 @@ async fn get_validator_stake<C: namada::ledger::queries::Client + Sync>(
 }
 
 pub async fn get_delegators_delegation<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     address: &Address,
@@ -2278,7 +2278,7 @@ pub async fn get_delegators_delegation<
 }
 
 pub async fn get_governance_parameters<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
 ) -> GovParams {

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -47,7 +47,7 @@ use crate::wallet::{
     gen_validator_keys, read_and_confirm_encryption_password, CliWalletUtils,
 };
 
-pub async fn submit_custom<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_custom<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     ctx: &mut Context,
     mut args: args::TxCustom,
@@ -59,7 +59,7 @@ pub async fn submit_custom<C: namada::ledger::queries::Client + Sync>(
     tx::submit_custom::<C, _>(client, &mut ctx.wallet, args).await
 }
 
-pub async fn submit_update_vp<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_update_vp<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     ctx: &mut Context,
     mut args: args::TxUpdateVp,
@@ -71,7 +71,7 @@ pub async fn submit_update_vp<C: namada::ledger::queries::Client + Sync>(
     tx::submit_update_vp::<C, _>(client, &mut ctx.wallet, args).await
 }
 
-pub async fn submit_init_account<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_init_account<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     ctx: &mut Context,
     mut args: args::TxInitAccount,
@@ -84,7 +84,7 @@ pub async fn submit_init_account<C: namada::ledger::queries::Client + Sync>(
 }
 
 pub async fn submit_init_validator<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     mut ctx: Context,
@@ -381,7 +381,6 @@ impl Default for CLIShieldedUtils {
 
 #[async_trait(?Send)]
 impl masp::ShieldedUtils for CLIShieldedUtils {
-    type C = crate::facade::tendermint_rpc::HttpClient;
 
     fn local_tx_prover(&self) -> LocalTxProver {
         if let Ok(params_dir) = env::var(masp::ENV_VAR_MASP_PARAMS_DIR) {
@@ -455,7 +454,7 @@ pub async fn submit_transfer(
     tx::submit_transfer(client, &mut ctx.wallet, &mut ctx.shielded, args).await
 }
 
-pub async fn submit_ibc_transfer<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_ibc_transfer<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     mut ctx: Context,
     mut args: args::TxIbcTransfer,
@@ -467,7 +466,7 @@ pub async fn submit_ibc_transfer<C: namada::ledger::queries::Client + Sync>(
     tx::submit_ibc_transfer::<C, _>(client, &mut ctx.wallet, args).await
 }
 
-pub async fn submit_init_proposal<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_init_proposal<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     mut ctx: Context,
     mut args: args::InitProposal,
@@ -625,7 +624,7 @@ pub async fn submit_init_proposal<C: namada::ledger::queries::Client + Sync>(
     }
 }
 
-pub async fn submit_vote_proposal<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_vote_proposal<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     mut ctx: Context,
     mut args: args::VoteProposal,
@@ -892,7 +891,7 @@ pub async fn submit_vote_proposal<C: namada::ledger::queries::Client + Sync>(
     }
 }
 
-pub async fn submit_reveal_pk<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_reveal_pk<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     ctx: &mut Context,
     mut args: args::RevealPk,
@@ -904,7 +903,7 @@ pub async fn submit_reveal_pk<C: namada::ledger::queries::Client + Sync>(
     tx::submit_reveal_pk::<C, _>(client, &mut ctx.wallet, args).await
 }
 
-pub async fn reveal_pk_if_needed<C: namada::ledger::queries::Client + Sync>(
+pub async fn reveal_pk_if_needed<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     ctx: &mut Context,
     public_key: &common::PublicKey,
@@ -921,14 +920,14 @@ pub async fn reveal_pk_if_needed<C: namada::ledger::queries::Client + Sync>(
         .await
 }
 
-pub async fn has_revealed_pk<C: namada::ledger::queries::Client + Sync>(
+pub async fn has_revealed_pk<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     addr: &Address,
 ) -> bool {
     tx::has_revealed_pk(client, addr).await
 }
 
-pub async fn submit_reveal_pk_aux<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_reveal_pk_aux<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     ctx: &mut Context,
     public_key: &common::PublicKey,
@@ -948,7 +947,7 @@ pub async fn submit_reveal_pk_aux<C: namada::ledger::queries::Client + Sync>(
 /// Check if current epoch is in the last third of the voting period of the
 /// proposal. This ensures that it is safe to optimize the vote writing to
 /// storage.
-async fn is_safe_voting_window<C: namada::ledger::queries::Client + Sync>(
+async fn is_safe_voting_window<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     proposal_id: u64,
     proposal_start_epoch: Epoch,
@@ -958,7 +957,7 @@ async fn is_safe_voting_window<C: namada::ledger::queries::Client + Sync>(
 
 /// Removes validators whose vote corresponds to that of the delegator (needless
 /// vote)
-async fn filter_delegations<C: namada::ledger::queries::Client + Sync>(
+async fn filter_delegations<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     delegations: HashSet<Address>,
     proposal_id: u64,
@@ -995,7 +994,7 @@ async fn filter_delegations<C: namada::ledger::queries::Client + Sync>(
     delegations.into_iter().flatten().collect()
 }
 
-pub async fn submit_bond<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_bond<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     ctx: &mut Context,
     mut args: args::Bond,
@@ -1007,7 +1006,7 @@ pub async fn submit_bond<C: namada::ledger::queries::Client + Sync>(
     tx::submit_bond::<C, _>(client, &mut ctx.wallet, args).await
 }
 
-pub async fn submit_unbond<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_unbond<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     ctx: &mut Context,
     mut args: args::Unbond,
@@ -1019,7 +1018,7 @@ pub async fn submit_unbond<C: namada::ledger::queries::Client + Sync>(
     tx::submit_unbond::<C, _>(client, &mut ctx.wallet, args).await
 }
 
-pub async fn submit_withdraw<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_withdraw<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     mut ctx: Context,
     mut args: args::Withdraw,
@@ -1032,7 +1031,7 @@ pub async fn submit_withdraw<C: namada::ledger::queries::Client + Sync>(
 }
 
 pub async fn submit_validator_commission_change<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     mut ctx: Context,
@@ -1051,7 +1050,7 @@ pub async fn submit_validator_commission_change<
 }
 
 pub async fn submit_unjail_validator<
-    C: namada::ledger::queries::Client + Sync,
+    C: namada::ledger::queries::Client + Send + Sync,
 >(
     client: &C,
     mut ctx: Context,
@@ -1066,7 +1065,7 @@ pub async fn submit_unjail_validator<
 
 /// Submit transaction and wait for result. Returns a list of addresses
 /// initialized in the transaction if any. In dry run, this is always empty.
-async fn process_tx<C: namada::ledger::queries::Client + Sync>(
+async fn process_tx<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     mut ctx: Context,
     args: &args::Tx,
@@ -1108,7 +1107,7 @@ pub async fn save_initialized_accounts<U: WalletUtils>(
 /// the tx has been successfully included into the mempool of a validator
 ///
 /// In the case of errors in any of those stages, an error message is returned
-pub async fn broadcast_tx<C: namada::ledger::queries::Client + Sync>(
+pub async fn broadcast_tx<C: namada::ledger::queries::Client + Send + Sync>(
     rpc_cli: &C,
     to_broadcast: &TxBroadcastData,
 ) -> Result<Response, tx::Error> {
@@ -1123,7 +1122,7 @@ pub async fn broadcast_tx<C: namada::ledger::queries::Client + Sync>(
 /// 3. The decrypted payload of the tx has been included on the blockchain.
 ///
 /// In the case of errors in any of those stages, an error message is returned
-pub async fn submit_tx<C: namada::ledger::queries::Client + Sync>(
+pub async fn submit_tx<C: namada::ledger::queries::Client + Send + Sync>(
     client: &C,
     to_broadcast: TxBroadcastData,
 ) -> Result<TxResponse, tx::Error> {

--- a/shared/src/ledger/masp.rs
+++ b/shared/src/ledger/masp.rs
@@ -345,9 +345,6 @@ impl<P1, R1, N1>
 pub trait ShieldedUtils:
     Sized + BorshDeserialize + BorshSerialize + Default + Clone
 {
-    /// The type of the Tendermint client to make queries with
-    type C: crate::ledger::queries::Client + std::marker::Sync;
-
     /// Get a MASP transaction prover
     fn local_tx_prover(&self) -> LocalTxProver;
 
@@ -631,9 +628,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
 
     /// Fetch the current state of the multi-asset shielded pool into a
     /// ShieldedContext
-    pub async fn fetch(
+    pub async fn fetch<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         sks: &[ExtendedSpendingKey],
         fvks: &[ViewingKey],
     ) {
@@ -699,8 +696,8 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// transactions as a vector. More concretely, the HEAD_TX_KEY location
     /// stores the index of the last accepted transaction and each transaction
     /// is stored at a key derived from its index.
-    pub async fn fetch_shielded_transfers(
-        client: &U::C,
+    pub async fn fetch_shielded_transfers<C: Client + Send + Sync>(
+        client: &C,
         last_txidx: u64,
     ) -> BTreeMap<(BlockHeight, TxIndex), (Epoch, Transfer, Transaction)> {
         // The address of the MASP account
@@ -710,7 +707,7 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
             .push(&HEAD_TX_KEY.to_owned())
             .expect("Cannot obtain a storage key");
         // Query for the index of the last accepted transaction
-        let head_txidx = query_storage_value::<U::C, u64>(client, &head_tx_key)
+        let head_txidx = query_storage_value::<C, u64>(client, &head_tx_key)
             .await
             .unwrap_or(0);
         let mut shielded_txs = BTreeMap::new();
@@ -723,7 +720,7 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
             // Obtain the current transaction
             let (tx_epoch, tx_height, tx_index, current_tx, current_stx) =
                 query_storage_value::<
-                    U::C,
+                    C,
                     (Epoch, BlockHeight, TxIndex, Transfer, Transaction),
                 >(client, &current_tx_key)
                 .await
@@ -913,9 +910,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
 
     /// Query the ledger for the decoding of the given asset type and cache it
     /// if it is found.
-    pub async fn decode_asset_type(
+    pub async fn decode_asset_type<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         asset_type: AssetType,
     ) -> Option<(Address, Option<Key>, MaspDenom, Epoch)> {
         // Try to find the decoding in the cache
@@ -938,9 +935,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
 
     /// Query the ledger for the conversion that is allowed for the given asset
     /// type and cache it.
-    async fn query_allowed_conversion<'a>(
+    async fn query_allowed_conversion<'a, C: Client + Send + Sync>(
         &'a mut self,
-        client: &U::C,
+        client: &C,
         asset_type: AssetType,
         conversions: &'a mut Conversions,
     ) {
@@ -963,9 +960,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// context and express that value in terms of the currently timestamped
     /// asset types. If the key is not in the context, then we do not know the
     /// balance and hence we return None.
-    pub async fn compute_exchanged_balance(
+    pub async fn compute_exchanged_balance<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         vk: &ViewingKey,
         target_epoch: Epoch,
     ) -> Option<MaspAmount> {
@@ -1047,9 +1044,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// note of the conversions that were used. Note that this function does
     /// not assume that allowed conversions from the ledger are expressed in
     /// terms of the latest asset types.
-    pub async fn compute_exchanged_amount(
+    pub async fn compute_exchanged_amount<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         mut input: MaspAmount,
         target_epoch: Epoch,
         mut conversions: Conversions,
@@ -1156,9 +1153,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// of the specified asset type. Return the total value accumulated plus
     /// notes and the corresponding diversifiers/merkle paths that were used to
     /// achieve the total value.
-    pub async fn collect_unspent_notes(
+    pub async fn collect_unspent_notes<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         vk: &ViewingKey,
         target: Amount,
         target_epoch: Epoch,
@@ -1226,8 +1223,8 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// keys to try to decrypt the output notes. If no transaction is pinned at
     /// the given payment address fails with
     /// `PinnedBalanceError::NoTransactionPinned`.
-    pub async fn compute_pinned_balance(
-        client: &U::C,
+    pub async fn compute_pinned_balance<C: Client + Send + Sync>(
+        client: &C,
         owner: PaymentAddress,
         viewing_key: &ViewingKey,
     ) -> Result<(Amount, Epoch), PinnedBalanceError> {
@@ -1249,7 +1246,7 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
             .push(&(PIN_KEY_PREFIX.to_owned() + &owner.hash()))
             .expect("Cannot obtain a storage key");
         // Obtain the transaction pointer at the key
-        let txidx = rpc::query_storage_value::<U::C, u64>(client, &pin_key)
+        let txidx = rpc::query_storage_value::<C, u64>(client, &pin_key)
             .await
             .ok_or(PinnedBalanceError::NoTransactionPinned)?;
         // Construct the key for where the pinned transaction is stored
@@ -1259,7 +1256,7 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
         // Obtain the pointed to transaction
         let (tx_epoch, _tx_height, _tx_index, _tx, shielded) =
             rpc::query_storage_value::<
-                U::C,
+                C,
                 (Epoch, BlockHeight, TxIndex, Transfer, Transaction),
             >(client, &tx_key)
             .await
@@ -1297,9 +1294,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// the epoch of the transaction or even before, so exchange all these
     /// amounts to the epoch of the transaction in order to get the value that
     /// would have been displayed in the epoch of the transaction.
-    pub async fn compute_exchanged_pinned_balance(
+    pub async fn compute_exchanged_pinned_balance<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         owner: PaymentAddress,
         viewing_key: &ViewingKey,
     ) -> Result<(MaspAmount, Epoch), PinnedBalanceError> {
@@ -1322,9 +1319,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// Convert an amount whose units are AssetTypes to one whose units are
     /// Addresses that they decode to. All asset types not corresponding to
     /// the given epoch are ignored.
-    pub async fn decode_amount(
+    pub async fn decode_amount<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         amt: Amount,
         target_epoch: Epoch,
     ) -> HashMap<TokenAddress, token::Change> {
@@ -1355,9 +1352,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
 
     /// Convert an amount whose units are AssetTypes to one whose units are
     /// Addresses that they decode to.
-    pub async fn decode_all_amounts(
+    pub async fn decode_all_amounts<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         amt: Amount,
     ) -> MaspAmount {
         let mut res: HashMap<(Epoch, TokenAddress), Change> =
@@ -1394,9 +1391,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// understood that transparent account changes are effected only by the
     /// amounts and signatures specified by the containing Transfer object.
     #[cfg(feature = "masp-tx-gen")]
-    pub async fn gen_shielded_transfer(
+    pub async fn gen_shielded_transfer<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         args: &args::TxTransfer,
         shielded_gas: bool,
     ) -> Result<
@@ -1611,9 +1608,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// transactions. If an owner is specified, then restrict the set to only
     /// transactions crediting/debiting the given owner. If token is specified,
     /// then restrict set to only transactions involving the given token.
-    pub async fn query_tx_deltas(
+    pub async fn query_tx_deltas<C: Client + Send + Sync>(
         &mut self,
-        client: &U::C,
+        client: &C,
         query_owner: &Either<BalanceOwner, Vec<Address>>,
         query_token: &Option<Address>,
         viewing_keys: &HashMap<String, ExtendedViewingKey>,

--- a/shared/src/ledger/tx.rs
+++ b/shared/src/ledger/tx.rs
@@ -1156,8 +1156,8 @@ pub async fn submit_ibc_transfer<
 /// Try to decode the given asset type and add its decoding to the supplied set.
 /// Returns true only if a new decoding has been added to the given set.
 async fn add_asset_type<
-    C: crate::ledger::queries::Client + Sync,
-    U: ShieldedUtils<C = C>,
+    C: crate::ledger::queries::Client + Send + Sync,
+    U: ShieldedUtils,
 >(
     asset_types: &mut HashSet<(Address, Option<Key>, MaspDenom, Epoch)>,
     shielded: &mut ShieldedContext<U>,
@@ -1177,8 +1177,8 @@ async fn add_asset_type<
 /// function provides the data necessary for offline wallets to present asset
 /// type information.
 async fn used_asset_types<
-    C: crate::ledger::queries::Client + Sync,
-    U: ShieldedUtils<C = C>,
+    C: crate::ledger::queries::Client + Send + Sync,
+    U: ShieldedUtils,
     P,
     R,
     K,
@@ -1228,9 +1228,9 @@ async fn used_asset_types<
 
 /// Submit an ordinary transfer
 pub async fn submit_transfer<
-    C: crate::ledger::queries::Client + Sync,
+    C: crate::ledger::queries::Client + Send + Sync,
     V: WalletUtils,
-    U: ShieldedUtils<C = C>,
+    U: ShieldedUtils,
 >(
     client: &C,
     wallet: &mut Wallet<V>,


### PR DESCRIPTION
This type was an attempt to reduce the number of generic parameters needed when interacting with MASP but resulted in making code re-use extremely difficult.