### PR TITLE
fix transparent balance query

### DIFF
--- a/apps/src/lib/cli/context.rs
+++ b/apps/src/lib/cli/context.rs
@@ -1,6 +1,5 @@
 //! CLI input types can be used for command arguments
 
-use std::collections::{HashMap, HashSet};
 use std::env;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
@@ -8,7 +7,6 @@ use std::str::FromStr;
 
 use color_eyre::eyre::Result;
 use namada::ledger::masp::ShieldedContext;
-use namada::ledger::wallet::store::AddressVpType;
 use namada::ledger::wallet::Wallet;
 use namada::types::address::Address;
 use namada::types::chain::ChainId;
@@ -192,32 +190,6 @@ impl Context {
     /// Read the given WASM file from the WASM directory or an absolute path.
     pub fn read_wasm(&self, file_name: impl AsRef<Path>) -> Vec<u8> {
         wasm_loader::read_wasm_or_exit(self.wasm_dir(), file_name)
-    }
-
-    /// Try to find an alias for a given address from the wallet. If not found,
-    /// formats the address into a string.
-    pub fn lookup_alias(&self, addr: &Address) -> String {
-        match self.wallet.find_alias(addr) {
-            Some(alias) => alias.to_string(),
-            None => addr.to_string(),
-        }
-    }
-
-    /// Get addresses with tokens VP type.
-    pub fn tokens(&self) -> HashSet<Address> {
-        self.wallet.get_addresses_with_vp_type(AddressVpType::Token)
-    }
-
-    /// Get addresses with tokens VP type associated with their aliases.
-    pub fn tokens_with_aliases(&self) -> HashMap<Address, String> {
-        self.wallet
-            .get_addresses_with_vp_type(AddressVpType::Token)
-            .into_iter()
-            .map(|addr| {
-                let alias = self.lookup_alias(&addr);
-                (addr, alias)
-            })
-            .collect()
     }
 }
 

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -193,7 +193,7 @@ pub async fn query_transfers<
         for (account, MaspChange { ref asset, change }) in tfer_delta {
             if account != masp() {
                 print!("  {}:", account);
-                let token_alias = lookup_alias(wallet, asset);
+                let token_alias = wallet.lookup_alias(asset);
                 let sign = match change.cmp(&Change::zero()) {
                     Ordering::Greater => "+",
                     Ordering::Less => "-",
@@ -216,7 +216,7 @@ pub async fn query_transfers<
             if fvk_map.contains_key(&account) {
                 print!("  {}:", fvk_map[&account]);
                 for (token_addr, val) in masp_change {
-                    let token_alias = lookup_alias(wallet, &token_addr);
+                    let token_alias = wallet.lookup_alias(&token_addr);
                     let sign = match val.cmp(&Change::zero()) {
                         Ordering::Greater => "+",
                         Ordering::Less => "-",
@@ -307,7 +307,7 @@ pub async fn query_transparent_balance<
         (Some(token), Some(owner)) => {
             let balance_key =
                 token::balance_key(&token, &owner.address().unwrap());
-            let token_alias = lookup_alias(wallet, &token);
+            let token_alias = wallet.lookup_alias(&token);
             match query_storage_value::<C, token::Amount>(client, &balance_key)
                 .await
             {
@@ -425,7 +425,7 @@ pub async fn query_pinned_balance<
                 println!("Payment address {} has not yet been consumed.", owner)
             }
             (Ok((balance, epoch)), Some(token)) => {
-                let token_alias = lookup_alias(wallet, token);
+                let token_alias = wallet.lookup_alias(token);
 
                 let total_balance = balance
                     .get(&(epoch, token.clone()))
@@ -513,7 +513,7 @@ async fn print_balances<C: namada::ledger::queries::Client + Sync>(
                 format!(
                     ": {}, owned by {}",
                     format_denominated_amount(client, tok, balance).await,
-                    lookup_alias(wallet, owner)
+                    wallet.lookup_alias(owner)
                 ),
             ),
             None => continue,
@@ -540,7 +540,7 @@ async fn print_balances<C: namada::ledger::queries::Client + Sync>(
                 // the token has been already printed
             }
             _ => {
-                let token_alias = lookup_alias(wallet, &t);
+                let token_alias = wallet.lookup_alias(&t);
                 writeln!(w, "Token {}", token_alias).unwrap();
                 print_token = Some(t);
             }
@@ -555,11 +555,11 @@ async fn print_balances<C: namada::ledger::queries::Client + Sync>(
             (Some(_), Some(target)) | (None, Some(target)) => writeln!(
                 w,
                 "No balances owned by {}",
-                lookup_alias(wallet, target)
+                wallet.lookup_alias(target)
             )
             .unwrap(),
             (Some(token), None) => {
-                let token_alias = lookup_alias(wallet, token);
+                let token_alias = wallet.lookup_alias(token);
                 writeln!(w, "No balances for token {}", token_alias).unwrap()
             }
             (None, None) => writeln!(w, "No balances").unwrap(),
@@ -750,7 +750,7 @@ pub async fn query_shielded_balance<
                     .expect("context should contain viewing key")
             };
 
-            let token_alias = lookup_alias(wallet, &token);
+            let token_alias = wallet.lookup_alias(&token);
 
             let total_balance = balance
                 .get(&(epoch, token.clone()))
@@ -847,10 +847,10 @@ pub async fn query_shielded_balance<
                     .as_ref(),
             )
             .unwrap();
-            let token_alias = lookup_alias(wallet, &token);
+            let token_alias = wallet.lookup_alias(&token);
             println!("Shielded Token {}:", token_alias);
             let mut found_any = false;
-            let token_alias = lookup_alias(wallet, &token);
+            let token_alias = wallet.lookup_alias(&token);
             println!("Shielded Token {}:", token_alias,);
             for fvk in viewing_keys {
                 // Query the multi-asset balance at the given spending key
@@ -928,7 +928,7 @@ pub async fn print_decoded_balance<
         {
             println!(
                 "{} : {}",
-                lookup_alias(wallet, token_addr),
+                wallet.lookup_alias(token_addr),
                 format_denominated_amount(client, token_addr, (*amount).into())
                     .await,
             );
@@ -2288,15 +2288,6 @@ pub async fn get_governance_parameters<
     client: &C,
 ) -> GovParams {
     namada::ledger::rpc::get_governance_parameters(client).await
-}
-
-/// Try to find an alias for a given address from the wallet. If not found,
-/// formats the address into a string.
-fn lookup_alias(wallet: &Wallet<CliWalletUtils>, addr: &Address) -> String {
-    match wallet.find_alias(addr) {
-        Some(alias) => format!("{}", alias),
-        None => format!("{}", addr),
-    }
 }
 
 /// A helper to unwrap client's response. Will shut down process on error.

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -645,11 +645,10 @@ pub fn init_network(
         })
     }
 
-    config.token.iter_mut().for_each(|(name, config)| {
+    config.token.iter_mut().for_each(|(_name, config)| {
         if config.address.is_none() {
             let address = address::gen_established_address("token");
             config.address = Some(address.to_string());
-            wallet.add_address(name.clone(), address, true);
         }
         if config.vp.is_none() {
             config.vp = Some("vp_token".to_string());

--- a/shared/src/ledger/wallet/mod.rs
+++ b/shared/src/ledger/wallet/mod.rs
@@ -5,7 +5,7 @@ mod keys;
 pub mod pre_genesis;
 pub mod store;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Display;
 use std::str::FromStr;
 
@@ -503,6 +503,15 @@ impl<U: WalletUtils> Wallet<U> {
         self.store.find_alias(address)
     }
 
+    /// Try to find an alias for a given address from the wallet. If not found,
+    /// formats the address into a string.
+    pub fn lookup_alias(&self, addr: &Address) -> String {
+        match self.find_alias(addr) {
+            Some(alias) => format!("{}", alias),
+            None => format!("{}", addr),
+        }
+    }
+
     /// Get all known addresses by their alias, paired with PKH, if known.
     pub fn get_addresses(&self) -> HashMap<String, Address> {
         self.store
@@ -677,5 +686,16 @@ impl<U: WalletUtils> Wallet<U> {
     /// Access storage location data
     pub fn store_dir(&self) -> &U::Storage {
         &self.store_dir
+    }
+
+    /// Get addresses with tokens VP type keyed and ordered by their aliases.
+    pub fn tokens_with_aliases(&self) -> BTreeMap<String, Address> {
+        self.get_addresses_with_vp_type(AddressVpType::Token)
+            .into_iter()
+            .map(|addr| {
+                let alias = self.lookup_alias(&addr);
+                (alias, addr)
+            })
+            .collect()
     }
 }

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -611,13 +611,41 @@ fn ledger_txs_and_queries() -> Result<()> {
                 &validator_one_rpc,
             ],
             // expect a decimal
-            r"nam: \d+(\.\d+)?",
+            vec![r"nam: \d+(\.\d+)?"],
+        ),
+        // Unspecified token expect all tokens from wallet derived from genesis
+        (
+            vec!["balance", "--owner", BERTHA, "--node", &validator_one_rpc],
+            // expect all genesis tokens, sorted by alias
+            vec![
+                r"apfel: \d+(\.\d+)?",
+                r"btc: \d+(\.\d+)?",
+                r"dot: \d+(\.\d+)?",
+                r"eth: \d+(\.\d+)?",
+                r"kartoffel: \d+(\.\d+)?",
+                r"schnitzel: \d+(\.\d+)?",
+            ],
         ),
     ];
     for (query_args, expected) in &query_args_and_expected_response {
+        // Run as a non-validator
         let mut client = run!(test, Bin::Client, query_args, Some(40))?;
-        client.exp_regex(expected)?;
+        for pattern in expected {
+            client.exp_regex(pattern)?;
+        }
+        client.assert_success();
 
+        // Run as a validator
+        let mut client = run_as!(
+            test,
+            Who::Validator(0),
+            Bin::Client,
+            query_args,
+            Some(40)
+        )?;
+        for pattern in expected {
+            client.exp_regex(pattern)?;
+        }
         client.assert_success();
     }
     let christel = find_address(&test, CHRISTEL)?;


### PR DESCRIPTION
## Describe your changes

Fixes:
- token VP types from genesis missing in wallet for both a validator and non-validator nodes
- client using a storage prefix for a query in which a full storage key is known

These 2 issues together affected the transparent balance query when a user address is specified but no explicit token is given.

Added an e2e test to cover this query.

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
