### PR TITLE
Fix bug in unjail-validator that crashed testnet v0.20.1

### DIFF
--- a/.changelog/unreleased/bug-fixes/1793-fix-unjail-bug.md
+++ b/.changelog/unreleased/bug-fixes/1793-fix-unjail-bug.md
@@ -1,0 +1,4 @@
+- Fixes buggy error handling in pos unjail_validator. Now properly enforces that
+  if an unjail tx is submitted when the validator state is something other than
+  Jailed in any of the current or future epochs, the tx will error out and fail.
+  ([\#1793](https://github.com/anoma/namada/pull/1793))

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -3927,11 +3927,8 @@ where
 
     // Check that the validator is jailed up to the pipeline epoch
     for epoch in current_epoch.iter_range(params.pipeline_len + 1) {
-        let state = validator_state_handle(validator).get(
-            storage,
-            current_epoch,
-            &params,
-        )?;
+        let state =
+            validator_state_handle(validator).get(storage, epoch, &params)?;
         if let Some(state) = state {
             if state != ValidatorState::Jailed {
                 return Err(UnjailValidatorError::NotJailed(

--- a/wasm/checksums.json
+++ b/wasm/checksums.json
@@ -9,7 +9,7 @@
     "tx_reveal_pk.wasm": "tx_reveal_pk.e6375abba3f750700c06fbdeb2d5edec22b6a382116a67a7f9d7f7ba49f134e1.wasm",
     "tx_transfer.wasm": "tx_transfer.e65b47bc94c5a09e3edc68298ad0e5e35041b91bc4d679bf5b7f433dffdce58e.wasm",
     "tx_unbond.wasm": "tx_unbond.4fd70d297ccedb369bf88d8a8459a47ea733d329410387a6f80a0e026c6e480d.wasm",
-    "tx_unjail_validator.wasm": "tx_unjail_validator.b8e7204b14e15a3c395432f35788eca45ef4332916d96dfba87627a5717916de.wasm",
+    "tx_unjail_validator.wasm": "tx_unjail_validator.28082f1002a97f06b52bc7a9267d1e5675a5241c5d37f7d0c58257f9fa2cc9b2.wasm",
     "tx_update_vp.wasm": "tx_update_vp.65c5ca3e48fdef70e696460eca7540cf6196511d76fb2465133b145409329b3e.wasm",
     "tx_vote_proposal.wasm": "tx_vote_proposal.e0a003d922230d32b741b57ca18913cbc4d5d2290f02cb37dfdaa7f27cebb486.wasm",
     "tx_withdraw.wasm": "tx_withdraw.40499cb0e268d3cc3d9bca5dacca05d8df35f5b90adf4087a5171505472d921a.wasm",


### PR DESCRIPTION
## Describe your changes

Resolves a bug in the error handling of `fn unjail_validator`.

This bug led to a failure in the testnet based on v0.20.1. In the testnet, a validator who had previously been jailed, and was eligible to unjail themselves, seems to have submitted an unjail transaction twice. The second submission mistakenly did not throw an error, leading to a second insertion of the validator back into the consensus set, which then led to a panic from CometBFT for duplicate validators.

closes #1790

## Indicate on which release or other PRs this topic is based on

v0.20.1

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
