### PR TITLE
Rename arse_merkle_tree to sparse_merkle_tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ ark-bls12-381 = {version = "0.3"}
 ark-serialize = {version = "0.3"}
 ark-std = "0.3.0"
 # branch = "bat/arse-merkle-tree"
-arse-merkle-tree = {package = "sparse-merkle-tree", git = "https://github.com/heliaxdev/sparse-merkle-tree", rev = "df7ec062e7c40d5e76b136064e9aaf8bd2490750", default-features = false, features = ["std", "borsh"]}
+sparse-merkle-tree = {package = "sparse-merkle-tree", git = "https://github.com/heliaxdev/sparse-merkle-tree", rev = "df7ec062e7c40d5e76b136064e9aaf8bd2490750", default-features = false, features = ["std", "borsh"]}
 assert_cmd = "1.0.7"
 assert_matches = "1.5.0"
 async-trait = {version = "0.1.51"}

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -71,7 +71,7 @@ namada_sdk = {path = "../sdk", default-features = false, features = ["wasm-runti
 namada_test_utils = {path = "../test_utils", optional = true}
 ark-serialize.workspace = true
 ark-std.workspace = true
-arse-merkle-tree = { workspace = true, features = ["blake2b"] }
+sparse-merkle-tree = { workspace = true, features = ["blake2b"] }
 assert_matches.workspace = true
 async-trait.workspace = true
 base64.workspace = true

--- a/apps/src/lib/node/ledger/storage/mod.rs
+++ b/apps/src/lib/node/ledger/storage/mod.rs
@@ -5,9 +5,9 @@ mod rocksdb;
 
 use std::fmt;
 
-use arse_merkle_tree::blake2b::Blake2bHasher;
-use arse_merkle_tree::traits::Hasher;
-use arse_merkle_tree::H256;
+use sparse_merkle_tree::blake2b::Blake2bHasher;
+use sparse_merkle_tree::traits::Hasher;
+use sparse_merkle_tree::H256;
 use blake2b_rs::{Blake2b, Blake2bBuilder};
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::Storage;

--- a/apps/src/lib/node/ledger/storage/mod.rs
+++ b/apps/src/lib/node/ledger/storage/mod.rs
@@ -5,12 +5,12 @@ mod rocksdb;
 
 use std::fmt;
 
-use sparse_merkle_tree::blake2b::Blake2bHasher;
-use sparse_merkle_tree::traits::Hasher;
-use sparse_merkle_tree::H256;
 use blake2b_rs::{Blake2b, Blake2bBuilder};
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::Storage;
+use sparse_merkle_tree::blake2b::Blake2bHasher;
+use sparse_merkle_tree::traits::Hasher;
+use sparse_merkle_tree::H256;
 
 #[derive(Default)]
 pub struct PersistentStorageHasher(Blake2bHasher);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,7 +53,7 @@ namada_macros = {path = "../macros"}
 ark-bls12-381.workspace = true
 ark-ec = {version = "0.3", optional = true}
 ark-serialize.workspace = true
-arse-merkle-tree.workspace = true
+sparse-merkle-tree.workspace = true
 bech32.workspace = true
 borsh.workspace = true
 borsh-ext.workspace = true

--- a/core/src/ledger/storage/ics23_specs.rs
+++ b/core/src/ledger/storage/ics23_specs.rs
@@ -1,7 +1,7 @@
 //! A module that contains
 
-use sparse_merkle_tree::H256;
 use ics23::{HashOp, LeafOp, LengthOp, ProofSpec};
+use sparse_merkle_tree::H256;
 
 use super::traits::StorageHasher;
 

--- a/core/src/ledger/storage/ics23_specs.rs
+++ b/core/src/ledger/storage/ics23_specs.rs
@@ -1,6 +1,6 @@
 //! A module that contains
 
-use arse_merkle_tree::H256;
+use sparse_merkle_tree::H256;
 use ics23::{HashOp, LeafOp, LengthOp, ProofSpec};
 
 use super::traits::StorageHasher;
@@ -47,7 +47,7 @@ pub fn ibc_leaf_spec<H: StorageHasher>() -> LeafOp {
 /// Get the proof specs for ibc
 #[allow(dead_code)]
 pub fn ibc_proof_specs<H: StorageHasher>() -> Vec<ProofSpec> {
-    let spec = arse_merkle_tree::proof_ics23::get_spec(H::hash_op());
+    let spec = sparse_merkle_tree::proof_ics23::get_spec(H::hash_op());
     let sub_tree_spec = ProofSpec {
         leaf_spec: Some(ibc_leaf_spec::<H>()),
         ..spec.clone()
@@ -62,7 +62,7 @@ pub fn ibc_proof_specs<H: StorageHasher>() -> Vec<ProofSpec> {
 /// Get the proof specs
 #[allow(dead_code)]
 pub fn proof_specs<H: StorageHasher>() -> Vec<ProofSpec> {
-    let spec = arse_merkle_tree::proof_ics23::get_spec(H::hash_op());
+    let spec = sparse_merkle_tree::proof_ics23::get_spec(H::hash_op());
     let sub_tree_spec = ProofSpec {
         leaf_spec: Some(leaf_spec::<H>()),
         ..spec.clone()

--- a/core/src/ledger/storage/merkle_tree.rs
+++ b/core/src/ledger/storage/merkle_tree.rs
@@ -2,15 +2,15 @@
 use std::fmt;
 use std::str::FromStr;
 
+use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_ext::BorshSerializeExt;
+use ics23::commitment_proof::Proof as Ics23Proof;
+use ics23::{CommitmentProof, ExistenceProof, NonExistenceProof};
 use sparse_merkle_tree::default_store::DefaultStore;
 use sparse_merkle_tree::error::Error as MtError;
 use sparse_merkle_tree::{
     Hash as SmtHash, Key as TreeKey, SparseMerkleTree as ArseMerkleTree, H256,
 };
-use borsh::{BorshDeserialize, BorshSerialize};
-use borsh_ext::BorshSerializeExt;
-use ics23::commitment_proof::Proof as Ics23Proof;
-use ics23::{CommitmentProof, ExistenceProof, NonExistenceProof};
 use thiserror::Error;
 
 use super::traits::{StorageHasher, SubTreeRead, SubTreeWrite};

--- a/core/src/ledger/storage/merkle_tree.rs
+++ b/core/src/ledger/storage/merkle_tree.rs
@@ -2,9 +2,9 @@
 use std::fmt;
 use std::str::FromStr;
 
-use arse_merkle_tree::default_store::DefaultStore;
-use arse_merkle_tree::error::Error as MtError;
-use arse_merkle_tree::{
+use sparse_merkle_tree::default_store::DefaultStore;
+use sparse_merkle_tree::error::Error as MtError;
+use sparse_merkle_tree::{
     Hash as SmtHash, Key as TreeKey, SparseMerkleTree as ArseMerkleTree, H256,
 };
 use borsh::{BorshDeserialize, BorshSerialize};

--- a/core/src/ledger/storage/traits.rs
+++ b/core/src/ledger/storage/traits.rs
@@ -3,13 +3,13 @@
 use std::convert::TryInto;
 use std::fmt;
 
-use sparse_merkle_tree::traits::{Hasher, Value};
-use sparse_merkle_tree::{Key as TreeKey, H256};
 use borsh::BorshDeserialize;
 use borsh_ext::BorshSerializeExt;
 use ics23::commitment_proof::Proof as Ics23Proof;
 use ics23::{CommitmentProof, ExistenceProof};
 use sha2::{Digest, Sha256};
+use sparse_merkle_tree::traits::{Hasher, Value};
+use sparse_merkle_tree::{Key as TreeKey, H256};
 use tiny_keccak::Hasher as KHasher;
 
 use super::ics23_specs;

--- a/core/src/ledger/storage/traits.rs
+++ b/core/src/ledger/storage/traits.rs
@@ -3,8 +3,8 @@
 use std::convert::TryInto;
 use std::fmt;
 
-use arse_merkle_tree::traits::{Hasher, Value};
-use arse_merkle_tree::{Key as TreeKey, H256};
+use sparse_merkle_tree::traits::{Hasher, Value};
+use sparse_merkle_tree::{Key as TreeKey, H256};
 use borsh::BorshDeserialize;
 use borsh_ext::BorshSerializeExt;
 use ics23::commitment_proof::Proof as Ics23Proof;

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -7,13 +7,13 @@ use std::num::ParseIntError;
 use std::ops::{Add, AddAssign, Deref, Div, Drop, Mul, Rem, Sub};
 use std::str::FromStr;
 
-use sparse_merkle_tree::InternalKey;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use data_encoding::{BASE32HEX_NOPAD, HEXUPPER};
 use ics23::CommitmentProof;
 use index_set::vec::VecIndexSet;
 use serde::{Deserialize, Serialize};
+use sparse_merkle_tree::InternalKey;
 use thiserror::Error;
 
 use super::key::common;

--- a/core/src/types/storage.rs
+++ b/core/src/types/storage.rs
@@ -7,7 +7,7 @@ use std::num::ParseIntError;
 use std::ops::{Add, AddAssign, Deref, Div, Drop, Mul, Rem, Sub};
 use std::str::FromStr;
 
-use arse_merkle_tree::InternalKey;
+use sparse_merkle_tree::InternalKey;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use data_encoding::{BASE32HEX_NOPAD, HEXUPPER};


### PR DESCRIPTION
Was there a reason to call it `arse_merkle_tree`?