### PR TITLE
Call `Message::parse` directly

### DIFF
--- a/.changelog/unreleased/improvements/1849-call-msg-parse.md
+++ b/.changelog/unreleased/improvements/1849-call-msg-parse.md
@@ -1,0 +1,2 @@
+- Call `Message::parse` directly
+  ([\#1849](https://github.com/anoma/namada/pull/1849))

--- a/core/src/types/key/secp256k1.rs
+++ b/core/src/types/key/secp256k1.rs
@@ -590,8 +590,7 @@ impl super::SigScheme for SigScheme {
         #[cfg(any(test, feature = "secp256k1-sign"))]
         {
             let message =
-                libsecp256k1::Message::parse_slice(&data.signable_hash::<H>())
-                    .expect("Message encoding should not fail");
+                libsecp256k1::Message::parse(&data.signable_hash::<H>());
             let (sig, recovery_id) = libsecp256k1::sign(&message, &keypair.0);
             Signature(sig, recovery_id)
         }
@@ -605,9 +604,7 @@ impl super::SigScheme for SigScheme {
     where
         H: 'static + StorageHasher,
     {
-        let message =
-            libsecp256k1::Message::parse_slice(&data.signable_hash::<H>())
-                .expect("Message encoding should not fail");
+        let message = libsecp256k1::Message::parse(&data.signable_hash::<H>());
         let is_valid = libsecp256k1::verify(&message, &sig.0, &pk.0);
         if is_valid {
             Ok(())


### PR DESCRIPTION
## Describe your changes

When calling into `libsecp256k1` functions, we do not need to attempt to parse message digests. This is because we have a `[u8; 32]` value ready to be passed to the library code.

## Indicate on which release or other PRs this topic is based on

`v0.21.1`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
