### PR TITLE
Remove non-essential fields from ERC20 transfer structs

### DIFF
--- a/.changelog/unreleased/features/1290-token-whitelist.md
+++ b/.changelog/unreleased/features/1290-token-whitelist.md
@@ -1,0 +1,2 @@
+- Implement Ethereum token whitelist.
+  ([\#1290](https://github.com/anoma/namada/issues/1290))

--- a/.changelog/unreleased/features/1781-cap-wnam.md
+++ b/.changelog/unreleased/features/1781-cap-wnam.md
@@ -1,0 +1,2 @@
+- Control the flow of NAM over the Ethereum bridge
+  ([\#1781](https://github.com/anoma/namada/pull/1781))

--- a/.changelog/unreleased/features/1789-update-ethbridge-rs.md
+++ b/.changelog/unreleased/features/1789-update-ethbridge-rs.md
@@ -1,0 +1,2 @@
+- Update ethbridge-rs to v0.22.0
+  ([\#1789](https://github.com/anoma/namada/pull/1789))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,8 +1999,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -2010,8 +2010,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -2021,8 +2021,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-events"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-governance-events",
@@ -2032,8 +2032,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -2043,8 +2043,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -2054,8 +2054,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethabi",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,8 +1999,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -2010,8 +2010,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -2021,8 +2021,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-events"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-governance-events",
@@ -2032,8 +2032,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -2043,8 +2043,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -2054,8 +2054,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethabi",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,8 +1999,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -2010,8 +2010,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -2021,8 +2021,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-events"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-governance-events",
@@ -2032,8 +2032,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -2043,8 +2043,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -2054,8 +2054,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethabi",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,8 +1999,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -2010,8 +2010,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -2021,8 +2021,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-events"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-governance-events",
@@ -2032,8 +2032,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -2043,8 +2043,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -2054,8 +2054,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethabi",
  "ethers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,12 @@ directories = "4.0.1"
 ed25519-consensus = "1.2.0"
 escargot = "0.5.7"
 ethabi = "18.0.0"
+ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0" }
 ethers = "2.0.0"
 expectrl = "0.7.0"
 eyre = "0.6.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,12 +66,12 @@ directories = "4.0.1"
 ed25519-consensus = "1.2.0"
 escargot = "0.5.7"
 ethabi = "18.0.0"
-ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
-ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
-ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
-ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
-ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
-ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0" }
+ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.22.0"}
+ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.22.0"}
+ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.22.0"}
+ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.22.0"}
+ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.22.0"}
+ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.22.0" }
 ethers = "2.0.0"
 expectrl = "0.7.0"
 eyre = "0.6.5"

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -87,9 +87,9 @@ derivative.workspace = true
 directories.workspace = true
 ed25519-consensus.workspace = true
 ethabi.workspace = true
-ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
-ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
-ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
+ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
+ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
+ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
 eyre.workspace = true
 fd-lock.workspace = true
 ferveo-common.workspace = true

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -87,9 +87,9 @@ derivative.workspace = true
 directories.workspace = true
 ed25519-consensus.workspace = true
 ethabi.workspace = true
-ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
-ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
-ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
+ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
 eyre.workspace = true
 fd-lock.workspace = true
 ferveo-common.workspace = true

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -87,9 +87,9 @@ derivative.workspace = true
 directories.workspace = true
 ed25519-consensus.workspace = true
 ethabi.workspace = true
-ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.18.0"}
-ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.18.0"}
-ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.18.0"}
+ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
+ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
+ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
 eyre.workspace = true
 fd-lock.workspace = true
 ferveo-common.workspace = true

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -87,9 +87,9 @@ derivative.workspace = true
 directories.workspace = true
 ed25519-consensus.workspace = true
 ethabi.workspace = true
-ethbridge-bridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
-ethbridge-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
-ethbridge-governance-events = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-bridge-events.workspace = true
+ethbridge-events.workspace = true
+ethbridge-governance-events.workspace = true
 eyre.workspace = true
 fd-lock.workspace = true
 ferveo-common.workspace = true

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2513,6 +2513,7 @@ pub mod args {
     pub const NET_ADDRESS: Arg<SocketAddr> = arg("net-address");
     pub const NAMADA_START_TIME: ArgOpt<DateTimeUtc> = arg_opt("time");
     pub const NO_CONVERSIONS: ArgFlag = flag("no-conversions");
+    pub const NUT: ArgFlag = flag("nut");
     pub const OUT_FILE_PATH_OPT: ArgOpt<PathBuf> = arg_opt("out-file-path");
     pub const OUTPUT_FOLDER_PATH: ArgOpt<PathBuf> =
         arg_opt("output-folder-path");
@@ -2787,6 +2788,7 @@ pub mod args {
     impl CliToSdk<EthereumBridgePool<SdkTypes>> for EthereumBridgePool<CliTypes> {
         fn to_sdk(self, ctx: &mut Context) -> EthereumBridgePool<SdkTypes> {
             EthereumBridgePool::<SdkTypes> {
+                nut: self.nut,
                 tx: self.tx.to_sdk(ctx),
                 asset: self.asset,
                 recipient: self.recipient,
@@ -2809,6 +2811,7 @@ pub mod args {
             let fee_amount = FEE_AMOUNT.parse(matches).amount;
             let fee_payer = FEE_PAYER.parse(matches);
             let code_path = PathBuf::from(TX_BRIDGE_POOL_WASM);
+            let nut = NUT.parse(matches);
             Self {
                 tx,
                 asset,
@@ -2818,6 +2821,7 @@ pub mod args {
                 fee_amount,
                 fee_payer,
                 code_path,
+                nut,
             }
         }
 
@@ -2852,6 +2856,10 @@ pub mod args {
                         "The Namada address of the account paying the fee.",
                     ),
                 )
+                .arg(NUT.def().help(
+                    "Add Non Usable Tokens (NUTs) to the Bridge pool. These \
+                     are usually obtained from invalid transfers to Namada.",
+                ))
         }
     }
 

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -909,10 +909,13 @@ pub fn genesis(
 }
 #[cfg(any(test, feature = "dev"))]
 pub fn genesis(num_validators: u64) -> Genesis {
-    use namada::ledger::eth_bridge::{Contracts, UpgradeableContract};
+    use namada::ledger::eth_bridge::{
+        Contracts, Erc20WhitelistEntry, UpgradeableContract,
+    };
     use namada::types::address::{
         self, apfel, btc, dot, eth, kartoffel, nam, schnitzel, wnam,
     };
+    use namada::types::ethereum_events::testing::DAI_ERC20_ETH_ADDRESS;
     use namada::types::ethereum_events::EthAddress;
 
     use crate::wallet;
@@ -1115,6 +1118,13 @@ pub fn genesis(num_validators: u64) -> Genesis {
         gov_params: GovernanceParameters::default(),
         pgf_params: PgfParameters::default(),
         ethereum_bridge_params: Some(EthereumBridgeConfig {
+            erc20_whitelist: vec![Erc20WhitelistEntry {
+                token_address: DAI_ERC20_ETH_ADDRESS,
+                token_cap: token::DenominatedAmount {
+                    amount: token::Amount::max(),
+                    denom: 18.into(),
+                },
+            }],
             eth_start_height: Default::default(),
             min_confirmations: Default::default(),
             contracts: Contracts {

--- a/apps/src/lib/node/ledger/ethereum_oracle/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_oracle/mod.rs
@@ -569,9 +569,8 @@ mod test_oracle {
     use namada::eth_bridge::ethers::types::H160;
     use namada::eth_bridge::structs::Erc20Transfer;
     use namada::types::address::testing::gen_established_address;
-    use namada::types::ethereum_events::{
-        EthAddress, TransferToEthereum, TransferToEthereumKind,
-    };
+    use namada::types::ethereum_events::{EthAddress, TransferToEthereum};
+    use namada::types::hash::Hash;
     use tokio::sync::oneshot::channel;
     use tokio::time::timeout;
 
@@ -828,13 +827,10 @@ mod test_oracle {
         let gas_payer = gen_established_address();
         let second_event = TransferToErcFilter {
             transfers: vec![Erc20Transfer {
-                kind: TransferToEthereumKind::Erc20 as u8,
                 amount: 0.into(),
                 from: H160([0; 20]),
-                sender: gas_payer.to_string(),
                 to: H160([1; 20]),
-                fee: 0.into(),
-                fee_from: gas_payer.to_string(),
+                namada_data_digest: [0; 32],
             }],
             valid_map: vec![true],
             relayer_address: gas_payer.to_string(),
@@ -898,13 +894,10 @@ mod test_oracle {
             assert_eq!(
                 transfer,
                 TransferToEthereum {
-                    kind: TransferToEthereumKind::Erc20,
                     amount: Default::default(),
                     asset: EthAddress([0; 20]),
-                    sender: gas_payer.clone(),
                     receiver: EthAddress([1; 20]),
-                    gas_amount: Default::default(),
-                    gas_payer: gas_payer.clone(),
+                    checksum: Hash::default(),
                 }
             );
         } else {

--- a/apps/src/lib/node/ledger/ethereum_oracle/mod.rs
+++ b/apps/src/lib/node/ledger/ethereum_oracle/mod.rs
@@ -569,7 +569,9 @@ mod test_oracle {
     use namada::eth_bridge::ethers::types::H160;
     use namada::eth_bridge::structs::Erc20Transfer;
     use namada::types::address::testing::gen_established_address;
-    use namada::types::ethereum_events::{EthAddress, TransferToEthereum};
+    use namada::types::ethereum_events::{
+        EthAddress, TransferToEthereum, TransferToEthereumKind,
+    };
     use tokio::sync::oneshot::channel;
     use tokio::time::timeout;
 
@@ -826,6 +828,7 @@ mod test_oracle {
         let gas_payer = gen_established_address();
         let second_event = TransferToErcFilter {
             transfers: vec![Erc20Transfer {
+                kind: TransferToEthereumKind::Erc20 as u8,
                 amount: 0.into(),
                 from: H160([0; 20]),
                 sender: gas_payer.to_string(),
@@ -895,6 +898,7 @@ mod test_oracle {
             assert_eq!(
                 transfer,
                 TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     amount: Default::default(),
                     asset: EthAddress([0; 20]),
                     sender: gas_payer.clone(),

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -1038,9 +1038,7 @@ mod test_finalize_block {
     };
     use namada::proto::{Code, Data, Section, Signature};
     use namada::types::dec::POS_DECIMAL_PRECISION;
-    use namada::types::ethereum_events::{
-        EthAddress, TransferToEthereum, TransferToEthereumKind, Uint as ethUint,
-    };
+    use namada::types::ethereum_events::{EthAddress, Uint as ethUint};
     use namada::types::hash::Hash;
     use namada::types::keccak::KeccakHash;
     use namada::types::key::tm_consensus_key_raw_hash;
@@ -1695,17 +1693,24 @@ mod test_finalize_block {
             }
             // write transfer to storage
             let transfer = {
-                use namada::core::types::eth_bridge_pool::PendingTransfer;
-                let transfer = TransferToEthereum {
-                    kind: TransferToEthereumKind::Erc20,
-                    amount: 10u64.into(),
-                    asset,
-                    receiver,
-                    gas_amount: 10u64.into(),
-                    sender: bertha.clone(),
-                    gas_payer: bertha.clone(),
+                use namada::core::types::eth_bridge_pool::{
+                    GasFee, PendingTransfer, TransferToEthereum,
+                    TransferToEthereumKind,
                 };
-                let pending = PendingTransfer::from(&transfer);
+                let pending = PendingTransfer {
+                    transfer: TransferToEthereum {
+                        kind: TransferToEthereumKind::Erc20,
+                        amount: 10u64.into(),
+                        asset,
+                        recipient: receiver,
+                        sender: bertha.clone(),
+                    },
+                    gas_fee: GasFee {
+                        amount: 10u64.into(),
+                        payer: bertha.clone(),
+                    },
+                };
+                let transfer = (&pending).into();
                 shell
                     .wl_storage
                     .write(&bridge_pool::get_pending_key(&pending), pending)

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -1039,7 +1039,7 @@ mod test_finalize_block {
     use namada::proto::{Code, Data, Section, Signature};
     use namada::types::dec::POS_DECIMAL_PRECISION;
     use namada::types::ethereum_events::{
-        EthAddress, TransferToEthereum, Uint as ethUint,
+        EthAddress, TransferToEthereum, TransferToEthereumKind, Uint as ethUint,
     };
     use namada::types::hash::Hash;
     use namada::types::keccak::KeccakHash;
@@ -1697,6 +1697,7 @@ mod test_finalize_block {
             let transfer = {
                 use namada::core::types::eth_bridge_pool::PendingTransfer;
                 let transfer = TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     amount: 10u64.into(),
                     asset,
                     receiver,

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use namada::core::ledger::eth_bridge;
-use namada::ledger::eth_bridge::{EthBridgeQueries, EthereumBridgeConfig};
+use namada::ledger::eth_bridge::{EthBridgeQueries, EthereumOracleConfig};
 use namada::ledger::events::log::EventLog;
 use namada::ledger::events::Event;
 use namada::ledger::gas::BlockGasMeter;
@@ -968,27 +968,16 @@ where
                 );
                 return;
             }
-            let Some(config) = EthereumBridgeConfig::read(&self.wl_storage) else {
-                tracing::info!(
-                    "Not starting oracle as the Ethereum bridge config couldn't be found in storage"
-                );
-                return;
-            };
+            let config = EthereumOracleConfig::read(&self.wl_storage).expect(
+                "The oracle config must be present in storage, since the \
+                 bridge is enabled",
+            );
             let start_block = self
                 .wl_storage
                 .storage
                 .ethereum_height
                 .clone()
-                .unwrap_or_else(|| {
-                    self.wl_storage
-                        .read(&eth_bridge::storage::eth_start_height_key())
-                        .expect(
-                            "Failed to read Ethereum start height from storage",
-                        )
-                        .expect(
-                            "The Ethereum start height should be in storage",
-                        )
-                });
+                .unwrap_or(config.eth_start_height);
             tracing::info!(
                 ?start_block,
                 "Found Ethereum height from which the Ethereum oracle should \

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -466,7 +466,8 @@ mod test_vote_extensions {
     #[cfg(feature = "abcipp")]
     use namada::types::eth_abi::Encode;
     use namada::types::ethereum_events::{
-        EthAddress, EthereumEvent, TransferToEthereum, Uint,
+        EthAddress, EthereumEvent, TransferToEthereum, TransferToEthereumKind,
+        Uint,
     };
     #[cfg(feature = "abcipp")]
     use namada::types::keccak::keccak_hash;
@@ -598,6 +599,7 @@ mod test_vote_extensions {
         let event_1 = EthereumEvent::TransfersToEthereum {
             nonce: 0.into(),
             transfers: vec![TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
                 sender: gen_established_address(),
@@ -611,6 +613,7 @@ mod test_vote_extensions {
         let event_2 = EthereumEvent::TransfersToEthereum {
             nonce: 1.into(),
             transfers: vec![TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
                 sender: gen_established_address(),
@@ -662,6 +665,7 @@ mod test_vote_extensions {
         let event_1 = EthereumEvent::TransfersToEthereum {
             nonce: 0.into(),
             transfers: vec![TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
                 sender: gen_established_address(),
@@ -724,6 +728,7 @@ mod test_vote_extensions {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
                 nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     amount: 100.into(),
                     sender: gen_established_address(),
                     asset: EthAddress([1; 20]),
@@ -818,6 +823,7 @@ mod test_vote_extensions {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
                 nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     amount: 100.into(),
                     sender: gen_established_address(),
                     asset: EthAddress([1; 20]),
@@ -895,6 +901,7 @@ mod test_vote_extensions {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
                 nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     amount: 100.into(),
                     sender: gen_established_address(),
                     asset: EthAddress([1; 20]),
@@ -977,6 +984,7 @@ mod test_vote_extensions {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
                 nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     amount: 100.into(),
                     sender: gen_established_address(),
                     asset: EthAddress([1; 20]),

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -461,9 +461,9 @@ mod test_vote_extensions {
     #[cfg(feature = "abcipp")]
     use namada::types::eth_abi::Encode;
     use namada::types::ethereum_events::{
-        EthAddress, EthereumEvent, TransferToEthereum, TransferToEthereumKind,
-        Uint,
+        EthAddress, EthereumEvent, TransferToEthereum, Uint,
     };
+    use namada::types::hash::Hash;
     #[cfg(feature = "abcipp")]
     use namada::types::keccak::keccak_hash;
     #[cfg(feature = "abcipp")]
@@ -594,13 +594,10 @@ mod test_vote_extensions {
         let event_1 = EthereumEvent::TransfersToEthereum {
             nonce: 0.into(),
             transfers: vec![TransferToEthereum {
-                kind: TransferToEthereumKind::Erc20,
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
-                sender: gen_established_address(),
                 receiver: EthAddress([2; 20]),
-                gas_amount: 10.into(),
-                gas_payer: gen_established_address(),
+                checksum: Hash::default(),
             }],
             valid_transfers_map: vec![true],
             relayer: gen_established_address(),
@@ -608,13 +605,10 @@ mod test_vote_extensions {
         let event_2 = EthereumEvent::TransfersToEthereum {
             nonce: 1.into(),
             transfers: vec![TransferToEthereum {
-                kind: TransferToEthereumKind::Erc20,
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
-                sender: gen_established_address(),
                 receiver: EthAddress([2; 20]),
-                gas_amount: 10.into(),
-                gas_payer: gen_established_address(),
+                checksum: Hash::default(),
             }],
             valid_transfers_map: vec![true],
             relayer: gen_established_address(),
@@ -660,13 +654,10 @@ mod test_vote_extensions {
         let event_1 = EthereumEvent::TransfersToEthereum {
             nonce: 0.into(),
             transfers: vec![TransferToEthereum {
-                kind: TransferToEthereumKind::Erc20,
                 amount: 100.into(),
                 asset: EthAddress([1; 20]),
-                sender: gen_established_address(),
                 receiver: EthAddress([2; 20]),
-                gas_amount: 10.into(),
-                gas_payer: gen_established_address(),
+                checksum: Hash::default(),
             }],
             valid_transfers_map: vec![true],
             relayer: gen_established_address(),
@@ -723,13 +714,10 @@ mod test_vote_extensions {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
                 nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
-                    kind: TransferToEthereumKind::Erc20,
                     amount: 100.into(),
-                    sender: gen_established_address(),
                     asset: EthAddress([1; 20]),
                     receiver: EthAddress([2; 20]),
-                    gas_amount: 10.into(),
-                    gas_payer: gen_established_address(),
+                    checksum: Hash::default(),
                 }],
                 valid_transfers_map: vec![true],
                 relayer: gen_established_address(),
@@ -818,13 +806,10 @@ mod test_vote_extensions {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
                 nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
-                    kind: TransferToEthereumKind::Erc20,
                     amount: 100.into(),
-                    sender: gen_established_address(),
                     asset: EthAddress([1; 20]),
                     receiver: EthAddress([2; 20]),
-                    gas_amount: 10.into(),
-                    gas_payer: gen_established_address(),
+                    checksum: Hash::default(),
                 }],
                 valid_transfers_map: vec![true],
                 relayer: gen_established_address(),
@@ -896,13 +881,10 @@ mod test_vote_extensions {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
                 nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
-                    kind: TransferToEthereumKind::Erc20,
                     amount: 100.into(),
-                    sender: gen_established_address(),
                     asset: EthAddress([1; 20]),
                     receiver: EthAddress([2; 20]),
-                    gas_amount: 10.into(),
-                    gas_payer: gen_established_address(),
+                    checksum: Hash::default(),
                 }],
                 valid_transfers_map: vec![true],
                 relayer: gen_established_address(),
@@ -979,13 +961,10 @@ mod test_vote_extensions {
             ethereum_events: vec![EthereumEvent::TransfersToEthereum {
                 nonce: 0.into(),
                 transfers: vec![TransferToEthereum {
-                    kind: TransferToEthereumKind::Erc20,
                     amount: 100.into(),
-                    sender: gen_established_address(),
                     asset: EthAddress([1; 20]),
                     receiver: EthAddress([2; 20]),
-                    gas_amount: 10.into(),
-                    gas_payer: gen_established_address(),
+                    checksum: Hash::default(),
                 }],
                 valid_transfers_map: vec![true],
                 relayer: gen_established_address(),

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -276,11 +276,6 @@ where
                     return Err(VoteExtensionError::InvalidNamNonce);
                 }
             }
-            EthereumEvent::UpdateBridgeWhitelist { .. } => {
-                // TODO: check nonce of whitelist update;
-                // for this, we need to store the nonce of
-                // whitelist updates somewhere
-            }
             // consider other ethereum event kinds valid
             _ => {}
         }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -66,7 +66,7 @@ data-encoding.workspace = true
 derivative.workspace = true
 ed25519-consensus.workspace = true
 ethabi.workspace = true
-ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0" }
+ethbridge-structs.workspace = true
 eyre.workspace = true
 ferveo = {optional = true, git = "https://github.com/anoma/ferveo", rev = "e5abd0acc938da90140351a65a26472eb495ce4d"}
 ferveo-common = {git = "https://github.com/anoma/ferveo", rev = "e5abd0acc938da90140351a65a26472eb495ce4d"}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -66,7 +66,7 @@ data-encoding.workspace = true
 derivative.workspace = true
 ed25519-consensus.workspace = true
 ethabi.workspace = true
-ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.18.0" }
+ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0" }
 eyre.workspace = true
 ferveo = {optional = true, git = "https://github.com/anoma/ferveo", rev = "e5abd0acc938da90140351a65a26472eb495ce4d"}
 ferveo-common = {git = "https://github.com/anoma/ferveo", rev = "e5abd0acc938da90140351a65a26472eb495ce4d"}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -66,7 +66,7 @@ data-encoding.workspace = true
 derivative.workspace = true
 ed25519-consensus.workspace = true
 ethabi.workspace = true
-ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0" }
+ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0" }
 eyre.workspace = true
 ferveo = {optional = true, git = "https://github.com/anoma/ferveo", rev = "e5abd0acc938da90140351a65a26472eb495ce4d"}
 ferveo-common = {git = "https://github.com/anoma/ferveo", rev = "e5abd0acc938da90140351a65a26472eb495ce4d"}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -66,7 +66,7 @@ data-encoding.workspace = true
 derivative.workspace = true
 ed25519-consensus.workspace = true
 ethabi.workspace = true
-ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0" }
+ethbridge-structs = { git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0" }
 eyre.workspace = true
 ferveo = {optional = true, git = "https://github.com/anoma/ferveo", rev = "e5abd0acc938da90140351a65a26472eb495ce4d"}
 ferveo-common = {git = "https://github.com/anoma/ferveo", rev = "e5abd0acc938da90140351a65a26472eb495ce4d"}

--- a/core/src/ledger/eth_bridge/storage/bridge_pool.rs
+++ b/core/src/ledger/eth_bridge/storage/bridge_pool.rs
@@ -415,7 +415,9 @@ mod test_bridge_pool_tree {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::types::eth_bridge_pool::{GasFee, TransferToEthereum};
+    use crate::types::eth_bridge_pool::{
+        GasFee, TransferToEthereum, TransferToEthereumKind,
+    };
     use crate::types::ethereum_events::EthAddress;
 
     /// An established user address for testing & development
@@ -432,6 +434,7 @@ mod test_bridge_pool_tree {
         assert_eq!(tree.root().0, [0; 32]);
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([1; 20]),
                 sender: bertha_address(),
                 recipient: EthAddress([2; 20]),
@@ -458,6 +461,7 @@ mod test_bridge_pool_tree {
         for i in 0..2 {
             let transfer = PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([i; 20]),
                     sender: bertha_address(),
                     recipient: EthAddress([i + 1; 20]),
@@ -485,6 +489,7 @@ mod test_bridge_pool_tree {
         for i in 0..3 {
             let transfer = PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([i; 20]),
                     sender: bertha_address(),
                     recipient: EthAddress([i + 1; 20]),
@@ -522,6 +527,7 @@ mod test_bridge_pool_tree {
 
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([1; 20]),
                 sender: bertha_address(),
                 recipient: EthAddress([2; 20]),
@@ -549,6 +555,7 @@ mod test_bridge_pool_tree {
         for i in 0..3 {
             let transfer = PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([i; 20]),
                     sender: bertha_address(),
                     recipient: EthAddress([i + 1; 20]),
@@ -579,6 +586,7 @@ mod test_bridge_pool_tree {
     fn test_parse_key() {
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([1; 20]),
                 sender: bertha_address(),
                 recipient: EthAddress([2; 20]),
@@ -602,6 +610,7 @@ mod test_bridge_pool_tree {
     fn test_key_multiple_segments() {
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([1; 20]),
                 sender: bertha_address(),
                 recipient: EthAddress([2; 20]),
@@ -637,6 +646,7 @@ mod test_bridge_pool_tree {
         let mut tree = BridgePoolTree::default();
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([1; 20]),
                 sender: bertha_address(),
                 recipient: EthAddress([2; 20]),
@@ -655,6 +665,7 @@ mod test_bridge_pool_tree {
         );
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([1; 20]),
                 sender: bertha_address(),
                 recipient: EthAddress([0; 20]),
@@ -686,6 +697,7 @@ mod test_bridge_pool_tree {
     fn test_single_leaf() {
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([0; 20]),
                 sender: bertha_address(),
                 recipient: EthAddress([0; 20]),
@@ -714,6 +726,7 @@ mod test_bridge_pool_tree {
         for i in 0..2 {
             let transfer = PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([i; 20]),
                     sender: bertha_address(),
                     recipient: EthAddress([i + 1; 20]),
@@ -743,6 +756,7 @@ mod test_bridge_pool_tree {
         for i in 0..3 {
             let transfer = PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([i; 20]),
                     sender: bertha_address(),
                     recipient: EthAddress([i + 1; 20]),
@@ -772,6 +786,7 @@ mod test_bridge_pool_tree {
         for i in 0..3 {
             let transfer = PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([i; 20]),
                     sender: bertha_address(),
                     recipient: EthAddress([i + 1; 20]),
@@ -799,6 +814,7 @@ mod test_bridge_pool_tree {
         for i in 0..2 {
             let transfer = PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([i; 20]),
                     sender: bertha_address(),
                     recipient: EthAddress([i + 1; 20]),
@@ -826,6 +842,7 @@ mod test_bridge_pool_tree {
         for i in 0..3 {
             let transfer = PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([i; 20]),
                     sender: bertha_address(),
                     recipient: EthAddress([i + 1; 20]),
@@ -853,6 +870,7 @@ mod test_bridge_pool_tree {
         for i in 0..5 {
             let transfer = PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([i; 20]),
                     sender: bertha_address(),
                     recipient: EthAddress([i + 1; 20]),
@@ -884,6 +902,7 @@ mod test_bridge_pool_tree {
                         .into_iter()
                         .map(|addr| PendingTransfer {
                             transfer: TransferToEthereum {
+                                kind: TransferToEthereumKind::Erc20,
                                 asset: EthAddress(addr),
                                 sender: bertha_address(),
                                 recipient: EthAddress(addr),

--- a/core/src/ledger/eth_bridge/storage/mod.rs
+++ b/core/src/ledger/eth_bridge/storage/mod.rs
@@ -1,5 +1,6 @@
 //! Functionality for accessing the storage subspace
 pub mod bridge_pool;
+pub mod whitelist;
 pub mod wrapped_erc20s;
 
 use super::ADDRESS;

--- a/core/src/ledger/eth_bridge/storage/whitelist.rs
+++ b/core/src/ledger/eth_bridge/storage/whitelist.rs
@@ -1,0 +1,117 @@
+//! ERC20 token whitelist storage data.
+//!
+//! These storage keys should only ever be written to by governance,
+//! or `InitChain`.
+
+use std::str::FromStr;
+
+use super::super::ADDRESS as BRIDGE_ADDRESS;
+use super::{prefix as ethbridge_key_prefix, wrapped_erc20s};
+use crate::types::ethereum_events::EthAddress;
+use crate::types::storage;
+use crate::types::storage::DbKeySeg;
+use crate::types::token::{denom_key, minted_balance_key};
+
+mod segments {
+    //! Storage key segments under the token whitelist.
+    use namada_macros::StorageKeys;
+
+    use crate::types::address::Address;
+    use crate::types::storage::{DbKeySeg, Key};
+
+    /// The name of the main storage segment.
+    pub(super) const MAIN_SEGMENT: &str = "whitelist";
+
+    /// Storage key segments under the token whitelist.
+    #[derive(StorageKeys)]
+    pub(super) struct Segments {
+        /// Whether an ERC20 asset is whitelisted or not.
+        pub whitelisted: &'static str,
+        /// The token cap of an ERC20 asset.
+        pub cap: &'static str,
+    }
+
+    /// All the values of the generated [`Segments`].
+    pub(super) const VALUES: Segments = Segments::VALUES;
+
+    /// Listing of each of the generated [`Segments`].
+    pub(super) const ALL: &[&str] = Segments::ALL;
+}
+
+/// Represents the type of a key relating to whitelisted ERC20.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub enum KeyType {
+    /// Whether an ERC20 asset is whitelisted or not.
+    Whitelisted,
+    /// The token cap of an ERC20 asset.
+    Cap,
+    /// The current supply of a wrapped ERC20 asset,
+    /// circulating in Namada.
+    WrappedSupply,
+    /// The denomination of the ERC20 asset.
+    Denomination,
+}
+
+/// Whitelisted ERC20 token storage sub-space.
+pub struct Key {
+    /// The specific ERC20 as identified by its Ethereum address.
+    pub asset: EthAddress,
+    /// The type of this key.
+    pub suffix: KeyType,
+}
+
+/// Return the whitelist storage key sub-space prefix.
+fn whitelist_prefix(asset: &EthAddress) -> storage::Key {
+    ethbridge_key_prefix()
+        .push(&segments::MAIN_SEGMENT.to_owned())
+        .expect("Should be able to push a storage key segment")
+        .push(&asset.to_canonical())
+        .expect("Should be able to push a storage key segment")
+}
+
+impl From<Key> for storage::Key {
+    #[inline]
+    fn from(key: Key) -> Self {
+        (&key).into()
+    }
+}
+
+impl From<&Key> for storage::Key {
+    fn from(key: &Key) -> Self {
+        match &key.suffix {
+            KeyType::Whitelisted => whitelist_prefix(&key.asset)
+                .push(&segments::VALUES.whitelisted.to_owned())
+                .expect("Should be able to push a storage key segment"),
+            KeyType::Cap => whitelist_prefix(&key.asset)
+                .push(&segments::VALUES.cap.to_owned())
+                .expect("Should be able to push a storage key segment"),
+            KeyType::WrappedSupply => {
+                let token = wrapped_erc20s::token(&key.asset);
+                minted_balance_key(&token)
+            }
+            KeyType::Denomination => {
+                let token = wrapped_erc20s::token(&key.asset);
+                denom_key(&token)
+            }
+        }
+    }
+}
+
+/// Check if some [`storage::Key`] is an Ethereum bridge whitelist key
+/// of type [`KeyType::Cap`] or [`KeyType::Whitelisted`].
+pub fn is_cap_or_whitelisted_key(key: &storage::Key) -> bool {
+    match &key.segments[..] {
+        [
+            DbKeySeg::AddressSeg(s1),
+            DbKeySeg::StringSeg(s2),
+            DbKeySeg::StringSeg(s3),
+            DbKeySeg::StringSeg(s4),
+        ] => {
+            s1 == &BRIDGE_ADDRESS
+                && s2 == segments::MAIN_SEGMENT
+                && EthAddress::from_str(s3).is_ok()
+                && segments::ALL.binary_search(&s4.as_str()).is_ok()
+        }
+        _ => false,
+    }
+}

--- a/core/src/ledger/eth_bridge/storage/whitelist.rs
+++ b/core/src/ledger/eth_bridge/storage/whitelist.rs
@@ -115,3 +115,50 @@ pub fn is_cap_or_whitelisted_key(key: &storage::Key) -> bool {
         _ => false,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ethereum_events::testing::DAI_ERC20_ETH_ADDRESS;
+
+    /// Test that storage key serialization yields the expected value.
+    #[test]
+    fn test_keys_whitelisted_to_string() {
+        let key: storage::Key = Key {
+            asset: DAI_ERC20_ETH_ADDRESS,
+            suffix: KeyType::Whitelisted,
+        }
+        .into();
+        let expected = "#atest1v9hx7w36g42ysgzzwf5kgem9ypqkgerjv4ehxgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpq8f99ew/whitelist/0x6b175474e89094c44da98b954eedeac495271d0f/whitelisted";
+        assert_eq!(expected, key.to_string());
+    }
+
+    /// Test that checking if a key is of type "cap" or "whitelisted" works.
+    #[test]
+    fn test_cap_or_whitelisted_key() {
+        let whitelisted_key: storage::Key = Key {
+            asset: DAI_ERC20_ETH_ADDRESS,
+            suffix: KeyType::Whitelisted,
+        }
+        .into();
+        assert!(is_cap_or_whitelisted_key(&whitelisted_key));
+
+        let cap_key: storage::Key = Key {
+            asset: DAI_ERC20_ETH_ADDRESS,
+            suffix: KeyType::Cap,
+        }
+        .into();
+        assert!(is_cap_or_whitelisted_key(&cap_key));
+
+        let unexpected_key = {
+            let mut k: storage::Key = Key {
+                asset: DAI_ERC20_ETH_ADDRESS,
+                suffix: KeyType::Cap,
+            }
+            .into();
+            k.segments[3] = DbKeySeg::StringSeg("abc".to_owned());
+            k
+        };
+        assert!(!is_cap_or_whitelisted_key(&unexpected_key));
+    }
+}

--- a/core/src/ledger/eth_bridge/storage/wrapped_erc20s.rs
+++ b/core/src/ledger/eth_bridge/storage/wrapped_erc20s.rs
@@ -14,6 +14,11 @@ pub fn token(address: &EthAddress) -> Address {
     Address::Internal(InternalAddress::Erc20(*address))
 }
 
+/// Construct a NUT token address from an ERC20 address.
+pub fn nut(address: &EthAddress) -> Address {
+    Address::Internal(InternalAddress::Nut(*address))
+}
+
 /// Represents the type of a key relating to a wrapped ERC20
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum KeyType {

--- a/core/src/types/address.rs
+++ b/core/src/types/address.rs
@@ -99,6 +99,8 @@ const PREFIX_INTERNAL: &str = "ano";
 const PREFIX_IBC: &str = "ibc";
 /// Fixed-length address strings prefix for Ethereum addresses.
 const PREFIX_ETH: &str = "eth";
+/// Fixed-length address strings prefix for Non-Usable-Token addresses.
+const PREFIX_NUT: &str = "nut";
 
 #[allow(missing_docs)]
 #[derive(Error, Debug)]
@@ -234,6 +236,11 @@ impl Address {
                             eth_addr.to_canonical().replace("0x", "");
                         format!("{}::{}", PREFIX_ETH, eth_addr)
                     }
+                    InternalAddress::Nut(eth_addr) => {
+                        let eth_addr =
+                            eth_addr.to_canonical().replace("0x", "");
+                        format!("{PREFIX_NUT}::{eth_addr}")
+                    }
                     InternalAddress::ReplayProtection => {
                         internal::REPLAY_PROTECTION.to_string()
                     }
@@ -330,12 +337,18 @@ impl Address {
                     "Invalid IBC internal address",
                 )),
             },
-            Some((PREFIX_ETH, raw)) => match string {
+            Some((prefix @ (PREFIX_ETH | PREFIX_NUT), raw)) => match string {
                 _ if raw.len() == HASH_HEX_LEN => {
                     match EthAddress::from_str(&format!("0x{}", raw)) {
-                        Ok(eth_addr) => Ok(Address::Internal(
-                            InternalAddress::Erc20(eth_addr),
-                        )),
+                        Ok(eth_addr) => Ok(match prefix {
+                            PREFIX_ETH => Address::Internal(
+                                InternalAddress::Erc20(eth_addr),
+                            ),
+                            PREFIX_NUT => Address::Internal(
+                                InternalAddress::Nut(eth_addr),
+                            ),
+                            _ => unreachable!(),
+                        }),
                         Err(e) => Err(Error::new(
                             ErrorKind::InvalidData,
                             e.to_string(),
@@ -543,6 +556,8 @@ pub enum InternalAddress {
     EthBridgePool,
     /// ERC20 token for Ethereum bridge
     Erc20(EthAddress),
+    /// Non-usable ERC20 tokens
+    Nut(EthAddress),
     /// Replay protection contains transactions' hash
     ReplayProtection,
     /// Multitoken
@@ -566,6 +581,7 @@ impl Display for InternalAddress {
                 Self::EthBridge => "EthBridge".to_string(),
                 Self::EthBridgePool => "EthBridgePool".to_string(),
                 Self::Erc20(eth_addr) => format!("Erc20: {}", eth_addr),
+                Self::Nut(eth_addr) => format!("Non-usable token: {eth_addr}"),
                 Self::ReplayProtection => "ReplayProtection".to_string(),
                 Self::Multitoken => "Multitoken".to_string(),
                 Self::Pgf => "PublicGoodFundings".to_string(),
@@ -861,6 +877,7 @@ pub mod testing {
             InternalAddress::EthBridge => {}
             InternalAddress::EthBridgePool => {}
             InternalAddress::Erc20(_) => {}
+            InternalAddress::Nut(_) => {}
             InternalAddress::ReplayProtection => {}
             InternalAddress::Pgf => {}
             InternalAddress::Multitoken => {} /* Add new addresses in the
@@ -876,6 +893,7 @@ pub mod testing {
             Just(InternalAddress::EthBridge),
             Just(InternalAddress::EthBridgePool),
             Just(arb_erc20()),
+            Just(arb_nut()),
             Just(InternalAddress::ReplayProtection),
             Just(InternalAddress::Multitoken),
             Just(InternalAddress::Pgf),
@@ -900,6 +918,13 @@ pub mod testing {
 
     fn arb_erc20() -> InternalAddress {
         use crate::types::ethereum_events::testing::arbitrary_eth_address;
+        // TODO: generate random erc20 addr data
         InternalAddress::Erc20(arbitrary_eth_address())
+    }
+
+    fn arb_nut() -> InternalAddress {
+        use crate::types::ethereum_events::testing::arbitrary_eth_address;
+        // TODO: generate random erc20 addr data
+        InternalAddress::Nut(arbitrary_eth_address())
     }
 }

--- a/core/src/types/eth_bridge_pool.rs
+++ b/core/src/types/eth_bridge_pool.rs
@@ -5,6 +5,7 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use ethabi::token::Token;
 use serde::{Deserialize, Serialize};
 
+use crate::ledger::eth_bridge::storage::wrapped_erc20s;
 use crate::types::address::Address;
 use crate::types::eth_abi::Encode;
 pub use crate::types::ethereum_events::TransferToEthereumKind;
@@ -68,6 +69,21 @@ pub struct PendingTransfer {
     /// The amount of gas fees (in NAM)
     /// paid by the user sending this transfer
     pub gas_fee: GasFee,
+}
+
+impl PendingTransfer {
+    /// Get a token [`Address`] from this [`PendingTransfer`].
+    #[inline]
+    pub fn token_address(&self) -> Address {
+        match &self.transfer.kind {
+            TransferToEthereumKind::Erc20 => {
+                wrapped_erc20s::token(&self.transfer.asset)
+            }
+            TransferToEthereumKind::Nut => {
+                wrapped_erc20s::nut(&self.transfer.asset)
+            }
+        }
+    }
 }
 
 impl From<PendingTransfer> for ethbridge_structs::Erc20Transfer {

--- a/core/src/types/eth_bridge_pool.rs
+++ b/core/src/types/eth_bridge_pool.rs
@@ -1,6 +1,8 @@
 //! The necessary type definitions for the contents of the
 //! Ethereum bridge pool
 
+use std::borrow::Cow;
+
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use ethabi::token::Token;
 use serde::{Deserialize, Serialize};
@@ -8,15 +10,107 @@ use serde::{Deserialize, Serialize};
 use crate::ledger::eth_bridge::storage::wrapped_erc20s;
 use crate::types::address::Address;
 use crate::types::eth_abi::Encode;
-pub use crate::types::ethereum_events::TransferToEthereumKind;
 use crate::types::ethereum_events::{
     EthAddress, TransferToEthereum as TransferToEthereumEvent,
 };
+use crate::types::hash::Hash as HashDigest;
 use crate::types::storage::{DbKeySeg, Key};
 use crate::types::token::Amount;
 
+/// A version used in our Ethereuem smart contracts
+const VERSION: u8 = 1;
+
 /// A namespace used in our Ethereuem smart contracts
 const NAMESPACE: &str = "transfer";
+
+/// Transfer to Ethereum kinds.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Serialize,
+    Deserialize,
+)]
+pub enum TransferToEthereumKind {
+    /// Transfer ERC20 assets from Namada to Ethereum.
+    ///
+    /// These transfers burn wrapped ERC20 assets in Namada, once
+    /// they have been confirmed.
+    Erc20,
+    /// Refund non-usable tokens.
+    ///
+    /// These Bridge pool transfers should be crafted for assets
+    /// that have been transferred to Namada, that had either not
+    /// been whitelisted or whose token caps had been exceeded in
+    /// Namada at the time of the transfer.
+    Nut,
+}
+
+/// Additional data appended to a [`TransferToEthereumEvent`] to
+/// construct a [`PendingTransfer`].
+#[derive(
+    Debug,
+    Clone,
+    Hash,
+    PartialOrd,
+    PartialEq,
+    Ord,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+)]
+pub struct PendingTransferAppendix<'transfer> {
+    /// The kind of the pending transfer to Ethereum.
+    pub kind: Cow<'transfer, TransferToEthereumKind>,
+    /// The sender of the transfer.
+    pub sender: Cow<'transfer, Address>,
+    /// The amount of gas fees (in NAM)
+    /// paid by the user sending this transfer
+    pub gas_fee: Cow<'transfer, GasFee>,
+}
+
+impl From<PendingTransfer> for PendingTransferAppendix<'static> {
+    #[inline]
+    fn from(pending: PendingTransfer) -> Self {
+        Self {
+            kind: Cow::Owned(pending.transfer.kind),
+            sender: Cow::Owned(pending.transfer.sender),
+            gas_fee: Cow::Owned(pending.gas_fee),
+        }
+    }
+}
+
+impl<'t> From<&'t PendingTransfer> for PendingTransferAppendix<'t> {
+    #[inline]
+    fn from(pending: &'t PendingTransfer) -> Self {
+        Self {
+            kind: Cow::Borrowed(&pending.transfer.kind),
+            sender: Cow::Borrowed(&pending.transfer.sender),
+            gas_fee: Cow::Borrowed(&pending.gas_fee),
+        }
+    }
+}
+
+impl<'transfer> PendingTransferAppendix<'transfer> {
+    /// Calculate the checksum of this [`PendingTransferAppendix`].
+    pub fn checksum(&self) -> HashDigest {
+        let serialized = self
+            .try_to_vec()
+            .expect("Serializing a PendingTransferAppendix should not fail");
+        HashDigest::sha256(serialized)
+    }
+}
 
 /// A transfer message to be submitted to Ethereum
 /// to move assets from Namada across the bridge.
@@ -84,51 +178,84 @@ impl PendingTransfer {
             }
         }
     }
+
+    /// Retrieve a reference to the appendix of this [`PendingTransfer`].
+    #[inline]
+    pub fn appendix(&self) -> PendingTransferAppendix<'_> {
+        self.into()
+    }
+
+    /// Retrieve the owned appendix of this [`PendingTransfer`].
+    #[inline]
+    pub fn into_appendix(self) -> PendingTransferAppendix<'static> {
+        self.into()
+    }
+
+    /// Craft a [`PendingTransfer`] from its constituents.
+    pub fn from_parts(
+        event: &TransferToEthereumEvent,
+        appendix: PendingTransferAppendix<'_>,
+    ) -> Self {
+        let transfer = TransferToEthereum {
+            kind: *appendix.kind,
+            asset: event.asset,
+            recipient: event.receiver,
+            sender: (*appendix.sender).clone(),
+            amount: event.amount,
+        };
+        let gas_fee = (*appendix.gas_fee).clone();
+        Self { transfer, gas_fee }
+    }
 }
 
-impl From<PendingTransfer> for ethbridge_structs::Erc20Transfer {
-    fn from(pending: PendingTransfer) -> Self {
+impl From<&PendingTransfer> for ethbridge_structs::Erc20Transfer {
+    fn from(pending: &PendingTransfer) -> Self {
+        let HashDigest(namada_data_digest) = pending.appendix().checksum();
         Self {
-            kind: pending.transfer.kind as u8,
             from: pending.transfer.asset.0.into(),
             to: pending.transfer.recipient.0.into(),
             amount: pending.transfer.amount.into(),
-            fee_from: pending.gas_fee.payer.to_string(),
-            fee: pending.gas_fee.amount.into(),
-            sender: pending.transfer.sender.to_string(),
+            namada_data_digest,
         }
     }
 }
 
-impl Encode<8> for PendingTransfer {
-    fn tokenize(&self) -> [Token; 8] {
-        // TODO: This version should be looked up from storage
-        let version = Token::Uint(1.into());
-        let namespace = Token::String(NAMESPACE.into());
-        let from = Token::Address(self.transfer.asset.0.into());
-        let fee = Token::Uint(self.gas_fee.amount.into());
-        let to = Token::Address(self.transfer.recipient.0.into());
-        let amount = Token::Uint(self.transfer.amount.into());
-        let fee_from = Token::String(self.gas_fee.payer.to_string());
-        let sender = Token::String(self.transfer.sender.to_string());
-        [version, namespace, from, to, amount, fee_from, fee, sender]
+impl From<&PendingTransfer> for TransferToEthereumEvent {
+    fn from(pending: &PendingTransfer) -> Self {
+        Self {
+            amount: pending.transfer.amount,
+            asset: pending.transfer.asset,
+            receiver: pending.transfer.recipient,
+            checksum: pending.appendix().checksum(),
+        }
     }
 }
 
-impl From<&TransferToEthereumEvent> for PendingTransfer {
-    fn from(event: &TransferToEthereumEvent) -> Self {
-        let transfer = TransferToEthereum {
-            kind: event.kind,
-            asset: event.asset,
-            recipient: event.receiver,
-            sender: event.sender.clone(),
-            amount: event.amount,
-        };
-        let gas_fee = GasFee {
-            amount: event.gas_amount,
-            payer: event.gas_payer.clone(),
-        };
-        Self { transfer, gas_fee }
+impl Encode<6> for PendingTransfer {
+    fn tokenize(&self) -> [Token; 6] {
+        // TODO: This version should be looked up from storage
+        let version = Token::Uint(VERSION.into());
+        let namespace = Token::String(NAMESPACE.into());
+        let from = Token::Address(self.transfer.asset.0.into());
+        let to = Token::Address(self.transfer.recipient.0.into());
+        let amount = Token::Uint(self.transfer.amount.into());
+        let checksum = Token::FixedBytes(self.appendix().checksum().0.into());
+        [version, namespace, from, to, amount, checksum]
+    }
+}
+
+// TODO: test that encode for `PendingTransfer` and
+// `TransferToEthereumEvent` yield the same keccak hash
+impl Encode<6> for TransferToEthereumEvent {
+    fn tokenize(&self) -> [Token; 6] {
+        // TODO: This version should be looked up from storage
+        let version = Token::Uint(VERSION.into());
+        let namespace = Token::String(NAMESPACE.into());
+        let from = Token::Address(self.asset.0.into());
+        let to = Token::Address(self.receiver.0.into());
+        let amount = Token::Uint(self.amount.into());
+        let checksum = Token::FixedBytes(self.checksum.0.into());
+        [version, namespace, from, to, amount, checksum]
     }
 }
 

--- a/core/src/types/eth_bridge_pool.rs
+++ b/core/src/types/eth_bridge_pool.rs
@@ -244,8 +244,6 @@ impl Encode<6> for PendingTransfer {
     }
 }
 
-// TODO: test that encode for `PendingTransfer` and
-// `TransferToEthereumEvent` yield the same keccak hash
 impl Encode<6> for TransferToEthereumEvent {
     fn tokenize(&self) -> [Token; 6] {
         // TODO: This version should be looked up from storage
@@ -291,4 +289,31 @@ pub struct GasFee {
     pub amount: Amount,
     /// The account of fee payer.
     pub payer: Address,
+}
+
+#[cfg(test)]
+mod test_eth_bridge_pool_types {
+    use super::*;
+    use crate::types::address::testing::established_address_1;
+
+    /// Test that [`PendingTransfer`] and [`TransferToEthereum`]
+    /// have the same keccak hash, after being ABI encoded.
+    #[test]
+    fn test_same_keccak_hash() {
+        let pending = PendingTransfer {
+            transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
+                amount: 10u64.into(),
+                asset: EthAddress([0xaa; 20]),
+                recipient: EthAddress([0xbb; 20]),
+                sender: established_address_1(),
+            },
+            gas_fee: GasFee {
+                amount: 10u64.into(),
+                payer: established_address_1(),
+            },
+        };
+        let event: TransferToEthereumEvent = (&pending).into();
+        assert_eq!(pending.keccak256(), event.keccak256());
+    }
 }

--- a/core/src/types/eth_bridge_pool.rs
+++ b/core/src/types/eth_bridge_pool.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::address::Address;
 use crate::types::eth_abi::Encode;
+pub use crate::types::ethereum_events::TransferToEthereumKind;
 use crate::types::ethereum_events::{
     EthAddress, TransferToEthereum as TransferToEthereumEvent,
 };
@@ -33,6 +34,8 @@ const NAMESPACE: &str = "transfer";
     BorshSchema,
 )]
 pub struct TransferToEthereum {
+    /// The kind of transfer to Ethereum.
+    pub kind: TransferToEthereumKind,
     /// The type of token
     pub asset: EthAddress,
     /// The recipient address
@@ -70,6 +73,7 @@ pub struct PendingTransfer {
 impl From<PendingTransfer> for ethbridge_structs::Erc20Transfer {
     fn from(pending: PendingTransfer) -> Self {
         Self {
+            kind: pending.transfer.kind as u8,
             from: pending.transfer.asset.0.into(),
             to: pending.transfer.recipient.0.into(),
             amount: pending.transfer.amount.into(),
@@ -98,6 +102,7 @@ impl Encode<8> for PendingTransfer {
 impl From<&TransferToEthereumEvent> for PendingTransfer {
     fn from(event: &TransferToEthereumEvent) -> Self {
         let transfer = TransferToEthereum {
+            kind: event.kind,
             asset: event.asset,
             recipient: event.receiver,
             sender: event.sender.clone(),

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -334,16 +334,6 @@ pub enum EthereumEvent {
         #[allow(dead_code)]
         address: EthAddress,
     },
-    /// Event indication a new Ethereum based token has been whitelisted for
-    /// transfer across the bridge
-    UpdateBridgeWhitelist {
-        /// Monotonically increasing nonce
-        #[allow(dead_code)]
-        nonce: Uint,
-        /// Tokens to be allowed to be transferred across the bridge
-        #[allow(dead_code)]
-        whitelist: Vec<TokenWhitelist>,
-    },
 }
 
 impl EthereumEvent {
@@ -460,30 +450,6 @@ pub struct TransferToEthereum {
     pub sender: Address,
     /// The account of fee payer.
     pub gas_payer: Address,
-}
-
-/// struct for whitelisting a token from Ethereum.
-/// Includes the address of issuing contract and
-/// a cap on the max amount of this token allowed to be
-/// held by the bridge.
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    BorshSerialize,
-    BorshDeserialize,
-    BorshSchema,
-)]
-#[allow(dead_code)]
-pub struct TokenWhitelist {
-    /// Address of Ethereum smart contract issuing token
-    pub token: EthAddress,
-    /// Maximum amount of token allowed on the bridge
-    pub cap: Amount,
 }
 
 #[cfg(test)]

--- a/core/src/types/ethereum_events.rs
+++ b/core/src/types/ethereum_events.rs
@@ -376,6 +376,60 @@ pub struct TransferToNamada {
     pub receiver: Address,
 }
 
+/// Transfer to Ethereum kinds.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Serialize,
+    Deserialize,
+)]
+#[repr(u8)]
+pub enum TransferToEthereumKind {
+    /// Transfer ERC20 assets from Namada to Ethereum.
+    ///
+    /// These transfers burn wrapped ERC20 assets in Namada, once
+    /// they have been confirmed.
+    Erc20 = Self::KIND_ERC20,
+    /// Refund non-usable tokens.
+    ///
+    /// These Bridge pool transfers should be crafted for assets
+    /// that have been transferred to Namada, that had either not
+    /// been whitelisted or whose token caps had been exceeded in
+    /// Namada at the time of the transfer.
+    Nut = Self::KIND_NUT,
+}
+
+// XXX: keep these values in sync with the smart contracts
+impl TransferToEthereumKind {
+    const KIND_ERC20: u8 = 0;
+    const KIND_NUT: u8 = 1;
+}
+
+impl TryFrom<u8> for TransferToEthereumKind {
+    type Error = eyre::Error;
+
+    fn try_from(kind: u8) -> Result<Self, Self::Error> {
+        match kind {
+            Self::KIND_ERC20 => Ok(Self::Erc20),
+            Self::KIND_NUT => Ok(Self::Nut),
+            _ => Err(eyre!(
+                "Only valid kinds are {} (ERC20) and {} (NUT)",
+                Self::KIND_ERC20,
+                Self::KIND_NUT
+            )),
+        }
+    }
+}
+
 /// An event transferring some kind of value from Namada to Ethereum
 #[derive(
     Clone,
@@ -392,6 +446,8 @@ pub struct TransferToNamada {
     Deserialize,
 )]
 pub struct TransferToEthereum {
+    /// The kind of transfer to Ethereum.
+    pub kind: TransferToEthereumKind,
     /// Quantity of wrapped Asset in the transfer
     pub amount: Amount,
     /// Address of the smart contract issuing the token

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -1254,7 +1254,6 @@ pub struct PrefixValue {
 pub struct EthEventsQueue {
     /// Queue of transfer to Namada events.
     pub transfers_to_namada: InnerEthEventsQueue<TransfersToNamada>,
-    // TODO: add queue of update whitelist events
 }
 
 /// A queue of confirmed Ethereum events of type `E`.

--- a/ethereum_bridge/src/parameters.rs
+++ b/ethereum_bridge/src/parameters.rs
@@ -11,7 +11,7 @@ use namada_core::ledger::storage_api::{StorageRead, StorageWrite};
 use namada_core::types::ethereum_events::EthAddress;
 use namada_core::types::ethereum_structs;
 use namada_core::types::storage::Key;
-use namada_core::types::token::DenominatedAmount;
+use namada_core::types::token::{DenominatedAmount, NATIVE_MAX_DECIMAL_PLACES};
 use serde::{Deserialize, Serialize};
 
 use crate::storage::eth_bridge_queries::{
@@ -218,6 +218,15 @@ impl EthereumBridgeConfig {
             token_cap: DenominatedAmount { amount: cap, denom },
         } in erc20_whitelist
         {
+            if addr == native_erc20
+                && denom != &NATIVE_MAX_DECIMAL_PLACES.into()
+            {
+                panic!(
+                    "Error writing Ethereum bridge config: The native token \
+                     should have {NATIVE_MAX_DECIMAL_PLACES} decimal places"
+                );
+            }
+
             let key = whitelist::Key {
                 asset: *addr,
                 suffix: whitelist::KeyType::Whitelisted,

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -1193,27 +1193,30 @@ mod tests {
             &wl_storage.storage.native_token,
             &BRIDGE_ADDRESS,
         );
+        let bridge_pool_native_erc20_supply_key =
+            minted_balance_key(&wrapped_erc20s::token(&wnam()));
         StorageWrite::write(
             &mut wl_storage,
             &bridge_pool_native_token_balance_key,
             bridge_pool_initial_balance,
         )?;
+        StorageWrite::write(
+            &mut wl_storage,
+            &bridge_pool_native_erc20_supply_key,
+            amount,
+        )?;
         let receiver_native_token_balance_key =
             token::balance_key(&wl_storage.storage.native_token, &receiver);
 
-        let native_erc20 = read_native_erc20_address(&wl_storage)?;
-        let changed_keys = redeem_native_token(
-            &mut wl_storage,
-            &native_erc20,
-            &receiver,
-            &amount,
-        )?;
+        let changed_keys =
+            redeem_native_token(&mut wl_storage, &wnam(), &receiver, &amount)?;
 
         assert_eq!(
             changed_keys,
             BTreeSet::from([
                 bridge_pool_native_token_balance_key.clone(),
-                receiver_native_token_balance_key.clone()
+                receiver_native_token_balance_key.clone(),
+                bridge_pool_native_erc20_supply_key.clone(),
             ])
         );
         assert_eq!(
@@ -1226,6 +1229,13 @@ mod tests {
         assert_eq!(
             StorageRead::read(&wl_storage, &receiver_native_token_balance_key)?,
             Some(amount)
+        );
+        assert_eq!(
+            StorageRead::read(
+                &wl_storage,
+                &bridge_pool_native_erc20_supply_key
+            )?,
+            Some(Amount::zero())
         );
 
         Ok(())

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -1245,7 +1245,7 @@ mod tests {
         let pending_transfers = init_bridge_pool_transfers(
             &mut wl_storage,
             [
-                (native_erc20, eth_bridge_pool::TransferToEthereumKind::Nut),
+                (native_erc20, eth_bridge_pool::TransferToEthereumKind::Erc20),
                 (
                     EthAddress([0xaa; 20]),
                     eth_bridge_pool::TransferToEthereumKind::Erc20,
@@ -1435,18 +1435,20 @@ mod tests {
 
             _ = act_on(wl_storage, event).unwrap();
 
-            // check post supply
+            // check post supply - the wNAM minted supply should increase
+            // by the transferred amount
             assert!(
                 wl_storage
                     .read_bytes(&balance_key(&wnam, &BRIDGE_POOL_ADDRESS))
                     .expect("Test failed")
                     .is_none()
             );
-            assert!(
+            assert_eq!(
                 wl_storage
-                    .read_bytes(&minted_balance_key(&wnam))
-                    .expect("Test failed")
-                    .is_none()
+                    .read::<Amount>(&minted_balance_key(&wnam))
+                    .expect("Reading from storage should not fail")
+                    .expect("The wNAM supply should have been updated"),
+                Amount::from_u64(10),
             );
 
             // check post balance

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -1188,6 +1188,16 @@ mod tests {
         let receiver = address::testing::established_address_1();
         let amount = Amount::from(100);
 
+        // pre wNAM balance - 0
+        let receiver_wnam_balance_key =
+            token::balance_key(&wrapped_erc20s::token(&wnam()), &receiver);
+        assert!(
+            wl_storage
+                .read_bytes(&receiver_wnam_balance_key)
+                .unwrap()
+                .is_none()
+        );
+
         let bridge_pool_initial_balance = Amount::from(100_000_000);
         let bridge_pool_native_token_balance_key = token::balance_key(
             &wl_storage.storage.native_token,
@@ -1236,6 +1246,16 @@ mod tests {
                 &bridge_pool_native_erc20_supply_key
             )?,
             Some(Amount::zero())
+        );
+
+        // post wNAM balance - 0
+        //
+        // wNAM is never minted, it's converted back to NAM
+        assert!(
+            wl_storage
+                .read_bytes(&receiver_wnam_balance_key)
+                .unwrap()
+                .is_none()
         );
 
         Ok(())

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -642,10 +642,8 @@ mod tests {
         update_epoch_parameter(wl_storage, &epoch_duration)
             .expect("Test failed");
         // set native ERC20 token
-        let native_erc20_key = bridge_storage::native_erc20_key();
-        let native_erc20 = EthAddress([0; 20]);
         wl_storage
-            .write_bytes(&native_erc20_key, encode(&native_erc20))
+            .write_bytes(&bridge_storage::native_erc20_key(), encode(&wnam()))
             .expect("Test failed");
     }
 
@@ -727,7 +725,7 @@ mod tests {
             .expect("Test failed");
 
         for transfer in pending_transfers {
-            if transfer.transfer.asset == EthAddress([0; 20]) {
+            if transfer.transfer.asset == wnam() {
                 // native ERC20
                 let sender_key = balance_key(&nam(), &transfer.transfer.sender);
                 let sender_balance = Amount::from(0);
@@ -1026,6 +1024,10 @@ mod tests {
                 &BRIDGE_POOL_ADDRESS
             ))
         );
+        assert!(
+            changed_keys
+                .remove(&minted_balance_key(&wrapped_erc20s::token(&wnam())))
+        );
         assert!(changed_keys.remove(&minted_balance_key(&random_erc20_token)));
         assert!(
             changed_keys.remove(&minted_balance_key(&random_erc20_token_2))
@@ -1146,7 +1148,7 @@ mod tests {
 
         // Check the balances
         for transfer in pending_transfers {
-            if transfer.transfer.asset == EthAddress([0; 20]) {
+            if transfer.transfer.asset == wnam() {
                 let sender_key = balance_key(&nam(), &transfer.transfer.sender);
                 let value =
                     wl_storage.read_bytes(&sender_key).expect("Test failed");

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -752,10 +752,6 @@ mod tests {
                 name: "bridge".to_string(),
                 address: arbitrary_eth_address(),
             },
-            EthereumEvent::UpdateBridgeWhitelist {
-                nonce: arbitrary_nonce(),
-                whitelist: vec![],
-            },
             EthereumEvent::UpgradedContract {
                 name: "bridge".to_string(),
                 address: arbitrary_eth_address(),

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -797,6 +797,16 @@ mod tests {
     fn test_act_on_transfers_to_namada_mints_wdai() {
         let mut wl_storage = TestWlStorage::default();
         test_utils::bootstrap_ethereum_bridge(&mut wl_storage);
+        test_utils::whitelist_tokens(
+            &mut wl_storage,
+            [(
+                DAI_ERC20_ETH_ADDRESS,
+                test_utils::WhitelistMeta {
+                    cap: Amount::max(),
+                    denom: 18,
+                },
+            )],
+        );
         let initial_stored_keys_count = stored_keys_count(&wl_storage);
 
         let amount = Amount::from(100);

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -596,6 +596,7 @@ mod tests {
                     sender: sender.clone(),
                     recipient: EthAddress([i as u8 + 1; 20]),
                     amount: Amount::from(10),
+                    kind: eth_bridge_pool::TransferToEthereumKind::Erc20,
                 },
                 gas_fee: GasFee {
                     amount: Amount::from(1),
@@ -822,6 +823,7 @@ mod tests {
         let mut transfers = vec![];
         for transfer in pending_transfers {
             let transfer_to_eth = TransferToEthereum {
+                kind: transfer.transfer.kind,
                 amount: transfer.transfer.amount,
                 asset: transfer.transfer.asset,
                 receiver: transfer.transfer.recipient,
@@ -912,6 +914,7 @@ mod tests {
                 sender: address::testing::established_address_1(),
                 recipient: EthAddress([5; 20]),
                 amount: Amount::from(10),
+                kind: eth_bridge_pool::TransferToEthereumKind::Erc20,
             },
             gas_fee: GasFee {
                 amount: Amount::from(1),
@@ -1077,6 +1080,7 @@ mod tests {
             .into_iter()
             .map(|transfer| {
                 let transfer_to_eth = TransferToEthereum {
+                    kind: transfer.transfer.kind,
                     amount: transfer.transfer.amount,
                     asset: transfer.transfer.asset,
                     receiver: transfer.transfer.recipient,

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -510,7 +510,7 @@ where
         );
         (escrow_balance_key, sender_balance_key)
     } else {
-        let token = wrapped_erc20s::token(&transfer.transfer.asset);
+        let token = transfer.token_address();
         let escrow_balance_key = balance_key(&token, &BRIDGE_POOL_ADDRESS);
         let sender_balance_key = balance_key(&token, &transfer.transfer.sender);
         (escrow_balance_key, sender_balance_key)
@@ -548,7 +548,7 @@ where
         return Ok(changed_keys);
     }
 
-    let token = wrapped_erc20s::token(&transfer.transfer.asset);
+    let token = transfer.token_address();
 
     let escrow_balance_key = balance_key(&token, &BRIDGE_POOL_ADDRESS);
     update::amount(wl_storage, &escrow_balance_key, |balance| {
@@ -690,7 +690,7 @@ mod tests {
                     )
                     .expect("Test failed");
             } else {
-                let token = wrapped_erc20s::token(&transfer.transfer.asset);
+                let token = transfer.token_address();
                 let sender_key = balance_key(&token, &transfer.transfer.sender);
                 let sender_balance = Amount::from(0);
                 wl_storage
@@ -1029,7 +1029,7 @@ mod tests {
                         .expect("Test failed");
                 assert_eq!(escrow_balance, Amount::from(0));
             } else {
-                let token = wrapped_erc20s::token(&transfer.transfer.asset);
+                let token = transfer.token_address();
                 let sender_key = balance_key(&token, &transfer.transfer.sender);
                 let value =
                     wl_storage.read_bytes(&sender_key).expect("Test failed");

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -145,14 +145,14 @@ where
             // TODO: query denomination of the whitelisted token from storage,
             // and print this amount with the proper formatting; for now, use
             // NAM's formatting
-            if !asset_count.erc20_amount.is_zero() {
+            if asset_count.should_mint_erc20s() {
                 tracing::info!(
                     "Minted wrapped ERC20s - (asset - {asset}, receiver - \
                      {receiver}, amount - {})",
                     asset_count.erc20_amount.to_string_native(),
                 );
             }
-            if !asset_count.nut_amount.is_zero() {
+            if asset_count.should_mint_nuts() {
                 tracing::info!(
                     "Minted NUTs - (asset - {asset}, receiver - {receiver}, \
                      amount - {})",
@@ -254,10 +254,12 @@ where
 
     let assets_to_mint = [
         // check if we should mint nuts
-        (!asset_count.nut_amount.is_zero())
+        asset_count
+            .should_mint_nuts()
             .then(|| (wrapped_erc20s::nut(asset), asset_count.nut_amount)),
         // check if we should mint erc20s
-        (!asset_count.erc20_amount.is_zero())
+        asset_count
+            .should_mint_erc20s()
             .then(|| (wrapped_erc20s::token(asset), asset_count.erc20_amount)),
     ]
     .into_iter()

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -330,6 +330,16 @@ mod tests {
         )]);
         let mut wl_storage = TestWlStorage::default();
         test_utils::bootstrap_ethereum_bridge(&mut wl_storage);
+        test_utils::whitelist_tokens(
+            &mut wl_storage,
+            [(
+                DAI_ERC20_ETH_ADDRESS,
+                test_utils::WhitelistMeta {
+                    cap: Amount::max(),
+                    denom: 18,
+                },
+            )],
+        );
 
         let changed_keys =
             apply_updates(&mut wl_storage, updates, voting_powers)?;
@@ -405,6 +415,16 @@ mod tests {
                 vec![(sole_validator.clone(), Amount::native_whole(100))],
             ));
         test_utils::bootstrap_ethereum_bridge(&mut wl_storage);
+        test_utils::whitelist_tokens(
+            &mut wl_storage,
+            [(
+                DAI_ERC20_ETH_ADDRESS,
+                test_utils::WhitelistMeta {
+                    cap: Amount::max(),
+                    denom: 18,
+                },
+            )],
+        );
         let receiver = address::testing::established_address_1();
 
         let event = EthereumEvent::TransfersToNamada {

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -1,9 +1,9 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use namada_core::hints;
-use namada_core::ledger::eth_bridge::storage::active_key;
 use namada_core::ledger::eth_bridge::storage::bridge_pool::{
     get_nonce_key, get_signed_root_key,
 };
+use namada_core::ledger::eth_bridge::storage::{active_key, whitelist};
 use namada_core::ledger::storage;
 use namada_core::ledger::storage::{StoreType, WlStorage};
 use namada_core::ledger::storage_api::StorageRead;
@@ -391,6 +391,55 @@ where
             },
             voting_powers_map,
         )
+    }
+
+    /// Check if the token at the given [`EthAddress`] is whitelisted.
+    pub fn is_token_whitelisted(self, &token: &EthAddress) -> bool {
+        let key = whitelist::Key {
+            asset: token,
+            suffix: whitelist::KeyType::Whitelisted,
+        }
+        .into();
+
+        self.wl_storage
+            .read(&key)
+            .expect("Reading from storage should not fail")
+            .unwrap_or(false)
+    }
+
+    /// Fetch the token cap of the asset associated with the given
+    /// [`EthAddress`].
+    ///
+    /// If the asset has never been whitelisted, return [`None`].
+    pub fn get_token_cap(self, &token: &EthAddress) -> Option<token::Amount> {
+        let key = whitelist::Key {
+            asset: token,
+            suffix: whitelist::KeyType::Cap,
+        }
+        .into();
+
+        self.wl_storage
+            .read(&key)
+            .expect("Reading from storage should not fail")
+    }
+
+    /// Fetch the token supply of the asset associated with the given
+    /// [`EthAddress`].
+    ///
+    /// If the asset has never been minted, return [`None`].
+    pub fn get_token_supply(
+        self,
+        &token: &EthAddress,
+    ) -> Option<token::Amount> {
+        let key = whitelist::Key {
+            asset: token,
+            suffix: whitelist::KeyType::WrappedSupply,
+        }
+        .into();
+
+        self.wl_storage
+            .read(&key)
+            .expect("Reading from storage should not fail")
     }
 }
 

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -500,6 +500,20 @@ pub struct EthAssetMint {
     pub erc20_amount: token::Amount,
 }
 
+impl EthAssetMint {
+    /// Check if NUTs should be minted.
+    #[inline]
+    pub fn should_mint_nuts(&self) -> bool {
+        !self.nut_amount.is_zero()
+    }
+
+    /// Check if ERC20s should be minted.
+    #[inline]
+    pub fn should_mint_erc20s(&self) -> bool {
+        !self.erc20_amount.is_zero()
+    }
+}
+
 /// A handle to the Ethereum addresses of the set of consensus
 /// validators in Namada, at some given epoch.
 pub struct ConsensusEthAddresses<'db, D, H>

--- a/ethereum_bridge/src/test_utils.rs
+++ b/ethereum_bridge/src/test_utils.rs
@@ -92,6 +92,8 @@ pub fn bootstrap_ethereum_bridge(
     wl_storage: &mut TestWlStorage,
 ) -> EthereumBridgeConfig {
     let config = EthereumBridgeConfig {
+        // start with empty erc20 whitelist
+        erc20_whitelist: vec![],
         eth_start_height: Default::default(),
         min_confirmations: MinimumConfirmations::from(unsafe {
             // SAFETY: The only way the API contract of `NonZeroU64` can
@@ -212,6 +214,7 @@ pub fn init_storage_with_validators(
     )
     .expect("Test failed");
     let config = EthereumBridgeConfig {
+        erc20_whitelist: vec![],
         eth_start_height: Default::default(),
         min_confirmations: Default::default(),
         contracts: Contracts {

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -100,8 +100,8 @@ clru.workspace = true
 data-encoding.workspace = true
 derivation-path.workspace = true
 derivative.workspace = true
-ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
-ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
+ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
+ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
 ethers.workspace = true
 eyre.workspace = true
 futures.workspace = true

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -100,8 +100,8 @@ clru.workspace = true
 data-encoding.workspace = true
 derivation-path.workspace = true
 derivative.workspace = true
-ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
-ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-bridge-contract.workspace = true
+ethbridge-governance-contract.workspace = true
 ethers.workspace = true
 eyre.workspace = true
 futures.workspace = true

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -100,8 +100,8 @@ clru.workspace = true
 data-encoding.workspace = true
 derivation-path.workspace = true
 derivative.workspace = true
-ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.18.0"}
-ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.18.0"}
+ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
+ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.19.0"}
 ethers.workspace = true
 eyre.workspace = true
 futures.workspace = true

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -100,8 +100,8 @@ clru.workspace = true
 data-encoding.workspace = true
 derivation-path.workspace = true
 derivative.workspace = true
-ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
-ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.20.0"}
+ethbridge-bridge-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
+ethbridge-governance-contract = {git = "https://github.com/heliaxdev/ethbridge-rs", tag = "v0.21.0"}
 ethers.workspace = true
 eyre.workspace = true
 futures.workspace = true

--- a/shared/src/ledger/args.rs
+++ b/shared/src/ledger/args.rs
@@ -701,6 +701,11 @@ pub struct RecommendBatch<C: NamadaTypes = SdkTypes> {
 /// A transfer to be added to the Ethereum bridge pool.
 #[derive(Clone, Debug)]
 pub struct EthereumBridgePool<C: NamadaTypes = SdkTypes> {
+    /// Whether the transfer is for a NUT.
+    ///
+    /// By default, we add wrapped ERC20s onto the
+    /// Bridge pool.
+    pub nut: bool,
     /// The args for building a tx to the bridge pool
     pub tx: Tx<C>,
     /// The type of token

--- a/shared/src/ledger/eth_bridge/bridge_pool.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool.rs
@@ -1,5 +1,6 @@
 //! Bridge pool SDK functionality.
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::io::Write;
@@ -17,7 +18,9 @@ use super::{block_on_eth_sync, eth_sync_or_exit, BlockOnEthSync};
 use crate::eth_bridge::ethers::abi::AbiDecode;
 use crate::eth_bridge::structs::RelayProof;
 use crate::ledger::args;
-use crate::ledger::queries::{Client, RPC};
+use crate::ledger::queries::{
+    Client, GenBridgePoolProofReq, GenBridgePoolProofRsp, RPC,
+};
 use crate::ledger::rpc::{query_wasm_code_hash, validate_amount};
 use crate::ledger::tx::{prepare_tx, Error};
 use crate::proto::Tx;
@@ -179,9 +182,8 @@ where
 /// bridge pool.
 async fn construct_bridge_pool_proof<C>(
     client: &C,
-    transfers: &[KeccakHash],
-    relayer: Address,
-) -> Halt<Vec<u8>>
+    args: GenBridgePoolProofReq<'_, '_>,
+) -> Halt<GenBridgePoolProofRsp>
 where
     C: Client + Sync,
 {
@@ -196,8 +198,8 @@ where
         .into_iter()
         .filter_map(|(ref transfer, voting_power)| {
             if voting_power > FractionalVotingPower::ONE_THIRD {
-                let hash = PendingTransfer::from(transfer).keccak256();
-                transfers.contains(&hash).then_some(hash)
+                let hash = transfer.keccak256();
+                args.transfers.contains(&hash).then_some(hash)
             } else {
                 None
             }
@@ -234,7 +236,7 @@ where
         }
     }
 
-    let data = (transfers, relayer).try_to_vec().unwrap();
+    let data = args.try_to_vec().unwrap();
     let response = RPC
         .shell()
         .eth_bridge()
@@ -242,7 +244,7 @@ where
         .await;
 
     response.map(|response| response.data).try_halt(|e| {
-        println!("Encountered error constructing proof:\n{:?}", e);
+        println!("Encountered error constructing proof:\n{e}");
     })
 }
 
@@ -265,25 +267,29 @@ pub async fn construct_proof<C>(
 where
     C: Client + Sync,
 {
-    let bp_proof_bytes = construct_bridge_pool_proof(
+    let GenBridgePoolProofRsp {
+        abi_encoded_proof: bp_proof_bytes,
+        appendices,
+    } = construct_bridge_pool_proof(
         client,
-        &args.transfers,
-        args.relayer.clone(),
+        GenBridgePoolProofReq {
+            transfers: args.transfers.as_slice().into(),
+            relayer: Cow::Borrowed(&args.relayer),
+            with_appendix: true,
+        },
     )
     .await?;
-    let bp_proof: RelayProof =
-        AbiDecode::decode(&bp_proof_bytes).try_halt(|error| {
-            println!("Unable to decode the generated proof: {:?}", error);
-        })?;
     let resp = BridgePoolProofResponse {
         hashes: args.transfers,
         relayer_address: args.relayer,
-        total_fees: bp_proof
-            .transfers
-            .iter()
-            .map(|t| t.fee.as_u64())
-            .sum::<u64>()
-            .into(),
+        total_fees: appendices
+            .map(|appendices| {
+                appendices
+                    .into_iter()
+                    .map(|app| app.gas_fee.amount)
+                    .sum::<Amount>()
+            })
+            .unwrap_or(Amount::zero()),
         abi_encoded_proof: bp_proof_bytes,
     };
     println!("{}", serde_json::to_string(&resp).unwrap());
@@ -316,9 +322,18 @@ where
         eth_sync_or_exit(&*eth_client).await?;
     }
 
-    let bp_proof =
-        construct_bridge_pool_proof(nam_client, &args.transfers, args.relayer)
-            .await?;
+    let GenBridgePoolProofRsp {
+        abi_encoded_proof: bp_proof,
+        ..
+    } = construct_bridge_pool_proof(
+        nam_client,
+        GenBridgePoolProofReq {
+            transfers: Cow::Owned(args.transfers),
+            relayer: Cow::Owned(args.relayer),
+            with_appendix: false,
+        },
+    )
+    .await?;
     let bridge = match RPC
         .shell()
         .eth_bridge()
@@ -468,8 +483,7 @@ mod recommendations {
             .transfer_to_ethereum_progress(client)
             .await
             .unwrap()
-            .keys()
-            .map(PendingTransfer::from)
+            .into_keys()
             .collect::<Vec<_>>();
 
         // get the signed bridge pool root so we can analyze the signatures

--- a/shared/src/ledger/eth_bridge/bridge_pool.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool.rs
@@ -28,7 +28,7 @@ use crate::types::control_flow::{
 };
 use crate::types::eth_abi::Encode;
 use crate::types::eth_bridge_pool::{
-    GasFee, PendingTransfer, TransferToEthereum,
+    GasFee, PendingTransfer, TransferToEthereum, TransferToEthereumKind,
 };
 use crate::types::keccak::KeccakHash;
 use crate::types::token::{Amount, DenominatedAmount};
@@ -60,6 +60,9 @@ pub async fn build_bridge_pool_tx<C: crate::ledger::queries::Client + Sync>(
             recipient,
             sender: sender.clone(),
             amount,
+            // TODO: dispatch on the transfer kind, based
+            // on CLI arguments
+            kind: TransferToEthereumKind::Erc20,
         },
         gas_fee: GasFee {
             amount: fee_amount,
@@ -672,6 +675,7 @@ mod recommendations {
         pub fn transfer(gas_amount: u64) -> PendingTransfer {
             PendingTransfer {
                 transfer: TransferToEthereum {
+                    kind: TransferToEthereumKind::Erc20,
                     asset: EthAddress([1; 20]),
                     recipient: EthAddress([2; 20]),
                     sender: bertha_address(),

--- a/shared/src/ledger/eth_bridge/bridge_pool.rs
+++ b/shared/src/ledger/eth_bridge/bridge_pool.rs
@@ -39,6 +39,7 @@ pub async fn build_bridge_pool_tx<C: crate::ledger::queries::Client + Sync>(
     client: &C,
     args::EthereumBridgePool {
         tx: tx_args,
+        nut,
         asset,
         recipient,
         sender,
@@ -60,9 +61,11 @@ pub async fn build_bridge_pool_tx<C: crate::ledger::queries::Client + Sync>(
             recipient,
             sender: sender.clone(),
             amount,
-            // TODO: dispatch on the transfer kind, based
-            // on CLI arguments
-            kind: TransferToEthereumKind::Erc20,
+            kind: if nut {
+                TransferToEthereumKind::Nut
+            } else {
+                TransferToEthereumKind::Erc20
+            },
         },
         gas_fee: GasFee {
             amount: fee_amount,

--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -19,7 +19,6 @@ use namada_core::ledger::eth_bridge::storage::bridge_pool::{
 };
 use namada_core::ledger::eth_bridge::ADDRESS as BRIDGE_ADDRESS;
 use namada_ethereum_bridge::parameters::read_native_erc20_address;
-use namada_ethereum_bridge::storage::wrapped_erc20s;
 
 use crate::ledger::native_vp::ethereum_bridge::vp::check_balance_changes;
 use crate::ledger::native_vp::{Ctx, NativeVp, StorageReader};
@@ -92,7 +91,7 @@ where
         transfer: &PendingTransfer,
     ) -> Result<bool, Error> {
         // check that the assets to be transferred were escrowed
-        let token = wrapped_erc20s::token(&transfer.transfer.asset);
+        let token = transfer.token_address();
         let owner_key = balance_key(&token, &transfer.transfer.sender);
         let escrow_key = balance_key(&token, &BRIDGE_POOL_ADDRESS);
         if keys_changed.contains(&owner_key)
@@ -347,6 +346,7 @@ mod test_bridge_pool_vp {
     use namada_ethereum_bridge::parameters::{
         Contracts, EthereumBridgeConfig, UpgradeableContract,
     };
+    use namada_ethereum_bridge::storage::wrapped_erc20s;
 
     use super::*;
     use crate::ledger::gas::VpGasMeter;

--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -762,14 +762,14 @@ mod test_bridge_pool_vp {
         insert_transfer: F,
         expect: Expect,
     ) where
-        F: FnOnce(PendingTransfer, &mut WriteLog) -> BTreeSet<Key>,
+        F: FnOnce(&mut PendingTransfer, &mut WriteLog) -> BTreeSet<Key>,
     {
         // setup
         let mut wl_storage = setup_storage();
         let tx = Tx::from_type(TxType::Raw);
 
         // the transfer to be added to the pool
-        let transfer = PendingTransfer {
+        let mut transfer = PendingTransfer {
             transfer: TransferToEthereum {
                 kind: TransferToEthereumKind::Erc20,
                 asset: ASSET,
@@ -784,7 +784,7 @@ mod test_bridge_pool_vp {
         };
         // add transfer to pool
         let mut keys_changed =
-            insert_transfer(transfer.clone(), &mut wl_storage.write_log);
+            insert_transfer(&mut transfer, &mut wl_storage.write_log);
 
         // change Bertha's balances
         let mut new_keys_changed = update_balances(
@@ -846,11 +846,11 @@ mod test_bridge_pool_vp {
             SignedAmount::Positive(TOKENS.into()),
             |transfer, log| {
                 log.write(
-                    &get_pending_key(&transfer),
+                    &get_pending_key(transfer),
                     transfer.try_to_vec().unwrap(),
                 )
                 .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::True,
         );
@@ -867,11 +867,11 @@ mod test_bridge_pool_vp {
             SignedAmount::Positive(TOKENS.into()),
             |transfer, log| {
                 log.write(
-                    &get_pending_key(&transfer),
+                    &get_pending_key(transfer),
                     transfer.try_to_vec().unwrap(),
                 )
                 .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::False,
         );
@@ -888,11 +888,11 @@ mod test_bridge_pool_vp {
             SignedAmount::Positive(TOKENS.into()),
             |transfer, log| {
                 log.write(
-                    &get_pending_key(&transfer),
+                    &get_pending_key(transfer),
                     transfer.try_to_vec().unwrap(),
                 )
                 .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::False,
         );
@@ -909,11 +909,11 @@ mod test_bridge_pool_vp {
             SignedAmount::Positive(TOKENS.into()),
             |transfer, log| {
                 log.write(
-                    &get_pending_key(&transfer),
+                    &get_pending_key(transfer),
                     transfer.try_to_vec().unwrap(),
                 )
                 .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::False,
         );
@@ -931,11 +931,11 @@ mod test_bridge_pool_vp {
             SignedAmount::Positive(10.into()),
             |transfer, log| {
                 log.write(
-                    &get_pending_key(&transfer),
+                    &get_pending_key(transfer),
                     transfer.try_to_vec().unwrap(),
                 )
                 .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::False,
         );
@@ -952,11 +952,11 @@ mod test_bridge_pool_vp {
             SignedAmount::Positive(10.into()),
             |transfer, log| {
                 log.write(
-                    &get_pending_key(&transfer),
+                    &get_pending_key(transfer),
                     transfer.try_to_vec().unwrap(),
                 )
                 .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::False,
         );
@@ -973,11 +973,11 @@ mod test_bridge_pool_vp {
             SignedAmount::Positive(TOKENS.into()),
             |transfer, log| {
                 log.write(
-                    &get_pending_key(&transfer),
+                    &get_pending_key(transfer),
                     transfer.try_to_vec().unwrap(),
                 )
                 .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::False,
         );
@@ -994,11 +994,11 @@ mod test_bridge_pool_vp {
             SignedAmount::Negative(TOKENS.into()),
             |transfer, log| {
                 log.write(
-                    &get_pending_key(&transfer),
+                    &get_pending_key(transfer),
                     transfer.try_to_vec().unwrap(),
                 )
                 .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::False,
         );
@@ -1013,7 +1013,7 @@ mod test_bridge_pool_vp {
             SignedAmount::Positive(GAS_FEE.into()),
             SignedAmount::Negative(TOKENS.into()),
             SignedAmount::Positive(TOKENS.into()),
-            |transfer, _| BTreeSet::from([get_pending_key(&transfer)]),
+            |transfer, _| BTreeSet::from([get_pending_key(transfer)]),
             Expect::Error,
         );
     }
@@ -1041,9 +1041,9 @@ mod test_bridge_pool_vp {
                         payer: bertha_address(),
                     },
                 };
-                log.write(&get_pending_key(&transfer), t.try_to_vec().unwrap())
+                log.write(&get_pending_key(transfer), t.try_to_vec().unwrap())
                     .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::False,
         );
@@ -1074,7 +1074,7 @@ mod test_bridge_pool_vp {
                 };
                 log.write(&get_pending_key(&t), transfer.try_to_vec().unwrap())
                     .unwrap();
-                BTreeSet::from([get_pending_key(&transfer)])
+                BTreeSet::from([get_pending_key(transfer)])
             },
             Expect::Error,
         );
@@ -1091,12 +1091,12 @@ mod test_bridge_pool_vp {
             SignedAmount::Positive(TOKENS.into()),
             |transfer, log| {
                 log.write(
-                    &get_pending_key(&transfer),
+                    &get_pending_key(transfer),
                     transfer.try_to_vec().unwrap(),
                 )
                 .unwrap();
                 BTreeSet::from([
-                    get_pending_key(&transfer),
+                    get_pending_key(transfer),
                     get_signed_root_key(),
                 ])
             },

--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -517,6 +517,8 @@ mod test_bridge_pool_vp {
 
     /// A set of balances for an address
     struct Balance {
+        /// The address of the Ethereum asset.
+        asset: EthAddress,
         /// NUT or ERC20 Ethereum asset kind.
         kind: TransferToEthereumKind,
         /// The owner of the ERC20 assets.
@@ -532,6 +534,7 @@ mod test_bridge_pool_vp {
         fn new(kind: TransferToEthereumKind, address: Address) -> Self {
             Self {
                 kind,
+                asset: ASSET,
                 owner: address,
                 gas: 0.into(),
                 token: 0.into(),
@@ -654,8 +657,12 @@ mod test_bridge_pool_vp {
         // get the balance keys
         let token_key = balance_key(
             &match balance.kind {
-                TransferToEthereumKind::Erc20 => wrapped_erc20s::token(&ASSET),
-                TransferToEthereumKind::Nut => wrapped_erc20s::nut(&ASSET),
+                TransferToEthereumKind::Erc20 => {
+                    wrapped_erc20s::token(&balance.asset)
+                }
+                TransferToEthereumKind::Nut => {
+                    wrapped_erc20s::nut(&balance.asset)
+                }
             },
             &balance.owner,
         );
@@ -790,6 +797,7 @@ mod test_bridge_pool_vp {
         let mut new_keys_changed = update_balances(
             &mut wl_storage.write_log,
             Balance {
+                asset: transfer.transfer.asset,
                 kind: TransferToEthereumKind::Erc20,
                 owner: bertha_address(),
                 gas: BERTHA_WEALTH.into(),
@@ -804,6 +812,7 @@ mod test_bridge_pool_vp {
         let mut new_keys_changed = update_balances(
             &mut wl_storage.write_log,
             Balance {
+                asset: transfer.transfer.asset,
                 kind: TransferToEthereumKind::Erc20,
                 owner: BRIDGE_POOL_ADDRESS,
                 gas: ESCROWED_AMOUNT.into(),
@@ -1131,6 +1140,7 @@ mod test_bridge_pool_vp {
         let mut new_keys_changed = update_balances(
             &mut wl_storage.write_log,
             Balance {
+                asset: ASSET,
                 kind: TransferToEthereumKind::Erc20,
                 owner: bertha_address(),
                 gas: BERTHA_WEALTH.into(),
@@ -1145,6 +1155,7 @@ mod test_bridge_pool_vp {
         let mut new_keys_changed = update_balances(
             &mut wl_storage.write_log,
             Balance {
+                asset: ASSET,
                 kind: TransferToEthereumKind::Erc20,
                 owner: BRIDGE_POOL_ADDRESS,
                 gas: ESCROWED_AMOUNT.into(),
@@ -1567,6 +1578,7 @@ mod test_bridge_pool_vp {
             &mut wl_storage.write_log,
             Balance {
                 kind,
+                asset: ASSET,
                 owner: daewon_address(),
                 gas: DAEWONS_GAS.into(),
                 token: DAES_NUTS.into(),
@@ -1581,6 +1593,7 @@ mod test_bridge_pool_vp {
             &mut wl_storage.write_log,
             Balance {
                 kind,
+                asset: ASSET,
                 owner: BRIDGE_POOL_ADDRESS,
                 gas: ESCROWED_AMOUNT.into(),
                 token: ESCROWED_NUTS.into(),

--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -357,7 +357,9 @@ mod test_bridge_pool_vp {
     use crate::ledger::storage_api::StorageWrite;
     use crate::types::address::{nam, wnam};
     use crate::types::chain::ChainId;
-    use crate::types::eth_bridge_pool::{GasFee, TransferToEthereum};
+    use crate::types::eth_bridge_pool::{
+        GasFee, TransferToEthereum, TransferToEthereumKind,
+    };
     use crate::types::hash::Hash;
     use crate::types::storage::TxIndex;
     use crate::types::transaction::TxType;
@@ -406,6 +408,7 @@ mod test_bridge_pool_vp {
     fn initial_pool() -> PendingTransfer {
         PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: ASSET,
                 sender: bertha_address(),
                 recipient: EthAddress([0; 20]),
@@ -570,6 +573,7 @@ mod test_bridge_pool_vp {
         // the transfer to be added to the pool
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: ASSET,
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),
@@ -826,6 +830,7 @@ mod test_bridge_pool_vp {
             |transfer, log| {
                 let t = PendingTransfer {
                     transfer: TransferToEthereum {
+                        kind: TransferToEthereumKind::Erc20,
                         asset: EthAddress([0; 20]),
                         sender: bertha_address(),
                         recipient: EthAddress([11; 20]),
@@ -856,6 +861,7 @@ mod test_bridge_pool_vp {
             |transfer, log| {
                 let t = PendingTransfer {
                     transfer: TransferToEthereum {
+                        kind: TransferToEthereumKind::Erc20,
                         asset: EthAddress([0; 20]),
                         sender: bertha_address(),
                         recipient: EthAddress([11; 20]),
@@ -977,6 +983,7 @@ mod test_bridge_pool_vp {
         // the transfer to be added to the pool
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: ASSET,
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),
@@ -1043,6 +1050,7 @@ mod test_bridge_pool_vp {
         // the transfer to be added to the pool
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: wnam(),
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),
@@ -1130,6 +1138,7 @@ mod test_bridge_pool_vp {
         // the transfer to be added to the pool
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: wnam(),
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),
@@ -1236,6 +1245,7 @@ mod test_bridge_pool_vp {
         // the transfer to be added to the pool
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: wnam(),
                 sender: bertha_address(),
                 recipient: EthAddress([1; 20]),

--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -539,6 +539,7 @@ mod test_bridge_pool_vp {
     fn setup_storage() -> WlStorage<MockDB, Sha256Hasher> {
         // a dummy config for testing
         let config = EthereumBridgeConfig {
+            erc20_whitelist: vec![],
             eth_start_height: Default::default(),
             min_confirmations: Default::default(),
             contracts: Contracts {

--- a/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -1639,4 +1639,48 @@ mod test_bridge_pool_vp {
     fn test_escrowing_nuts_happy_flow() {
         test_nut_aux(TransferToEthereumKind::Nut, Expect::True)
     }
+
+    /// Test that the Bridge pool VP rejects a wNAM NUT transfer.
+    #[test]
+    fn test_bridge_pool_vp_rejects_wnam_nut() {
+        assert_bridge_pool(
+            SignedAmount::Negative(GAS_FEE.into()),
+            SignedAmount::Positive(GAS_FEE.into()),
+            SignedAmount::Negative(TOKENS.into()),
+            SignedAmount::Positive(TOKENS.into()),
+            |transfer, log| {
+                transfer.transfer.kind = TransferToEthereumKind::Nut;
+                transfer.transfer.asset = wnam();
+                log.write(
+                    &get_pending_key(transfer),
+                    transfer.try_to_vec().unwrap(),
+                )
+                .unwrap();
+                BTreeSet::from([get_pending_key(transfer)])
+            },
+            Expect::False,
+        );
+    }
+
+    /// Test that the Bridge pool VP accepts a wNAM ERC20 transfer.
+    #[test]
+    fn test_bridge_pool_vp_accepts_wnam_erc20() {
+        assert_bridge_pool(
+            SignedAmount::Negative(GAS_FEE.into()),
+            SignedAmount::Positive(GAS_FEE.into()),
+            SignedAmount::Negative(TOKENS.into()),
+            SignedAmount::Positive(TOKENS.into()),
+            |transfer, log| {
+                transfer.transfer.kind = TransferToEthereumKind::Erc20;
+                transfer.transfer.asset = wnam();
+                log.write(
+                    &get_pending_key(transfer),
+                    transfer.try_to_vec().unwrap(),
+                )
+                .unwrap();
+                BTreeSet::from([get_pending_key(transfer)])
+            },
+            Expect::True,
+        );
+    }
 }

--- a/shared/src/ledger/native_vp/ethereum_bridge/mod.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/mod.rs
@@ -3,4 +3,5 @@
 //! pool.
 
 pub mod bridge_pool_vp;
+pub mod nut;
 pub mod vp;

--- a/shared/src/ledger/native_vp/ethereum_bridge/nut.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/nut.rs
@@ -1,0 +1,119 @@
+//! Validity predicate for Non Usable Tokens (NUTs).
+
+use std::collections::BTreeSet;
+
+use eyre::WrapErr;
+use namada_core::ledger::storage as ledger_storage;
+use namada_core::ledger::storage::traits::StorageHasher;
+use namada_core::types::address::{Address, InternalAddress};
+use namada_core::types::storage::Key;
+use namada_core::types::token::Amount;
+
+use crate::ledger::native_vp::{Ctx, NativeVp, VpEnv};
+use crate::proto::Tx;
+use crate::types::token::is_any_token_balance_key;
+use crate::vm::WasmCacheAccess;
+
+/// Generic error that may be returned by the validity predicate
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+pub struct Error(#[from] eyre::Report);
+
+/// Validity predicate for non-usable tokens.
+///
+/// All this VP does is reject NUT transfers whose destination
+/// address is not the Bridge pool escrow address.
+pub struct NonUsableTokens<'ctx, DB, H, CA>
+where
+    DB: ledger_storage::DB + for<'iter> ledger_storage::DBIter<'iter>,
+    H: StorageHasher,
+    CA: 'static + WasmCacheAccess,
+{
+    /// Context to interact with the host structures.
+    pub ctx: Ctx<'ctx, DB, H, CA>,
+}
+
+impl<'a, DB, H, CA> NativeVp for NonUsableTokens<'a, DB, H, CA>
+where
+    DB: 'static + ledger_storage::DB + for<'iter> ledger_storage::DBIter<'iter>,
+    H: 'static + StorageHasher,
+    CA: 'static + WasmCacheAccess,
+{
+    type Error = Error;
+
+    fn validate_tx(
+        &self,
+        _: &Tx,
+        keys_changed: &BTreeSet<Key>,
+        verifiers: &BTreeSet<Address>,
+    ) -> Result<bool, Self::Error> {
+        tracing::debug!(
+            keys_changed_len = keys_changed.len(),
+            verifiers_len = verifiers.len(),
+            "Non usable tokens VP triggered",
+        );
+
+        let is_multitoken =
+            verifiers.contains(&Address::Internal(InternalAddress::Multitoken));
+        if !is_multitoken {
+            tracing::debug!("Rejecting non-multitoken transfer tx");
+            return Ok(false);
+        }
+
+        let nut_owners =
+            keys_changed.iter().filter_map(
+                |key| match is_any_token_balance_key(key) {
+                    Some(
+                        [Address::Internal(InternalAddress::Nut(_)), owner],
+                    ) => Some((key, owner)),
+                    _ => None,
+                },
+            );
+
+        for (changed_key, token_owner) in nut_owners {
+            let pre: Amount = self
+                .ctx
+                .read_pre(changed_key)
+                .context("Reading pre amount failed")
+                .map_err(Error)?
+                .unwrap_or_default();
+            let post: Amount = self
+                .ctx
+                .read_post(changed_key)
+                .context("Reading post amount failed")
+                .map_err(Error)?
+                .unwrap_or_default();
+
+            match token_owner {
+                // the NUT balance of the bridge pool should increase
+                Address::Internal(InternalAddress::EthBridgePool) => {
+                    if post < pre {
+                        tracing::debug!(
+                            %changed_key,
+                            pre_amount = ?pre,
+                            post_amount = ?post,
+                            "Bridge pool balance should have increased"
+                        );
+                        return Ok(false);
+                    }
+                }
+                // arbitrary addresses should have their balance decrease
+                _addr => {
+                    if post > pre {
+                        tracing::debug!(
+                            %changed_key,
+                            pre_amount = ?pre,
+                            post_amount = ?post,
+                            "Balance should have decreased"
+                        );
+                        return Ok(false);
+                    }
+                }
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+// TODO: add tests

--- a/shared/src/ledger/native_vp/ethereum_bridge/nut.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/nut.rs
@@ -116,4 +116,124 @@ where
     }
 }
 
-// TODO: add tests
+#[cfg(test)]
+mod test_nuts {
+    use std::env::temp_dir;
+
+    use assert_matches::assert_matches;
+    use borsh::BorshSerialize;
+    use namada_core::ledger::storage::testing::TestWlStorage;
+    use namada_core::ledger::storage_api::StorageWrite;
+    use namada_core::types::address::testing::arb_non_internal_address;
+    use namada_core::types::ethereum_events::testing::DAI_ERC20_ETH_ADDRESS;
+    use namada_core::types::storage::TxIndex;
+    use namada_core::types::token::balance_key;
+    use namada_core::types::transaction::TxType;
+    use namada_ethereum_bridge::storage::wrapped_erc20s;
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::ledger::gas::VpGasMeter;
+    use crate::vm::wasm::VpCache;
+    use crate::vm::WasmCacheRwAccess;
+
+    /// Run a VP check on a NUT transfer between the two provided addresses.
+    fn check_nut_transfer(src: Address, dst: Address) -> Option<bool> {
+        let nut = wrapped_erc20s::nut(&DAI_ERC20_ETH_ADDRESS);
+        let src_balance_key = balance_key(&nut, &src);
+        let dst_balance_key = balance_key(&nut, &dst);
+
+        let wl_storage = {
+            let mut wl = TestWlStorage::default();
+
+            // write initial balances
+            wl.write(&src_balance_key, Amount::from(200_u64))
+                .expect("Test failed");
+            wl.write(&dst_balance_key, Amount::from(100_u64))
+                .expect("Test failed");
+            wl.commit_block().expect("Test failed");
+
+            // write the updated balances
+            wl.write_log
+                .write(
+                    &src_balance_key,
+                    Amount::from(100_u64).try_to_vec().expect("Test failed"),
+                )
+                .expect("Test failed");
+            wl.write_log
+                .write(
+                    &dst_balance_key,
+                    Amount::from(200_u64).try_to_vec().expect("Test failed"),
+                )
+                .expect("Test failed");
+
+            wl
+        };
+
+        let keys_changed = {
+            let mut keys = BTreeSet::new();
+            keys.insert(src_balance_key);
+            keys.insert(dst_balance_key);
+            keys
+        };
+        let verifiers = {
+            let mut v = BTreeSet::new();
+            v.insert(Address::Internal(InternalAddress::Multitoken));
+            v
+        };
+
+        let tx = Tx::from_type(TxType::Raw);
+        let ctx = Ctx::<_, _, WasmCacheRwAccess>::new(
+            &Address::Internal(InternalAddress::Nut(DAI_ERC20_ETH_ADDRESS)),
+            &wl_storage.storage,
+            &wl_storage.write_log,
+            &tx,
+            &TxIndex(0),
+            VpGasMeter::new(0u64),
+            &keys_changed,
+            &verifiers,
+            VpCache::new(temp_dir(), 100usize),
+        );
+        let vp = NonUsableTokens { ctx };
+
+        // print debug info in case we run into failures
+        for key in &keys_changed {
+            let pre: Amount = vp
+                .ctx
+                .read_pre(key)
+                .expect("Test failed")
+                .unwrap_or_default();
+            let post: Amount = vp
+                .ctx
+                .read_post(key)
+                .expect("Test failed")
+                .unwrap_or_default();
+            println!("{key}: PRE={pre:?} POST={post:?}");
+        }
+
+        vp.validate_tx(&tx, &keys_changed, &verifiers).ok()
+    }
+
+    proptest! {
+        /// Test that transferring NUTs between two arbitrary addresses
+        /// will always fail.
+        #[test]
+        fn test_nut_transfer_rejected(
+            (src, dst) in (arb_non_internal_address(), arb_non_internal_address())
+        ) {
+            let status = check_nut_transfer(src, dst);
+            assert_matches!(status, Some(false));
+        }
+
+        /// Test that transferring NUTs from an arbitrary address to the
+        /// Bridge pool address passes.
+        #[test]
+        fn test_nut_transfer_passes(src in arb_non_internal_address()) {
+            let status = check_nut_transfer(
+                src,
+                Address::Internal(InternalAddress::EthBridgePool),
+            );
+            assert_matches!(status, Some(true));
+        }
+    }
+}

--- a/shared/src/ledger/native_vp/ethereum_bridge/vp.rs
+++ b/shared/src/ledger/native_vp/ethereum_bridge/vp.rs
@@ -393,6 +393,7 @@ mod tests {
 
         // a dummy config for testing
         let config = EthereumBridgeConfig {
+            erc20_whitelist: vec![],
             eth_start_height: Default::default(),
             min_confirmations: Default::default(),
             contracts: Contracts {

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -586,7 +586,8 @@ where
                             result
                         }
                         InternalAddress::IbcToken(_)
-                        | InternalAddress::Erc20(_) => {
+                        | InternalAddress::Erc20(_)
+                        | InternalAddress::Nut(_) => {
                             // The address should be a part of a multitoken key
                             gas_meter = ctx.gas_meter.into_inner();
                             Ok(verifiers.contains(&Address::Internal(

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -11,6 +11,7 @@ use crate::ledger::gas::{self, BlockGasMeter, VpGasMeter};
 use crate::ledger::governance::GovernanceVp;
 use crate::ledger::ibc::vp::Ibc;
 use crate::ledger::native_vp::ethereum_bridge::bridge_pool_vp::BridgePoolVp;
+use crate::ledger::native_vp::ethereum_bridge::nut::NonUsableTokens;
 use crate::ledger::native_vp::ethereum_bridge::vp::EthBridge;
 use crate::ledger::native_vp::multitoken::MultitokenVp;
 use crate::ledger::native_vp::parameters::{self, ParametersVp};
@@ -72,6 +73,8 @@ pub enum Error {
     ReplayProtectionNativeVpError(
         crate::ledger::native_vp::replay_protection::Error,
     ),
+    #[error("Non usable tokens native VP error: {0}")]
+    NutNativeVpError(native_vp::ethereum_bridge::nut::Error),
     #[error("Access to an internal address {0} is forbidden")]
     AccessForbidden(InternalAddress),
 }
@@ -585,9 +588,17 @@ where
                             gas_meter = pgf_vp.ctx.gas_meter.into_inner();
                             result
                         }
+                        InternalAddress::Nut(_) => {
+                            let non_usable_tokens = NonUsableTokens { ctx };
+                            let result = non_usable_tokens
+                                .validate_tx(tx, &keys_changed, &verifiers)
+                                .map_err(Error::NutNativeVpError);
+                            gas_meter =
+                                non_usable_tokens.ctx.gas_meter.into_inner();
+                            result
+                        }
                         InternalAddress::IbcToken(_)
-                        | InternalAddress::Erc20(_)
-                        | InternalAddress::Nut(_) => {
+                        | InternalAddress::Erc20(_) => {
                             // The address should be a part of a multitoken key
                             gas_meter = ctx.gas_meter.into_inner();
                             Ok(verifiers.contains(&Address::Internal(

--- a/shared/src/ledger/queries/mod.rs
+++ b/shared/src/ledger/queries/mod.rs
@@ -12,6 +12,9 @@ pub use types::{
 };
 use vp::{Vp, VP};
 
+pub use self::shell::eth_bridge::{
+    Erc20FlowControl, GenBridgePoolProofReq, GenBridgePoolProofRsp,
+};
 use super::storage::traits::StorageHasher;
 use super::storage::{DBIter, DB};
 use super::storage_api;

--- a/shared/src/ledger/queries/shell.rs
+++ b/shared/src/ledger/queries/shell.rs
@@ -1,4 +1,4 @@
-mod eth_bridge;
+pub(super) mod eth_bridge;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use masp_primitives::asset_type::AssetType;

--- a/shared/src/ledger/queries/shell/eth_bridge.rs
+++ b/shared/src/ledger/queries/shell/eth_bridge.rs
@@ -588,7 +588,7 @@ mod test_ethbridge_router {
     use crate::ledger::queries::RPC;
     use crate::types::eth_abi::Encode;
     use crate::types::eth_bridge_pool::{
-        GasFee, PendingTransfer, TransferToEthereum,
+        GasFee, PendingTransfer, TransferToEthereum, TransferToEthereumKind,
     };
     use crate::types::ethereum_events::EthAddress;
 
@@ -788,6 +788,7 @@ mod test_ethbridge_router {
 
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([0; 20]),
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
@@ -829,6 +830,7 @@ mod test_ethbridge_router {
         let mut client = TestClient::new(RPC);
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([0; 20]),
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
@@ -889,6 +891,7 @@ mod test_ethbridge_router {
         let mut client = TestClient::new(RPC);
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([0; 20]),
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
@@ -998,6 +1001,7 @@ mod test_ethbridge_router {
         let mut client = TestClient::new(RPC);
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([0; 20]),
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
@@ -1088,6 +1092,7 @@ mod test_ethbridge_router {
         let mut client = TestClient::new(RPC);
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([0; 20]),
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
@@ -1159,6 +1164,7 @@ mod test_ethbridge_router {
         let mut client = TestClient::new(RPC);
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([0; 20]),
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
@@ -1183,6 +1189,7 @@ mod test_ethbridge_router {
 
         let event_transfer =
             namada_core::types::ethereum_events::TransferToEthereum {
+                kind: transfer.transfer.kind,
                 asset: transfer.transfer.asset,
                 receiver: transfer.transfer.recipient,
                 amount: transfer.transfer.amount,
@@ -1269,6 +1276,7 @@ mod test_ethbridge_router {
         test_utils::init_default_storage(&mut client.wl_storage);
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: EthAddress([0; 20]),
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),

--- a/tests/src/native_vp/eth_bridge_pool.rs
+++ b/tests/src/native_vp/eth_bridge_pool.rs
@@ -12,7 +12,7 @@ mod test_bridge_pool_vp {
     use namada::types::address::{nam, wnam};
     use namada::types::chain::ChainId;
     use namada::types::eth_bridge_pool::{
-        GasFee, PendingTransfer, TransferToEthereum,
+        GasFee, PendingTransfer, TransferToEthereum, TransferToEthereumKind,
     };
     use namada::types::ethereum_events::EthAddress;
     use namada::types::key::{common, ed25519, SecretKey};
@@ -119,6 +119,7 @@ mod test_bridge_pool_vp {
     fn validate_erc20_tx() {
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: ASSET,
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
@@ -136,6 +137,7 @@ mod test_bridge_pool_vp {
     fn validate_mint_wnam_tx() {
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: wnam(),
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),
@@ -153,6 +155,7 @@ mod test_bridge_pool_vp {
     fn validate_mint_wnam_different_sender_tx() {
         let transfer = PendingTransfer {
             transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
                 asset: wnam(),
                 recipient: EthAddress([0; 20]),
                 sender: bertha_address(),

--- a/tests/src/native_vp/eth_bridge_pool.rs
+++ b/tests/src/native_vp/eth_bridge_pool.rs
@@ -63,6 +63,7 @@ mod test_bridge_pool_vp {
             ..Default::default()
         };
         let config = EthereumBridgeConfig {
+            erc20_whitelist: vec![],
             eth_start_height: Default::default(),
             min_confirmations: Default::default(),
             contracts: Contracts {

--- a/tests/src/native_vp/eth_bridge_pool.rs
+++ b/tests/src/native_vp/eth_bridge_pool.rs
@@ -5,7 +5,8 @@ mod test_bridge_pool_vp {
     use borsh::{BorshDeserialize, BorshSerialize};
     use namada::core::ledger::eth_bridge::storage::bridge_pool::BRIDGE_POOL_ADDRESS;
     use namada::ledger::eth_bridge::{
-        wrapped_erc20s, Contracts, EthereumBridgeConfig, UpgradeableContract,
+        wrapped_erc20s, Contracts, Erc20WhitelistEntry, EthereumBridgeConfig,
+        UpgradeableContract,
     };
     use namada::ledger::native_vp::ethereum_bridge::bridge_pool_vp::BridgePoolVp;
     use namada::proto::Tx;
@@ -63,7 +64,10 @@ mod test_bridge_pool_vp {
             ..Default::default()
         };
         let config = EthereumBridgeConfig {
-            erc20_whitelist: vec![],
+            erc20_whitelist: vec![Erc20WhitelistEntry {
+                token_address: wnam(),
+                token_cap: Amount::max().native_denominated(),
+            }],
             eth_start_height: Default::default(),
             min_confirmations: Default::default(),
             contracts: Contracts {

--- a/tests/src/native_vp/eth_bridge_pool.rs
+++ b/tests/src/native_vp/eth_bridge_pool.rs
@@ -30,6 +30,7 @@ mod test_bridge_pool_vp {
     const BERTHA_TOKENS: u64 = 10_000;
     const GAS_FEE: u64 = 100;
     const TOKENS: u64 = 10;
+    const TOKEN_CAP: u64 = TOKENS;
 
     /// A signing keypair for good old Bertha.
     fn bertha_keypair() -> common::SecretKey {
@@ -66,7 +67,7 @@ mod test_bridge_pool_vp {
         let config = EthereumBridgeConfig {
             erc20_whitelist: vec![Erc20WhitelistEntry {
                 token_address: wnam(),
-                token_cap: Amount::max().native_denominated(),
+                token_cap: Amount::from_u64(TOKEN_CAP).native_denominated(),
             }],
             eth_start_height: Default::default(),
             min_confirmations: Default::default(),
@@ -96,16 +97,23 @@ mod test_bridge_pool_vp {
         env
     }
 
-    fn validate_tx(tx: Tx) {
+    fn run_vp(tx: Tx) -> bool {
         let env = setup_env(tx);
         tx_host_env::set(env);
         let mut tx_env = tx_host_env::take();
         tx_env.execute_tx().expect("Test failed.");
         let vp_env = TestNativeVpEnv::from_tx_env(tx_env, BRIDGE_POOL_ADDRESS);
-        let result = vp_env
+        vp_env
             .validate_tx(|ctx| BridgePoolVp { ctx })
-            .expect("Test failed");
-        assert!(result);
+            .expect("Test failed")
+    }
+
+    fn validate_tx(tx: Tx) {
+        assert!(run_vp(tx));
+    }
+
+    fn invalidate_tx(tx: Tx) {
+        assert!(!run_vp(tx));
     }
 
     fn create_tx(transfer: PendingTransfer, keypair: &common::SecretKey) -> Tx {
@@ -154,6 +162,24 @@ mod test_bridge_pool_vp {
             },
         };
         validate_tx(create_tx(transfer, &bertha_keypair()));
+    }
+
+    #[test]
+    fn invalidate_wnam_over_cap_tx() {
+        let transfer = PendingTransfer {
+            transfer: TransferToEthereum {
+                kind: TransferToEthereumKind::Erc20,
+                asset: wnam(),
+                recipient: EthAddress([0; 20]),
+                sender: bertha_address(),
+                amount: Amount::from(TOKEN_CAP + 1),
+            },
+            gas_fee: GasFee {
+                amount: Amount::from(GAS_FEE),
+                payer: bertha_address(),
+            },
+        };
+        invalidate_tx(create_tx(transfer, &bertha_keypair()));
     }
 
     #[test]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1677,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -1688,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1699,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -1710,8 +1710,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1721,8 +1721,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethabi",
  "ethers",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1677,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -1688,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1699,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -1710,8 +1710,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1721,8 +1721,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethabi",
  "ethers",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1677,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -1688,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1699,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -1710,8 +1710,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1721,8 +1721,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethabi",
  "ethers",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1677,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -1688,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1699,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -1710,8 +1710,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1721,8 +1721,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethabi",
  "ethers",

--- a/wasm/wasm_source/src/tx_bridge_pool.rs
+++ b/wasm/wasm_source/src/tx_bridge_pool.rs
@@ -1,7 +1,7 @@
 //! A tx for adding a transfer request across the Ethereum bridge
 //! into the bridge pool.
 use borsh::{BorshDeserialize, BorshSerialize};
-use eth_bridge::storage::{bridge_pool, native_erc20_key, wrapped_erc20s};
+use eth_bridge::storage::{bridge_pool, native_erc20_key};
 use eth_bridge_pool::{GasFee, PendingTransfer, TransferToEthereum};
 use namada_tx_prelude::*;
 
@@ -45,7 +45,7 @@ fn apply_tx(ctx: &mut Ctx, signed: Tx) -> TxResult {
         )?;
     } else {
         // Otherwise we escrow ERC20 tokens.
-        let token = wrapped_erc20s::token(&asset);
+        let token = transfer.token_address();
         token::transfer(
             ctx,
             sender,

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -1677,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -1688,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1699,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -1710,8 +1710,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1721,8 +1721,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.21.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
+version = "0.22.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.22.0#1c1028a823a7c2148b3efacea800bfc6c8969c20"
 dependencies = [
  "ethabi",
  "ethers",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -1677,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -1688,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1699,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -1710,8 +1710,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1721,8 +1721,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.18.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.18.0#d49a0d110bb726c526896ff440d542585ced12f2"
+version = "0.19.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
 dependencies = [
  "ethabi",
  "ethers",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -1677,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -1688,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1699,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -1710,8 +1710,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1721,8 +1721,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
+version = "0.21.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.21.0#781782307aac9c4529fe4c6600ea671ec98353d9"
 dependencies = [
  "ethabi",
  "ethers",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -1677,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -1688,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1699,8 +1699,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-contract"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethbridge-governance-events",
  "ethbridge-structs",
@@ -1710,8 +1710,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-governance-events"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1721,8 +1721,8 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.19.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.19.0#70122ae122dbf59d6b0de804f232e6acbfc8bc6f"
+version = "0.20.0"
+source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.20.0#1b905d96f7c121dd35e92e153f190943f6dfea0b"
 dependencies = [
  "ethabi",
  "ethers",


### PR DESCRIPTION
## Describe your changes

To implement #1704, a new field would have to be added to the `Erc20Transfer` struct in `Bridge.sol`, such that we could preserve the token type used to pay gas fees. Namada stores pending Bridge pool transfers as part of the protocol, so there is no reason for the Ethereum smart contracts to have any knowledge of Namada-specific metadata. This PR addresses this, by removing all non-essential fields. A mapping of confirmed Ethereum events to pending transfers kept in Namada's storage can still be obtained by hashing all Namada metadata, and storing it in `Erc20Transfer` structs.

The PR is configured to merge into the base ([tiago/cap-wnam](https://github.com/anoma/namada/tree/tiago/cap-wnam)) to make reviewing easier. It should be changed back to `main`, once the base is upstreamed.

## Indicate on which release or other PRs this topic is based on

Based on #1781

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
