### PR TITLE
Parallel vps' gas accounting rework

### DIFF
--- a/.changelog/unreleased/bug-fixes/1835-fix-parallel-vps.md
+++ b/.changelog/unreleased/bug-fixes/1835-fix-parallel-vps.md
@@ -1,0 +1,2 @@
+- Fixed a bug in the parallel gas accounting of validity predicates.
+  ([\#1835](https://github.com/anoma/namada/pull/1835))

--- a/core/src/ledger/gas.rs
+++ b/core/src/ledger/gas.rs
@@ -198,7 +198,7 @@ pub struct VpGasMeter {
     Clone, Debug, Default, BorshSerialize, BorshDeserialize, BorshSchema,
 )]
 pub struct VpsGas {
-    max: Option<Gas>,
+    max: Gas,
     rest: Vec<Gas>,
 }
 
@@ -313,40 +313,28 @@ impl VpsGas {
     /// Set the gas cost from a VP run. It consumes the [`VpGasMeter`]
     /// instance which shouldn't be accessed passed this point.
     pub fn set(&mut self, vp_gas_meter: VpGasMeter) -> Result<()> {
-        match self.max {
-            Some(previous_max) => {
-                if vp_gas_meter.current_gas > previous_max {
-                    self.rest.push(previous_max);
-                    self.max = Some(vp_gas_meter.current_gas);
-                } else {
-                    self.rest.push(vp_gas_meter.current_gas);
-                }
-            }
-            None => self.max = Some(vp_gas_meter.current_gas),
+        if vp_gas_meter.current_gas > self.max {
+            self.rest.push(self.max);
+            self.max = vp_gas_meter.current_gas;
+        } else {
+            self.rest.push(vp_gas_meter.current_gas);
         }
+
         self.check_limit(&vp_gas_meter)
     }
 
     /// Merge validity predicates gas meters from parallelized runs. Consumes
-    /// the other 'VpsGas' instance which shouldn't be used passed this point.
+    /// the other `VpsGas` instance which shouldn't be used passed this point.
     pub fn merge(
         &mut self,
         mut other: VpsGas,
         tx_gas_meter: &TxGasMeter,
     ) -> Result<()> {
-        match (self.max, other.max) {
-            (None, Some(_)) => {
-                self.max = other.max;
-            }
-            (Some(this_max), Some(other_max)) => {
-                if this_max < other_max {
-                    self.rest.push(this_max);
-                    self.max = other.max;
-                } else {
-                    self.rest.push(other_max);
-                }
-            }
-            _ => {}
+        if self.max < other.max {
+            self.rest.push(self.max);
+            self.max = other.max;
+        } else {
+            self.rest.push(other.max);
         }
         self.rest.append(&mut other.rest);
 
@@ -372,10 +360,7 @@ impl VpsGas {
             self.rest.iter().try_fold(Gas::default(), |acc, gas| {
                 acc.checked_add(*gas).ok_or(Error::GasOverflow)
             })? / PARALLEL_GAS_DIVIDER;
-        self.max
-            .unwrap_or_default()
-            .checked_add(parallel_gas)
-            .ok_or(Error::GasOverflow)
+        self.max.checked_add(parallel_gas).ok_or(Error::GasOverflow)
     }
 }
 

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -1069,7 +1069,7 @@ fn merge_vp_results(
     errors.append(&mut b.errors);
     let mut gas_used = a.gas_used;
 
-    gas_used.merge(&mut b.gas_used, tx_gas_meter)?;
+    gas_used.merge(b.gas_used, tx_gas_meter)?;
 
     Ok(VpsResult {
         accepted_vps,


### PR DESCRIPTION
## Describe your changes

Currently, during the parallel execution of vps (more specifically in the `try_fold` function we use the `set` method of `VpsGas` to set the gas cost of the current Vp. This function only updates the `max` field as it assumes the `VpsGas` instance to have been just initialized and, therefore, be empty. From the rayon documentation though (https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#method.fold), it is stated that the sequence might be subdivided before being folded. In this case, more than on VP would be aggregated in one of these chunks and all of the VP following the first one would see a non-default `VpsGas` instance, i.e. an instance with the `max` field containing the gas cost of the previous vp. Given that the current implementation of `set` only overwrites the `max` field, we would end up under assessing the gas cost of the transaction. The correct logic, in this case, would be to update the maximum (if needed) and push the cheaper vp cost to the `rest` field.

I have tested this thing and it actually looks like rayon never produces subsequences with more than one element, i.e. all of the vps are allocated to their own subsequence and therefore do not incur in this problem. From some tests I saw that to trigger the misbehavior the collection needs to contain at least 8 elements, but this number is variable (depends from run to run) and also depends on the number of logical cpus allocated to rayon (which for Namada is non-constant, since we use half of the available logical cores). **IMPORTANT**: We might never come to such number of vps for a single transaction.

In the `set` method we also have a couple of `debug_asserts` verifying that the `VpsGas` instance is indeed empty (and therefore the current logic is correct).

My concern is that if the internals of rayon change (which might even go unnoticed by SemVer), or if we start triggering more vps per transaction than we currently do, we might start to experience this issue on some machines. If we don't catch this with the `debug_asserts` and the code gets shipped we might end up with a non-consistent gas accounting which would eventually lead to a break in consensus.

So this PR carries a small rework that ensures that the `identity` argument of `try_fold` is indeed an identity function and would guarantee the correct execution logic regardless of the rayon internals/execution context.

## Indicate on which release or other PRs this topic is based on

v0.22.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
