### PR TITLE
Sign relayer Ethereum transactions

### DIFF
--- a/.changelog/unreleased/improvements/2012-sign-eth-txs.md
+++ b/.changelog/unreleased/improvements/2012-sign-eth-txs.md
@@ -1,0 +1,2 @@
+- Sign transactions originating from the Namada relayer that are sent to
+  Ethereum ([\#2012](https://github.com/anoma/namada/pull/2012))

--- a/apps/src/lib/cli/relayer.rs
+++ b/apps/src/lib/cli/relayer.rs
@@ -1,7 +1,4 @@
-use std::sync::Arc;
-
 use color_eyre::eyre::{eyre, Report, Result};
-use namada::eth_bridge::ethers::providers::{Http, Provider};
 use namada::ledger::eth_bridge::{bridge_pool, validator_set};
 use namada::types::control_flow::ProceedOrElse;
 use namada::types::io::Io;
@@ -10,6 +7,7 @@ use crate::cli;
 use crate::cli::api::{CliApi, CliClient};
 use crate::cli::args::{CliToSdk, CliToSdkCtxless};
 use crate::cli::cmds::*;
+use crate::cli::utils::get_eth_rpc_client;
 
 fn error() -> Report {
     eyre!("Fatal error")
@@ -74,10 +72,8 @@ impl<IO: Io> CliApi<IO> {
                         .wait_until_node_is_synced::<IO>()
                         .await
                         .proceed_or_else(error)?;
-                    let eth_client = Arc::new(
-                        Provider::<Http>::try_from(&args.eth_rpc_endpoint)
-                            .unwrap(),
-                    );
+                    let eth_client =
+                        get_eth_rpc_client(&args.eth_rpc_endpoint, None);
                     let args = args.to_sdk_ctxless();
                     bridge_pool::relay_bridge_pool_proof::<_, _, IO>(
                         eth_client, &client, args,
@@ -191,10 +187,8 @@ impl<IO: Io> CliApi<IO> {
                         .wait_until_node_is_synced::<IO>()
                         .await
                         .proceed_or_else(error)?;
-                    let eth_client = Arc::new(
-                        Provider::<Http>::try_from(&args.eth_rpc_endpoint)
-                            .unwrap(),
-                    );
+                    let eth_client =
+                        get_eth_rpc_client(&args.eth_rpc_endpoint, None);
                     let args = args.to_sdk_ctxless();
                     validator_set::relay_validator_set_update::<_, _, IO>(
                         eth_client, &client, args,

--- a/apps/src/lib/cli/relayer.rs
+++ b/apps/src/lib/cli/relayer.rs
@@ -73,7 +73,7 @@ impl<IO: Io> CliApi<IO> {
                         .await
                         .proceed_or_else(error)?;
                     let eth_client =
-                        get_eth_rpc_client(&args.eth_rpc_endpoint, None);
+                        get_eth_rpc_client(&args.eth_rpc_endpoint).await;
                     let args = args.to_sdk_ctxless();
                     bridge_pool::relay_bridge_pool_proof::<_, _, IO>(
                         eth_client, &client, args,
@@ -188,7 +188,7 @@ impl<IO: Io> CliApi<IO> {
                         .await
                         .proceed_or_else(error)?;
                     let eth_client =
-                        get_eth_rpc_client(&args.eth_rpc_endpoint, None);
+                        get_eth_rpc_client(&args.eth_rpc_endpoint).await;
                     let args = args.to_sdk_ctxless();
                     validator_set::relay_validator_set_update::<_, _, IO>(
                         eth_client, &client, args,

--- a/apps/src/lib/cli/utils.rs
+++ b/apps/src/lib/cli/utils.rs
@@ -3,16 +3,25 @@ use std::fmt::Debug;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use clap::{ArgAction, ArgMatches};
 use color_eyre::eyre::Result;
 use data_encoding::HEXLOWER_PERMISSIVE;
 use namada::eth_bridge::ethers::core::k256::elliptic_curve::SecretKey as Secp256k1Sk;
+use namada::eth_bridge::ethers::middleware::SignerMiddleware;
+use namada::eth_bridge::ethers::providers::{Http, Middleware, Provider};
 use namada::eth_bridge::ethers::signers::{Signer, Wallet};
 
 use super::args;
 use super::context::{Context, FromContext};
 use crate::cli::api::CliIo;
+
+/// Environment variable where Ethereum relayer private
+/// keys are stored.
+// TODO: remove this in favor of getting eth keys from
+// namadaw, ledger, or something more secure
+const RELAYER_KEY_ENV_VAR: &str = "NAMADA_RELAYER_KEY";
 
 // We only use static strings
 pub type App = clap::Command;
@@ -369,11 +378,8 @@ pub fn safe_exit(_: i32) -> ! {
 /// Load an Ethereum wallet from the environment.
 ///
 /// If no chain id is provided, Ethereum main net is assumed.
-#[allow(dead_code)]
-pub fn get_eth_signer_from_env(chain_id: Option<u64>) -> Option<impl Signer> {
-    const RELAYER_KEY: &str = "NAMADA_RELAYER_KEY";
-
-    let relayer_key = std::env::var(RELAYER_KEY).ok()?;
+fn get_eth_signer_from_env(chain_id: Option<u64>) -> Option<impl Signer> {
+    let relayer_key = std::env::var(RELAYER_KEY_ENV_VAR).ok()?;
     let relayer_key = HEXLOWER_PERMISSIVE.decode(relayer_key.as_ref()).ok()?;
     let relayer_key = Secp256k1Sk::from_slice(&relayer_key).ok()?;
 
@@ -381,4 +387,19 @@ pub fn get_eth_signer_from_env(chain_id: Option<u64>) -> Option<impl Signer> {
     let wallet = wallet.with_chain_id(chain_id.unwrap_or(1));
 
     Some(wallet)
+}
+
+/// Return an Ethereum RPC client.
+///
+/// If no chain id is provided, Ethereum main net is assumed.
+pub fn get_eth_rpc_client(
+    url: &str,
+    chain_id: Option<u64>,
+) -> Arc<impl Middleware> {
+    let client = Provider::<Http>::try_from(url)
+        .expect("Failed to instantiate Ethereum RPC client");
+    let signer = get_eth_signer_from_env(chain_id).unwrap_or_else(|| {
+        panic!("Failed to get Ethereum key from {RELAYER_KEY_ENV_VAR} env var")
+    });
+    Arc::new(SignerMiddleware::new(client, signer))
 }


### PR DESCRIPTION
## Describe your changes

Introduce an environment variable to load a secp256k1 private key from, which is used to sign transactions originating from Namada's relayer sent to Ethereum.

This implementation is kinda hacky, but it should allow immediate testing with e.g. [Sepolia](https://sepolia.dev/). There are for sure ways to improve it, in the future, namely:

- Loading keys from other sources (e.g. `namadaw`, `ledger`, or `aws kms`)
- Deriving the `ethereum-address` SDK/CLI argument from a `Signer` implementation (see [this link](https://docs.rs/ethers/2.0.6/ethers/signers/trait.Signer.html#tymethod.address))

Notice that the SDK code remains unchanged. This is because it accepts a `Middleware` client, which may or may not sign txs.

## Indicate on which release or other PRs this topic is based on

`v0.23.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
