### PR TITLE
Makes async traits in the SDK be `Send`

### DIFF
--- a/.changelog/unreleased/SDK/1894-sdk-async-traits-send.md
+++ b/.changelog/unreleased/SDK/1894-sdk-async-traits-send.md
@@ -1,0 +1,3 @@
+- Added the `Send` bound to the `Client` and `ShieldedUtils` `async_trait`s'.
+  This allows the SDK to be used in environments which are both asynchronous and
+  multithread. ([\#1894](https://github.com/anoma/namada/pull/1894))

--- a/.changelog/unreleased/improvements/1894-sdk-async-traits-send.md
+++ b/.changelog/unreleased/improvements/1894-sdk-async-traits-send.md
@@ -1,0 +1,2 @@
+- Forced the `async_trait`s' futures in the SDK to be `Send`.
+  ([\#1894](https://github.com/anoma/namada/pull/1894))

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -4,7 +4,6 @@ use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use async_trait::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize};
 use masp_proofs::prover::LocalTxProver;
 use namada::core::ledger::governance::cli::offline::{
@@ -574,7 +573,8 @@ impl Default for CLIShieldedUtils {
     }
 }
 
-#[async_trait]
+#[cfg_attr(feature = "async-send", async_trait::async_trait)]
+#[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
 impl masp::ShieldedUtils for CLIShieldedUtils {
     fn local_tx_prover(&self) -> LocalTxProver {
         if let Ok(params_dir) = env::var(masp::ENV_VAR_MASP_PARAMS_DIR) {

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -574,7 +574,7 @@ impl Default for CLIShieldedUtils {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl masp::ShieldedUtils for CLIShieldedUtils {
     fn local_tx_prover(&self) -> LocalTxProver {
         if let Ok(params_dir) = env::var(masp::ENV_VAR_MASP_PARAMS_DIR) {

--- a/apps/src/lib/node/ledger/shell/testing/node.rs
+++ b/apps/src/lib/node/ledger/shell/testing/node.rs
@@ -308,7 +308,7 @@ impl MockNode {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl<'a> Client for &'a MockNode {
     type Error = Report;
 

--- a/apps/src/lib/node/ledger/shell/testing/node.rs
+++ b/apps/src/lib/node/ledger/shell/testing/node.rs
@@ -308,7 +308,8 @@ impl MockNode {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-send", async_trait::async_trait)]
+#[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
 impl<'a> Client for &'a MockNode {
     type Error = Report;
 

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -550,7 +550,8 @@ pub struct BenchShieldedUtils {
     context_dir: WrapperTempDir,
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-send", async_trait::async_trait)]
+#[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
 impl ShieldedUtils for BenchShieldedUtils {
     fn local_tx_prover(&self) -> LocalTxProver {
         if let Ok(params_dir) = std::env::var(masp::ENV_VAR_MASP_PARAMS_DIR) {
@@ -614,7 +615,8 @@ impl ShieldedUtils for BenchShieldedUtils {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-send", async_trait::async_trait)]
+#[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
 impl Client for BenchShell {
     type Error = std::io::Error;
 

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -550,7 +550,7 @@ pub struct BenchShieldedUtils {
     context_dir: WrapperTempDir,
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl ShieldedUtils for BenchShieldedUtils {
     fn local_tx_prover(&self) -> LocalTxProver {
         if let Ok(params_dir) = std::env::var(masp::ENV_VAR_MASP_PARAMS_DIR) {
@@ -614,7 +614,7 @@ impl ShieldedUtils for BenchShieldedUtils {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl Client for BenchShell {
     type Error = std::io::Error;
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -42,6 +42,10 @@ wasm-runtime = [
 async-client = [
   "async-trait",
 ]
+
+# Requires async traits to be safe to send across threads
+async-send = []
+
 # tendermint-rpc support
 tendermint-rpc = [
   "async-client",

--- a/shared/src/ledger/masp.rs
+++ b/shared/src/ledger/masp.rs
@@ -7,7 +7,6 @@ use std::fmt::Debug;
 use std::ops::Deref;
 use std::path::PathBuf;
 
-use async_trait::async_trait;
 // use async_std::io::prelude::WriteExt;
 // use async_std::io::{self};
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -388,7 +387,8 @@ impl<P1, R1, N1>
 
 /// Abstracts platform specific details away from the logic of shielded pool
 /// operations.
-#[async_trait]
+#[cfg_attr(feature = "async-send", async_trait::async_trait)]
+#[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
 pub trait ShieldedUtils:
     Sized + BorshDeserialize + BorshSerialize + Default + Clone
 {

--- a/shared/src/ledger/masp.rs
+++ b/shared/src/ledger/masp.rs
@@ -388,7 +388,7 @@ impl<P1, R1, N1>
 
 /// Abstracts platform specific details away from the logic of shielded pool
 /// operations.
-#[async_trait(? Send)]
+#[async_trait]
 pub trait ShieldedUtils:
     Sized + BorshDeserialize + BorshSerialize + Default + Clone
 {

--- a/shared/src/ledger/queries/mod.rs
+++ b/shared/src/ledger/queries/mod.rs
@@ -172,7 +172,7 @@ mod testing {
         }
     }
 
-    #[async_trait::async_trait(?Send)]
+    #[async_trait::async_trait]
     impl<RPC> Client for TestClient<RPC>
     where
         RPC: Router + Sync,

--- a/shared/src/ledger/queries/mod.rs
+++ b/shared/src/ledger/queries/mod.rs
@@ -172,7 +172,8 @@ mod testing {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-send", async_trait::async_trait)]
+    #[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
     impl<RPC> Client for TestClient<RPC>
     where
         RPC: Router + Sync,

--- a/shared/src/ledger/queries/types.rs
+++ b/shared/src/ledger/queries/types.rs
@@ -81,7 +81,8 @@ pub trait Router {
 /// A client with async request dispatcher method, which can be used to invoke
 /// type-safe methods from a root [`Router`], generated via `router!` macro.
 #[cfg(any(test, feature = "async-client"))]
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-send", async_trait::async_trait)]
+#[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
 pub trait Client {
     /// `std::io::Error` can happen in decoding with
     /// `BorshDeserialize::try_from_slice`
@@ -306,7 +307,8 @@ pub enum Error {
     InvalidHeight(BlockHeight),
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-send", async_trait::async_trait)]
+#[cfg_attr(not(feature = "async-send"), async_trait::async_trait(?Send))]
 impl<C: tendermint_rpc::Client + std::marker::Sync> Client for C {
     type Error = Error;
 

--- a/shared/src/ledger/queries/types.rs
+++ b/shared/src/ledger/queries/types.rs
@@ -81,7 +81,7 @@ pub trait Router {
 /// A client with async request dispatcher method, which can be used to invoke
 /// type-safe methods from a root [`Router`], generated via `router!` macro.
 #[cfg(any(test, feature = "async-client"))]
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 pub trait Client {
     /// `std::io::Error` can happen in decoding with
     /// `BorshDeserialize::try_from_slice`
@@ -306,7 +306,7 @@ pub enum Error {
     InvalidHeight(BlockHeight),
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl<C: tendermint_rpc::Client + std::marker::Sync> Client for C {
     type Error = Error;
 


### PR DESCRIPTION
## Describe your changes

Requires the `Send` bound on the `async_traits`s in the SDK. This allow the usage of the SDK in an environment which is both async and multithread (see https://rust-lang.github.io/async-book/07_workarounds/03_send_approximation.html).

## Indicate on which release or other PRs this topic is based on

v0.22.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
