### PR TITLE
deps: switch to tower-abci branch with overloaded service handling

### DIFF
--- a/.changelog/unreleased/bug-fixes/2103-tower-abci-err.md
+++ b/.changelog/unreleased/bug-fixes/2103-tower-abci-err.md
@@ -1,0 +1,2 @@
+- Handle overloaded services in tower-abci.
+  ([\#2103](https://github.com/anoma/namada/pull/2103))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.9",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7077,8 +7091,9 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/tower-abci.git?rev=cf9573dc02eba0faf1f9807244b156630e4c18d1#cf9573dc02eba0faf1f9807244b156630e4c18d1"
+source = "git+https://github.com/heliaxdev/tower-abci.git?rev=c22bdb42eec522a12866dd3355dd489ecfaf04b7#c22bdb42eec522a12866dd3355dd489ecfaf04b7"
 dependencies = [
+ "backoff",
  "bytes",
  "futures",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ tonic = "0.8.3"
 tonic-build = "0.8.4"
 tower = "0.4"
 # Also, using the same version of tendermint-rs as we do here.
-tower-abci = {git = "https://github.com/heliaxdev/tower-abci.git", rev = "cf9573dc02eba0faf1f9807244b156630e4c18d1"}
+tower-abci = {git = "https://github.com/heliaxdev/tower-abci.git", rev = "c22bdb42eec522a12866dd3355dd489ecfaf04b7"}
 tracing = "0.1.30"
 tracing-appender = "0.2.2"
 tracing-log = "0.1.2"


### PR DESCRIPTION
## Describe your changes

https://github.com/heliaxdev/tower-abci/pull/12:
- added exponential backoff when a service overloaded
- peek requests in case a service call fails to be able to retry them - this avoids crashing CometBFT (it *should* be possible to shed query requests when the query service is overloaded, but at the moment the implementation doesn't distinguish this and shedding mempool requests does crash Comet)

## Indicate on which release or other PRs this topic is based on

0.25.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
