### PR TITLE
Don't merkelize replay protection keys

### DIFF
--- a/.changelog/unreleased/improvements/1863-unmerkle-replay-protection.md
+++ b/.changelog/unreleased/improvements/1863-unmerkle-replay-protection.md
@@ -1,0 +1,2 @@
+- Removed replay protection storage keys from the merkle tree.
+  ([\#1863](https://github.com/anoma/namada/pull/1863))

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -212,7 +212,7 @@ where
                         .update_header(TxType::Raw)
                         .header_hash();
                     let tx_hash_key =
-                        replay_protection::get_tx_hash_key(&tx_hash);
+                        replay_protection::get_replay_protection_key(&tx_hash);
                     self.wl_storage
                         .delete(&tx_hash_key)
                         .expect("Error while deleting tx hash from storage");
@@ -229,16 +229,19 @@ where
                     let processed_tx =
                         Tx::try_from(processed_tx.tx.as_ref()).unwrap();
                     let wrapper_tx_hash_key =
-                        replay_protection::get_tx_hash_key(&hash::Hash(
-                            processed_tx.header_hash().0,
-                        ));
+                        replay_protection::get_replay_protection_key(
+                            &hash::Hash(processed_tx.header_hash().0),
+                        );
                     self.wl_storage
                         .write_bytes(&wrapper_tx_hash_key, vec![])
                         .expect("Error while writing tx hash to storage");
 
-                    let inner_tx_hash_key = replay_protection::get_tx_hash_key(
-                        &tx.clone().update_header(TxType::Raw).header_hash(),
-                    );
+                    let inner_tx_hash_key =
+                        replay_protection::get_replay_protection_key(
+                            &tx.clone()
+                                .update_header(TxType::Raw)
+                                .header_hash(),
+                        );
                     self.wl_storage
                         .write_bytes(&inner_tx_hash_key, vec![])
                         .expect("Error while writing tx hash to storage");
@@ -493,7 +496,7 @@ where
                             msg
                         {
                             let tx_hash_key =
-                                replay_protection::get_tx_hash_key(&hash);
+                                replay_protection::get_replay_protection_key(&hash);
                             self.wl_storage
                                 .delete(&tx_hash_key)
                                 .expect(
@@ -2279,7 +2282,7 @@ mod test_finalize_block {
         }));
 
         // Write inner hash in storage
-        let inner_hash_key = replay_protection::get_tx_hash_key(
+        let inner_hash_key = replay_protection::get_replay_protection_key(
             &wrapper_tx.clone().update_header(TxType::Raw).header_hash(),
         );
         shell

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -889,7 +889,8 @@ where
     ) -> Result<()> {
         let inner_tx_hash =
             wrapper.clone().update_header(TxType::Raw).header_hash();
-        let inner_hash_key = replay_protection::get_tx_hash_key(&inner_tx_hash);
+        let inner_hash_key =
+            replay_protection::get_replay_protection_key(&inner_tx_hash);
         if temp_wl_storage
             .has_key(&inner_hash_key)
             .expect("Error while checking inner tx hash key in storage")
@@ -909,7 +910,7 @@ where
             Tx::try_from(tx_bytes).expect("Deserialization shouldn't fail");
         let wrapper_hash = tx.header_hash();
         let wrapper_hash_key =
-            replay_protection::get_tx_hash_key(&wrapper_hash);
+            replay_protection::get_replay_protection_key(&wrapper_hash);
         if temp_wl_storage
             .has_key(&wrapper_hash_key)
             .expect("Error while checking wrapper tx hash key in storage")
@@ -1203,7 +1204,7 @@ where
                 inner_tx.update_header(TxType::Raw);
                 let inner_tx_hash = &inner_tx.header_hash();
                 let inner_hash_key =
-                    replay_protection::get_tx_hash_key(inner_tx_hash);
+                    replay_protection::get_replay_protection_key(inner_tx_hash);
                 if self
                     .wl_storage
                     .storage
@@ -1223,7 +1224,7 @@ where
                     .expect("Deserialization shouldn't fail");
                 let wrapper_hash = hash::Hash(tx.header_hash().0);
                 let wrapper_hash_key =
-                    replay_protection::get_tx_hash_key(&wrapper_hash);
+                    replay_protection::get_replay_protection_key(&wrapper_hash);
                 if self
                     .wl_storage
                     .storage
@@ -2252,7 +2253,7 @@ mod test_mempool_validate {
         // Write wrapper hash to storage
         let wrapper_hash = wrapper.header_hash();
         let wrapper_hash_key =
-            replay_protection::get_tx_hash_key(&wrapper_hash);
+            replay_protection::get_replay_protection_key(&wrapper_hash);
         shell
             .wl_storage
             .storage
@@ -2291,7 +2292,8 @@ mod test_mempool_validate {
         let inner_tx_hash =
             wrapper.clone().update_header(TxType::Raw).header_hash();
         // Write inner hash in storage
-        let inner_hash_key = replay_protection::get_tx_hash_key(&inner_tx_hash);
+        let inner_hash_key =
+            replay_protection::get_replay_protection_key(&inner_tx_hash);
         shell
             .wl_storage
             .storage

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -1030,8 +1030,9 @@ mod test_prepare_proposal {
 
         // Write wrapper hash to storage
         let wrapper_unsigned_hash = wrapper.header_hash();
-        let hash_key =
-            replay_protection::get_tx_hash_key(&wrapper_unsigned_hash);
+        let hash_key = replay_protection::get_replay_protection_key(
+            &wrapper_unsigned_hash,
+        );
         shell
             .wl_storage
             .storage
@@ -1124,7 +1125,8 @@ mod test_prepare_proposal {
             wrapper.clone().update_header(TxType::Raw).header_hash();
 
         // Write inner hash to storage
-        let hash_key = replay_protection::get_tx_hash_key(&inner_unsigned_hash);
+        let hash_key =
+            replay_protection::get_replay_protection_key(&inner_unsigned_hash);
         shell
             .wl_storage
             .storage

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -2094,8 +2094,9 @@ mod test_process_proposal {
 
         // Write wrapper hash to storage
         let wrapper_unsigned_hash = wrapper.header_hash();
-        let hash_key =
-            replay_protection::get_tx_hash_key(&wrapper_unsigned_hash);
+        let hash_key = replay_protection::get_replay_protection_key(
+            &wrapper_unsigned_hash,
+        );
         shell
             .wl_storage
             .storage
@@ -2228,7 +2229,8 @@ mod test_process_proposal {
             wrapper.clone().update_header(TxType::Raw).header_hash();
 
         // Write inner hash to storage
-        let hash_key = replay_protection::get_tx_hash_key(&inner_unsigned_hash);
+        let hash_key =
+            replay_protection::get_replay_protection_key(&inner_unsigned_hash);
         shell
             .wl_storage
             .storage

--- a/core/src/ledger/replay_protection.rs
+++ b/core/src/ledger/replay_protection.rs
@@ -9,12 +9,12 @@ pub const ADDRESS: Address =
     Address::Internal(InternalAddress::ReplayProtection);
 
 /// Check if a key is a replay protection key
-pub fn is_tx_hash_key(key: &Key) -> bool {
+pub fn is_replay_protection_key(key: &Key) -> bool {
     matches!(&key.segments[0], DbKeySeg::AddressSeg(addr) if addr == &ADDRESS)
 }
 
 /// Get the transaction hash key
-pub fn get_tx_hash_key(hash: &Hash) -> Key {
+pub fn get_replay_protection_key(hash: &Hash) -> Key {
     Key::from(ADDRESS.to_db_key())
         .push(&hash.to_string())
         .expect("Cannot obtain a valid db key")

--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -27,7 +27,7 @@ pub use wl_storage::{
 #[cfg(feature = "wasm-runtime")]
 pub use self::masp_conversions::update_allowed_conversions;
 pub use self::masp_conversions::{encode_asset_type, ConversionState};
-use super::replay_protection::is_tx_hash_key;
+use super::replay_protection::is_replay_protection_key;
 use crate::ledger::eth_bridge::storage::bridge_pool::is_pending_transfer_key;
 use crate::ledger::gas::MIN_STORAGE_GAS;
 use crate::ledger::parameters::{self, EpochDuration, Parameters};
@@ -638,7 +638,7 @@ where
             let height =
                 self.block.height.try_to_vec().expect("Encoding failed");
             self.block.tree.update(key, height)?;
-        } else if !is_tx_hash_key(key) {
+        } else if !is_replay_protection_key(key) {
             // TODO: hack, would be better to pull replay protection out of the
             // subspace into a new storage root key which doesn't get merkelized
             // Update the merkle tree for all but replay-protection entries
@@ -1008,7 +1008,7 @@ where
             let height =
                 self.block.height.try_to_vec().expect("Encoding failed");
             self.block.tree.update(key, height)?;
-        } else if !is_tx_hash_key(key) {
+        } else if !is_replay_protection_key(key) {
             // TODO: hack, would be better to pull replay protection out of the
             // subspace into a new storage root key which doesn't get merkelized
             // Update the merkle tree for all but replay-protection entries

--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -639,8 +639,6 @@ where
                 self.block.height.try_to_vec().expect("Encoding failed");
             self.block.tree.update(key, height)?;
         } else if !is_replay_protection_key(key) {
-            // TODO: hack, would be better to pull replay protection out of the
-            // subspace into a new storage root key which doesn't get merkelized
             // Update the merkle tree for all but replay-protection entries
             self.block.tree.update(key, value)?;
         }
@@ -659,7 +657,9 @@ where
         // but with gas and storage bytes len diff accounting
         let mut deleted_bytes_len = 0;
         if self.has_key(key)?.0 {
-            self.block.tree.delete(key)?;
+            if !is_replay_protection_key(key) {
+                self.block.tree.delete(key)?;
+            }
             deleted_bytes_len =
                 self.db.delete_subspace_val(self.block.height, key)?;
         }
@@ -1009,8 +1009,6 @@ where
                 self.block.height.try_to_vec().expect("Encoding failed");
             self.block.tree.update(key, height)?;
         } else if !is_replay_protection_key(key) {
-            // TODO: hack, would be better to pull replay protection out of the
-            // subspace into a new storage root key which doesn't get merkelized
             // Update the merkle tree for all but replay-protection entries
             self.block.tree.update(key, value)?;
         }

--- a/core/src/ledger/storage/wl_storage.rs
+++ b/core/src/ledger/storage/wl_storage.rs
@@ -4,7 +4,6 @@ use std::iter::Peekable;
 
 use super::EPOCH_SWITCH_BLOCKS_DELAY;
 use crate::ledger::parameters::EpochDuration;
-use crate::ledger::replay_protection::is_replay_protection_key;
 use crate::ledger::storage::write_log::{self, WriteLog};
 use crate::ledger::storage::{DBIter, Storage, StorageHasher, DB};
 use crate::ledger::storage_api::{ResultExt, StorageRead, StorageWrite};
@@ -400,18 +399,7 @@ where
             }
             None => {
                 // when not found in write log, try to check the storage
-                if is_replay_protection_key(key) {
-                    // Replay protection keys are not included in the merkle
-                    // tree
-                    Ok(self
-                        .storage()
-                        .db
-                        .read_subspace_val(key)
-                        .into_storage_result()?
-                        .is_some())
-                } else {
-                    self.storage().block.tree.has_key(key).into_storage_result()
-                }
+                Ok(self.storage().has_key(key).into_storage_result()?.0)
             }
         }
     }


### PR DESCRIPTION
## Describe your changes

Avoid adding the replay protection storage subkey to the merkle tree.
This does **NOT** address (not even partially) #1566.

## Indicate on which release or other PRs this topic is based on

v0.21.1

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
