### PR TITLE
Add the Bridge pool as a default wallet address

### DIFF
--- a/.changelog/unreleased/improvements/1848-wallet-bridge-pool-addr.md
+++ b/.changelog/unreleased/improvements/1848-wallet-bridge-pool-addr.md
@@ -1,0 +1,2 @@
+- Add the Bridge pool as a default wallet address
+  ([\#1848](https://github.com/anoma/namada/pull/1848))

--- a/apps/src/lib/wallet/defaults.rs
+++ b/apps/src/lib/wallet/defaults.rs
@@ -7,6 +7,7 @@ pub use dev::{
     ester_address, ester_keypair, keys, validator_address, validator_keypair,
     validator_keys,
 };
+use namada::core::ledger::eth_bridge::storage::bridge_pool::BRIDGE_POOL_ADDRESS;
 use namada::ledger::wallet::alias::Alias;
 use namada::ledger::{eth_bridge, governance, pgf, pos};
 use namada::types::address::Address;
@@ -22,6 +23,7 @@ pub fn addresses_from_genesis(genesis: GenesisConfig) -> Vec<(Alias, Address)> {
         ("pos_slash_pool".into(), pos::SLASH_POOL_ADDRESS),
         ("governance".into(), governance::ADDRESS),
         ("eth_bridge".into(), eth_bridge::ADDRESS),
+        ("bridge_pool".into(), BRIDGE_POOL_ADDRESS),
         ("pgf".into(), pgf::ADDRESS),
     ];
     // Genesis validators


### PR DESCRIPTION
## Describe your changes

Adds the Bridge pool internal address as a default wallet address. This can be useful for checking the escrow of tokens under the Bridge pool.

## Indicate on which release or other PRs this topic is based on

`v0.21.1`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
