### PR TITLE
Prevent crash on failed pgf payment

### DIFF
--- a/.changelog/unreleased/bug-fixes/1991-fix-pgf-payment-crash.md
+++ b/.changelog/unreleased/bug-fixes/1991-fix-pgf-payment-crash.md
@@ -1,0 +1,2 @@
+- Fixed a bug that would cause the ledger to crash on a failed PGF payment.
+  ([\#1991](https://github.com/anoma/namada/pull/1991))

--- a/apps/src/lib/node/ledger/shell/governance.rs
+++ b/apps/src/lib/node/ledger/shell/governance.rs
@@ -374,19 +374,28 @@ where
                 }
             },
             PGFAction::Retro(target) => {
-                token::transfer(
+                match token::transfer(
                     storage,
                     token,
                     &ADDRESS,
                     &target.target,
                     target.amount,
-                )?;
-                tracing::info!(
-                    "Execute RetroPgf from proposal id {}: sent {} to {}.",
-                    proposal_id,
-                    target.amount.to_string_native(),
-                    target.target
-                );
+                ) {
+                    Ok(()) => tracing::info!(
+                        "Execute RetroPgf from proposal id {}: sent {} to {}.",
+                        proposal_id,
+                        target.amount.to_string_native(),
+                        target.target
+                    ),
+                    Err(e) => tracing::warn!(
+                        "Error in RetroPgf transfer from proposal id {}, \
+                         amount {} to {}: {}",
+                        proposal_id,
+                        target.amount.to_string_native(),
+                        target.target,
+                        e
+                    ),
+                }
             }
         }
     }


### PR DESCRIPTION
## Describe your changes

Fixes a bug for which the ledger crashed in case of a failed PGF payment.

## Indicate on which release or other PRs this topic is based on

Commit 3f979bf3b2707db4d065a4fae6e8c2340ae1d54b from `base` branch

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
