### PR TITLE
Add `ZeroizeOnDrop` to ed25519 keys

### DIFF
--- a/.changelog/unreleased/miscellaneous/1958-k256.md
+++ b/.changelog/unreleased/miscellaneous/1958-k256.md
@@ -1,0 +1,2 @@
+- Switched from using `libsecp256k1` to `k256` crate.
+  ([\#1958](https://github.com/anoma/namada/pull/1958))

--- a/.changelog/unreleased/miscellaneous/1958-zeroize-secret-keys.md
+++ b/.changelog/unreleased/miscellaneous/1958-zeroize-secret-keys.md
@@ -1,0 +1,2 @@
+- Tag `ed25519` keys with `ZeroizeOnDrop`
+  ([\#1958](https://github.com/anoma/namada/pull/1958))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,6 +1832,7 @@ dependencies = [
  "digest 0.10.6",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature 2.1.0",
  "spki",
 ]
@@ -1898,6 +1899,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -3033,17 +3035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.7",
- "hmac 0.8.1",
-]
-
-[[package]]
 name = "hmac-sha512"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3482,6 +3473,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2 0.10.6",
  "signature 2.1.0",
 ]
@@ -3587,55 +3579,11 @@ dependencies = [
  "arrayref",
  "crunchy",
  "digest 0.8.1",
- "hmac-drbg 0.2.0",
+ "hmac-drbg",
  "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.1",
  "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "arrayref",
- "base64 0.13.1",
- "digest 0.9.0",
- "hmac-drbg 0.3.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.5",
- "serde 1.0.163",
- "sha2 0.9.9",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle 2.4.1",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "libsecp256k1-core",
 ]
 
 [[package]]
@@ -4028,7 +3976,7 @@ dependencies = [
  "eyre",
  "futures",
  "itertools",
- "libsecp256k1 0.7.0",
+ "k256",
  "loupe",
  "masp_primitives",
  "masp_proofs",
@@ -4211,7 +4159,7 @@ dependencies = [
  "impl-num-traits",
  "index-set",
  "itertools",
- "libsecp256k1 0.7.0",
+ "k256",
  "masp_primitives",
  "namada_macros",
  "num-integer",
@@ -6033,6 +5981,7 @@ dependencies = [
  "der",
  "generic-array 0.14.7",
  "pkcs8",
+ "serdect",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -6209,6 +6158,16 @@ dependencies = [
  "linked-hash-map",
  "serde 1.0.163",
  "yaml-rust",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -6804,7 +6763,7 @@ checksum = "01b874a4992538d4b2f4fbbac11b9419d685f4b39bdc3fed95b04e07bfd76040"
 dependencies = [
  "base58 0.1.0",
  "hmac 0.7.1",
- "libsecp256k1 0.3.5",
+ "libsecp256k1",
  "memzero",
  "sha2 0.8.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,10 +85,10 @@ git2 = "0.13.25"
 ics23 = "0.9.0"
 index-set = {git = "https://github.com/heliaxdev/index-set", tag = "v0.7.1", features = ["serialize-borsh", "serialize-serde"]}
 itertools = "0.10.0"
+k256 = { version = "0.13.0", default-features = false, features = ["ecdsa", "pkcs8", "precomputed-tables", "serde", "std"]}
 lazy_static = "1.4.0"
 libc = "0.2.97"
 libloading = "0.7.2"
-libsecp256k1 = {git = "https://github.com/heliaxdev/libsecp256k1", rev = "bbb3bd44a49db361f21d9db80f9a087c194c0ae9", default-features = false, features = ["std", "static-context"]}
 # branch = "murisi/namada-integration"
 masp_primitives = { git = "https://github.com/anoma/masp", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e" }
 masp_proofs = { git = "https://github.com/anoma/masp", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e", default-features = false, features = ["local-prover"] }

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1612,11 +1612,11 @@ mod test_utils {
                 ref sig,
                 ref recovery_id,
             )) => {
-                let mut sig_bytes = sig.serialize();
-                let recovery_id_bytes = recovery_id.serialize();
+                let mut sig_bytes = sig.to_vec();
+                let recovery_id_bytes = recovery_id.to_byte();
                 sig_bytes[0] = sig_bytes[0].wrapping_add(1);
                 let bytes: [u8; 65] =
-                    [sig_bytes.as_slice(), [recovery_id_bytes].as_slice()]
+                    [sig_bytes.as_slice(), &[recovery_id_bytes]]
                         .concat()
                         .try_into()
                         .unwrap();

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,11 +25,6 @@ ferveo-tpke = [
 wasm-runtime = [
   "rayon",
 ]
-# secp256k1 key signing, disabled in WASM build by default as it bloats the 
-# build a lot
-secp256k1-sign = [
-  "libsecp256k1/hmac",
-]
 
 abciplus = [
   "ibc",
@@ -78,7 +73,7 @@ ics23.workspace = true
 impl-num-traits = "0.1.2"
 index-set.workspace = true
 itertools.workspace = true
-libsecp256k1.workspace = true
+k256.workspace = true
 masp_primitives.workspace = true
 num256.workspace = true
 num-integer = "0.1.45"
@@ -104,7 +99,6 @@ zeroize.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
-libsecp256k1 = {workspace = true, features = ["hmac"]}
 pretty_assertions.workspace = true
 proptest.workspace = true
 rand.workspace = true

--- a/core/src/types/key/ed25519.rs
+++ b/core/src/types/key/ed25519.rs
@@ -10,7 +10,7 @@ use data_encoding::HEXLOWER;
 #[cfg(feature = "rand")]
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use super::{
     ParsePublicKeyError, ParseSecretKeyError, ParseSignatureError, RefTo,
@@ -125,7 +125,7 @@ impl FromStr for PublicKey {
 }
 
 /// Ed25519 secret key
-#[derive(Debug, Serialize, Deserialize, Zeroize)]
+#[derive(Debug, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct SecretKey(pub Box<ed25519_consensus::SigningKey>);
 
 impl super::SecretKey for SecretKey {
@@ -220,12 +220,6 @@ impl FromStr for SecretKey {
             .map_err(ParseSecretKeyError::InvalidHex)?;
         BorshDeserialize::try_from_slice(&vec)
             .map_err(ParseSecretKeyError::InvalidEncoding)
-    }
-}
-
-impl Drop for SecretKey {
-    fn drop(&mut self) {
-        self.0.zeroize();
     }
 }
 

--- a/core/src/types/key/mod.rs
+++ b/core/src/types/key/mod.rs
@@ -692,17 +692,15 @@ mod more_tests {
     fn zeroize_keypair_secp256k1() {
         use rand::thread_rng;
 
-        let mut sk = secp256k1::SigScheme::generate(&mut thread_rng());
-        let sk_scalar = sk.0.to_scalar_ref();
-        let len = sk_scalar.0.len();
-        let ptr = sk_scalar.0.as_ref().as_ptr();
-
-        let original_data = sk_scalar.0;
-
+        let sk = secp256k1::SigScheme::generate(&mut thread_rng());
+        let (ptr, original_data) = {
+            let sk_scalar = sk.0.as_scalar_primitive().as_ref();
+            (sk_scalar.as_ptr(), sk_scalar.to_owned())
+        };
         drop(sk);
 
-        assert_ne!(&original_data, unsafe {
-            core::slice::from_raw_parts(ptr, len)
+        assert_ne!(original_data.as_slice(), unsafe {
+            core::slice::from_raw_parts(ptr, secp256k1::SECRET_KEY_SIZE)
         });
     }
 }

--- a/ethereum_bridge/Cargo.toml
+++ b/ethereum_bridge/Cargo.toml
@@ -29,7 +29,7 @@ testing = [
 ]
 
 [dependencies]
-namada_core = {path = "../core", default-features = false, features = ["secp256k1-sign", "ferveo-tpke", "ethers-derive"]}
+namada_core = {path = "../core", default-features = false, features = ["ferveo-tpke", "ethers-derive"]}
 namada_macros = {path = "../macros"}
 namada_proof_of_stake = {path = "../proof_of_stake", default-features = false}
 borsh.workspace = true
@@ -46,7 +46,7 @@ tracing = "0.1.30"
 
 [dev-dependencies]
 # Added "testing" feature.
-namada_core = {path = "../core", default-features = false, features = ["secp256k1-sign", "ferveo-tpke", "ethers-derive", "testing"]}
+namada_core = {path = "../core", default-features = false, features = ["ferveo-tpke", "ethers-derive", "testing"]}
 assert_matches.workspace = true
 data-encoding.workspace = true
 ethabi.workspace = true

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -93,7 +93,7 @@ namada-sdk = [
 multicore = ["masp_proofs/multicore"]
 
 [dependencies]
-namada_core = {path = "../core", default-features = false, features = ["secp256k1-sign"]}
+namada_core = {path = "../core", default-features = false}
 namada_proof_of_stake = {path = "../proof_of_stake", default-features = false}
 namada_ethereum_bridge = {path = "../ethereum_bridge", default-features = false}
 async-trait = {version = "0.1.51", optional = true}
@@ -152,14 +152,14 @@ tokio = {workspace = true, features = ["full"]}
 wasmtimer = "0.2.0"
 
 [dev-dependencies]
-namada_core = {path = "../core", default-features = false, features = ["secp256k1-sign", "testing", "ibc-mocks"]}
+namada_core = {path = "../core", default-features = false, features = ["testing", "ibc-mocks"]}
 namada_ethereum_bridge = {path = "../ethereum_bridge", default-features = false, features = ["testing"]}
 namada_test_utils = {path = "../test_utils"}
 assert_matches.workspace = true
 async-trait.workspace = true
 base58.workspace = true
 byte-unit.workspace = true
-libsecp256k1.workspace = true
+k256.workspace = true
 pretty_assertions.workspace = true
 proptest.workspace = true
 tempfile.workspace = true

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1447,6 +1447,7 @@ dependencies = [
  "digest 0.10.6",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature 2.1.0",
  "spki",
 ]
@@ -1513,6 +1514,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -2524,17 +2526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.7",
- "hmac 0.8.1",
-]
-
-[[package]]
 name = "hmac-sha512"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2939,6 +2930,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2 0.10.6",
  "signature 2.1.0",
 ]
@@ -2995,55 +2987,11 @@ dependencies = [
  "arrayref",
  "crunchy",
  "digest 0.8.1",
- "hmac-drbg 0.2.0",
+ "hmac-drbg",
  "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.1",
  "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "arrayref",
- "base64 0.13.1",
- "digest 0.9.0",
- "hmac-drbg 0.3.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.5",
- "serde",
- "sha2 0.9.9",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle 2.4.1",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "libsecp256k1-core",
 ]
 
 [[package]]
@@ -3393,7 +3341,7 @@ dependencies = [
  "impl-num-traits",
  "index-set",
  "itertools",
- "libsecp256k1 0.7.0",
+ "k256",
  "masp_primitives",
  "namada_macros",
  "num-integer",
@@ -4883,6 +4831,7 @@ dependencies = [
  "der",
  "generic-array 0.14.7",
  "pkcs8",
+ "serdect",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -5028,6 +4977,16 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -5553,7 +5512,7 @@ checksum = "01b874a4992538d4b2f4fbbac11b9419d685f4b39bdc3fed95b04e07bfd76040"
 dependencies = [
  "base58",
  "hmac 0.7.1",
- "libsecp256k1 0.3.5",
+ "libsecp256k1",
  "memzero",
  "sha2 0.8.2",
 ]

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -1447,6 +1447,7 @@ dependencies = [
  "digest 0.10.6",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature 2.1.0",
  "spki",
 ]
@@ -1513,6 +1514,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -2524,17 +2526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array 0.14.7",
- "hmac 0.8.1",
-]
-
-[[package]]
 name = "hmac-sha512"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2939,6 +2930,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2 0.10.6",
  "signature 2.1.0",
 ]
@@ -2995,55 +2987,11 @@ dependencies = [
  "arrayref",
  "crunchy",
  "digest 0.8.1",
- "hmac-drbg 0.2.0",
+ "hmac-drbg",
  "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.1",
  "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "arrayref",
- "base64 0.13.1",
- "digest 0.9.0",
- "hmac-drbg 0.3.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.5",
- "serde",
- "sha2 0.9.9",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle 2.4.1",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/libsecp256k1?rev=bbb3bd44a49db361f21d9db80f9a087c194c0ae9#bbb3bd44a49db361f21d9db80f9a087c194c0ae9"
-dependencies = [
- "libsecp256k1-core",
 ]
 
 [[package]]
@@ -3393,7 +3341,7 @@ dependencies = [
  "impl-num-traits",
  "index-set",
  "itertools",
- "libsecp256k1 0.7.0",
+ "k256",
  "masp_primitives",
  "namada_macros",
  "num-integer",
@@ -4876,6 +4824,7 @@ dependencies = [
  "der",
  "generic-array 0.14.7",
  "pkcs8",
+ "serdect",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -5021,6 +4970,16 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -5546,7 +5505,7 @@ checksum = "01b874a4992538d4b2f4fbbac11b9419d685f4b39bdc3fed95b04e07bfd76040"
 dependencies = [
  "base58",
  "hmac 0.7.1",
- "libsecp256k1 0.3.5",
+ "libsecp256k1",
  "memzero",
  "sha2 0.8.2",
 ]


### PR DESCRIPTION
## Describe your changes

- Tag `ed25519` keys with `ZeroizeOnDrop`, to indicate their bytes are cleared uppon the key being dropped.
- ~~Switch to `k256` for `secp256k1` keys. It natively implements `Zeroize`~~ - done in base #1958

## Indicate on which release or other PRs this topic is based on

#1958 (first commit here 609e70d62ce56842633b85aab5958d0324122416)

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
