### PR TITLE
protocol: remove `panic::catch_unwind` for PoS VP

### DIFF
--- a/.changelog/unreleased/miscellaneous/2145-pos-vp-no-catch.md
+++ b/.changelog/unreleased/miscellaneous/2145-pos-vp-no-catch.md
@@ -1,0 +1,2 @@
+- Removed catching of panics from PoS VP.
+  ([\#2145](https://github.com/anoma/namada/pull/2145))

--- a/shared/src/ledger/pos/vp.rs
+++ b/shared/src/ledger/pos/vp.rs
@@ -1,7 +1,6 @@
 //! Proof-of-Stake native validity predicate.
 
 use std::collections::BTreeSet;
-use std::panic::{RefUnwindSafe, UnwindSafe};
 
 use namada_core::ledger::storage_api::governance;
 // use borsh::BorshDeserialize;
@@ -56,30 +55,6 @@ where
     pub fn new(ctx: Ctx<'a, DB, H, CA>) -> Self {
         Self { ctx }
     }
-}
-
-// TODO this is temporarily to run PoS native VP in a new thread to avoid
-// crashing the ledger (in apps/src/lib/node/ledger/protocol/mod.rs). The
-// RefCells contained within PosVP are not thread-safe, but each thread has its
-// own instances.
-impl<DB, H, CA> UnwindSafe for PosVP<'_, DB, H, CA>
-where
-    DB: 'static + ledger_storage::DB + for<'iter> ledger_storage::DBIter<'iter>,
-    H: 'static + StorageHasher,
-    CA: 'static + WasmCacheAccess,
-{
-}
-
-// TODO this is temporarily to run PoS native VP in a new thread to avoid
-// crashing the ledger (in apps/src/lib/node/ledger/protocol/mod.rs). The
-// RefCells contained within PosVP are not thread-safe, but each thread has its
-// own instances.
-impl<DB, H, CA> RefUnwindSafe for PosVP<'_, DB, H, CA>
-where
-    DB: 'static + ledger_storage::DB + for<'iter> ledger_storage::DBIter<'iter>,
-    H: 'static + StorageHasher,
-    CA: 'static + WasmCacheAccess,
-{
 }
 
 impl<'a, DB, H, CA> NativeVp for PosVP<'a, DB, H, CA>

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -1,6 +1,5 @@
 //! The ledger's protocol
 use std::collections::BTreeSet;
-use std::panic;
 
 use borsh_ext::BorshSerializeExt;
 use eyre::{eyre, WrapErr};
@@ -854,26 +853,13 @@ where
                                 // and `RefUnwindSafe` in
                                 // shared/src/ledger/pos/vp.rs)
                                 let keys_changed_ref = &keys_changed;
-                                let result =
-                                    match panic::catch_unwind(move || {
-                                        pos_ref
-                                            .validate_tx(
-                                                tx,
-                                                keys_changed_ref,
-                                                verifiers_addr_ref,
-                                            )
-                                            .map_err(Error::PosNativeVpError)
-                                    }) {
-                                        Ok(result) => result,
-                                        Err(err) => {
-                                            tracing::error!(
-                                                "PoS native VP failed with \
-                                                 {:#?}",
-                                                err
-                                            );
-                                            Err(Error::PosNativeVpRuntime)
-                                        }
-                                    };
+                                let result = pos_ref
+                                    .validate_tx(
+                                        tx,
+                                        keys_changed_ref,
+                                        verifiers_addr_ref,
+                                    )
+                                    .map_err(Error::PosNativeVpError);
                                 // Take the gas meter and sentinel
                                 // back
                                 // out of the context


### PR DESCRIPTION
## Describe your changes

closes #21. We are safe to remove the temp panic catcher as the PoS VP currently only handles PoS params validation.

## Indicate on which release or other PRs this topic is based on 

v0.25.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
