### PR TITLE
Deriving Traits for Address::DecodeError

### DIFF
--- a/core/src/types/address.rs
+++ b/core/src/types/address.rs
@@ -102,7 +102,7 @@ const PREFIX_IBC: &str = "ibc";
 const PREFIX_ETH: &str = "eth";
 
 #[allow(missing_docs)]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum DecodeError {
     #[error("Error decoding address from Bech32m: {0}")]
     DecodeBech32(bech32::Error),

--- a/core/src/types/masp.rs
+++ b/core/src/types/masp.rs
@@ -1,7 +1,7 @@
 //! MASP types
 
 use std::fmt::Display;
-use std::io::{Error, ErrorKind};
+use std::io::ErrorKind;
 use std::str::FromStr;
 
 use bech32::{FromBase32, ToBase32};
@@ -74,7 +74,7 @@ impl FromStr for ExtendedViewingKey {
         let bytes: Vec<u8> = FromBase32::from_base32(&base32)
             .map_err(DecodeError::DecodeBase32)?;
         masp_primitives::zip32::ExtendedFullViewingKey::read(&mut &bytes[..])
-            .map_err(DecodeError::InvalidInnerEncoding)
+            .map_err(|op| DecodeError::InvalidInnerEncodingStr(op.to_string()))
             .map(Self)
     }
 }
@@ -209,16 +209,16 @@ impl FromStr for PaymentAddress {
             _ => return Err(DecodeError::UnexpectedBech32Variant(variant)),
         }
         let addr_len_err = |_| {
-            DecodeError::InvalidInnerEncoding(Error::new(
+            DecodeError::InvalidInnerEncoding(
                 ErrorKind::InvalidData,
-                "expected 43 bytes for the payment address",
-            ))
+                "expected 43 bytes for the payment address".to_string(),
+            )
         };
         let addr_data_err = || {
-            DecodeError::InvalidInnerEncoding(Error::new(
+            DecodeError::InvalidInnerEncoding(
                 ErrorKind::InvalidData,
-                "invalid payment address provided",
-            ))
+                "invalid payment address provided".to_string(),
+            )
         };
         let bytes: Vec<u8> = FromBase32::from_base32(&base32)
             .map_err(DecodeError::DecodeBase32)?;
@@ -298,7 +298,7 @@ impl FromStr for ExtendedSpendingKey {
         let bytes: Vec<u8> = FromBase32::from_base32(&base32)
             .map_err(DecodeError::DecodeBase32)?;
         masp_primitives::zip32::ExtendedSpendingKey::read(&mut &bytes[..])
-            .map_err(DecodeError::InvalidInnerEncoding)
+            .map_err(|op| DecodeError::InvalidInnerEncodingStr(op.to_string()))
             .map(Self)
     }
 }


### PR DESCRIPTION
## Describe your changes

These trait derivations should make it easier for code who wish
to ingest this type to themselves derive traits like Eq and Clone.

This Topic relies on #1818 as it sets the ground work for being able
to derive this information. However, this work can be done by hand
another way, and alternative strategies can be had to derive such
information

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
