### PR TITLE
Support validators' hostnames in config

### DIFF
--- a/.changelog/unreleased/improvements/1886-validators-by-hostnames.md
+++ b/.changelog/unreleased/improvements/1886-validators-by-hostnames.md
@@ -1,0 +1,2 @@
+- Added support for validators' hostnames in configuration.
+  ([\#1886](https://github.com/anoma/namada/pull/1886))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2455,7 +2455,6 @@ pub mod args {
     use std::collections::HashMap;
     use std::convert::TryFrom;
     use std::env;
-    use std::net::SocketAddr;
     use std::path::PathBuf;
     use std::str::FromStr;
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2611,7 +2611,7 @@ pub mod args {
         arg("max-commission-rate-change");
     pub const MAX_ETH_GAS: ArgOpt<u64> = arg_opt("max_eth-gas");
     pub const MODE: ArgOpt<String> = arg_opt("mode");
-    pub const NET_ADDRESS: Arg<SocketAddr> = arg("net-address");
+    pub const NET_ADDRESS: Arg<String> = arg("net-address");
     pub const NAMADA_START_TIME: ArgOpt<DateTimeUtc> = arg_opt("time");
     pub const NO_CONVERSIONS: ArgFlag = flag("no-conversions");
     pub const NUT: ArgFlag = flag("nut");
@@ -5567,7 +5567,7 @@ pub mod args {
         pub alias: String,
         pub commission_rate: Dec,
         pub max_commission_rate_change: Dec,
-        pub net_address: SocketAddr,
+        pub net_address: String,
         pub unsafe_dont_encrypt: bool,
         pub key_scheme: SchemeType,
     }

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
-use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -1050,7 +1049,7 @@ pub fn init_genesis_validator(
                 tendermint_node_key: Some(HexString(
                     pre_genesis.tendermint_node_key.ref_to().to_string(),
                 )),
-                net_address: Some(net_address.to_string()),
+                net_address: Some(net_address),
                 ..Default::default()
             },
         )]),

--- a/apps/src/lib/client/utils.rs
+++ b/apps/src/lib/client/utils.rs
@@ -799,8 +799,8 @@ pub fn init_network(
             config.ledger.cometbft.p2p.addr_book_strict = !localhost;
             // Clear the net address from the config and use it to set ports
             let net_address = validator_config.net_address.take().unwrap();
-            let _ip = SocketAddr::from_str(&net_address).unwrap().ip();
-            let first_port = SocketAddr::from_str(&net_address).unwrap().port();
+            let split: Vec<&str> = net_address.split(':').collect();
+            let first_port = split[1].parse::<u16>().unwrap();
             if localhost {
                 config.ledger.cometbft.p2p.laddr = TendermintAddress::from_str(
                     &format!("127.0.0.1:{}", first_port),

--- a/apps/src/lib/config/utils.rs
+++ b/apps/src/lib/config/utils.rs
@@ -47,8 +47,7 @@ fn num_of_threads_aux(
     }
 }
 
-// fixme: Handle this gracefully with either an Option or a Result. Ensure that
-// hostname resolution works.
+// FIXME: Handle this gracefully with either an Option or a Result.
 pub fn convert_tm_addr_to_socket_addr(
     tm_addr: &TendermintAddress,
 ) -> SocketAddr {

--- a/genesis/e2e-tests-single-node.toml
+++ b/genesis/e2e-tests-single-node.toml
@@ -18,7 +18,7 @@ validator_vp = "vp_validator"
 commission_rate = "0.05"
 # Maximum change per epoch in the commission rate
 max_commission_rate_change = "0.01"
-# Public IP:port address.
+# (Public IP | Hostname):port address.
 # We set the port to be the default+1000, so that if a local node was running at
 # the same time as the E2E tests, it wouldn't affect them.
 net_address = "127.0.0.1:27656"

--- a/tests/src/e2e/helpers.rs
+++ b/tests/src/e2e/helpers.rs
@@ -167,14 +167,9 @@ pub fn get_actor_rpc(test: &Test, who: &Who) -> String {
     };
     let config =
         Config::load(base_dir, &test.net.chain_id, Some(tendermint_mode));
-    let ip = convert_tm_addr_to_socket_addr(&config.ledger.cometbft.rpc.laddr)
-        .ip()
-        .to_string();
-    let port =
-        convert_tm_addr_to_socket_addr(&config.ledger.cometbft.rpc.laddr)
-            .port()
-            .to_string();
-    format!("{}:{}", ip, port)
+    let socket_addr =
+        convert_tm_addr_to_socket_addr(&config.ledger.cometbft.rpc.laddr);
+    format!("{}:{}", socket_addr.ip(), socket_addr.port())
 }
 
 /// Get the public key of the validator

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fmt::Display;
 use std::fs::{File, OpenOptions};
-use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
@@ -124,7 +123,7 @@ where
     let other_validators = validator_0.clone();
     let validator_0_target = validator_0.net_address.clone().unwrap();
     let split: Vec<&str> = validator_0_target.split(':').collect();
-    let (mut net_target_0, net_address_port_0) =
+    let (net_target_0, net_address_port_0) =
         (split[0], split[1].parse::<u16>().unwrap());
     for ix in 0..num {
         let mut validator = other_validators.clone();

--- a/tests/src/e2e/setup.rs
+++ b/tests/src/e2e/setup.rs
@@ -122,17 +122,17 @@ where
     let validator_0 = genesis.validator.get_mut("validator-0").unwrap();
     // Clone the first validator before modifying it
     let other_validators = validator_0.clone();
-    let net_address_0 =
-        SocketAddr::from_str(validator_0.net_address.as_ref().unwrap())
-            .unwrap();
-    let net_address_port_0 = net_address_0.port();
+    let validator_0_target = validator_0.net_address.clone().unwrap();
+    let split: Vec<&str> = validator_0_target.split(':').collect();
+    let (mut net_target_0, net_address_port_0) =
+        (split[0], split[1].parse::<u16>().unwrap());
     for ix in 0..num {
         let mut validator = other_validators.clone();
-        let mut net_address = net_address_0;
+        let mut net_target = net_target_0.to_string();
         // 6 ports for each validator
         let first_port = net_address_port_0 + port_offset(ix);
-        net_address.set_port(first_port);
-        validator.net_address = Some(net_address.to_string());
+        net_target = format!("{}:{}", net_target, first_port);
+        validator.net_address = Some(net_target.to_string());
         let name = format!("validator-{}", ix);
         genesis.validator.insert(name, validator);
     }


### PR DESCRIPTION
## Describe your changes

Closes #576.
Closes #929.

Allows the usage of hostnames instead of IP addresses for validators in configuration.

## Indicate on which release or other PRs this topic is based on

v0.22.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
