### PR TITLE
Validate txs moving 0 value to the Bridge pool

### DIFF
--- a/.changelog/unreleased/improvements/1892-bridge-pool-zero-fees.md
+++ b/.changelog/unreleased/improvements/1892-bridge-pool-zero-fees.md
@@ -1,0 +1,2 @@
+- Allow Bridge pool transfers to pay zero gas fees
+  ([\#1892](https://github.com/anoma/namada/pull/1892))


### PR DESCRIPTION
## Describe your changes

This patch makes the ledger validate Bridge pool transfers that move no value (either gas fees, or token amounts). This is not necessarily an incorrect behavior per se, albeit an unlikely one, with honest actors in the system. Might be useful to some people, though.

## Indicate on which release or other PRs this topic is based on

`v0.22.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
