### PR TITLE
Rework voting on Ethereum tallies across epoch boundaries

### DIFF
--- a/.changelog/unreleased/improvements/1865-eth-voting-power.md
+++ b/.changelog/unreleased/improvements/1865-eth-voting-power.md
@@ -1,0 +1,2 @@
+- Rework voting on Ethereum tallies across epoch boundaries
+  ([\#1865](https://github.com/anoma/namada/pull/1865))

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -190,9 +190,13 @@ impl Amount {
         denom: impl Into<u8>,
     ) -> Result<Self, AmountParseError> {
         let denom = denom.into();
+        let uint = uint.into();
+        if denom == 0 {
+            return Ok(Self { raw: uint });
+        }
         match Uint::from(10)
             .checked_pow(Uint::from(denom))
-            .and_then(|scaling| scaling.checked_mul(uint.into()))
+            .and_then(|scaling| scaling.checked_mul(uint))
         {
             Some(amount) => Ok(Self { raw: amount }),
             None => Err(AmountParseError::ConvertToDecimal),

--- a/core/src/types/voting_power.rs
+++ b/core/src/types/voting_power.rs
@@ -185,10 +185,7 @@ impl Mul<&Amount> for FractionalVotingPower {
     fn mul(self, &rhs: &Amount) -> Self::Output {
         let whole: Uint = rhs.into();
         let fraction = (self.0 * whole).to_integer();
-        match Amount::from_uint(fraction, 0u8) {
-            Ok(amount) => amount,
-            _ => unreachable!(),
-        }
+        Amount::from_uint(fraction, 0u8).unwrap()
     }
 }
 

--- a/core/src/types/voting_power.rs
+++ b/core/src/types/voting_power.rs
@@ -12,6 +12,7 @@ use num_traits::ops::checked::CheckedAdd;
 use serde::de::Visitor;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::types::token::Amount;
 use crate::types::uint::Uint;
 
 /// Namada voting power, normalized to the range `0 - 2^32`.
@@ -167,6 +168,27 @@ impl Mul<&FractionalVotingPower> for FractionalVotingPower {
 
     fn mul(self, rhs: &FractionalVotingPower) -> Self::Output {
         Self(self.0 * rhs.0)
+    }
+}
+
+impl Mul<Amount> for FractionalVotingPower {
+    type Output = Amount;
+
+    fn mul(self, rhs: Amount) -> Self::Output {
+        self * &rhs
+    }
+}
+
+impl Mul<&Amount> for FractionalVotingPower {
+    type Output = Amount;
+
+    fn mul(self, &rhs: &Amount) -> Self::Output {
+        let whole: Uint = rhs.into();
+        let fraction = (self.0 * whole).to_integer();
+        match Amount::from_uint(fraction, 0u8) {
+            Ok(amount) => amount,
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
+++ b/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
@@ -7,9 +7,9 @@ use namada_core::ledger::storage::{DBIter, StorageHasher, WlStorage, DB};
 use namada_core::ledger::storage_api::StorageWrite;
 use namada_core::types::address::Address;
 use namada_core::types::storage::BlockHeight;
+use namada_core::types::token::Amount;
 use namada_core::types::transaction::TxResult;
 use namada_core::types::vote_extensions::bridge_pool_roots::MultiSignedVext;
-use namada_core::types::voting_power::FractionalVotingPower;
 use namada_proof_of_stake::pos_queries::PosQueries;
 
 use crate::protocol::transactions::utils::GetVoters;
@@ -140,7 +140,7 @@ fn apply_update<D, H>(
     wl_storage: &mut WlStorage<D, H>,
     mut update: BridgePoolRoot,
     seen_by: Votes,
-    voting_powers: &HashMap<(Address, BlockHeight), FractionalVotingPower>,
+    voting_powers: &HashMap<(Address, BlockHeight), Amount>,
 ) -> Result<(ChangedKeys, bool)>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
@@ -199,8 +199,8 @@ mod test_apply_bp_roots_to_storage {
     use namada_core::types::ethereum_events::Uint;
     use namada_core::types::keccak::{keccak_hash, KeccakHash};
     use namada_core::types::storage::Key;
-    use namada_core::types::token::Amount;
     use namada_core::types::vote_extensions::bridge_pool_roots;
+    use namada_core::types::voting_power::FractionalVotingPower;
     use namada_proof_of_stake::parameters::PosParams;
     use namada_proof_of_stake::write_pos_params;
 
@@ -431,7 +431,7 @@ mod test_apply_bp_roots_to_storage {
             .read::<EpochedVotingPower>(&bp_root_key.voting_power())
             .expect("Test failed")
             .expect("Test failed")
-            .average_voting_power(&wl_storage);
+            .fractional_stake(&wl_storage);
         assert_eq!(
             voting_power,
             FractionalVotingPower::new_u64(5, 12).unwrap()
@@ -450,7 +450,7 @@ mod test_apply_bp_roots_to_storage {
             .read::<EpochedVotingPower>(&bp_root_key.voting_power())
             .expect("Test failed")
             .expect("Test failed")
-            .average_voting_power(&wl_storage);
+            .fractional_stake(&wl_storage);
         assert_eq!(voting_power, FractionalVotingPower::new_u64(5, 6).unwrap());
     }
 

--- a/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
+++ b/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
@@ -196,17 +196,13 @@ mod test_apply_bp_roots_to_storage {
     use namada_core::ledger::storage_api::StorageRead;
     use namada_core::proto::{SignableEthMessage, Signed};
     use namada_core::types::address;
-    use namada_core::types::dec::Dec;
     use namada_core::types::ethereum_events::Uint;
     use namada_core::types::keccak::{keccak_hash, KeccakHash};
-    use namada_core::types::key::RefTo;
     use namada_core::types::storage::Key;
     use namada_core::types::token::Amount;
     use namada_core::types::vote_extensions::bridge_pool_roots;
     use namada_proof_of_stake::parameters::PosParams;
-    use namada_proof_of_stake::{
-        become_validator, bond_tokens, write_pos_params, BecomeValidator,
-    };
+    use namada_proof_of_stake::write_pos_params;
 
     use super::*;
     use crate::protocol::transactions::votes::{
@@ -720,32 +716,16 @@ mod test_apply_bp_roots_to_storage {
             pipeline_len: 1,
             ..Default::default()
         };
-        write_pos_params(&mut wl_storage, params.clone()).expect("Test failed");
+        write_pos_params(&mut wl_storage, params).expect("Test failed");
 
         // insert validators 2 and 3 at epoch 1
-        for (validator, stake) in [
-            (&validator_2, validator_2_stake),
-            (&validator_3, validator_3_stake),
-        ] {
-            let keys = test_utils::TestValidatorKeys::generate();
-            let consensus_key = &keys.consensus.ref_to();
-            let eth_cold_key = &keys.eth_gov.ref_to();
-            let eth_hot_key = &keys.eth_bridge.ref_to();
-            become_validator(BecomeValidator {
-                storage: &mut wl_storage,
-                params: &params,
-                address: validator,
-                consensus_key,
-                eth_cold_key,
-                eth_hot_key,
-                current_epoch: 0.into(),
-                commission_rate: Dec::new(5, 2).unwrap(),
-                max_commission_rate_change: Dec::new(1, 2).unwrap(),
-            })
-            .expect("Test failed");
-            bond_tokens(&mut wl_storage, None, validator, stake, 0.into())
-                .expect("Test failed");
-        }
+        test_utils::append_validators_to_storage(
+            &mut wl_storage,
+            HashMap::from([
+                (validator_2.clone(), validator_2_stake),
+                (validator_3.clone(), validator_3_stake),
+            ]),
+        );
 
         // query validators to make sure they were inserted correctly
         macro_rules! query_validators {
@@ -771,12 +751,24 @@ mod test_apply_bp_roots_to_storage {
             HashMap::from([(validator_1.clone(), validator_1_stake)])
         );
         assert_eq!(
+            wl_storage
+                .pos_queries()
+                .get_total_voting_power(Some(0.into())),
+            validator_1_stake,
+        );
+        assert_eq!(
             epoch_1_validators,
             HashMap::from([
                 (validator_1.clone(), validator_1_stake),
                 (validator_2, validator_2_stake),
                 (validator_3, validator_3_stake),
             ])
+        );
+        assert_eq!(
+            wl_storage
+                .pos_queries()
+                .get_total_voting_power(Some(1.into())),
+            validator_1_stake + validator_2_stake + validator_3_stake,
         );
 
         // set up the bridge pool's storage

--- a/ethereum_bridge/src/protocol/transactions/utils.rs
+++ b/ethereum_bridge/src/protocol/transactions/utils.rs
@@ -6,7 +6,6 @@ use namada_core::ledger::storage::{DBIter, StorageHasher, WlStorage, DB};
 use namada_core::types::address::Address;
 use namada_core::types::storage::BlockHeight;
 use namada_core::types::token;
-use namada_core::types::voting_power::FractionalVotingPower;
 use namada_proof_of_stake::pos_queries::PosQueries;
 use namada_proof_of_stake::types::WeightedValidator;
 
@@ -25,7 +24,7 @@ pub(super) trait GetVoters {
 pub(super) fn get_voting_powers<D, H, P>(
     wl_storage: &WlStorage<D, H>,
     proof: P,
-) -> eyre::Result<HashMap<(Address, BlockHeight), FractionalVotingPower>>
+) -> eyre::Result<HashMap<(Address, BlockHeight), token::Amount>>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
@@ -85,15 +84,13 @@ where
 pub(super) fn get_voting_powers_for_selected(
     all_consensus: &BTreeMap<BlockHeight, BTreeSet<WeightedValidator>>,
     selected: HashSet<(Address, BlockHeight)>,
-) -> eyre::Result<HashMap<(Address, BlockHeight), FractionalVotingPower>> {
-    let total_voting_powers =
-        sum_voting_powers_for_block_heights(all_consensus);
+) -> eyre::Result<HashMap<(Address, BlockHeight), token::Amount>> {
     let voting_powers = selected
         .into_iter()
         .map(
             |(addr, height)| -> eyre::Result<(
                 (Address, BlockHeight),
-                FractionalVotingPower,
+                token::Amount,
             )> {
                 let consensus_validators =
                     all_consensus.get(&height).ok_or_else(|| {
@@ -101,7 +98,7 @@ pub(super) fn get_voting_powers_for_selected(
                             "No consensus validators found for height {height}"
                         )
                     })?;
-                let individual_voting_power = consensus_validators
+                let voting_power = consensus_validators
                     .iter()
                     .find(|&v| v.address == addr)
                     .ok_or_else(|| {
@@ -111,44 +108,14 @@ pub(super) fn get_voting_powers_for_selected(
                         )
                     })?
                     .bonded_stake;
-                let total_voting_power = total_voting_powers
-                    .get(&height)
-                    .ok_or_else(|| {
-                        eyre!(
-                            "No total voting power provided for height \
-                             {height}"
-                        )
-                    })?
-                    .to_owned();
                 Ok((
                     (addr, height),
-                    FractionalVotingPower::new(
-                        individual_voting_power.into(),
-                        total_voting_power.into(),
-                    )?,
+                    voting_power,
                 ))
             },
         )
         .try_collect()?;
     Ok(voting_powers)
-}
-
-pub(super) fn sum_voting_powers_for_block_heights(
-    validators: &BTreeMap<BlockHeight, BTreeSet<WeightedValidator>>,
-) -> BTreeMap<BlockHeight, token::Amount> {
-    validators
-        .iter()
-        .map(|(h, vs)| (h.to_owned(), sum_voting_powers(vs)))
-        .collect()
-}
-
-pub(super) fn sum_voting_powers(
-    validators: &BTreeSet<WeightedValidator>,
-) -> token::Amount {
-    validators
-        .iter()
-        .map(|validator| validator.bonded_stake)
-        .sum::<token::Amount>()
 }
 
 #[cfg(test)]
@@ -158,6 +125,7 @@ mod tests {
     use assert_matches::assert_matches;
     use namada_core::types::address;
     use namada_core::types::ethereum_events::testing::arbitrary_bonded_stake;
+    use namada_core::types::voting_power::FractionalVotingPower;
 
     use super::*;
 
@@ -190,7 +158,7 @@ mod tests {
         assert_eq!(voting_powers.len(), 1);
         assert_matches!(
             voting_powers.get(&(sole_validator, BlockHeight(100))),
-            Some(v) if *v == FractionalVotingPower::WHOLE
+            Some(v) if *v == bonded_stake
         );
     }
 
@@ -263,6 +231,7 @@ mod tests {
                 weighted_validator_2,
             ]),
         )]);
+        let bonded_stake = bonded_stake_1 + bonded_stake_2;
 
         let result =
             get_voting_powers_for_selected(&consensus_validators, validators);
@@ -272,56 +241,17 @@ mod tests {
             Err(error) => panic!("error: {:?}", error),
         };
         assert_eq!(voting_powers.len(), 2);
+        let expected_stake =
+            FractionalVotingPower::new_u64(100, 300).unwrap() * bonded_stake;
         assert_matches!(
             voting_powers.get(&(validator_1, BlockHeight(100))),
-            Some(v) if *v == FractionalVotingPower::new_u64(100, 300).unwrap()
+            Some(v) if *v == expected_stake
         );
+        let expected_stake =
+            FractionalVotingPower::new_u64(200, 300).unwrap() * bonded_stake;
         assert_matches!(
             voting_powers.get(&(validator_2, BlockHeight(100))),
-            Some(v) if *v == FractionalVotingPower::new_u64(200, 300).unwrap()
+            Some(v) if *v == expected_stake
         );
-    }
-
-    #[test]
-    /// Test summing the voting powers for a set of validators containing only
-    /// one validator
-    fn test_sum_voting_powers_sole_validator() {
-        let sole_validator = address::testing::established_address_1();
-        let bonded_stake = arbitrary_bonded_stake();
-        let weighted_sole_validator = WeightedValidator {
-            bonded_stake,
-            address: sole_validator,
-        };
-        let validators = BTreeSet::from_iter(vec![weighted_sole_validator]);
-
-        let total = sum_voting_powers(&validators);
-
-        assert_eq!(total, bonded_stake);
-    }
-
-    #[test]
-    /// Test summing the voting powers for a set of validators containing two
-    /// validators
-    fn test_sum_voting_powers_two_validators() {
-        let validator_1 = address::testing::established_address_1();
-        let validator_2 = address::testing::established_address_2();
-        let bonded_stake_1 = token::Amount::from(100);
-        let bonded_stake_2 = token::Amount::from(200);
-        let weighted_validator_1 = WeightedValidator {
-            bonded_stake: bonded_stake_1,
-            address: validator_1,
-        };
-        let weighted_validator_2 = WeightedValidator {
-            bonded_stake: bonded_stake_2,
-            address: validator_2,
-        };
-        let validators = BTreeSet::from_iter(vec![
-            weighted_validator_1,
-            weighted_validator_2,
-        ]);
-
-        let total = sum_voting_powers(&validators);
-
-        assert_eq!(total, token::Amount::from(300));
     }
 }

--- a/ethereum_bridge/src/protocol/transactions/validator_set_update/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/validator_set_update/mod.rs
@@ -6,11 +6,11 @@ use eyre::Result;
 use namada_core::ledger::storage::{DBIter, StorageHasher, WlStorage, DB};
 use namada_core::types::address::Address;
 use namada_core::types::storage::{BlockHeight, Epoch};
+use namada_core::types::token::Amount;
 #[allow(unused_imports)]
 use namada_core::types::transaction::protocol::ProtocolTxType;
 use namada_core::types::transaction::TxResult;
 use namada_core::types::vote_extensions::validator_set_update;
-use namada_core::types::voting_power::FractionalVotingPower;
 
 use super::ChangedKeys;
 use crate::protocol::transactions::utils;
@@ -85,7 +85,7 @@ fn apply_update<D, H>(
     ext: validator_set_update::VextDigest,
     signing_epoch: Epoch,
     epoch_2nd_height: BlockHeight,
-    voting_powers: HashMap<(Address, BlockHeight), FractionalVotingPower>,
+    voting_powers: HashMap<(Address, BlockHeight), Amount>,
 ) -> Result<ChangedKeys>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
@@ -199,7 +199,6 @@ where
 #[cfg(test)]
 mod test_valset_upd_state_changes {
     use namada_core::types::address;
-    use namada_core::types::token::Amount;
     use namada_core::types::vote_extensions::validator_set_update::VotingPowersMap;
     use namada_core::types::voting_power::FractionalVotingPower;
     use namada_proof_of_stake::pos_queries::PosQueries;

--- a/ethereum_bridge/src/protocol/transactions/votes.rs
+++ b/ethereum_bridge/src/protocol/transactions/votes.rs
@@ -5,7 +5,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use eyre::{eyre, Result};
-use namada_core::hints;
 use namada_core::ledger::storage::{DBIter, StorageHasher, WlStorage, DB};
 use namada_core::types::address::Address;
 use namada_core::types::storage::{BlockHeight, Epoch};
@@ -27,31 +26,48 @@ pub(super) mod update;
 pub type Votes = BTreeMap<Address, BlockHeight>;
 
 /// The voting power behind a tally aggregated over multiple epochs.
-pub type EpochedVotingPower = BTreeMap<Epoch, FractionalVotingPower>;
+pub type EpochedVotingPower = BTreeMap<Epoch, token::Amount>;
 
 /// Extension methods for [`EpochedVotingPower`] instances.
 pub trait EpochedVotingPowerExt {
-    /// Get the total voting power staked across all epochs
-    /// in this [`EpochedVotingPower`].
-    fn get_epoch_voting_powers<D, H>(
+    /// Query the stake of the most secure [`Epoch`] referenced by an
+    /// [`EpochedVotingPower`]. This translates to the [`Epoch`] with
+    /// the most staked tokens.
+    fn epoch_max_voting_power<D, H>(
         &self,
         wl_storage: &WlStorage<D, H>,
-    ) -> HashMap<Epoch, token::Amount>
+    ) -> Option<token::Amount>
     where
         D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
         H: 'static + StorageHasher + Sync;
 
-    /// Get the weighted average of some tally's voting powers pertaining to all
-    /// epochs it was held in.
-    fn average_voting_power<D, H>(
+    /// Fetch the sum of the stake tallied on an
+    /// [`EpochedVotingPower`].
+    fn tallied_stake(&self) -> token::Amount;
+
+    /// Fetch the sum of the stake tallied on an
+    /// [`EpochedVotingPower`], as a fraction over
+    /// the maximum stake seen in the epochs voted on.
+    #[inline]
+    fn fractional_stake<D, H>(
         &self,
         wl_storage: &WlStorage<D, H>,
     ) -> FractionalVotingPower
     where
         D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
-        H: 'static + StorageHasher + Sync;
+        H: 'static + StorageHasher + Sync,
+    {
+        let Some(max_voting_power) = self.epoch_max_voting_power(wl_storage) else {
+            return FractionalVotingPower::NULL;
+        };
+        FractionalVotingPower::new(
+            self.tallied_stake().into(),
+            max_voting_power.into(),
+        )
+        .unwrap()
+    }
 
-    /// Check if the [`Tally`] associated with this [`EpochedVotingPower`]
+    /// Check if the [`Tally`] associated with an [`EpochedVotingPower`]
     /// can be considered `seen`.
     #[inline]
     fn has_majority_quorum<D, H>(&self, wl_storage: &WlStorage<D, H>) -> bool
@@ -59,16 +75,29 @@ pub trait EpochedVotingPowerExt {
         D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
         H: 'static + StorageHasher + Sync,
     {
-        self.average_voting_power(wl_storage)
-            > FractionalVotingPower::TWO_THIRDS
+        let Some(max_voting_power) = self.epoch_max_voting_power(wl_storage) else {
+            return false;
+        };
+        // NB: Preserve the safety property of the Tendermint protocol across
+        // all the epochs we vote on.
+        //
+        // PROOF: We calculate the maximum amount of tokens S_max staked on
+        // one of the epochs the tally occurred in. At most F = 1/3 * S_max
+        // of the combined stake can be Byzantine, for the protocol to uphold
+        // its linearizability property whilst remaining "secure" against
+        // arbitrarily faulty nodes. Therefore, we can consider a tally secure
+        // if has accumulated an amount of stake greater than the threshold
+        // stake of S_max - F = 2/3 S_max.
+        let threshold = FractionalVotingPower::TWO_THIRDS * max_voting_power;
+        self.tallied_stake() > threshold
     }
 }
 
 impl EpochedVotingPowerExt for EpochedVotingPower {
-    fn get_epoch_voting_powers<D, H>(
+    fn epoch_max_voting_power<D, H>(
         &self,
         wl_storage: &WlStorage<D, H>,
-    ) -> HashMap<Epoch, token::Amount>
+    ) -> Option<token::Amount>
     where
         D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
         H: 'static + StorageHasher + Sync,
@@ -76,57 +105,13 @@ impl EpochedVotingPowerExt for EpochedVotingPower {
         self.keys()
             .copied()
             .map(|epoch| {
-                (
-                    epoch,
-                    wl_storage
-                        .pos_queries()
-                        .get_total_voting_power(Some(epoch)),
-                )
+                wl_storage.pos_queries().get_total_voting_power(Some(epoch))
             })
-            .collect()
+            .max()
     }
 
-    fn average_voting_power<D, H>(
-        &self,
-        wl_storage: &WlStorage<D, H>,
-    ) -> FractionalVotingPower
-    where
-        D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
-        H: 'static + StorageHasher + Sync,
-    {
-        // if we only voted across a single epoch, we can avoid doing
-        // expensive I/O operations
-        if hints::likely(self.len() == 1) {
-            // TODO: switch to [`BTreeMap::first_entry`] when we start
-            // using Rust >= 1.66
-            let Some(&power) = self.values().next() else {
-                hints::cold();
-                unreachable!("The map has one value");
-            };
-            return power;
-        }
-
-        let epoch_voting_powers = self.get_epoch_voting_powers(wl_storage);
-        let total_voting_power = epoch_voting_powers
-            .values()
-            .fold(token::Amount::from(0u64), |accum, &stake| accum + stake);
-
-        self.iter().map(|(&epoch, &power)| (epoch, power)).fold(
-            FractionalVotingPower::NULL,
-            |average, (epoch, aggregated_voting_power)| {
-                let epoch_voting_power = epoch_voting_powers
-                    .get(&epoch)
-                    .copied()
-                    .expect("This value should be in the map");
-                debug_assert!(epoch_voting_power > 0.into());
-                let weight = FractionalVotingPower::new(
-                    epoch_voting_power.into(),
-                    total_voting_power.into(),
-                )
-                .unwrap();
-                average + weight * aggregated_voting_power
-            },
-        )
+    fn tallied_stake(&self) -> token::Amount {
+        self.values().copied().sum::<token::Amount>()
     }
 }
 
@@ -153,7 +138,7 @@ pub struct Tally {
 pub fn calculate_new<D, H>(
     wl_storage: &WlStorage<D, H>,
     seen_by: Votes,
-    voting_powers: &HashMap<(Address, BlockHeight), FractionalVotingPower>,
+    voting_powers: &HashMap<(Address, BlockHeight), token::Amount>,
 ) -> Result<Tally>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
@@ -164,14 +149,14 @@ where
         match voting_powers
             .get(&(validator.to_owned(), block_height.to_owned()))
         {
-            Some(voting_power) => {
+            Some(&voting_power) => {
                 let epoch = wl_storage
                     .pos_queries()
                     .get_epoch(*block_height)
                     .expect("The queried epoch should be known");
                 let aggregated = seen_by_voting_power
                     .entry(epoch)
-                    .or_insert(FractionalVotingPower::NULL);
+                    .or_insert_with(token::Amount::zero);
                 *aggregated += voting_power;
             }
             None => {
@@ -202,7 +187,6 @@ pub fn dedupe(signers: BTreeSet<(Address, BlockHeight)>) -> Votes {
 mod tests {
     use std::collections::BTreeSet;
 
-    use namada_core::ledger::storage::testing::TestWlStorage;
     use namada_core::types::storage::BlockHeight;
     use namada_core::types::{address, token};
     use namada_proof_of_stake::parameters::PosParams;
@@ -301,18 +285,21 @@ mod tests {
     /// fast path of the algorithm.
     #[test]
     fn test_tally_vote_single_epoch() {
-        let dummy_storage = TestWlStorage::default();
+        let (_, dummy_validator_stake) = test_utils::default_validator();
+        let (dummy_storage, _) = test_utils::setup_default_storage();
 
-        let aggregated =
-            EpochedVotingPower::from([(0.into(), FractionalVotingPower::HALF)]);
+        let aggregated = EpochedVotingPower::from([(
+            0.into(),
+            FractionalVotingPower::HALF * dummy_validator_stake,
+        )]);
         assert_eq!(
-            aggregated.average_voting_power(&dummy_storage),
+            aggregated.fractional_stake(&dummy_storage),
             FractionalVotingPower::HALF
         );
     }
 
     /// Test that voting on a tally across epoch boundaries accounts
-    /// for the average voting power attained along those epochs.
+    /// for the maximum voting power attained along those epochs.
     #[test]
     fn test_voting_across_epoch_boundaries() {
         // the validators that will vote in the tally
@@ -324,6 +311,9 @@ mod tests {
 
         let validator_3 = address::testing::established_address_3();
         let validator_3_stake = token::Amount::native_whole(100);
+
+        let total_stake =
+            validator_1_stake + validator_2_stake + validator_3_stake;
 
         // start epoch 0 with validator 1
         let (mut wl_storage, _) = test_utils::setup_storage_with_validators(
@@ -379,17 +369,17 @@ mod tests {
             wl_storage
                 .pos_queries()
                 .get_total_voting_power(Some(1.into())),
-            validator_1_stake + validator_2_stake + validator_3_stake,
+            total_stake,
         );
 
         // check that voting works as expected
         let aggregated = EpochedVotingPower::from([
-            (0.into(), FractionalVotingPower::ONE_THIRD),
-            (1.into(), FractionalVotingPower::ONE_THIRD),
+            (0.into(), FractionalVotingPower::ONE_THIRD * total_stake),
+            (1.into(), FractionalVotingPower::ONE_THIRD * total_stake),
         ]);
         assert_eq!(
-            aggregated.average_voting_power(&wl_storage),
-            FractionalVotingPower::ONE_THIRD
+            aggregated.fractional_stake(&wl_storage),
+            FractionalVotingPower::TWO_THIRDS
         );
     }
 }

--- a/ethereum_bridge/src/protocol/transactions/votes/storage.rs
+++ b/ethereum_bridge/src/protocol/transactions/votes/storage.rs
@@ -116,16 +116,16 @@ where
 mod tests {
     use std::collections::BTreeMap;
 
-    use namada_core::ledger::storage::testing::TestWlStorage;
-    use namada_core::types::address;
     use namada_core::types::ethereum_events::EthereumEvent;
-    use namada_core::types::voting_power::FractionalVotingPower;
 
     use super::*;
+    use crate::test_utils;
 
     #[test]
     fn test_write_tally() {
-        let mut wl_storage = TestWlStorage::default();
+        let (mut wl_storage, _) = test_utils::setup_default_storage();
+        let (validator, validator_voting_power) =
+            test_utils::default_validator();
         let event = EthereumEvent::TransfersToNamada {
             nonce: 0.into(),
             transfers: vec![],
@@ -135,12 +135,9 @@ mod tests {
         let tally = Tally {
             voting_power: EpochedVotingPower::from([(
                 0.into(),
-                FractionalVotingPower::ONE_THIRD,
+                validator_voting_power,
             )]),
-            seen_by: BTreeMap::from([(
-                address::testing::established_address_1(),
-                10.into(),
-            )]),
+            seen_by: BTreeMap::from([(validator, 10.into())]),
             seen: false,
         };
 
@@ -175,7 +172,9 @@ mod tests {
 
     #[test]
     fn test_read_tally() {
-        let mut wl_storage = TestWlStorage::default();
+        let (mut wl_storage, _) = test_utils::setup_default_storage();
+        let (validator, validator_voting_power) =
+            test_utils::default_validator();
         let event = EthereumEvent::TransfersToNamada {
             nonce: 0.into(),
             transfers: vec![],
@@ -185,12 +184,9 @@ mod tests {
         let tally = Tally {
             voting_power: EpochedVotingPower::from([(
                 0.into(),
-                FractionalVotingPower::ONE_THIRD,
+                validator_voting_power,
             )]),
-            seen_by: BTreeMap::from([(
-                address::testing::established_address_1(),
-                10.into(),
-            )]),
+            seen_by: BTreeMap::from([(validator, 10.into())]),
             seen: false,
         };
         wl_storage

--- a/ethereum_bridge/src/test_utils.rs
+++ b/ethereum_bridge/src/test_utils.rs
@@ -73,21 +73,27 @@ pub fn setup_default_storage()
     (wl_storage, all_keys)
 }
 
-/// Set up a [`TestWlStorage`] initialized at genesis with a single
-/// validator.
-///
-/// The validator's address is [`address::testing::established_address_1`].
+/// Set up a [`TestWlStorage`] initialized at genesis with
+/// [`default_validator`].
 #[inline]
 pub fn init_default_storage(
     wl_storage: &mut TestWlStorage,
 ) -> HashMap<Address, TestValidatorKeys> {
     init_storage_with_validators(
         wl_storage,
-        HashMap::from_iter([(
-            address::testing::established_address_1(),
-            token::Amount::native_whole(100),
-        )]),
+        HashMap::from_iter([default_validator()]),
     )
+}
+
+/// Default validator used in tests.
+///
+/// The validator's address is [`address::testing::established_address_1`],
+/// and its voting power is proportional to the stake of 100 NAM.
+#[inline]
+pub fn default_validator() -> (Address, token::Amount) {
+    let addr = address::testing::established_address_1();
+    let voting_power = token::Amount::native_whole(100);
+    (addr, voting_power)
 }
 
 /// Writes a dummy [`EthereumBridgeConfig`] to the given [`TestWlStorage`], and
@@ -217,23 +223,7 @@ pub fn init_storage_with_validators(
         0.into(),
     )
     .expect("Test failed");
-    let config = EthereumBridgeConfig {
-        erc20_whitelist: vec![],
-        eth_start_height: Default::default(),
-        min_confirmations: Default::default(),
-        contracts: Contracts {
-            native_erc20: wnam(),
-            bridge: UpgradeableContract {
-                address: EthAddress([42; 20]),
-                version: Default::default(),
-            },
-            governance: UpgradeableContract {
-                address: EthAddress([18; 20]),
-                version: Default::default(),
-            },
-        },
-    };
-    config.init_storage(wl_storage);
+    bootstrap_ethereum_bridge(wl_storage);
 
     for (validator, keys) in all_keys.iter() {
         let protocol_key = keys.protocol.ref_to();

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -4000,7 +4000,9 @@ where
     }
 }
 
-fn get_total_consensus_stake<S>(
+/// Find the total amount of tokens staked at the given `epoch`,
+/// belonging to the set of consensus validators.
+pub fn get_total_consensus_stake<S>(
     storage: &S,
     epoch: Epoch,
     params: &PosParams,

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -1128,10 +1128,13 @@ mod tests {
     fn test_apply_protocol_tx_duplicate_eth_events_vext() -> Result<()> {
         let validator_a = address::testing::established_address_2();
         let validator_b = address::testing::established_address_3();
+        let validator_a_stake = Amount::native_whole(100);
+        let validator_b_stake = Amount::native_whole(100);
+        let total_stake = validator_a_stake + validator_b_stake;
         let (mut wl_storage, _) = test_utils::setup_storage_with_validators(
             HashMap::from_iter(vec![
-                (validator_a.clone(), Amount::native_whole(100)),
-                (validator_b, Amount::native_whole(100)),
+                (validator_a.clone(), validator_a_stake),
+                (validator_b, validator_b_stake),
             ]),
         );
         let event = EthereumEvent::TransfersToNamada {
@@ -1166,8 +1169,10 @@ mod tests {
         // the vote should have only be applied once
         let voting_power: EpochedVotingPower =
             wl_storage.read(&eth_msg_keys.voting_power())?.unwrap();
-        let expected =
-            EpochedVotingPower::from([(0.into(), FractionalVotingPower::HALF)]);
+        let expected = EpochedVotingPower::from([(
+            0.into(),
+            FractionalVotingPower::HALF * total_stake,
+        )]);
         assert_eq!(voting_power, expected);
 
         Ok(())
@@ -1180,10 +1185,13 @@ mod tests {
     fn test_apply_protocol_tx_duplicate_bp_roots_vext() -> Result<()> {
         let validator_a = address::testing::established_address_2();
         let validator_b = address::testing::established_address_3();
+        let validator_a_stake = Amount::native_whole(100);
+        let validator_b_stake = Amount::native_whole(100);
+        let total_stake = validator_a_stake + validator_b_stake;
         let (mut wl_storage, keys) = test_utils::setup_storage_with_validators(
             HashMap::from_iter(vec![
-                (validator_a.clone(), Amount::native_whole(100)),
-                (validator_b, Amount::native_whole(100)),
+                (validator_a.clone(), validator_a_stake),
+                (validator_b, validator_b_stake),
             ]),
         );
         bridge_pool_vp::init_storage(&mut wl_storage);
@@ -1222,8 +1230,10 @@ mod tests {
         // the vote should have only be applied once
         let voting_power: EpochedVotingPower =
             wl_storage.read(&bp_root_keys.voting_power())?.unwrap();
-        let expected =
-            EpochedVotingPower::from([(0.into(), FractionalVotingPower::HALF)]);
+        let expected = EpochedVotingPower::from([(
+            0.into(),
+            FractionalVotingPower::HALF * total_stake,
+        )]);
         assert_eq!(voting_power, expected);
 
         Ok(())

--- a/shared/src/ledger/queries/shell/eth_bridge.rs
+++ b/shared/src/ledger/queries/shell/eth_bridge.rs
@@ -504,7 +504,7 @@ where
                     "Iterating over storage should not yield keys without \
                      values.",
                 )
-                .average_voting_power(ctx.wl_storage);
+                .fractional_stake(ctx.wl_storage);
             for transfer in transfers {
                 let key = get_key_from_hash(&transfer.keccak256());
                 let transfer = ctx
@@ -1275,6 +1275,7 @@ mod test_ethbridge_router {
             },
         };
         // write validator to storage
+        let (_, dummy_validator_stake) = test_utils::default_validator();
         test_utils::init_default_storage(&mut client.wl_storage);
 
         // write a transfer into the bridge pool
@@ -1307,9 +1308,12 @@ mod test_ethbridge_router {
             .wl_storage
             .write_bytes(
                 &eth_msg_key.voting_power(),
-                EpochedVotingPower::from([(0.into(), voting_power)])
-                    .try_to_vec()
-                    .expect("Test failed"),
+                EpochedVotingPower::from([(
+                    0.into(),
+                    voting_power * dummy_validator_stake,
+                )])
+                .try_to_vec()
+                .expect("Test failed"),
             )
             .expect("Test failed");
         client


### PR DESCRIPTION
## Describe your changes

Closes #1288

This PR changes the way voting across epochs on Ethereum tallies works. Instead of accounting for the average voting power available across all epochs $E$ some tally $t$ takes place in, $t$ is considered `seen` if its accumulated voting power is greater than $2/3 \max(\sigma(e) : e \in E)$, where $\sigma$ is the function that returns the voting power available in the input epoch.

With this strategy, tallies won't stall if they cross epoch boundaries, while still respecting the Tendermint BFT protocol's safety property (i.e. linearizability is preserved).

## Indicate on which release or other PRs this topic is based on

`v0.22.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
