### PR TITLE
Fix available_memory

### DIFF
--- a/.changelog/unreleased/bug-fixes/1801-fix-available-memory.md
+++ b/.changelog/unreleased/bug-fixes/1801-fix-available-memory.md
@@ -1,0 +1,2 @@
+- Fix available_memory size
+  ([\#1801](https://github.com/anoma/namada/issues/1801))

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -329,7 +329,7 @@ async fn run_aux_setup(
     // Find the system available memory
     let available_memory_bytes = Lazy::new(|| {
         let sys = System::new_with_specifics(RefreshKind::new().with_memory());
-        let available_memory_bytes = sys.available_memory() * 1024;
+        let available_memory_bytes = sys.available_memory();
         tracing::info!(
             "Available memory: {}",
             Byte::from_bytes(available_memory_bytes as u128)


### PR DESCRIPTION
## Describe your changes
The available_memory unit was changed from `KB` to `Byte` when `sysinfo` was updated from v0.21.1 to v0.29.4 at #1695.

v0.21.1: https://docs.rs/sysinfo/0.21.1/sysinfo/trait.SystemExt.html#tymethod.available_memory
> Returns the amount of available RAM in KB.

v0.29.4: https://docs.rs/sysinfo/0.29.4/sysinfo/trait.SystemExt.html#tymethod.available_memory
> Returns the amount of available RAM in bytes.

The WASM cache size and the RocksDB cache size were huge due to this issue.
```
2023-08-09T19:07:13.014083Z  INFO namada_apps::node::ledger: VP WASM compilation cache size not configured, using 1/6 of available memory.
2023-08-09T19:07:13.014154Z  INFO namada_apps::node::ledger: Available memory: 29.93 TiB
2023-08-09T19:07:13.014163Z  INFO namada_apps::node::ledger: VP WASM compilation cache size: 4.99 TiB
2023-08-09T19:07:13.014169Z  INFO namada_apps::node::ledger: Tx WASM compilation cache size not configured, using 1/6 of available memory.
2023-08-09T19:07:13.014172Z  INFO namada_apps::node::ledger: Tx WASM compilation cache size: 4.99 TiB
2023-08-09T19:07:13.014177Z  INFO namada_apps::node::ledger: Block cache size not configured, using 1/3 of available memory.
2023-08-09T19:07:13.014181Z  INFO namada_apps::node::ledger: RocksDB block cache size: 9.98 TiB
```

## Indicate on which release or other PRs this topic is based on
v0.20.1

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
