### PR TITLE
Fix transmitting protocol txs if validator node

### DIFF
--- a/.changelog/unreleased/bug-fixes/1964-fix-protocol-txs.md
+++ b/.changelog/unreleased/bug-fixes/1964-fix-protocol-txs.md
@@ -1,0 +1,2 @@
+- Fix broadcasting logic for protocol txs when a node operating the network is a
+  validator ([\#1964](https://github.com/anoma/namada/pull/1964))

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -1982,6 +1982,7 @@ mod test_finalize_block {
         let (mut shell, _recv, _, _) = setup_with_cfg(SetupCfg {
             last_height: 0,
             num_validators: 4,
+            ..Default::default()
         });
 
         let mut validator_set: BTreeSet<WeightedValidator> =
@@ -2651,6 +2652,7 @@ mod test_finalize_block {
         let (mut shell, _recv, _, _) = setup_with_cfg(SetupCfg {
             last_height: 0,
             num_validators,
+            ..Default::default()
         });
         let mut params = read_pos_params(&shell.wl_storage).unwrap();
         params.unbonding_len = 4;
@@ -3029,6 +3031,7 @@ mod test_finalize_block {
         let (mut shell, _recv, _, _) = setup_with_cfg(SetupCfg {
             last_height: 0,
             num_validators,
+            ..Default::default()
         });
         let mut params = read_pos_params(&shell.wl_storage).unwrap();
         params.unbonding_len = 4;

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -2141,22 +2141,63 @@ mod test_utils {
     }
 }
 
-#[cfg(all(test, not(feature = "abcipp")))]
-mod abciplus_mempool_tests {
+#[cfg(test)]
+mod shell_tests {
     use namada::proto::{
-        Data, Section, SignableEthMessage, Signature, Signed, Tx,
+        Code, Data, Section, SignableEthMessage, Signature, Signed, Tx,
     };
     use namada::types::ethereum_events::EthereumEvent;
     use namada::types::key::RefTo;
-    use namada::types::storage::BlockHeight;
+    use namada::types::storage::{BlockHeight, Epoch};
     use namada::types::transaction::protocol::{
         ethereum_tx_data_variants, ProtocolTx, ProtocolTxType,
     };
+    use namada::types::transaction::{Fee, WrapperTx};
     use namada::types::vote_extensions::{bridge_pool_roots, ethereum_events};
 
     use super::*;
     use crate::node::ledger::shell::test_utils;
     use crate::wallet;
+
+    const GAS_LIMIT_MULTIPLIER: u64 = 100_000;
+
+    /// Check that the shell broadcasts validator set updates,
+    /// even when the Ethereum oracle is not running (e.g.
+    /// because the bridge is disabled).
+    #[tokio::test]
+    async fn test_broadcast_valset_upd_inspite_oracle_off() {
+        // this height should result in a validator set
+        // update being broadcasted
+        let (mut shell, mut broadcaster_rx, _, _) =
+            test_utils::setup_with_cfg(test_utils::SetupCfg {
+                last_height: 1,
+                enable_ethereum_oracle: false,
+                ..Default::default()
+            });
+
+        // broadcast validator set update
+        shell.broadcast_protocol_txs();
+
+        // check data inside tx - it should be a validator set update
+        // signed at epoch 0
+        let signed_valset_upd = loop {
+            // attempt to receive validator set update
+            let serialized_tx = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                async { broadcaster_rx.recv().await.unwrap() },
+            )
+            .await
+            .unwrap();
+            let tx = Tx::try_from(&serialized_tx[..]).unwrap();
+
+            match ethereum_tx_data_variants::ValSetUpdateVext::try_from(&tx) {
+                Ok(signed_valset_upd) => break signed_valset_upd,
+                Err(_) => continue,
+            }
+        };
+
+        assert_eq!(signed_valset_upd.data.signing_epoch, Epoch(0));
+    }
 
     /// Check that broadcasting expired Ethereum events works
     /// as expected.
@@ -2334,17 +2375,6 @@ mod abciplus_mempool_tests {
         let rsp = shell.mempool_validate(&tx, Default::default());
         assert_eq!(rsp.code, u32::from(ErrorCodes::InvalidVoteExtension));
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use namada::proof_of_stake::Epoch;
-    use namada::proto::{Code, Data, Section, Signature, Tx};
-    use namada::types::transaction::{Fee, WrapperTx};
-
-    use super::*;
-
-    const GAS_LIMIT_MULTIPLIER: u64 = 100_000;
 
     /// Mempool validation must reject unsigned wrappers
     #[test]

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -879,6 +879,7 @@ mod test_prepare_proposal {
             test_utils::setup_with_cfg(test_utils::SetupCfg {
                 last_height: FIRST_HEIGHT,
                 num_validators: 2,
+                ..Default::default()
             });
 
         let params = shell.wl_storage.pos_queries().get_pos_params();


### PR DESCRIPTION
## Describe your changes

A bug was introduced by #1899 where no protocol txs are broadcasted to the network, unless the Ethereum oracle is enabled. This PR fixes the underlying issue.

## Indicate on which release or other PRs this topic is based on

`v0.23.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
