### PR TITLE
"testing" feature guard masp proofs load/save

### DIFF
--- a/.changelog/unreleased/improvements/1828-feature-guard-masp-proof-load.md
+++ b/.changelog/unreleased/improvements/1828-feature-guard-masp-proof-load.md
@@ -1,0 +1,2 @@
+- Ensure that Namada (shared) crate can be built for WASM target.
+  ([\#1828](https://github.com/anoma/namada/pull/1828))

--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,12 @@ check:
 check-mainnet:
 	$(cargo) check --workspace --features "mainnet"
 
-# Check that every crate can be built with default features
+# Check that every crate can be built with default features and that shared crate
+# can be built for wasm
 check-crates:
 	$(foreach p,$(crates), echo "Checking $(p)" && cargo +$(nightly) check -Z unstable-options --tests -p $(p) && ) \
-		make -C $(wasms_for_tests) check
+		make -C $(wasms_for_tests) check && \
+		cargo check --package namada --target wasm32-unknown-unknown --no-default-features --features "abciplus,namada-sdk"
 
 clippy-wasm = $(cargo) +$(nightly) clippy --manifest-path $(wasm)/Cargo.toml --all-targets -- -D warnings
 

--- a/shared/src/ledger/masp.rs
+++ b/shared/src/ledger/masp.rs
@@ -116,6 +116,7 @@ pub struct ShieldedTransfer {
     pub epoch: Epoch,
 }
 
+#[cfg(feature = "testing")]
 #[derive(Clone, Copy, Debug)]
 enum LoadOrSaveProofs {
     Load,
@@ -1601,6 +1602,7 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
         }
 
         // To speed up integration tests, we can save and load proofs
+        #[cfg(feature = "testing")]
         let load_or_save = if let Ok(masp_proofs) =
             env::var(ENV_VAR_MASP_TEST_PROOFS)
         {
@@ -1625,54 +1627,71 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
         };
 
         let builder_clone = builder.clone().map_builder(WalletMap);
+        #[cfg(feature = "testing")]
         let builder_bytes = BorshSerialize::try_to_vec(&builder_clone).unwrap();
-        let builder_hash =
-            namada_core::types::hash::Hash::sha256(&builder_bytes);
-        let saved_filepath = env::current_dir()
-            .unwrap()
-            // One up from "tests" dir to the root dir
-            .parent()
-            .unwrap()
-            .join(MASP_TEST_PROOFS_DIR)
-            .join(format!("{builder_hash}.bin"));
+        let build_transfer =
+            || -> Result<ShieldedTransfer, builder::Error<std::convert::Infallible>> {
+                let (masp_tx, metadata) = builder.build(
+                    &self.utils.local_tx_prover(),
+                    &FeeRule::non_standard(tx_fee),
+                )?;
+                Ok(ShieldedTransfer {
+                    builder: builder_clone,
+                    masp_tx,
+                    metadata,
+                    epoch,
+            })
+        };
 
-        if let LoadOrSaveProofs::Load = load_or_save {
-            let recommendation = format!(
-                "Re-run the tests with {ENV_VAR_MASP_TEST_PROOFS}=save to \
-                 re-generate proofs."
-            );
-            let exp_str = format!(
-                "Read saved MASP proofs from {}. {recommendation}",
-                saved_filepath.to_string_lossy()
-            );
-            let loaded_bytes =
-                tokio::fs::read(&saved_filepath).await.expect(&exp_str);
-            let exp_str = format!(
-                "Valid `ShieldedTransfer` bytes in {}. {recommendation}",
-                saved_filepath.to_string_lossy()
-            );
-            let loaded: ShieldedTransfer =
-                BorshDeserialize::try_from_slice(&loaded_bytes)
-                    .expect(&exp_str);
-            Ok(Some(loaded))
-        } else {
-            // Build and return the constructed transaction
-            let (masp_tx, metadata) = builder.build(
-                &self.utils.local_tx_prover(),
-                &FeeRule::non_standard(tx_fee),
-            )?;
-            let built = ShieldedTransfer {
-                builder: builder_clone,
-                masp_tx,
-                metadata,
-                epoch,
-            };
-            if let LoadOrSaveProofs::Save = load_or_save {
-                let built_bytes = BorshSerialize::try_to_vec(&built).unwrap();
-                tokio::fs::write(&saved_filepath, built_bytes)
-                    .await
-                    .unwrap();
+        #[cfg(feature = "testing")]
+        {
+            let builder_hash =
+                namada_core::types::hash::Hash::sha256(&builder_bytes);
+            let saved_filepath = env::current_dir()
+                .unwrap()
+                // One up from "tests" dir to the root dir
+                .parent()
+                .unwrap()
+                .join(MASP_TEST_PROOFS_DIR)
+                .join(format!("{builder_hash}.bin"));
+
+            if let LoadOrSaveProofs::Load = load_or_save {
+                let recommendation = format!(
+                    "Re-run the tests with {ENV_VAR_MASP_TEST_PROOFS}=save to \
+                     re-generate proofs."
+                );
+                let exp_str = format!(
+                    "Read saved MASP proofs from {}. {recommendation}",
+                    saved_filepath.to_string_lossy()
+                );
+                let loaded_bytes =
+                    tokio::fs::read(&saved_filepath).await.expect(&exp_str);
+                let exp_str = format!(
+                    "Valid `ShieldedTransfer` bytes in {}. {recommendation}",
+                    saved_filepath.to_string_lossy()
+                );
+                let loaded: ShieldedTransfer =
+                    BorshDeserialize::try_from_slice(&loaded_bytes)
+                        .expect(&exp_str);
+                Ok(Some(loaded))
+            } else {
+                // Build and return the constructed transaction
+                let built = build_transfer()?;
+                if let LoadOrSaveProofs::Save = load_or_save {
+                    let built_bytes =
+                        BorshSerialize::try_to_vec(&built).unwrap();
+                    tokio::fs::write(&saved_filepath, built_bytes)
+                        .await
+                        .unwrap();
+                }
+                Ok(Some(built))
             }
+        }
+
+        #[cfg(not(feature = "testing"))]
+        {
+            // Build and return the constructed transaction
+            let built = build_transfer()?;
             Ok(Some(built))
         }
     }

--- a/shared/src/types/control_flow.rs
+++ b/shared/src/types/control_flow.rs
@@ -7,6 +7,7 @@ use std::ops::ControlFlow;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+#[cfg(any(unix, windows))]
 use futures::future::FutureExt;
 #[cfg(any(unix, windows))]
 use tokio::sync::oneshot;


### PR DESCRIPTION
## Describe your changes

To avoid issues with using shared crate for web wasm build, the newly added #1768 is put behind "testing" feature. Additionally, `make check-crates` that runs in the CI is extended to ensure that the wasm for web can be built from shared crate.

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
