### PR TITLE
fix and check namada_ethereum_bridge crate build with default features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ audit-ignores += RUSTSEC-2021-0076
 crates := namada_core
 crates += namada
 crates += namada_apps
+crates += namada_ethereum_bridge
 crates += namada_encoding_spec
 crates += namada_macros
 crates += namada_proof_of_stake

--- a/ethereum_bridge/Cargo.toml
+++ b/ethereum_bridge/Cargo.toml
@@ -45,6 +45,8 @@ tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs.git", rev 
 tracing = "0.1.30"
 
 [dev-dependencies]
+# Added "testing" feature.
+namada_core = {path = "../core", default-features = false, features = ["secp256k1-sign", "ferveo-tpke", "ethers-derive", "testing"]}
 assert_matches.workspace = true
 data-encoding.workspace = true
 ethabi.workspace = true


### PR DESCRIPTION
## Describe your changes

Enables to e.g. `cd ethereum_bridge && cargo test` with default features

## Indicate on which release or other PRs this topic is based on: 0.22

## Checklist before merging to `draft`
- ~~[ ] I have added a changelog~~
- [x] Git history is in acceptable state
