### PR TITLE
Remove `From<u64>` on Ethereum bridge voting power type

### DIFF
--- a/core/src/types/eth_abi.rs
+++ b/core/src/types/eth_abi.rs
@@ -198,7 +198,7 @@ mod tests {
                 )
                 .expect("Test failed"),
             ],
-            voting_powers: vec![8828299.into()],
+            voting_powers: vec![8828299.try_into().unwrap()],
             epoch: 0.into(),
         };
         let encoded = valset_update.encode().into_inner();

--- a/core/src/types/voting_power.rs
+++ b/core/src/types/voting_power.rs
@@ -47,7 +47,8 @@ impl From<&FractionalVotingPower> for EthBridgeVotingPower {
     fn from(ratio: &FractionalVotingPower) -> Self {
         // normalize the voting power
         // https://github.com/anoma/ethereum-bridge/blob/fe93d2e95ddb193a759811a79c8464ad4d709c12/test/utils/utilities.js#L29
-        const NORMALIZED_VOTING_POWER: Uint = Uint::from_u64(1 << 32);
+        const NORMALIZED_VOTING_POWER: Uint =
+            Uint::from_u64(EthBridgeVotingPower::MAX.0);
 
         let voting_power = ratio.0 * NORMALIZED_VOTING_POWER;
         let voting_power = voting_power.round().to_integer().low_u64();

--- a/core/src/types/voting_power.rs
+++ b/core/src/types/voting_power.rs
@@ -37,9 +37,16 @@ impl EthBridgeVotingPower {
     pub const MAX: Self = Self(1 << 32);
 }
 
-impl From<u64> for EthBridgeVotingPower {
-    fn from(val: u64) -> Self {
-        Self(val)
+impl TryFrom<u64> for EthBridgeVotingPower {
+    type Error = ();
+
+    #[inline]
+    fn try_from(val: u64) -> Result<Self, ()> {
+        if val <= Self::MAX.0 {
+            Ok(Self(val))
+        } else {
+            Err(())
+        }
     }
 }
 

--- a/core/src/types/voting_power.rs
+++ b/core/src/types/voting_power.rs
@@ -31,6 +31,12 @@ use crate::types::uint::Uint;
 )]
 pub struct EthBridgeVotingPower(u64);
 
+impl EthBridgeVotingPower {
+    /// Maximum value that can be represented for the voting power
+    /// stored in an Ethereum bridge smart contract.
+    pub const MAX: Self = Self(1 << 32);
+}
+
 impl From<u64> for EthBridgeVotingPower {
     fn from(val: u64) -> Self {
         Self(val)


### PR DESCRIPTION
Allowing constructing an `EthBridgeVotingPower` from arbitrary `u64` values may break the invariants of this type, and introduce bugs across the bridge. Remove this `From` implementation, and replace it with a `TryFrom`.