### PR TITLE
IBC token hash type for addresses

### DIFF
--- a/.changelog/unreleased/improvements/2046-ibc-token-addr.md
+++ b/.changelog/unreleased/improvements/2046-ibc-token-addr.md
@@ -1,0 +1,2 @@
+- Replace strings with a specialized IBC token hash type in addresses
+  ([\#2046](https://github.com/anoma/namada/pull/2046))

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -41,7 +41,7 @@ use namada::ledger::storage::ConversionState;
 use namada::proof_of_stake::types::{ValidatorState, WeightedValidator};
 use namada::types::address::{masp, Address, InternalAddress};
 use namada::types::hash::Hash;
-use namada::types::ibc::is_ibc_denom;
+use namada::types::ibc::{is_ibc_denom, IbcTokenHash};
 use namada::types::io::Io;
 use namada::types::key::*;
 use namada::types::masp::{BalanceOwner, ExtendedViewingKey, PaymentAddress};
@@ -635,7 +635,8 @@ async fn lookup_token_alias<'a>(
     owner: &Address,
 ) -> String {
     if let Address::Internal(InternalAddress::IbcToken(trace_hash)) = token {
-        let ibc_denom_key = ibc_denom_key(owner.to_string(), trace_hash);
+        let ibc_denom_key =
+            ibc_denom_key(owner.to_string(), trace_hash.to_string());
         match query_storage_value::<_, String>(context.client(), &ibc_denom_key)
             .await
         {
@@ -687,6 +688,9 @@ async fn query_tokens<'a>(
                 if let Some((_, hash)) = is_ibc_denom_key(&key) {
                     let ibc_denom_alias =
                         get_ibc_denom_alias(context, ibc_denom).await;
+                    let hash: IbcTokenHash = hash.parse().expect(
+                        "Parsing an IBC token hash from storage shouldn't fail",
+                    );
                     let ibc_token =
                         Address::Internal(InternalAddress::IbcToken(hash));
                     tokens.insert(ibc_denom_alias, ibc_token);

--- a/core/src/types/ibc.rs
+++ b/core/src/types/ibc.rs
@@ -2,13 +2,53 @@
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use data_encoding::{DecodePartial, HEXLOWER, HEXLOWER_PERMISSIVE};
+use serde::{Deserialize, Serialize};
+
+use super::address::HASH_LEN;
 
 /// The event type defined in ibc-rs for receiving a token
 pub const EVENT_TYPE_PACKET: &str = "fungible_token_packet";
 /// The event type defined in ibc-rs for IBC denom
 pub const EVENT_TYPE_DENOM_TRACE: &str = "denomination_trace";
+
+/// IBC token hash derived from a denomination.
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
+#[repr(transparent)]
+pub struct IbcTokenHash(pub [u8; HASH_LEN]);
+
+impl std::fmt::Display for IbcTokenHash {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", HEXLOWER.encode(&self.0))
+    }
+}
+
+impl FromStr for IbcTokenHash {
+    type Err = DecodePartial;
+
+    fn from_str(h: &str) -> std::result::Result<Self, Self::Err> {
+        let mut output = [0u8; HASH_LEN];
+        HEXLOWER_PERMISSIVE.decode_mut(h.as_ref(), &mut output)?;
+        Ok(IbcTokenHash(output))
+    }
+}
 
 /// Wrapped IbcEvent
 #[derive(

--- a/sdk/src/rpc.rs
+++ b/sdk/src/rpc.rs
@@ -1101,12 +1101,12 @@ pub async fn query_ibc_denom<'a, N: Namada<'a>>(
     owner: Option<&Address>,
 ) -> String {
     let hash = match token {
-        Address::Internal(InternalAddress::IbcToken(hash)) => hash,
+        Address::Internal(InternalAddress::IbcToken(hash)) => hash.to_string(),
         _ => return token.to_string(),
     };
 
     if let Some(owner) = owner {
-        let ibc_denom_key = ibc_denom_key(owner.to_string(), hash);
+        let ibc_denom_key = ibc_denom_key(owner.to_string(), &hash);
         if let Ok(ibc_denom) =
             query_storage_value::<_, String>(context.client(), &ibc_denom_key)
                 .await
@@ -1122,7 +1122,7 @@ pub async fn query_ibc_denom<'a, N: Namada<'a>>(
     {
         for (key, ibc_denom) in ibc_denoms {
             if let Some((_, token_hash)) = is_ibc_denom_key(&key) {
-                if token_hash == *hash {
+                if token_hash == hash {
                     return ibc_denom;
                 }
             }

--- a/tests/src/native_vp/pos.rs
+++ b/tests/src/native_vp/pos.rs
@@ -603,6 +603,7 @@ pub mod testing {
     pub type PosStorageChanges = Vec<PosStorageChange>;
 
     #[derive(Clone, Debug)]
+    #[allow(clippy::large_enum_variant)]
     pub enum ValidPosAction {
         InitValidator {
             address: Address,


### PR DESCRIPTION
## Describe your changes

Precursor to #2018

This PR swaps IBC token hashes stored in the `Address` type as `String` values with new `IbcTokenHash` values, which internally are represented by an array of 20 bytes.

## Indicate on which release or other PRs this topic is based on

`v0.25.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
