### PR TITLE
test/e2e: wait for wasm VP build queue before tx queue

### DIFF
--- a/tests/src/e2e/helpers.rs
+++ b/tests/src/e2e/helpers.rs
@@ -443,7 +443,8 @@ pub fn epoch_sleep(
 /// Wait for txs and VPs WASM compilations to finish. This is useful to avoid a
 /// timeout when submitting a first tx.
 pub fn wait_for_wasm_pre_compile(ledger: &mut NamadaCmd) -> Result<()> {
-    ledger.exp_string("Finished compiling all")?;
-    ledger.exp_string("Finished compiling all")?;
+    // Assumes that VPs are always done compiling before txs
+    ledger.exp_string("Finished compiling all VP.")?;
+    ledger.exp_string("Finished compiling all Tx.")?;
     Ok(())
 }


### PR DESCRIPTION
based on 0.19

this seems to resolve the latest flakiness from `e2e::ledger_tests::test_genesis_validators` as sometimes both VP and tx queues are finished by the time `wait_for_wasm_pre_compile` is called and then only the latest printout is matched