### PR TITLE
Never overwrite recent Bridge pool proofs in storage

### DIFF
--- a/.changelog/unreleased/bug-fixes/1893-bridge-pool-roots-signing.md
+++ b/.changelog/unreleased/bug-fixes/1893-bridge-pool-roots-signing.md
@@ -1,0 +1,2 @@
+- Never overwrite recent Bridge pool proofs in storage
+  ([\#1893](https://github.com/anoma/namada/pull/1893))

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -497,6 +497,13 @@ impl Key {
         Ok(Key { segments })
     }
 
+    /// Takes ownership of the key, appends a new segment to it,
+    /// and returns the modified key.
+    pub fn with_segment<T: KeySeg>(mut self, other: T) -> Self {
+        self.segments.push(other.to_db_key());
+        self
+    }
+
     /// Returns a new key with segments of `Self` and the given key
     pub fn join(&self, other: &Key) -> Self {
         let mut segments = self.segments.clone();

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -499,6 +499,7 @@ impl Key {
 
     /// Takes ownership of the key, appends a new segment to it,
     /// and returns the modified key.
+    #[must_use]
     pub fn with_segment<T: KeySeg>(mut self, other: T) -> Self {
         self.segments.push(other.to_db_key());
         self

--- a/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
+++ b/ethereum_bridge/src/protocol/transactions/bridge_pool_roots.rs
@@ -90,6 +90,10 @@ where
                 true
             });
         if should_write_root {
+            tracing::debug!(
+                ?root_height,
+                "New Bridge pool root proof acquired"
+            );
             wl_storage
                 .write(&signed_root_key, (proof, root_height))
                 .expect(
@@ -97,6 +101,11 @@ where
                      fail.",
                 );
             changed.insert(get_signed_root_key());
+        } else {
+            tracing::debug!(
+                ?root_height,
+                "Discarding outdated Bridge pool root proof"
+            );
         }
     }
 

--- a/ethereum_bridge/src/storage/vote_tallies.rs
+++ b/ethereum_bridge/src/storage/vote_tallies.rs
@@ -189,7 +189,7 @@ impl From<&Hash> for Keys<EthereumEvent> {
 
 /// A wrapper struct for managing keys related to
 /// tracking signatures over bridge pool roots and nonces.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct BridgePoolRoot(pub BridgePoolRootProof);
 
 impl BorshSerialize for BridgePoolRoot {

--- a/ethereum_bridge/src/storage/vote_tallies.rs
+++ b/ethereum_bridge/src/storage/vote_tallies.rs
@@ -8,8 +8,8 @@ use namada_core::ledger::eth_bridge::ADDRESS;
 use namada_core::types::address::Address;
 use namada_core::types::ethereum_events::{EthereumEvent, Uint};
 use namada_core::types::hash::Hash;
-use namada_core::types::keccak::KeccakHash;
-use namada_core::types::storage::{DbKeySeg, Epoch, Key};
+use namada_core::types::keccak::{keccak_hash, KeccakHash};
+use namada_core::types::storage::{BlockHeight, DbKeySeg, Epoch, Key};
 use namada_core::types::vote_extensions::validator_set_update::VotingPowersMap;
 use namada_macros::StorageKeys;
 
@@ -207,25 +207,27 @@ impl BorshDeserialize for BridgePoolRoot {
     }
 }
 
-impl<'a> From<&'a BridgePoolRoot> for Keys<BridgePoolRoot> {
-    fn from(bp_root: &BridgePoolRoot) -> Self {
-        let hash = [bp_root.0.data.0.to_string(), bp_root.0.data.1.to_string()]
-            .concat();
+impl From<(&BridgePoolRoot, BlockHeight)> for Keys<BridgePoolRoot> {
+    fn from(
+        (BridgePoolRoot(bp_root), root_height): (&BridgePoolRoot, BlockHeight),
+    ) -> Self {
+        let hash = {
+            let (KeccakHash(root), nonce) = &bp_root.data;
+
+            let mut to_hash = [0u8; 64];
+            to_hash[..32].copy_from_slice(root);
+            to_hash[32..].copy_from_slice(&nonce.to_bytes());
+
+            keccak_hash(to_hash).to_string()
+        };
         let prefix = super::prefix()
-            .push(&BRIDGE_POOL_ROOT_PREFIX_KEY_SEGMENT.to_owned())
-            .expect("should always be able to construct this key")
-            .push(&hash)
-            .expect("should always be able to construct this key");
+            .with_segment(BRIDGE_POOL_ROOT_PREFIX_KEY_SEGMENT.to_owned())
+            .with_segment(root_height)
+            .with_segment(hash);
         Keys {
             prefix,
             _phantom: std::marker::PhantomData,
         }
-    }
-}
-
-impl From<BridgePoolRoot> for Keys<BridgePoolRoot> {
-    fn from(bp_root: BridgePoolRoot) -> Self {
-        Self::from(&bp_root)
     }
 }
 

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -1210,9 +1210,10 @@ mod tests {
         apply_eth_tx(tx.clone(), &mut wl_storage)?;
         apply_eth_tx(tx, &mut wl_storage)?;
 
-        let bp_root_keys = vote_tallies::Keys::from(
-            vote_tallies::BridgePoolRoot(EthereumProof::new((root, nonce))),
-        );
+        let bp_root_keys = vote_tallies::Keys::from((
+            &vote_tallies::BridgePoolRoot(EthereumProof::new((root, nonce))),
+            100.into(),
+        ));
         let root_seen_by_bytes =
             wl_storage.read_bytes(&bp_root_keys.seen_by())?;
         assert_eq!(


### PR DESCRIPTION
## Describe your changes

Only write signed Bridge pool proofs to storage if they are more recent than the previously available proof in storage.

## Indicate on which release or other PRs this topic is based on

`v0.22.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
