### PR TITLE
Emit Ethereum Bridge pool transfer events

### DIFF
--- a/.changelog/unreleased/SDK/1995-eth-tx-emits-events.md
+++ b/.changelog/unreleased/SDK/1995-eth-tx-emits-events.md
@@ -1,0 +1,2 @@
+- Introduce a method to query the status (pending, relayed or expired) of Bridge
+  pool transfers ([\#1995](https://github.com/anoma/namada/pull/1995))

--- a/.changelog/unreleased/improvements/1995-eth-tx-emits-events.md
+++ b/.changelog/unreleased/improvements/1995-eth-tx-emits-events.md
@@ -1,0 +1,2 @@
+- Emit Bridge pool transfer status update events from FinalizeBlock
+  ([\#1995](https://github.com/anoma/namada/pull/1995))

--- a/core/src/types/ethereum_structs.rs
+++ b/core/src/types/ethereum_structs.rs
@@ -9,6 +9,67 @@ pub use ethbridge_structs::*;
 use num256::Uint256;
 use serde::{Deserialize, Serialize};
 
+use crate::types::keccak::KeccakHash;
+
+/// Status of some Bridge pool transfer.
+#[derive(
+    Hash,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+pub enum BpTransferStatus {
+    /// The transfer has been relayed.
+    Relayed,
+    /// The transfer has expired.
+    Expired,
+}
+
+/// Ethereum bridge events on Namada's event log.
+#[derive(
+    Hash,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+pub enum EthBridgeEvent {
+    /// Bridge pool transfer status update event.
+    BridgePool {
+        /// Hash of the Bridge pool transfer.
+        tx_hash: KeccakHash,
+        /// Status of the Bridge pool transfer.
+        status: BpTransferStatus,
+    },
+}
+
+impl EthBridgeEvent {
+    /// Return a new Bridge pool expired transfer event.
+    pub const fn new_bridge_pool_expired(tx_hash: KeccakHash) -> Self {
+        Self::BridgePool {
+            tx_hash,
+            status: BpTransferStatus::Expired,
+        }
+    }
+
+    /// Return a new Bridge pool relayed transfer event.
+    pub const fn new_bridge_pool_relayed(tx_hash: KeccakHash) -> Self {
+        Self::BridgePool {
+            tx_hash,
+            status: BpTransferStatus::Relayed,
+        }
+    }
+}
+
 /// This type must be able to represent any valid Ethereum block height. It must
 /// also be Borsh serializeable, so that it can be stored in blockchain storage.
 ///

--- a/core/src/types/transaction/mod.rs
+++ b/core/src/types/transaction/mod.rs
@@ -28,6 +28,7 @@ pub use wrapper::*;
 
 use crate::ledger::gas::{Gas, VpsGas};
 use crate::types::address::Address;
+use crate::types::ethereum_structs::EthBridgeEvent;
 use crate::types::hash::Hash;
 use crate::types::ibc::IbcEvent;
 use crate::types::storage;
@@ -53,6 +54,8 @@ pub struct TxResult {
     pub initialized_accounts: Vec<Address>,
     /// IBC events emitted by the transaction
     pub ibc_events: BTreeSet<IbcEvent>,
+    /// Ethereum bridge events emitted by the transaction
+    pub eth_bridge_events: BTreeSet<EthBridgeEvent>,
 }
 
 impl TxResult {

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/events.rs
@@ -18,6 +18,7 @@ use namada_core::ledger::storage::traits::StorageHasher;
 use namada_core::ledger::storage::{DBIter, WlStorage, DB};
 use namada_core::ledger::storage_api::{StorageRead, StorageWrite};
 use namada_core::types::address::Address;
+use namada_core::types::eth_abi::Encode;
 use namada_core::types::eth_bridge_pool::{
     PendingTransfer, TransferToEthereumKind,
 };
@@ -25,6 +26,7 @@ use namada_core::types::ethereum_events::{
     EthAddress, EthereumEvent, TransferToEthereum, TransferToNamada,
     TransfersToNamada,
 };
+use namada_core::types::ethereum_structs::EthBridgeEvent;
 use namada_core::types::storage::{BlockHeight, Key, KeySeg};
 use namada_core::types::token;
 use namada_core::types::token::{balance_key, minted_balance_key};
@@ -39,7 +41,7 @@ use crate::storage::eth_bridge_queries::{EthAssetMint, EthBridgeQueries};
 pub(super) fn act_on<D, H>(
     wl_storage: &mut WlStorage<D, H>,
     event: EthereumEvent,
-) -> Result<BTreeSet<Key>>
+) -> Result<(BTreeSet<Key>, BTreeSet<EthBridgeEvent>)>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
@@ -58,7 +60,7 @@ where
         } => act_on_transfers_to_eth(wl_storage, transfers, relayer),
         _ => {
             tracing::debug!(?event, "No actions taken for Ethereum event");
-            Ok(BTreeSet::default())
+            Ok(Default::default())
         }
     }
 }
@@ -66,7 +68,7 @@ where
 fn act_on_transfers_to_namada<'tx, D, H>(
     wl_storage: &mut WlStorage<D, H>,
     transfer_event: TransfersToNamada,
-) -> Result<BTreeSet<Key>>
+) -> Result<(BTreeSet<Key>, BTreeSet<EthBridgeEvent>)>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
@@ -88,7 +90,11 @@ where
             transfers.iter(),
         )?;
     }
-    Ok(changed_keys)
+    Ok((
+        changed_keys,
+        // no tx events when we get a transfer to namada
+        BTreeSet::new(),
+    ))
 }
 
 fn update_transfers_to_namada_state<'tx, D, H>(
@@ -301,13 +307,14 @@ fn act_on_transfers_to_eth<D, H>(
     wl_storage: &mut WlStorage<D, H>,
     transfers: &[TransferToEthereum],
     relayer: &Address,
-) -> Result<BTreeSet<Key>>
+) -> Result<(BTreeSet<Key>, BTreeSet<EthBridgeEvent>)>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
     tracing::debug!(?transfers, "Acting on transfers to Ethereum");
     let mut changed_keys = BTreeSet::default();
+    let mut tx_events = BTreeSet::default();
 
     // the BP nonce should always be incremented, even if no valid
     // transfers to Ethereum were relayed. failing to do this
@@ -363,10 +370,13 @@ where
         _ = changed_keys.insert(key);
         _ = changed_keys.insert(pool_balance_key);
         _ = changed_keys.insert(relayer_rewards_key);
+        _ = tx_events.insert(EthBridgeEvent::new_bridge_pool_relayed(
+            pending_transfer.keccak256(),
+        ));
     }
 
     if pending_keys.is_empty() {
-        return Ok(changed_keys);
+        return Ok((changed_keys, tx_events));
     }
 
     // TODO the timeout height is min_num_blocks of an epoch for now
@@ -383,13 +393,15 @@ where
             )
             .expect("BlockHeight should be decoded");
             if inserted_height <= timeout_height {
-                let mut keys = refund_transfer(wl_storage, key)?;
+                let (mut keys, mut new_tx_events) =
+                    refund_transfer(wl_storage, key)?;
                 changed_keys.append(&mut keys);
+                tx_events.append(&mut new_tx_events);
             }
         }
     }
 
-    Ok(changed_keys)
+    Ok((changed_keys, tx_events))
 }
 
 fn increment_bp_nonce<D, H>(
@@ -412,12 +424,13 @@ where
 fn refund_transfer<D, H>(
     wl_storage: &mut WlStorage<D, H>,
     key: Key,
-) -> Result<BTreeSet<Key>>
+) -> Result<(BTreeSet<Key>, BTreeSet<EthBridgeEvent>)>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
     let mut changed_keys = BTreeSet::default();
+    let mut tx_events = BTreeSet::default();
 
     let transfer = match wl_storage.read_bytes(&key)? {
         Some(v) => PendingTransfer::try_from_slice(&v[..])?,
@@ -430,7 +443,12 @@ where
     wl_storage.delete(&key)?;
     _ = changed_keys.insert(key);
 
-    Ok(changed_keys)
+    // Emit expiration event
+    _ = tx_events.insert(EthBridgeEvent::new_bridge_pool_expired(
+        transfer.keccak256(),
+    ));
+
+    Ok((changed_keys, tx_events))
 }
 
 fn refund_transfer_fees<D, H>(
@@ -1034,7 +1052,7 @@ mod tests {
                 .expect("Test failed"),
         )
         .expect("Test failed");
-        let mut changed_keys = act_on(&mut wl_storage, event).unwrap();
+        let (mut changed_keys, _) = act_on(&mut wl_storage, event).unwrap();
 
         for erc20 in [
             random_erc20_token,

--- a/sdk/src/queries/mod.rs
+++ b/sdk/src/queries/mod.rs
@@ -16,7 +16,7 @@ use vp::{Vp, VP};
 
 pub use self::shell::eth_bridge::{
     Erc20FlowControl, GenBridgePoolProofReq, GenBridgePoolProofRsp,
-    TransferToErcArgs,
+    TransferToErcArgs, TransferToEthereumStatus,
 };
 use crate::{MaybeSend, MaybeSync};
 

--- a/sdk/src/queries/shell/eth_bridge.rs
+++ b/sdk/src/queries/shell/eth_bridge.rs
@@ -218,14 +218,18 @@ where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
+    let mut transfer_hashes: HashSet<KeccakHash> =
+        BorshDeserialize::try_from_slice(&request.data)
+            .into_storage_result()?;
+
+    if transfer_hashes.is_empty() {
+        return Ok(Default::default());
+    }
+
     let mut status = TransferToEthereumStatus {
         queried_height: ctx.wl_storage.storage.get_last_block_height(),
         ..Default::default()
     };
-
-    let transfer_hashes: HashSet<KeccakHash> =
-        BorshDeserialize::try_from_slice(request.data.as_slice())
-            .into_storage_result()?;
 
     // check which transfers in the Bridge pool match the requested hashes
     let merkle_tree = ctx
@@ -242,17 +246,30 @@ where
         _ => unreachable!(),
     };
     if hints::likely(store.len() > transfer_hashes.len()) {
-        for hash in transfer_hashes.iter() {
-            if store.contains_key(hash) {
+        transfer_hashes.retain(|hash| {
+            let transfer_in_pool = store.contains_key(hash);
+            if transfer_in_pool {
                 status.pending.insert(hash.clone());
             }
-        }
+            !transfer_in_pool
+        });
     } else {
         for hash in store.keys() {
-            if transfer_hashes.contains(hash) {
+            if transfer_hashes.remove(hash) {
                 status.pending.insert(hash.clone());
             }
+            if transfer_hashes.is_empty() {
+                break;
+            }
         }
+    }
+
+    if transfer_hashes.is_empty() {
+        let data = status.serialize_to_vec();
+        return Ok(EncodedResponseQuery {
+            data,
+            ..Default::default()
+        });
     }
 
     // INVARIANT: transfers that are in the event log will have already
@@ -277,16 +294,22 @@ where
             .as_str()
             .try_into()
             .expect("We must have a valid KeccakHash");
-        if !transfer_hashes.contains(&tx_hash) {
+        if !transfer_hashes.remove(&tx_hash) {
             return None;
         }
-        Some((tx_hash, is_relayed))
+        Some((tx_hash, is_relayed, transfer_hashes.is_empty()))
     });
-    for (hash, is_relayed) in completed_transfers {
+    for (hash, is_relayed, early_exit) in completed_transfers {
         if hints::likely(is_relayed) {
             status.relayed.insert(hash.clone());
         } else {
             status.expired.insert(hash.clone());
+        }
+        if early_exit {
+            // early drop of the transfer hashes, in
+            // case its storage capacity was big
+            transfer_hashes = Default::default();
+            break;
         }
     }
 

--- a/sdk/src/queries/shell/eth_bridge.rs
+++ b/sdk/src/queries/shell/eth_bridge.rs
@@ -41,6 +41,7 @@ use namada_ethereum_bridge::storage::{
     bridge_contract_key, native_erc20_key, vote_tallies,
 };
 use namada_proof_of_stake::pos_queries::PosQueries;
+use serde::{Deserialize, Serialize};
 
 use crate::eth_bridge::ethers::abi::AbiDecode;
 use crate::events::EventType;
@@ -48,7 +49,15 @@ use crate::queries::{EncodedResponseQuery, RequestCtx, RequestQuery};
 
 /// Container for the status of queried transfers to Ethereum.
 #[derive(
-    Default, Debug, Clone, Eq, PartialEq, BorshSerialize, BorshDeserialize,
+    Default,
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    BorshSerialize,
+    BorshDeserialize,
+    Serialize,
+    Deserialize,
 )]
 pub struct TransferToEthereumStatus {
     /// The block height at which the query was performed.

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -194,6 +194,7 @@ where
                 vps_result: VpsResult::default(),
                 initialized_accounts: vec![],
                 ibc_events: BTreeSet::default(),
+                eth_bridge_events: BTreeSet::default(),
             })
         }
         TxType::Decrypted(DecryptedTx::Undecryptable) => {
@@ -608,6 +609,7 @@ where
         vps_result,
         initialized_accounts,
         ibc_events,
+        eth_bridge_events: BTreeSet::default(),
     })
 }
 


### PR DESCRIPTION
## Describe your changes

Ethereum Bridge pool transfer events are useful to the Namada web interface. They should allow informing users whether their transfers have expired from the Bridge pool, or if they have been successfully relayed.

Since Namada's event log size is finite (currently, IIRC it's hard-coded to 50k slots), the query may fail with an "incomplete" state. The gist is, when a transfer is neither in the Bridge pool nor in the event log, it's because it has either been relayed or expired. The only way to consult this is to go through each block height since the transfer was first sent to the Bridge pool, until a Bridge pool event containing the transfer hash is found. This is not implemented on purpose, as it requires querying a potentially huge number of blocks.

## Indicate on which release or other PRs this topic is based on

`v0.28.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
