### PR TITLE
Dummy PoW solution field for hardware wallet

### DIFF
--- a/.changelog/unreleased/bug-fixes/1949-pow-solution-fix.md
+++ b/.changelog/unreleased/bug-fixes/1949-pow-solution-fix.md
@@ -1,0 +1,2 @@
+- Reintroduced a dummy field in order to achieve compatibility with hardware
+  wallet. ([\#1949](https://github.com/anoma/namada/pull/1949))

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -1000,7 +1000,7 @@ mod test_process_proposal {
     use namada::types::token;
     use namada::types::token::Amount;
     use namada::types::transaction::protocol::EthereumTxData;
-    use namada::types::transaction::{Fee, WrapperTx};
+    use namada::types::transaction::{Fee, Solution, WrapperTx};
     #[cfg(feature = "abcipp")]
     use namada::types::vote_extensions::bridge_pool_roots::MultiSignedVext;
     #[cfg(feature = "abcipp")]
@@ -2005,6 +2005,7 @@ mod test_process_proposal {
             epoch: Epoch(0),
             gas_limit: GAS_LIMIT_MULTIPLIER.into(),
             unshield_section_hash: None,
+            pow_solution: Solution::None,
         };
 
         let tx = Tx::from_type(TxType::Wrapper(Box::new(wrapper)));

--- a/core/src/types/transaction/wrapper.rs
+++ b/core/src/types/transaction/wrapper.rs
@@ -164,6 +164,21 @@ pub mod wrapper_tx {
         }
     }
 
+    /// A degenerate PoW solution type
+    #[derive(
+        Debug,
+        Clone,
+        BorshSerialize,
+        BorshDeserialize,
+        BorshSchema,
+        Serialize,
+        Deserialize,
+    )]
+    pub enum Solution {
+        /// No PoW solution
+        None,
+    }
+
     /// A transaction with an encrypted payload, an optional shielded pool
     /// unshielding tx for fee payment and some non-encrypted metadata for
     /// inclusion and / or verification purposes
@@ -190,6 +205,8 @@ pub mod wrapper_tx {
         /// The hash of the optional, unencrypted, unshielding transaction for
         /// fee payment
         pub unshield_section_hash: Option<Hash>,
+        /// Mandatory 0x00 byte for deprecated field
+        pub pow_solution: Solution,
     }
 
     impl WrapperTx {
@@ -211,6 +228,7 @@ pub mod wrapper_tx {
                 epoch,
                 gas_limit,
                 unshield_section_hash: unshield_hash,
+                pow_solution: Solution::None,
             }
         }
 


### PR DESCRIPTION
## Describe your changes
Removal of the `pub pow_solution: Option<crate::ledger::testnet_pow::Solution>` field from `WrapperTx` broke hardware wallet support for Namada `Tx`s. This PR reintroduces the field, albeit in a degenerate form.

## Indicate on which release or other PRs this topic is based on
v0.23.0 .

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
