### PR TITLE
test/e2e/slashing: wait for wasm on original validator

### DIFF
--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -2678,7 +2678,7 @@ fn pos_init_validator() -> Result<()> {
     let validator_1_base_dir = test.get_base_dir(&Who::NonValidator);
     let mut validator_1 = setup::run_cmd(
         Bin::Node,
-        &["ledger"],
+        ["ledger"],
         Some(60),
         &test.working_dir,
         validator_1_base_dir,
@@ -4428,7 +4428,7 @@ fn double_signing_gets_slashed() -> Result<()> {
     // `validator_0` and `validator_0_copy` should start double signing
     let mut validator_0_copy = setup::run_cmd(
         Bin::Node,
-        &["ledger"],
+        ["ledger"],
         Some(40),
         &test.working_dir,
         validator_0_base_dir_copy,

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -2672,9 +2672,7 @@ fn pos_init_validator() -> Result<()> {
     // Stop the non-validator node and run it as the new validator
     let mut non_validator = bg_non_validator.foreground();
     non_validator.interrupt()?;
-
-    // it takes a bit before the node is shutdown. We dont want flasky test.
-    sleep(6);
+    non_validator.exp_eof()?;
 
     let loc = format!("{}:{}", std::file!(), std::line!());
     let validator_1_base_dir = test.get_base_dir(&Who::NonValidator);

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -4409,11 +4409,13 @@ fn double_signing_gets_slashed() -> Result<()> {
         run_as!(test, Who::Validator(0), Bin::Node, args, Some(40))?;
     validator_0.exp_string("Namada ledger node started")?;
     validator_0.exp_string("This node is a validator")?;
+    wait_for_wasm_pre_compile(&mut validator_0)?;
     let _bg_validator_0 = validator_0.background();
     let mut validator_1 =
         run_as!(test, Who::Validator(1), Bin::Node, args, Some(40))?;
     validator_1.exp_string("Namada ledger node started")?;
     validator_1.exp_string("This node is a validator")?;
+    wait_for_wasm_pre_compile(&mut validator_1)?;
     let bg_validator_1 = validator_1.background();
 
     // 2. Copy the first genesis validator base-dir
@@ -4506,7 +4508,6 @@ fn double_signing_gets_slashed() -> Result<()> {
     )?;
     validator_0_copy.exp_string("Namada ledger node started")?;
     validator_0_copy.exp_string("This node is a validator")?;
-    wait_for_wasm_pre_compile(&mut validator_0_copy)?;
     let _bg_validator_0_copy = validator_0_copy.background();
 
     // 5. Submit a valid token transfer tx to validator 0

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -401,6 +401,7 @@ mod macros {
     }
 }
 
+#[derive(Clone)]
 pub enum Who {
     // A non-validator
     NonValidator,


### PR DESCRIPTION
as seen in e.g. https://github.com/anoma/namada/actions/runs/5541777593/jobs/10115627826, sometimes the validator-0-copy is created after the original validator-0 has finished compiling its wasm, in which case the copy is created with the wasm cache. With this change, the copy is created only after original is done compiling