### PR TITLE
Parse Eth addresses from the CLI

### DIFF
--- a/.changelog/unreleased/improvements/1850-cli-parse-eth-addrs.md
+++ b/.changelog/unreleased/improvements/1850-cli-parse-eth-addrs.md
@@ -1,0 +1,2 @@
+- Parse Eth addresses from the CLI
+  ([\#1850](https://github.com/anoma/namada/pull/1850))


### PR DESCRIPTION
## Describe your changes

Parse `Address` values from Ethereum addresses. This is useful for users who want to interact with wrapped ERC20 assets in Namada, without going through the pain of manually finding the bech32 encoding of the address (I did, it sucks).

## Indicate on which release or other PRs this topic is based on

`v0.21.1`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
