### PR TITLE
Allow ethereum oracle control from ledger.

### DIFF
--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -204,7 +204,7 @@ where
         if let Some(config) = genesis.ethereum_bridge_params {
             tracing::debug!("Initializing Ethereum bridge storage.");
             config.init_storage(&mut self.wl_storage);
-            self.update_eth_oracle();
+            self.update_eth_oracle(&Default::default());
         } else {
             self.wl_storage
                 .write_bytes(

--- a/ethereum_bridge/src/oracle/config.rs
+++ b/ethereum_bridge/src/oracle/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub governance_contract: EthAddress,
     /// The earliest Ethereum block from which events may be processed.
     pub start_block: ethereum_structs::BlockHeight,
+    /// The status of the Ethereum bridge (active / inactive)
+    pub active: bool,
 }
 
 // TODO: this production Default implementation is temporary, there should be no
@@ -29,6 +31,7 @@ impl std::default::Default for Config {
             bridge_contract: EthAddress([0; 20]),
             governance_contract: EthAddress([1; 20]),
             start_block: 0.into(),
+            active: true,
         }
     }
 }

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -37,14 +37,34 @@ pub enum SendValsetUpd {
     AtPrevHeight,
 }
 
-#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(
+    Debug,
+    Clone,
+    BorshDeserialize,
+    BorshSerialize,
+    PartialEq,
+    Eq,
+    Hash,
+    Ord,
+    PartialOrd,
+)]
 /// An enum indicating if the Ethereum bridge is enabled.
 pub enum EthBridgeStatus {
     Disabled,
     Enabled(EthBridgeEnabled),
 }
 
-#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(
+    Debug,
+    Clone,
+    BorshDeserialize,
+    BorshSerialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
 /// Enum indicating if the bridge was initialized at genesis
 /// or a later epoch.
 pub enum EthBridgeEnabled {


### PR DESCRIPTION
Resolves Issue #1726
Allow eth-oracle to be activated / deactivated via config updates sent from ledger. This allows governance to shutdown the ledger w/o restarts and not resulting in the ledger crashing.

This is covered with a test, but it is flaky due to async channel race conditions.