### PR TITLE
Write governance proposal results to storage

### DIFF
--- a/.changelog/unreleased/improvements/1979-proposal-result-in-storage.md
+++ b/.changelog/unreleased/improvements/1979-proposal-result-in-storage.md
@@ -1,0 +1,2 @@
+- Persist the results of governance proposals in storage to allow recovering old
+  results. ([\#1979](https://github.com/anoma/namada/pull/1979))

--- a/apps/src/lib/node/ledger/shell/governance.rs
+++ b/apps/src/lib/node/ledger/shell/governance.rs
@@ -74,6 +74,10 @@ where
         )?;
         let proposal_result =
             compute_proposal_result(votes, total_voting_power, tally_type);
+        let proposal_result_key = gov_storage::get_proposal_result_key(id);
+        shell
+            .wl_storage
+            .write(&proposal_result_key, proposal_result)?;
 
         let transfer_address = match proposal_result.result {
             TallyResult::Passed => {

--- a/core/src/ledger/governance/storage/keys.rs
+++ b/core/src/ledger/governance/storage/keys.rs
@@ -26,6 +26,7 @@ struct Keys {
     min_grace_epoch: &'static str,
     counter: &'static str,
     pending: &'static str,
+    result: &'static str,
 }
 
 /// Check if key is inside governance address space
@@ -456,6 +457,15 @@ pub fn get_proposal_execution_key(id: u64) -> Key {
         .push(&Keys::VALUES.pending.to_owned())
         .expect("Cannot obtain a storage key")
         .push(&id.to_string())
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get the proposal result key
+pub fn get_proposal_result_key(id: u64) -> Key {
+    proposal_prefix()
+        .push(&id.to_string())
+        .expect("Cannot obtain a storage key")
+        .push(&Keys::VALUES.result.to_owned())
         .expect("Cannot obtain a storage key")
 }
 

--- a/core/src/ledger/governance/utils.rs
+++ b/core/src/ledger/governance/utils.rs
@@ -75,6 +75,7 @@ impl TallyType {
 }
 
 /// The result of a proposal
+#[derive(Copy, Clone, BorshSerialize, BorshDeserialize)]
 pub enum TallyResult {
     /// Proposal was accepted with the associated value
     Passed,
@@ -126,6 +127,7 @@ impl TallyResult {
 }
 
 /// The result with votes of a proposal
+#[derive(Clone, Copy, BorshDeserialize, BorshSerialize)]
 pub struct ProposalResult {
     /// The result of a proposal
     pub result: TallyResult,


### PR DESCRIPTION
## Describe your changes

Store the result of a governance proposal under the corresponding storage subkey. This allows to recover the result even after the validator set has changed.

Also, update the client to leverage this key in storage if present to avoid recomputing the result. 

## Indicate on which release or other PRs this topic is based on

Commit 3f979bf3b2707db4d065a4fae6e8c2340ae1d54b on `base` branch

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
