### PR TITLE
fix: vp/tx wasm caching

### DIFF
--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -546,6 +546,7 @@ where
             // TODO: config event log params
             event_log: EventLog::default(),
         };
+
         shell.update_eth_oracle();
         shell
     }


### PR DESCRIPTION
## Describe your changes
Remove `loope` size check for wasm vp/tx caching.

## Indicate on which release or other PRs this topic is based on
0.24.0

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
