### PR TITLE
avoid enabling "testing" feature in workspace from benches

### DIFF
--- a/.changelog/unreleased/improvements/1955-avoid-testing-feature-in-workspace.md
+++ b/.changelog/unreleased/improvements/1955-avoid-testing-feature-in-workspace.md
@@ -1,0 +1,3 @@
+- Refactor benchmarks to avoid enabling `"testing`" and `"dev"`` features by 
+  default in the workspace.
+  ([\#1955](https://github.com/anoma/namada/pull/1955))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4167,22 +4167,14 @@ dependencies = [
 name = "namada_benchmarks"
 version = "0.23.0"
 dependencies = [
- "async-trait",
  "borsh 0.9.4",
  "criterion",
  "ferveo-common",
- "masp_primitives",
- "masp_proofs",
  "namada",
  "namada_apps",
- "namada_test_utils",
- "prost",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "sha2 0.9.9",
- "tempfile",
- "tokio",
- "tracing-subscriber 0.3.17",
 ]
 
 [[package]]

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -57,7 +57,7 @@ mainnet = [
 dev = ["namada/dev"]
 std = ["ed25519-consensus/std", "rand/std", "rand_core/std", "namada/std"]
 # for integration tests and test utilies
-testing = ["dev"]
+testing = ["dev", "namada_test_utils"]
 
 abciplus = [
     "namada/abciplus",
@@ -67,6 +67,7 @@ abciplus = [
 
 [dependencies]
 namada = {path = "../shared", features = ["ferveo-tpke", "masp-tx-gen", "multicore", "http-client"]}
+namada_test_utils = {path = "../test_utils", optional = true}
 ark-serialize.workspace = true
 ark-std.workspace = true
 arse-merkle-tree = { workspace = true, features = ["blake2b"] }

--- a/apps/src/lib/bench_utils.rs
+++ b/apps/src/lib/bench_utils.rs
@@ -1,18 +1,5 @@
-//! Benchmarks module based on criterion.
-//!
-//! Measurements are taken on the elapsed wall-time.
-//!
-//! The benchmarks only focus on sucessfull transactions and vps: in case of
-//! failure, the bench function shall panic to avoid timing incomplete execution
-//! paths.
-//!
-//! In addition, this module also contains benchmarks for
-//! [`WrapperTx`][`namada::core::types::transaction::wrapper::WrapperTx`]
-//! validation and [`host_env`][`namada::vm::host_env`] exposed functions that
-//! define the gas constants of [`gas`][`namada::core::ledger::gas`].
-//!
-//! For more realistic results these benchmarks should be run on all the
-//! combination of supported OS/architecture.
+//! Library code for benchmarks provides a wrapper of the ledger's shell
+//! `BenchShell` and helper functions to generate transactions.
 
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};

--- a/apps/src/lib/bench_utils.rs
+++ b/apps/src/lib/bench_utils.rs
@@ -91,19 +91,20 @@ use namada::types::transaction::governance::InitProposalData;
 use namada::types::transaction::pos::Bond;
 use namada::types::transaction::GasLimit;
 use namada::vm::wasm::run;
-use namada_apps::cli::args::{Tx as TxArgs, TxTransfer};
-use namada_apps::cli::context::FromContext;
-use namada_apps::cli::Context;
-use namada_apps::config::TendermintMode;
-use namada_apps::facade::tendermint_proto::abci::RequestInitChain;
-use namada_apps::facade::tendermint_proto::google::protobuf::Timestamp;
-use namada_apps::node::ledger::shell::Shell;
-use namada_apps::wallet::{defaults, CliWalletUtils};
-use namada_apps::{config, wasm_loader};
 use namada_test_utils::tx_data::TxWriteData;
 use rand_core::OsRng;
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
+
+use crate::cli::args::{Tx as TxArgs, TxTransfer};
+use crate::cli::context::FromContext;
+use crate::cli::Context;
+use crate::config::TendermintMode;
+use crate::facade::tendermint_proto::abci::RequestInitChain;
+use crate::facade::tendermint_proto::google::protobuf::Timestamp;
+use crate::node::ledger::shell::Shell;
+use crate::wallet::{defaults, CliWalletUtils};
+use crate::{config, wasm_loader};
 
 pub const WASM_DIR: &str = "../wasm";
 pub const TX_BOND_WASM: &str = "tx_bond.wasm";
@@ -681,13 +682,12 @@ impl Default for BenchShieldedCtx {
     fn default() -> Self {
         let mut shell = BenchShell::default();
 
-        let mut ctx =
-            Context::new::<DefaultIo>(namada_apps::cli::args::Global {
-                chain_id: None,
-                base_dir: shell.tempdir.as_ref().canonicalize().unwrap(),
-                wasm_dir: Some(WASM_DIR.into()),
-            })
-            .unwrap();
+        let mut ctx = Context::new::<DefaultIo>(crate::cli::args::Global {
+            chain_id: None,
+            base_dir: shell.tempdir.as_ref().canonicalize().unwrap(),
+            wasm_dir: Some(WASM_DIR.into()),
+        })
+        .unwrap();
 
         // Generate spending key for Albert and Bertha
         ctx.wallet.gen_spending_key(
@@ -700,7 +700,7 @@ impl Default for BenchShieldedCtx {
             None,
             true,
         );
-        namada_apps::wallet::save(&ctx.wallet).unwrap();
+        crate::wallet::save(&ctx.wallet).unwrap();
 
         // Generate payment addresses for both Albert and Bertha
         for (alias, viewing_alias) in [
@@ -732,7 +732,7 @@ impl Default for BenchShieldedCtx {
                 .unwrap();
         }
 
-        namada_apps::wallet::save(&ctx.wallet).unwrap();
+        crate::wallet::save(&ctx.wallet).unwrap();
         namada::ledger::storage::update_allowed_conversions(
             &mut shell.wl_storage,
         )

--- a/apps/src/lib/config/genesis.rs
+++ b/apps/src/lib/config/genesis.rs
@@ -15,7 +15,6 @@ use namada::types::key::dkg_session_keys::DkgPublicKey;
 use namada::types::key::*;
 use namada::types::time::{DateTimeUtc, DurationSecs};
 use namada::types::token::Denomination;
-use namada::types::uint::Uint;
 use namada::types::{storage, token};
 
 /// Genesis configuration file format
@@ -908,6 +907,7 @@ pub fn genesis(num_validators: u64) -> Genesis {
     };
     use namada::types::ethereum_events::testing::DAI_ERC20_ETH_ADDRESS;
     use namada::types::ethereum_events::EthAddress;
+    use namada::types::uint::Uint;
 
     use crate::wallet;
 

--- a/apps/src/lib/mod.rs
+++ b/apps/src/lib/mod.rs
@@ -5,6 +5,8 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
 
+#[cfg(feature = "testing")]
+pub mod bench_utils;
 pub mod cli;
 pub mod client;
 pub mod config;

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,10 +12,6 @@ readme.workspace = true
 repository.workspace = true
 version.workspace = true
 
-[lib]
-name = "namada_benches"
-path = "lib.rs"
-
 [[bench]]
 name = "whitelisted_txs"
 harness = false
@@ -42,21 +38,21 @@ harness = false
 path = "host_env.rs"
 
 [dependencies]
-async-trait.workspace = true
-borsh.workspace = true
-ferveo-common.workspace = true
-masp_primitives.workspace = true
-masp_proofs.workspace = true
+
+[dev-dependencies]
 namada = { path = "../shared", features = ["testing"] }
 namada_apps = { path = "../apps", features = ["testing"] }
 namada_test_utils = { path = "../test_utils" }
-prost.workspace = true
-rand.workspace = true
-rand_core.workspace = true
-sha2.workspace = true
-tokio.workspace = true
-tempfile.workspace = true
-tracing-subscriber = { workspace = true, features = ["std"]}
-
-[dev-dependencies]
+async-trait.workspace = true
+borsh.workspace = true
 criterion = { version = "0.5", features = ["html_reports"] }
+ferveo-common.workspace = true
+masp_primitives.workspace = true
+masp_proofs.workspace = true
+prost.workspace = true
+rand_core.workspace = true
+rand.workspace = true
+sha2.workspace = true
+tempfile.workspace = true
+tokio.workspace = true
+tracing-subscriber = { workspace = true, features = ["std"]}

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -42,17 +42,9 @@ path = "host_env.rs"
 [dev-dependencies]
 namada = { path = "../shared", features = ["testing"] }
 namada_apps = { path = "../apps", features = ["testing"] }
-namada_test_utils = { path = "../test_utils" }
-async-trait.workspace = true
 borsh.workspace = true
 criterion = { version = "0.5", features = ["html_reports"] }
 ferveo-common.workspace = true
-masp_primitives.workspace = true
-masp_proofs.workspace = true
-prost.workspace = true
 rand_core.workspace = true
 rand.workspace = true
 sha2.workspace = true
-tempfile.workspace = true
-tokio.workspace = true
-tracing-subscriber = { workspace = true, features = ["std"]}

--- a/benches/README.md
+++ b/benches/README.md
@@ -2,6 +2,16 @@
 
 The benchmarks are built with [criterion.rs](https://bheisler.github.io/criterion.rs/book).
 
+Measurements are taken on the elapsed wall-time.
+
+The benchmarks only focus on sucessfull transactions and vps: in case of failure, the bench function shall panic to avoid timing incomplete execution paths.
+
+In addition, this crate also contains benchmarks for `WrapperTx` (`namada::core::types::transaction::wrapper::WrapperTx`) validation and `host_env` (`namada::vm::host_env`) exposed functions that define the gas constants of `gas` (`namada::core::ledger::gas`).
+
+For more realistic results these benchmarks should be run on all the combination of supported OS/architecture.
+
+## Testing & running
+
 To enable tracing logs, run with e.g. `RUST_LOG=debug`.
 
 To ensure that the benches can run successfully without performing measurement, you can run `make test-benches` from the workspace run.

--- a/benches/native_vps.rs
+++ b/benches/native_vps.rs
@@ -32,12 +32,12 @@ use namada::types::storage::{Epoch, TxIndex};
 use namada::types::transaction::governance::{
     InitProposalData, VoteProposalData,
 };
-use namada_apps::wallet::defaults;
-use namada_benches::{
+use namada_apps::bench_utils::{
     generate_foreign_key_tx, generate_ibc_transfer_tx, generate_ibc_tx,
     generate_tx, BenchShell, TX_IBC_WASM, TX_INIT_PROPOSAL_WASM,
     TX_TRANSFER_WASM, TX_VOTE_PROPOSAL_WASM,
 };
+use namada_apps::wallet::defaults;
 
 fn replay_protection(c: &mut Criterion) {
     // Write a random key under the replay protection subspace

--- a/benches/process_wrapper.rs
+++ b/benches/process_wrapper.rs
@@ -7,9 +7,9 @@ use namada::types::key::RefTo;
 use namada::types::storage::BlockHeight;
 use namada::types::time::DateTimeUtc;
 use namada::types::transaction::{Fee, WrapperTx};
+use namada_apps::bench_utils::{generate_tx, BenchShell, TX_TRANSFER_WASM};
 use namada_apps::node::ledger::shell::process_proposal::ValidationMeta;
 use namada_apps::wallet::defaults;
-use namada_benches::{generate_tx, BenchShell, TX_TRANSFER_WASM};
 
 fn process_tx(c: &mut Criterion) {
     let mut shell = BenchShell::default();

--- a/benches/txs.rs
+++ b/benches/txs.rs
@@ -22,14 +22,14 @@ use namada::types::transaction::governance::{
 };
 use namada::types::transaction::pos::{Bond, CommissionChange, Withdraw};
 use namada::types::transaction::EllipticCurve;
-use namada_apps::wallet::defaults;
-use namada_benches::{
+use namada_apps::bench_utils::{
     generate_ibc_transfer_tx, generate_tx, BenchShell, BenchShieldedCtx,
     ALBERT_PAYMENT_ADDRESS, ALBERT_SPENDING_KEY, BERTHA_PAYMENT_ADDRESS,
     TX_BOND_WASM, TX_CHANGE_VALIDATOR_COMMISSION_WASM, TX_INIT_PROPOSAL_WASM,
     TX_REVEAL_PK_WASM, TX_UNBOND_WASM, TX_UNJAIL_VALIDATOR_WASM,
     TX_UPDATE_ACCOUNT_WASM, TX_VOTE_PROPOSAL_WASM, VP_VALIDATOR_WASM,
 };
+use namada_apps::wallet::defaults;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use sha2::Digest;

--- a/benches/vps.rs
+++ b/benches/vps.rs
@@ -19,14 +19,14 @@ use namada::types::storage::{Key, TxIndex};
 use namada::types::transaction::governance::VoteProposalData;
 use namada::types::transaction::pos::{Bond, CommissionChange};
 use namada::vm::wasm::run;
-use namada_apps::wallet::defaults;
-use namada_benches::{
+use namada_apps::bench_utils::{
     generate_foreign_key_tx, generate_tx, BenchShell, BenchShieldedCtx,
     ALBERT_PAYMENT_ADDRESS, ALBERT_SPENDING_KEY, BERTHA_PAYMENT_ADDRESS,
     TX_BOND_WASM, TX_CHANGE_VALIDATOR_COMMISSION_WASM, TX_REVEAL_PK_WASM,
     TX_TRANSFER_WASM, TX_UNBOND_WASM, TX_UPDATE_ACCOUNT_WASM,
     TX_VOTE_PROPOSAL_WASM, VP_VALIDATOR_WASM,
 };
+use namada_apps::wallet::defaults;
 use sha2::Digest;
 
 const VP_USER_WASM: &str = "vp_user.wasm";


### PR DESCRIPTION
## Describe your changes

The changes from #1907 inadvertently affected the whole workspace as benches have non-dev dependency on `namada` and `namada_apps` with `"testing"` feature on, which in turn enables the `"dev"` feature. This means that in 0.23.0 building from the root would switch on these features by default even for the build of the binaries (e.g. `cargo build` or `cargo run`).

- To fix this 0613ac2c3a1bcc749cb4f1112e1b923220f76c5d moves the library code of benches that requires the `"testing"` feature into namada_apps crate and feature-guard it with the same feature `"testing"`. This allowed to switch all the `[dependencies]` in benches to `[dev-dependencies]` and so the workspace build is no longer affected by these.
- 4dc0304d2f38ac49c0779000f61b77baf6eecece - updates docs for bench
- 5aaa83e6a8d3d520df244c7947d6f188c6c485c7 - removes deps from benches that are no longer needed

## Indicate on which release or other PRs this topic is based on

0.23.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
