### PR TITLE
Fixes pgf inflation

### DIFF
--- a/.changelog/unreleased/bug-fixes/1999-fix-pgf-stewards-funding.md
+++ b/.changelog/unreleased/bug-fixes/1999-fix-pgf-stewards-funding.md
@@ -1,0 +1,2 @@
+- Fixed the pgf stewards reward to be constant regardless of the number of
+  stewards. ([\#1999](https://github.com/anoma/namada/pull/1999))


### PR DESCRIPTION
## Describe your changes

Makes the reward of pff stewards constant regardless of the number of stewards.

## Indicate on which release or other PRs this topic is based on

v0.23.1

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
