### PR TITLE
apps: turn off rocksdb jemalloc on windows

### DIFF
--- a/.changelog/unreleased/bug-fixes/2047-win-build.md
+++ b/.changelog/unreleased/bug-fixes/2047-win-build.md
@@ -1,0 +1,2 @@
+- Fix Windows build by disabling RocksDB jemalloc feature.
+  ([\#2047](https://github.com/anoma/namada/pull/2047))

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -120,7 +120,6 @@ regex.workspace = true
 reqwest.workspace = true
 ripemd.workspace = true
 rlimit.workspace = true
-rocksdb.workspace = true
 rpassword.workspace = true
 serde_bytes.workspace = true
 serde_json = {workspace = true, features = ["raw_value"]}
@@ -143,9 +142,14 @@ tracing-subscriber = { workspace = true, features = ["std", "json", "ansi", "tra
 tracing.workspace = true
 winapi.workspace = true
 zeroize.workspace = true
-
 warp = "0.3.2"
 bytes = "1.1.0"
+
+[target.'cfg(not(windows))'.dependencies]
+rocksdb = { workspace = true, features = ['jemalloc'] } # jemalloc is not supported on windows
+
+[target.'cfg(windows)'.dependencies]
+rocksdb = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
## Describe your changes

rocksdb (tikv-)jemalloc is not supported on windows (https://github.com/tikv/jemallocator#platform-support)

## Indicate on which release or other PRs this topic is based on

0.25.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
