### PR TITLE
Removes fee panics from sdk

### DIFF
--- a/.changelog/unreleased/SDK/1878-remove-sdk-fee-panics.md
+++ b/.changelog/unreleased/SDK/1878-remove-sdk-fee-panics.md
@@ -1,0 +1,3 @@
+- Added two new variants to the `TxError` enum, `BalanceToLowForFees` and
+  `FeeUnshieldingError`, representing possible failures in transactions' fees.
+  ([\#1878](https://github.com/anoma/namada/pull/1878))

--- a/.changelog/unreleased/bug-fixes/1878-remove-sdk-fee-panics.md
+++ b/.changelog/unreleased/bug-fixes/1878-remove-sdk-fee-panics.md
@@ -1,0 +1,2 @@
+- Removed gas and fees related panics from the sdk.
+  ([\#1878](https://github.com/anoma/namada/pull/1878))

--- a/shared/src/ledger/tx.rs
+++ b/shared/src/ledger/tx.rs
@@ -163,7 +163,7 @@ pub async fn prepare_tx<
     if !args.dry_run {
         let epoch = rpc::query_epoch(client).await?;
 
-        Ok(signing::wrap_tx(
+        signing::wrap_tx(
             client,
             shielded,
             tx,
@@ -174,7 +174,7 @@ pub async fn prepare_tx<
             #[cfg(not(feature = "mainnet"))]
             requires_pow,
         )
-        .await)
+        .await
     } else {
         Ok(None)
     }

--- a/shared/src/types/error.rs
+++ b/shared/src/types/error.rs
@@ -189,6 +189,12 @@ pub enum TxError {
          to be transferred. Amount to transfer is {2} and the balance is {3}."
     )]
     BalanceTooLow(Address, Address, String, String),
+    /// Balance is too low for fee payment
+    #[error(
+        "The balance of the source {0} of token {1} is lower than the amount \
+         required for fees. Amount of the fees is {2} and the balance is {3}."
+    )]
+    BalanceTooLowForFees(Address, Address, String, String),
     /// Token Address does not exist on chain
     #[error("The token address {0} doesn't exist on chain.")]
     TokenDoesNotExist(Address),
@@ -213,6 +219,9 @@ pub enum TxError {
     /// No Balance found for token
     #[error("{0}")]
     MaspError(String),
+    /// Error in the fee unshielding transaction
+    #[error("Error in fee unshielding: {0}")]
+    FeeUnshieldingError(String),
     /// Wasm validation failed
     #[error("Validity predicate code validation failed with {0}")]
     WasmValidationFailure(WasmValidationError),


### PR DESCRIPTION
## Describe your changes

Removes some wrong `panic!` that were mistakenly brought into the sdk by the gas&fee pr.

## Indicate on which release or other PRs this topic is based on

v0.22.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
