### PR TITLE
[draft] Modify the funds of an account in-place

### DIFF
--- a/apps/src/bin/namada-node/cli.rs
+++ b/apps/src/bin/namada-node/cli.rs
@@ -2,6 +2,7 @@
 
 use eyre::{Context, Result};
 use namada::types::time::{DateTimeUtc, Utc};
+use namada_apps::cli::args::CliToSdk;
 use namada_apps::cli::{self, cmds};
 use namada_apps::node::ledger;
 
@@ -27,6 +28,10 @@ pub fn main() -> Result<()> {
             }
             cmds::Ledger::DumpDb(cmds::LedgerDumpDb(args)) => {
                 ledger::dump_db(ctx.config.ledger, args);
+            }
+            cmds::Ledger::SetFunds(cmds::LedgerSetFunds(args)) => {
+                let args = args.to_sdk(&mut ctx);
+                ledger::set_funds(ctx.config.ledger, args);
             }
             cmds::Ledger::RollBack(_) => {
                 ledger::rollback(ctx.config.ledger)

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -16,7 +16,7 @@ use byte_unit::Byte;
 use futures::future::TryFutureExt;
 use namada::core::ledger::governance::storage::keys as governance_storage;
 use namada::eth_bridge::ethers::providers::{Http, Provider};
-use namada::types::storage::Key;
+use namada::types::storage::{BlockHeight, Key};
 use once_cell::unsync::Lazy;
 use sysinfo::{RefreshKind, System, SystemExt};
 use tokio::sync::mpsc;
@@ -166,6 +166,13 @@ impl Shell {
             }
         }
     }
+}
+
+/// Determine if the ledger is migrating state.
+pub fn migrating_state() -> Option<BlockHeight> {
+    const ENV_INITIAL_HEIGHT: &str = "NAMADA_INITIAL_HEIGHT";
+    let height = std::env::var(ENV_INITIAL_HEIGHT).ok()?;
+    height.parse::<u64>().ok().map(BlockHeight)
 }
 
 /// Run the ledger with an async runtime

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -120,10 +120,21 @@ where
             )?;
         }
 
-        // Invariant: Has to be applied before `record_slashes_from_evidence`
-        // because it potentially needs to be able to read validator state from
-        // previous epoch and jailing validator removes the historical state
-        self.log_block_rewards(&req.votes, height, current_epoch, new_epoch)?;
+        // NOTE: this condition is required for hard-forks
+        // TODO: load block signatures from external sources for
+        // hard-forks, so we can still distribute PoS rewards
+        if hints::likely(!req.votes.is_empty()) {
+            // Invariant: Has to be applied before
+            // `record_slashes_from_evidence` because it potentially
+            // needs to be able to read validator state from
+            // previous epoch and jailing validator removes the historical state
+            self.log_block_rewards(
+                &req.votes,
+                height,
+                current_epoch,
+                new_epoch,
+            )?;
+        }
         if new_epoch {
             self.apply_inflation(current_epoch)?;
         }

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -422,6 +422,12 @@ async fn write_tm_genesis(
     genesis.genesis_time = genesis_time
         .try_into()
         .expect("Couldn't convert DateTimeUtc to Tendermint Time");
+    if let Some(height) = super::migrating_state() {
+        genesis.initial_height = height
+            .0
+            .try_into()
+            .expect("Failed to convert initial genesis height");
+    }
     let size = block::Size {
         // maximum size of a serialized Tendermint block
         // cannot go over 100 MiB

--- a/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/apps/src/lib/node/ledger/tendermint_node.rs
@@ -191,6 +191,23 @@ pub fn reset(tendermint_dir: impl AsRef<Path>) -> Result<()> {
     Ok(())
 }
 
+pub fn reset_state(tendermint_dir: impl AsRef<Path>) -> Result<()> {
+    let tendermint_path = from_env_or_default()?;
+    let tendermint_dir = tendermint_dir.as_ref().to_string_lossy();
+    // reset all the Tendermint state, if any
+    std::process::Command::new(tendermint_path)
+        .args([
+            "unsafe-reset-all",
+            // NOTE: log config: https://docs.tendermint.com/master/nodes/logging.html#configuring-log-levels
+            // "--log-level=\"*debug\"",
+            "--home",
+            &tendermint_dir,
+        ])
+        .output()
+        .expect("Failed to reset tendermint node's data");
+    Ok(())
+}
+
 pub fn rollback(tendermint_dir: impl AsRef<Path>) -> Result<BlockHeight> {
     let tendermint_path = from_env_or_default()?;
     let tendermint_dir = tendermint_dir.as_ref().to_string_lossy();

--- a/core/src/ledger/storage/mockdb.rs
+++ b/core/src/ledger/storage/mockdb.rs
@@ -590,6 +590,17 @@ impl DB for MockDB {
 
         Ok(())
     }
+
+    #[cold]
+    fn overwrite_entry(
+        &mut self,
+        _batch: &mut Self::WriteBatch,
+        _height: Option<BlockHeight>,
+        _key: &Key,
+        _new_value: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        unimplemented!()
+    }
 }
 
 impl<'iter> DBIter<'iter> for MockDB {

--- a/core/src/ledger/storage/mod.rs
+++ b/core/src/ledger/storage/mod.rs
@@ -372,6 +372,16 @@ pub trait DB: std::fmt::Debug {
         batch: &mut Self::WriteBatch,
         key: &Key,
     ) -> Result<()>;
+
+    /// Overwrite a new value in storage, taking into
+    /// account values stored at a previous height
+    fn overwrite_entry(
+        &mut self,
+        batch: &mut Self::WriteBatch,
+        height: Option<BlockHeight>,
+        key: &Key,
+        new_value: impl AsRef<[u8]>,
+    ) -> Result<()>;
 }
 
 /// A database prefix iterator.


### PR DESCRIPTION
## Describe your changes

Implement a hard-forking util to modify the funds of a given account in-place (i.e. directly writing to RocksDB).

The current flow is something like:

1. Stop the ledger at height $H$.
2. Run the `set-funds` CLI.
3. Start the ledger with the env var `NAMADA_INITIAL_HEIGHT` set to $H+1$.
4. To confirm that the hard-fork worked as expected, kill the ledger, unset `NAMADA_INITIAL_HEIGHT` and run the ledger once more.

## Indicate on which release or other PRs this topic is based on

`v0.24.1`

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
