### PR TITLE
Outdated Ethereum event nonce fixes

### DIFF
--- a/.changelog/unreleased/bug-fixes/2035-outdated-eth-nonces.md
+++ b/.changelog/unreleased/bug-fixes/2035-outdated-eth-nonces.md
@@ -1,0 +1,2 @@
+- Fix Ethereum event validation/state updates when more than one validator is
+  running the chain ([\#2035](https://github.com/anoma/namada/pull/2035))

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -1760,7 +1760,7 @@ mod test_finalize_block {
                 transfer
             };
             let ethereum_event = EthereumEvent::TransfersToEthereum {
-                nonce: 0u64.into(),
+                nonce: 1u64.into(),
                 transfers: vec![transfer],
                 relayer: bertha,
             };

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -2201,6 +2201,75 @@ mod abciplus_mempool_tests {
         );
     }
 
+    /// Test that Ethereum events with outdated nonces are
+    /// not validated by `CheckTx`.
+    #[test]
+    fn test_outdated_nonce_mempool_validate() {
+        use namada::types::storage::InnerEthEventsQueue;
+
+        const LAST_HEIGHT: BlockHeight = BlockHeight(3);
+
+        let (mut shell, _recv, _, _) = test_utils::setup_at_height(LAST_HEIGHT);
+        shell
+            .wl_storage
+            .storage
+            .eth_events_queue
+            // sent transfers to namada nonce to 5
+            .transfers_to_namada = InnerEthEventsQueue::new_at(5.into());
+
+        let (protocol_key, _, _) = wallet::defaults::validator_keys();
+
+        // only bad events
+        {
+            let ethereum_event = EthereumEvent::TransfersToNamada {
+                nonce: 3u64.into(),
+                transfers: vec![],
+            };
+            let ext = {
+                let ext = ethereum_events::Vext {
+                    validator_addr: wallet::defaults::validator_address(),
+                    block_height: LAST_HEIGHT,
+                    ethereum_events: vec![ethereum_event],
+                }
+                .sign(&protocol_key);
+                assert!(ext.verify(&protocol_key.ref_to()).is_ok());
+                ext
+            };
+            let tx = EthereumTxData::EthEventsVext(ext)
+                .sign(&protocol_key, shell.chain_id.clone())
+                .to_bytes();
+            let rsp = shell.mempool_validate(&tx, Default::default());
+            assert!(rsp.code != 0, "Validation should have failed");
+        }
+
+        // at least one good event
+        {
+            let e1 = EthereumEvent::TransfersToNamada {
+                nonce: 3u64.into(),
+                transfers: vec![],
+            };
+            let e2 = EthereumEvent::TransfersToNamada {
+                nonce: 5u64.into(),
+                transfers: vec![],
+            };
+            let ext = {
+                let ext = ethereum_events::Vext {
+                    validator_addr: wallet::defaults::validator_address(),
+                    block_height: LAST_HEIGHT,
+                    ethereum_events: vec![e1, e2],
+                }
+                .sign(&protocol_key);
+                assert!(ext.verify(&protocol_key.ref_to()).is_ok());
+                ext
+            };
+            let tx = EthereumTxData::EthEventsVext(ext)
+                .sign(&protocol_key, shell.chain_id.clone())
+                .to_bytes();
+            let rsp = shell.mempool_validate(&tx, Default::default());
+            assert!(rsp.code == 0, "Validation should have passed");
+        }
+    }
+
     /// Test that we do not include protocol txs in the mempool,
     /// voting on ethereum events or signing bridge pool roots
     /// and nonces if the bridge is inactive.

--- a/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -514,10 +514,12 @@ mod test_prepare_proposal {
     #[cfg(feature = "abcipp")]
     use namada::types::key::common;
     use namada::types::key::RefTo;
-    use namada::types::storage::BlockHeight;
+    use namada::types::storage::{BlockHeight, InnerEthEventsQueue};
     use namada::types::token;
     use namada::types::token::Amount;
-    use namada::types::transaction::protocol::EthereumTxData;
+    use namada::types::transaction::protocol::{
+        ethereum_tx_data_variants, EthereumTxData,
+    };
     use namada::types::transaction::{Fee, TxType, WrapperTx};
     #[cfg(feature = "abcipp")]
     use namada::types::vote_extensions::bridge_pool_roots;
@@ -1651,5 +1653,116 @@ mod test_prepare_proposal {
         let result = shell.prepare_proposal(req);
         eprintln!("Proposal: {:?}", result.txs);
         assert!(result.txs.is_empty());
+    }
+
+    /// Test that Ethereum events with outdated nonces are
+    /// not proposed during `PrepareProposal`.
+    #[test]
+    fn test_outdated_nonce_proposal() {
+        const LAST_HEIGHT: BlockHeight = BlockHeight(3);
+
+        let (mut shell, _recv, _, _) = test_utils::setup_at_height(LAST_HEIGHT);
+        shell
+            .wl_storage
+            .storage
+            .eth_events_queue
+            // sent transfers to namada nonce to 5
+            .transfers_to_namada = InnerEthEventsQueue::new_at(5.into());
+
+        let (protocol_key, _, _) = wallet::defaults::validator_keys();
+        let validator_addr = wallet::defaults::validator_address();
+
+        // test an extension containing solely events with
+        // bad nonces
+        {
+            let ethereum_event = EthereumEvent::TransfersToNamada {
+                // outdated nonce (3 < 5)
+                nonce: 3u64.into(),
+                transfers: vec![],
+            };
+            let ext = {
+                let ext = ethereum_events::Vext {
+                    validator_addr: validator_addr.clone(),
+                    block_height: LAST_HEIGHT,
+                    ethereum_events: vec![ethereum_event],
+                }
+                .sign(&protocol_key);
+                assert!(ext.verify(&protocol_key.ref_to()).is_ok());
+                ext
+            };
+            let tx = EthereumTxData::EthEventsVext(ext)
+                .sign(&protocol_key, shell.chain_id.clone())
+                .to_bytes();
+            let req = RequestPrepareProposal {
+                txs: vec![tx],
+                ..Default::default()
+            };
+            let proposed_txs =
+                shell.prepare_proposal(req).txs.into_iter().map(|tx_bytes| {
+                    Tx::try_from(tx_bytes.as_slice()).expect("Test failed")
+                });
+            // since no events with valid nonces are contained in the vote
+            // extension, we drop it from the proposal
+            for tx in proposed_txs {
+                if ethereum_tx_data_variants::EthEventsVext::try_from(&tx)
+                    .is_ok()
+                {
+                    panic!(
+                        "No ethereum events should have been found in the \
+                         proposal"
+                    );
+                }
+            }
+        }
+
+        // test an extension containing at least one event
+        // with a good nonce
+        {
+            let event1 = EthereumEvent::TransfersToNamada {
+                // outdated nonce (3 < 5)
+                nonce: 3u64.into(),
+                transfers: vec![],
+            };
+            let event2 = EthereumEvent::TransfersToNamada {
+                // outdated nonce (10 >= 5)
+                nonce: 10u64.into(),
+                transfers: vec![],
+            };
+            let ext = {
+                let ext = ethereum_events::Vext {
+                    validator_addr,
+                    block_height: LAST_HEIGHT,
+                    ethereum_events: vec![event1, event2.clone()],
+                }
+                .sign(&protocol_key);
+                assert!(ext.verify(&protocol_key.ref_to()).is_ok());
+                ext
+            };
+            let tx = EthereumTxData::EthEventsVext(ext)
+                .sign(&protocol_key, shell.chain_id.clone())
+                .to_bytes();
+            let req = RequestPrepareProposal {
+                txs: vec![tx],
+                ..Default::default()
+            };
+            let proposed_txs =
+                shell.prepare_proposal(req).txs.into_iter().map(|tx_bytes| {
+                    Tx::try_from(tx_bytes.as_slice()).expect("Test failed")
+                });
+            // find the event with the good nonce
+            let mut ext = 'ext: {
+                for tx in proposed_txs {
+                    if let Ok(ext) =
+                        ethereum_tx_data_variants::EthEventsVext::try_from(&tx)
+                    {
+                        break 'ext ext;
+                    }
+                }
+                panic!("No ethereum events found in proposal");
+            };
+            assert_eq!(ext.data.ethereum_events.len(), 2);
+            let found_event = ext.data.ethereum_events.remove(1);
+            assert_eq!(found_event, event2);
+        }
     }
 }

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -2912,4 +2912,76 @@ mod test_process_proposal {
             );
         }
     }
+
+    /// Test that Ethereum events with outdated nonces are
+    /// not validated by `ProcessProposal`.
+    #[test]
+    fn test_outdated_nonce_process_proposal() {
+        use namada::types::storage::InnerEthEventsQueue;
+
+        const LAST_HEIGHT: BlockHeight = BlockHeight(3);
+
+        let (mut shell, _recv, _, _) = test_utils::setup_at_height(LAST_HEIGHT);
+        shell
+            .wl_storage
+            .storage
+            .eth_events_queue
+            // sent transfers to namada nonce to 5
+            .transfers_to_namada = InnerEthEventsQueue::new_at(5.into());
+
+        let (protocol_key, _, _) = wallet::defaults::validator_keys();
+
+        // only bad events
+        {
+            let ethereum_event = EthereumEvent::TransfersToNamada {
+                // outdated nonce (3 < 5)
+                nonce: 3u64.into(),
+                transfers: vec![],
+            };
+            let ext = {
+                let ext = ethereum_events::Vext {
+                    validator_addr: wallet::defaults::validator_address(),
+                    block_height: LAST_HEIGHT,
+                    ethereum_events: vec![ethereum_event],
+                }
+                .sign(&protocol_key);
+                assert!(ext.verify(&protocol_key.ref_to()).is_ok());
+                ext
+            };
+            let tx = EthereumTxData::EthEventsVext(ext)
+                .sign(&protocol_key, shell.chain_id.clone())
+                .to_bytes();
+            let req = ProcessProposal { txs: vec![tx] };
+            let rsp = shell.process_proposal(req);
+            assert!(rsp.is_err());
+        }
+
+        // at least one good event
+        {
+            let e1 = EthereumEvent::TransfersToNamada {
+                nonce: 3u64.into(),
+                transfers: vec![],
+            };
+            let e2 = EthereumEvent::TransfersToNamada {
+                nonce: 5u64.into(),
+                transfers: vec![],
+            };
+            let ext = {
+                let ext = ethereum_events::Vext {
+                    validator_addr: wallet::defaults::validator_address(),
+                    block_height: LAST_HEIGHT,
+                    ethereum_events: vec![e1, e2],
+                }
+                .sign(&protocol_key);
+                assert!(ext.verify(&protocol_key.ref_to()).is_ok());
+                ext
+            };
+            let tx = EthereumTxData::EthEventsVext(ext)
+                .sign(&protocol_key, shell.chain_id.clone())
+                .to_bytes();
+            let req = ProcessProposal { txs: vec![tx] };
+            let rsp = shell.process_proposal(req);
+            assert!(rsp.is_ok());
+        }
+    }
 }

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -35,10 +35,8 @@ pub enum VoteExtensionError {
     ValsetUpdProofAvailable,
     #[error("The length of the transfers and their validity map differ")]
     TransfersLenMismatch,
-    #[error("The bridge pool nonce in the vote extension is invalid")]
-    InvalidBpNonce,
-    #[error("The transfer to Namada nonce in the vote extension is invalid")]
-    InvalidNamNonce,
+    #[error("The nonce in the Ethereum event is invalid")]
+    InvalidEthEventNonce,
     #[error("The vote extension was issued for an unexpected block height")]
     UnexpectedBlockHeight,
     #[error("The vote extension was issued for an unexpected epoch")]

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -144,11 +144,8 @@ where
     /// an [`ethereum_events::Vext`].
     ///
     /// The supplied Ethereum events must be ordered in
-    /// ascending ordering, and must not contain any dupes.
-    ///
-    /// A detailed description of the validation applied
-    /// to each event kind can be found in the docstring
-    /// of [`Shell::validate_eth_event`].
+    /// ascending ordering, must not contain any dupes
+    /// and must have valid nonces.
     fn validate_eth_events(
         &self,
         ext: &ethereum_events::Vext,
@@ -170,79 +167,17 @@ where
             );
             return Err(VoteExtensionError::HaveDupesOrNonSorted);
         }
-        ext.ethereum_events
-            .iter()
-            .try_for_each(|event| self.validate_eth_event(event))
-    }
-
-    /// Valdidate an [`EthereumEvent`] against the current state
-    /// of the ledger.
-    ///
-    /// # Event kinds
-    ///
-    /// In this section, we shall describe the checks perform for
-    /// each kind of relevant Ethereum event.
-    ///
-    /// ## Transfers to Ethereum
-    ///
-    /// We need to check if the nonce in the event corresponds to
-    /// the most recent bridge pool nonce. Unless the nonces match,
-    /// no state updates derived from the event should be applied.
-    /// In case the nonces are different, we reject the event, and
-    /// thus the inclusion of its container Ethereum events vote
-    /// extension.
-    ///
-    /// ## Transfers to Namada
-    ///
-    /// For a transfers to Namada event to be considered valid,
-    /// the nonce of this kind of event must not be lower than
-    /// the one stored in Namada.
-    fn validate_eth_event(
-        &self,
-        event: &EthereumEvent,
-    ) -> std::result::Result<(), VoteExtensionError> {
-        // TODO: on the transfer events, maybe perform additional checks:
-        // - some token asset is not whitelisted
-        // - do we have enough balance for the transfer
-        // in practice, some events may have a variable degree of garbage
-        // data in them; we can simply rely on quorum decisions to filter
-        // out such events, which will time out in storage
-        match event {
-            EthereumEvent::TransfersToEthereum {
-                nonce: ext_nonce, ..
-            } => {
-                let current_bp_nonce =
-                    self.wl_storage.ethbridge_queries().get_bridge_pool_nonce();
-                if &current_bp_nonce != ext_nonce {
-                    tracing::debug!(
-                        %current_bp_nonce,
-                        %ext_nonce,
-                        "The Ethereum events vote extension's BP nonce is \
-                         invalid"
-                    );
-                    return Err(VoteExtensionError::InvalidBpNonce);
-                }
+        ext.ethereum_events.iter().try_for_each(|event| {
+            if self
+                .wl_storage
+                .ethbridge_queries()
+                .validate_eth_event_nonce(event)
+            {
+                Ok(())
+            } else {
+                Err(VoteExtensionError::InvalidEthEventNonce)
             }
-            EthereumEvent::TransfersToNamada {
-                nonce: ext_nonce, ..
-            } => {
-                let next_nam_transfers_nonce = self
-                    .wl_storage
-                    .ethbridge_queries()
-                    .get_next_nam_transfers_nonce();
-                if &next_nam_transfers_nonce > ext_nonce {
-                    tracing::debug!(
-                        ?event,
-                        %next_nam_transfers_nonce,
-                        "Attempt to replay a transfer to Namada event"
-                    );
-                    return Err(VoteExtensionError::InvalidNamNonce);
-                }
-            }
-            // consider other ethereum event kinds valid
-            _ => {}
-        }
-        Ok(())
+        })
     }
 
     /// Checks the channel from the Ethereum oracle monitoring
@@ -416,6 +351,7 @@ mod test_vote_extensions {
         NestedSubKey, SubKey,
     };
     use namada::eth_bridge::storage::bridge_pool;
+    use namada::ledger::eth_bridge::EthBridgeQueries;
     use namada::ledger::pos::PosQueries;
     use namada::proof_of_stake::types::WeightedValidator;
     use namada::proof_of_stake::{
@@ -474,55 +410,83 @@ mod test_vote_extensions {
         // eth transfers with the same nonce as the bp nonce in storage are
         // valid
         shell
-            .validate_eth_event(&EthereumEvent::TransfersToEthereum {
+            .wl_storage
+            .ethbridge_queries()
+            .validate_eth_event_nonce(&EthereumEvent::TransfersToEthereum {
                 nonce,
                 transfers: vec![],
                 relayer: gen_established_address(),
             })
+            .then_some(())
+            .ok_or(())
             .expect("Test failed");
 
         // eth transfers with different nonces are invalid
         shell
-            .validate_eth_event(&EthereumEvent::TransfersToEthereum {
+            .wl_storage
+            .ethbridge_queries()
+            .validate_eth_event_nonce(&EthereumEvent::TransfersToEthereum {
                 nonce: nonce + 1,
                 transfers: vec![],
                 relayer: gen_established_address(),
             })
+            .then_some(())
+            .ok_or(())
             .expect_err("Test failed");
         shell
-            .validate_eth_event(&EthereumEvent::TransfersToEthereum {
+            .wl_storage
+            .ethbridge_queries()
+            .validate_eth_event_nonce(&EthereumEvent::TransfersToEthereum {
                 nonce: nonce - 1,
                 transfers: vec![],
                 relayer: gen_established_address(),
             })
+            .then_some(())
+            .ok_or(())
             .expect_err("Test failed");
 
         // nam transfers with nonces >= the nonce in storage are valid
         shell
-            .validate_eth_event(&EthereumEvent::TransfersToNamada {
+            .wl_storage
+            .ethbridge_queries()
+            .validate_eth_event_nonce(&EthereumEvent::TransfersToNamada {
                 nonce,
                 transfers: vec![],
             })
+            .then_some(())
+            .ok_or(())
             .expect("Test failed");
         shell
-            .validate_eth_event(&EthereumEvent::TransfersToNamada {
+            .wl_storage
+            .ethbridge_queries()
+            .validate_eth_event_nonce(&EthereumEvent::TransfersToNamada {
                 nonce: nonce + 5,
                 transfers: vec![],
             })
+            .then_some(())
+            .ok_or(())
             .expect("Test failed");
 
         // nam transfers with lower nonces are invalid
         shell
-            .validate_eth_event(&EthereumEvent::TransfersToNamada {
+            .wl_storage
+            .ethbridge_queries()
+            .validate_eth_event_nonce(&EthereumEvent::TransfersToNamada {
                 nonce: nonce - 1,
                 transfers: vec![],
             })
+            .then_some(())
+            .ok_or(())
             .expect_err("Test failed");
         shell
-            .validate_eth_event(&EthereumEvent::TransfersToNamada {
+            .wl_storage
+            .ethbridge_queries()
+            .validate_eth_event_nonce(&EthereumEvent::TransfersToNamada {
                 nonce: nonce - 2,
                 transfers: vec![],
             })
+            .then_some(())
+            .ok_or(())
             .expect_err("Test failed");
     }
 

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -183,6 +183,7 @@ where
     /// Checks the channel from the Ethereum oracle monitoring
     /// the fullnode and retrieves all seen Ethereum events.
     pub fn new_ethereum_events(&mut self) -> Vec<EthereumEvent> {
+        let queries = self.wl_storage.ethbridge_queries();
         match &mut self.mode {
             ShellMode::Validator {
                 eth_oracle:
@@ -191,7 +192,9 @@ where
                     }),
                 ..
             } => {
-                ethereum_receiver.fill_queue();
+                ethereum_receiver.fill_queue(|event| {
+                    queries.validate_eth_event_nonce(event)
+                });
                 ethereum_receiver.get_events()
             }
             _ => vec![],

--- a/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions/eth_events.rs
@@ -167,17 +167,17 @@ where
             );
             return Err(VoteExtensionError::HaveDupesOrNonSorted);
         }
-        ext.ethereum_events.iter().try_for_each(|event| {
-            if self
-                .wl_storage
+        // for the proposal to be valid, at least one of the
+        // event's nonces must be valid
+        if ext.ethereum_events.iter().any(|event| {
+            self.wl_storage
                 .ethbridge_queries()
                 .validate_eth_event_nonce(event)
-            {
-                Ok(())
-            } else {
-                Err(VoteExtensionError::InvalidEthEventNonce)
-            }
-        })
+        }) {
+            Ok(())
+        } else {
+            Err(VoteExtensionError::InvalidEthEventNonce)
+        }
     }
 
     /// Checks the channel from the Ethereum oracle monitoring

--- a/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
+++ b/ethereum_bridge/src/protocol/transactions/ethereum_events/mod.rs
@@ -872,4 +872,89 @@ mod tests {
             (_, Some(_)) => {}
         });
     }
+
+    /// Test that [`MultiSignedEthEvent`]s with outdated nonces do
+    /// not result in votes in storage.
+    #[test]
+    fn test_apply_derived_tx_outdated_nonce() -> Result<()> {
+        let (mut wl_storage, _) = test_utils::setup_default_storage();
+
+        let new_multisigned = |nonce: u64| {
+            let (validator, _) = test_utils::default_validator();
+            let event = EthereumEvent::TransfersToNamada {
+                nonce: nonce.into(),
+                transfers: vec![TransferToNamada {
+                    amount: Amount::from(100),
+                    asset: DAI_ERC20_ETH_ADDRESS,
+                    receiver: validator.clone(),
+                }],
+            };
+            let signers = BTreeSet::from([(validator, BlockHeight(100))]);
+            (
+                MultiSignedEthEvent {
+                    event: event.clone(),
+                    signers,
+                },
+                event,
+            )
+        };
+        macro_rules! nonce_ok {
+            ($nonce:expr) => {
+                let (multisigned, event) = new_multisigned($nonce);
+                let tx_result =
+                    apply_derived_tx(&mut wl_storage, vec![multisigned])?;
+
+                let eth_msg_keys = vote_tallies::Keys::from(&event);
+                assert!(
+                    tx_result.changed_keys.contains(&eth_msg_keys.seen()),
+                    "The Ethereum event should have been seen",
+                );
+                assert_eq!(
+                    wl_storage
+                        .ethbridge_queries()
+                        .get_next_nam_transfers_nonce(),
+                    ($nonce + 1).into(),
+                    "The transfers to Namada nonce should have been \
+                     incremented",
+                );
+            };
+        }
+        macro_rules! nonce_err {
+            ($nonce:expr) => {
+                let (multisigned, event) = new_multisigned($nonce);
+                let tx_result =
+                    apply_derived_tx(&mut wl_storage, vec![multisigned])?;
+
+                let eth_msg_keys = vote_tallies::Keys::from(&event);
+                assert!(
+                    !tx_result.changed_keys.contains(&eth_msg_keys.seen()),
+                    "The Ethereum event should have been ignored",
+                );
+                assert_eq!(
+                    wl_storage
+                        .ethbridge_queries()
+                        .get_next_nam_transfers_nonce(),
+                    NEXT_NONCE_TO_PROCESS.into(),
+                    "The transfers to Namada nonce should not have changed",
+                );
+            };
+        }
+
+        // update storage with valid events
+        const NEXT_NONCE_TO_PROCESS: u64 = 3;
+        for nonce in 0..NEXT_NONCE_TO_PROCESS {
+            nonce_ok!(nonce);
+        }
+
+        // attempts to replay events with older nonces should
+        // result in the events getting ignored
+        for nonce in 0..NEXT_NONCE_TO_PROCESS {
+            nonce_err!(nonce);
+        }
+
+        // process new valid event
+        nonce_ok!(NEXT_NONCE_TO_PROCESS);
+
+        Ok(())
+    }
 }

--- a/ethereum_bridge/src/storage/eth_bridge_queries.rs
+++ b/ethereum_bridge/src/storage/eth_bridge_queries.rs
@@ -10,7 +10,7 @@ use namada_core::types::address::Address;
 use namada_core::types::eth_abi::Encode;
 use namada_core::types::eth_bridge_pool::PendingTransfer;
 use namada_core::types::ethereum_events::{
-    EthAddress, GetEventNonce, TransferToEthereum, Uint,
+    EthAddress, EthereumEvent, GetEventNonce, TransferToEthereum, Uint,
 };
 use namada_core::types::keccak::KeccakHash;
 use namada_core::types::storage::{BlockHeight, Epoch, Key as StorageKey};
@@ -533,6 +533,53 @@ where
             .read(&pending_key)
             .expect("Reading from storage should not fail")
             .zip(Some(pending_key))
+    }
+
+    /// Valdidate an [`EthereumEvent`]'s nonce against the current
+    /// state of the ledger.
+    ///
+    /// # Event kinds
+    ///
+    /// In this section, we shall describe the checks perform for
+    /// each kind of relevant Ethereum event.
+    ///
+    /// ## Transfers to Ethereum
+    ///
+    /// We need to check if the nonce in the event corresponds to
+    /// the most recent bridge pool nonce. Unless the nonces match,
+    /// no state updates derived from the event should be applied.
+    /// In case the nonces are different, we reject the event, and
+    /// thus the inclusion of its container Ethereum events vote
+    /// extension.
+    ///
+    /// ## Transfers to Namada
+    ///
+    /// For a transfers to Namada event to be considered valid,
+    /// the nonce of this kind of event must not be lower than
+    /// the one stored in Namada.
+    pub fn validate_eth_event_nonce(&self, event: &EthereumEvent) -> bool {
+        match event {
+            EthereumEvent::TransfersToEthereum {
+                nonce: ext_nonce, ..
+            } => {
+                let current_bp_nonce = self.get_bridge_pool_nonce();
+                if &current_bp_nonce != ext_nonce {
+                    return false;
+                }
+            }
+            EthereumEvent::TransfersToNamada {
+                nonce: ext_nonce, ..
+            } => {
+                let next_nam_transfers_nonce =
+                    self.get_next_nam_transfers_nonce();
+                if &next_nam_transfers_nonce > ext_nonce {
+                    return false;
+                }
+            }
+            // consider other ethereum event kinds valid
+            _ => {}
+        }
+        true
     }
 }
 


### PR DESCRIPTION
## Describe your changes

Fixes Ethereum event validation/state updates when more than one validator is running the chain.

Specifically, before this patchset, validators would reject block proposals containing vote extensions storing Ethereum events with an invalid (outdated) nonce. This would hinder in the best case the latency of Ethereum bridge operations, and in the worst case its liveness, since events with nonces that could be processed would be mixed with events with outdated nonces.

With these changes, we allow extensions with at least one good event to be processed, and ignore state updates from events with invalid nonces.

## Indicate on which release or other PRs this topic is based on

`v0.23.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
