### PR TITLE
Fix wasm compilation cache size setting for all computers

### DIFF
--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -352,7 +352,11 @@ async fn run_aux_setup(
                     "VP WASM compilation cache size not configured, using 1/6 \
                      of available memory."
                 );
-                *available_memory_bytes / 6
+                if *available_memory_bytes > 0 {
+                    *available_memory_bytes / 6
+                } else {
+                    50000000
+                }
             }
         };
     tracing::info!(
@@ -375,7 +379,11 @@ async fn run_aux_setup(
                     "Tx WASM compilation cache size not configured, using 1/6 \
                      of available memory."
                 );
-                *available_memory_bytes / 6
+                if *available_memory_bytes > 0 {
+                    *available_memory_bytes / 6
+                } else {
+                    100000000
+                }
             }
         };
     tracing::info!(


### PR DESCRIPTION
## Describe your changes

See #1760, which is broken for ARM computers it seems. Some default cache size is provided if the available memory bytes is read as 0.

## Indicate on which release or other PRs this topic is based on

v0.20.0

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
