### PR TITLE
Fix Display for Dec

### DIFF
--- a/.changelog/unreleased/bug-fixes/1774-fix-dec-display.md
+++ b/.changelog/unreleased/bug-fixes/1774-fix-dec-display.md
@@ -1,0 +1,2 @@
+- Fixes buggy Display for the Dec type when the number is some multiple of 10
+  ([\#1774](https://github.com/anoma/namada/pull/1774))

--- a/core/src/types/dec.rs
+++ b/core/src/types/dec.rs
@@ -410,7 +410,8 @@ impl Display for Dec {
             str_pre.push_str(string.as_str());
             string = str_pre;
         };
-        let stripped_string = string.trim_end_matches(['.', '0']);
+        let stripped_string = string.trim_end_matches('0');
+        let stripped_string = stripped_string.trim_end_matches('.');
         if stripped_string.is_empty() {
             f.write_str("0")
         } else if is_neg {
@@ -619,5 +620,12 @@ mod test_dec {
         let smaller = Dec::from_str("6483947304.195066085701").unwrap();
         let larger = Dec::from_str("32418116583.390243854642").unwrap();
         assert!(smaller < larger);
+    }
+
+    #[test]
+    fn test_dec_display() {
+        let num = Dec::from_str("14000.0000").unwrap();
+        let s = format!("{}", num);
+        assert_eq!(s, String::from("14000"));
     }
 }


### PR DESCRIPTION
## Describe your changes

The `Display` trait for `Dec` is buggy such that if I have a number `14000.000`, the number is displayed as `14`. We attempt to strip the zeros to the right of the `.` and the `.` itself, but we end up stripping all the zeros left-adjacent to the `.` as well. The stripping is fixed now.

## Indicate on which release or other PRs this topic is based on

v0.20.1

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
