### PR TITLE
Win build, attempt #2

### DIFF
--- a/.changelog/unreleased/bug-fixes/2100-win-build.md
+++ b/.changelog/unreleased/bug-fixes/2100-win-build.md
@@ -1,0 +1,2 @@
+- Fix Windows build by disabling RocksDB jemalloc feature.
+  ([\#2100](https://github.com/anoma/namada/pull/2100))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ regex = "1.4.5"
 reqwest = "0.11.4"
 ripemd = "0.1"
 rlimit = "0.5.4"
-rocksdb = {version = "0.21.0", features = ['zstd', 'jemalloc'], default-features = false}
+rocksdb = {version = "0.21.0", features = ['zstd'], default-features = false}
 rpassword = "5.0.1"
 serde = {version = "1.0.125", features = ["derive"]}
 serde_bytes = "0.11.5"


### PR DESCRIPTION
## Describe your changes

Follow-up to #2047, we have to remove jemalloc from rocksdb workspace features to support win build.

## Indicate on which release or other PRs this topic is based on

0.25.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
