### PR TITLE
updating cometbft directory permission in Dockerfile

### DIFF
--- a/docker/namada/Dockerfile
+++ b/docker/namada/Dockerfile
@@ -43,6 +43,9 @@ COPY --from=builder --chmod=0755 /app/target/release/namadaw /usr/local/bin
 COPY --from=builder --chmod=0755 /app/target/release/namadac /usr/local/bin
 COPY --from=tendermint-builder --chmod=0755 /app/cometbft/build/cometbft /usr/local/bin
 
+USER root
+RUN chmod -R 755 /usr/local/bin/cometbft
+
 EXPOSE 26656
 EXPOSE 26660
 EXPOSE 26659


### PR DESCRIPTION
for some reason COPY --chmod=0755 doesn't work for cometbft:

The application panicked (crashed).
Message:  Tendermint failed to initialize with Output {
    status: ExitStatus(
        unix_wait_status(
            512,
        ),
    ),
    stdout: "",
    stderr: "panic: could not create directory \"/.namada/public-testnet-14.5d79b6958580/cometbft/config\"

## Describe your changes

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
