### PR TITLE
temp: try to run tests with opt-level=2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ test: test-unit test-e2e test-wasm
 
 # Integration and unit tests with coverage report
 test-coverage:
+	RUSTFLAGS="-C opt-level=2 -C linker=clang -C link-arg=-fuse-ld=/usr/local/bin/mold" \
 	$(cargo) +$(nightly) llvm-cov --output-dir target \
 		--features namada/testing \
 		--html \


### PR DESCRIPTION
the masp integration tests are taking too long to generate proofs in debug build - trying to build with `opt-level=2`