### PR TITLE
Make namada::ledger::tx::Error cloneable

### DIFF
--- a/shared/src/ledger/tx.rs
+++ b/shared/src/ledger/tx.rs
@@ -202,7 +202,7 @@ pub enum Error {
     WasmValidationFailure(WasmValidationError),
     /// Encoding transaction failure
     #[error("Encoding tx data, {0}, shouldn't fail")]
-    EncodeTxFailure(std::io::Error),
+    EncodeTxFailure(String),
     /// Like EncodeTxFailure but for the encode error type
     #[error("Encoding tx data, {0}, shouldn't fail")]
     EncodeFailure(EncodeError),
@@ -787,7 +787,7 @@ pub async fn build_unjail_validator<
     let _data = validator
         .clone()
         .try_to_vec()
-        .map_err(Error::EncodeTxFailure)?;
+        .map_err(|err| Error::EncodeTxFailure(err.to_string()))?;
 
     let chain_id = tx_args.chain_id.clone().unwrap();
     let mut tx = Tx::new(chain_id, tx_args.expiration);

--- a/shared/src/ledger/tx.rs
+++ b/shared/src/ledger/tx.rs
@@ -95,7 +95,7 @@ pub const TX_CHANGE_COMMISSION_WASM: &str =
 const DEFAULT_NAMADA_EVENTS_MAX_WAIT_TIME_SECONDS: u64 = 60;
 
 /// Errors to do with transaction events.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
     /// Accepted tx timeout
     #[error("Timed out waiting for tx to be accepted")]

--- a/shared/src/ledger/tx.rs
+++ b/shared/src/ledger/tx.rs
@@ -221,9 +221,6 @@ pub enum Error {
     /// The proposal can't be found
     #[error("Proposal {0} can't be found")]
     ProposalDoesNotExist(u64),
-    /// Encoding public key failure
-    #[error("Encoding a public key, {0}, shouldn't fail")]
-    EncodeKeyFailure(std::io::Error),
     /// Updating an VP of an implicit account
     #[error(
         "A validity predicate of an implicit address cannot be directly \

--- a/shared/src/ledger/tx.rs
+++ b/shared/src/ledger/tx.rs
@@ -196,7 +196,7 @@ pub enum Error {
     ),
     /// No Balance found for token
     #[error("{0}")]
-    MaspError(builder::Error<std::convert::Infallible>),
+    MaspError(String),
     /// Wasm validation failed
     #[error("Validity predicate code validation failed with {0}")]
     WasmValidationFailure(WasmValidationError),
@@ -1598,7 +1598,7 @@ pub async fn build_transfer<
                 Box::new(args.tx.gas_token.clone()),
             ))
         }
-        Err(err) => Err(Error::MaspError(err)),
+        Err(err) => Err(Error::MaspError(err.to_string())),
     }?;
 
     let chain_id = args.tx.chain_id.clone().unwrap();

--- a/shared/src/vm/mod.rs
+++ b/shared/src/vm/mod.rs
@@ -37,7 +37,7 @@ const UNTRUSTED_WASM_FEATURES: WasmFeatures = WasmFeatures {
 };
 
 #[allow(missing_docs)]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum WasmValidationError {
     #[error(
         "Invalid WASM using forbidden features: {0}. Expected: \


### PR DESCRIPTION
## Describe your changes

This topic simply makes `namada::ledger::tx::Error` cloneable. 

This will be used in future work

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
