### PR TITLE
Fix submit_reveal_aux

### DIFF
--- a/.changelog/unreleased/improvements/1846-simplify-reveal.md
+++ b/.changelog/unreleased/improvements/1846-simplify-reveal.md
@@ -1,0 +1,2 @@
+- Call submit_reveal_tx() without CLI context
+  ([\#1846](https://github.com/anoma/namada/issues/1846))

--- a/apps/src/lib/cli/client.rs
+++ b/apps/src/lib/cli/client.rs
@@ -268,7 +268,7 @@ impl<IO> CliApi<IO> {
                         } else {
                             tx::submit_reveal_aux(
                                 &client,
-                                &mut ctx,
+                                &mut ctx.wallet,
                                 tx_args.clone(),
                                 &args.sender,
                             )


### PR DESCRIPTION
## Describe your changes
To call `submit_reveal_aux` without the CLI context from a client application, e.g. IBC relayer.
It is enough to give only the wallet since `submit_reveal_aux` requires only the wallet of the CLI context.

## Indicate on which release or other PRs this topic is based on
v0.21.1

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
