### PR TITLE
Misc PoS tasks

### DIFF
--- a/.changelog/unreleased/improvements/2178-misc-pos-tasks.md
+++ b/.changelog/unreleased/improvements/2178-misc-pos-tasks.md
@@ -1,0 +1,3 @@
+- Various improvements to the PoS code, including adding a panic on a slashing
+  failure, some more checked arithmetics, aesthetic code cleanup, and fixing a
+  bug in is_delegator. ([\#2178](https://github.com/anoma/namada/pull/2178))

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -105,7 +105,7 @@ where
                 current_epoch,
                 current_epoch + pos_params.pipeline_len,
             )?;
-            namada_proof_of_stake::store_total_consensus_stake(
+            namada_proof_of_stake::compute_and_store_total_consensus_stake(
                 &mut self.wl_storage,
                 current_epoch,
             )?;

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -157,7 +157,7 @@ where
         self.apply_genesis_txs_transfer(&genesis);
         self.apply_genesis_txs_bonds(&genesis);
 
-        pos::namada_proof_of_stake::store_total_consensus_stake(
+        pos::namada_proof_of_stake::compute_and_store_total_consensus_stake(
             &mut self.wl_storage,
             Default::default(),
         )

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -803,6 +803,7 @@ where
                 current_epoch,
                 err
             );
+            panic!("Error while processing slashes");
         }
     }
 

--- a/ethereum_bridge/src/test_utils.rs
+++ b/ethereum_bridge/src/test_utils.rs
@@ -19,8 +19,8 @@ use namada_proof_of_stake::parameters::OwnedPosParams;
 use namada_proof_of_stake::pos_queries::PosQueries;
 use namada_proof_of_stake::types::GenesisValidator;
 use namada_proof_of_stake::{
-    become_validator, bond_tokens, staking_token_address,
-    store_total_consensus_stake, BecomeValidator,
+    become_validator, bond_tokens, compute_and_store_total_consensus_stake,
+    staking_token_address, BecomeValidator,
 };
 
 use crate::parameters::{
@@ -293,7 +293,7 @@ pub fn append_validators_to_storage(
         all_keys.insert(validator, keys);
     }
 
-    store_total_consensus_stake(
+    compute_and_store_total_consensus_stake(
         wl_storage,
         current_epoch + params.pipeline_len,
     )

--- a/proof_of_stake/src/epoched.rs
+++ b/proof_of_stake/src/epoched.rs
@@ -402,8 +402,6 @@ where
     }
 
     /// Update data by removing old epochs
-    // TODO: should we consider more complex handling of empty epochs in the
-    // data below?
     pub fn update_data<S>(
         &self,
         storage: &mut S,

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -753,9 +753,18 @@ where
             }
             Ok(false)
         }
-        None => Ok(storage_api::iter_prefix_bytes(storage, &prefix)?
-            .next()
-            .is_some()),
+        None => {
+            let iter = storage_api::iter_prefix_bytes(storage, &prefix)?;
+            for res in iter {
+                let (key, _) = res?;
+                if let Some((bond_id, _epoch)) = is_bond_key(&key) {
+                    if bond_id.source != bond_id.validator {
+                        return Ok(true);
+                    }
+                }
+            }
+            Ok(false)
+        }
     }
 }
 

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -327,7 +327,7 @@ where
             current_epoch,
             epoch,
         )?;
-        store_total_consensus_stake(storage, epoch)?;
+        compute_and_store_total_consensus_stake(storage, epoch)?;
     }
     Ok(())
 }
@@ -1482,8 +1482,8 @@ where
         })
 }
 
-/// Store total consensus stake
-pub fn store_total_consensus_stake<S>(
+/// Compute and then store the total consensus stake
+pub fn compute_and_store_total_consensus_stake<S>(
     storage: &mut S,
     epoch: Epoch,
 ) -> storage_api::Result<()>
@@ -1492,7 +1492,7 @@ where
 {
     let total = compute_total_consensus_stake(storage, epoch)?;
     tracing::debug!(
-        "Computed total consensus stake for epoch {}: {}",
+        "Total consensus stake for epoch {}: {}",
         epoch,
         total.to_string_native()
     );
@@ -5670,7 +5670,7 @@ pub mod test_utils {
             )?;
         }
         // Store the total consensus validator stake to storage
-        store_total_consensus_stake(storage, current_epoch)?;
+        compute_and_store_total_consensus_stake(storage, current_epoch)?;
 
         // Copy validator sets and positions
         copy_genesis_validator_sets(storage, params, current_epoch)?;

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -322,7 +322,7 @@ where
             current_epoch,
             epoch,
         )?;
-        compute_and_store_total_consensus_stake(storage, epoch)?;
+        // compute_and_store_total_consensus_stake(storage, epoch)?;
     }
     Ok(())
 }

--- a/proof_of_stake/src/pos_queries.rs
+++ b/proof_of_stake/src/pos_queries.rs
@@ -2,12 +2,9 @@
 //! data. This includes validator and epoch related data.
 
 use namada_core::ledger::parameters::storage::get_max_proposal_bytes_key;
-use namada_core::ledger::parameters::EpochDuration;
 use namada_core::ledger::storage::WlStorage;
 use namada_core::ledger::storage_api::collections::lazy_map::NestedSubKey;
 use namada_core::ledger::{storage, storage_api};
-use namada_core::tendermint_proto::google::protobuf;
-use namada_core::tendermint_proto::types::EvidenceParams;
 use namada_core::types::address::Address;
 use namada_core::types::chain::ProposalBytes;
 use namada_core::types::storage::{BlockHeight, Epoch};
@@ -138,31 +135,6 @@ where
             // an epoch that hasn't been reached yet. let's "fail" by
             // returning a total stake of 0 NAM
             .unwrap_or_default()
-    }
-
-    /// Return evidence parameters.
-    // TODO: impove this docstring
-    pub fn get_evidence_params(
-        self,
-        epoch_duration: &EpochDuration,
-        pos_params: &PosParams,
-    ) -> EvidenceParams {
-        // Minimum number of epochs before tokens are unbonded and can be
-        // withdrawn
-        let len_before_unbonded =
-            std::cmp::max(pos_params.unbonding_len as i64 - 1, 0);
-        let max_age_num_blocks: i64 =
-            epoch_duration.min_num_of_blocks as i64 * len_before_unbonded;
-        let min_duration_secs = epoch_duration.min_duration.0 as i64;
-        let max_age_duration = Some(protobuf::Duration {
-            seconds: min_duration_secs * len_before_unbonded,
-            nanos: 0,
-        });
-        EvidenceParams {
-            max_age_num_blocks,
-            max_age_duration,
-            ..EvidenceParams::default()
-        }
     }
 
     /// Lookup data about a validator from their protocol signing key.

--- a/proof_of_stake/src/rewards.rs
+++ b/proof_of_stake/src/rewards.rs
@@ -90,6 +90,11 @@ impl PosRewardsCalculator {
 
     /// Implement as ceiling of (2/3) * validator set stake
     fn get_min_required_votes(&self) -> Amount {
-        ((self.total_stake * 2u64) + (3u64 - 1u64)) / 3u64
+        (self
+            .total_stake
+            .checked_mul(2.into())
+            .expect("Amount overflow while computing minimum required votes")
+            + (3u64 - 1u64))
+            / 3u64
     }
 }

--- a/proof_of_stake/src/rewards.rs
+++ b/proof_of_stake/src/rewards.rs
@@ -55,7 +55,6 @@ impl PosRewardsCalculator {
     /// the validator's signing behavior and stake to determine the fraction of
     /// the block rewards earned.
     pub fn get_reward_coeffs(&self) -> Result<PosRewards, RewardsError> {
-        // TODO: think about possibility of u64 overflow
         let votes_needed = self.get_min_required_votes();
 
         let Self {

--- a/proof_of_stake/src/tests.rs
+++ b/proof_of_stake/src/tests.rs
@@ -2501,7 +2501,6 @@ fn test_compute_modified_redelegation() {
     let mut bob = validator2.clone();
 
     // Ensure a ranking order of alice > bob
-    // TODO: check why this needs to be > (am I just confusing myself?)
     if bob > alice {
         alice = validator2;
         bob = validator1;

--- a/proof_of_stake/src/tests.rs
+++ b/proof_of_stake/src/tests.rs
@@ -53,7 +53,8 @@ use crate::{
     apply_list_slashes, become_validator, below_capacity_validator_set_handle,
     bond_handle, bond_tokens, bonds_and_unbonds,
     compute_amount_after_slashing_unbond,
-    compute_amount_after_slashing_withdraw, compute_bond_at_epoch,
+    compute_amount_after_slashing_withdraw,
+    compute_and_store_total_consensus_stake, compute_bond_at_epoch,
     compute_modified_redelegation, compute_new_redelegated_unbonds,
     compute_slash_bond_at_epoch, compute_slashable_amount,
     consensus_validator_set_handle, copy_validator_sets_and_positions,
@@ -66,9 +67,9 @@ use crate::{
     read_consensus_validator_set_addresses_with_stake, read_total_stake,
     read_validator_deltas_value, read_validator_stake, slash,
     slash_redelegation, slash_validator, slash_validator_redelegation,
-    staking_token_address, store_total_consensus_stake, total_bonded_handle,
-    total_deltas_handle, total_unbonded_handle, unbond_handle, unbond_tokens,
-    unjail_validator, update_validator_deltas, update_validator_set,
+    staking_token_address, total_bonded_handle, total_deltas_handle,
+    total_unbonded_handle, unbond_handle, unbond_tokens, unjail_validator,
+    update_validator_deltas, update_validator_set,
     validator_consensus_key_handle, validator_incoming_redelegations_handle,
     validator_outgoing_redelegations_handle, validator_set_positions_handle,
     validator_set_update_tendermint, validator_slashes_handle,
@@ -2195,7 +2196,7 @@ fn get_tendermint_set_updates(
 fn advance_epoch(s: &mut TestWlStorage, params: &PosParams) -> Epoch {
     s.storage.block.epoch = s.storage.block.epoch.next();
     let current_epoch = s.storage.block.epoch;
-    store_total_consensus_stake(s, current_epoch).unwrap();
+    compute_and_store_total_consensus_stake(s, current_epoch).unwrap();
     copy_validator_sets_and_positions(
         s,
         params,

--- a/proof_of_stake/src/types.rs
+++ b/proof_of_stake/src/types.rs
@@ -24,8 +24,6 @@ pub use rev_order::ReverseOrdTokenAmount;
 
 use crate::parameters::PosParams;
 
-// TODO: review the offsets for each epoched type!!
-
 /// Stored positions of validators in validator sets
 pub type ValidatorSetPositions = crate::epoched::NestedEpoched<
     LazyMap<Address, Position>,
@@ -71,11 +69,11 @@ pub type ValidatorStates = crate::epoched::Epoched<
 /// A map from a position to an address in a Validator Set
 pub type ValidatorPositionAddresses = LazyMap<Position, Address>;
 
-/// New validator set construction, keyed by staked token amount
+/// Consensus validator set, keyed by staked token amount
 pub type ConsensusValidatorSet =
     NestedMap<token::Amount, ValidatorPositionAddresses>;
 
-/// New validator set construction, keyed by staked token amount
+/// Below-capacity validator set, keyed by staked token amount
 pub type BelowCapacityValidatorSet =
     NestedMap<ReverseOrdTokenAmount, ValidatorPositionAddresses>;
 
@@ -128,8 +126,7 @@ pub type Bonds = crate::epoched::EpochedDelta<
     crate::epoched::OffsetMaxU64,
 >;
 
-/// An epoched lazy set of all known active validator addresses (consensus,
-/// below-capacity, below-threshold, jailed)
+/// An epoched lazy set of all known validator addresses
 pub type ValidatorAddresses = crate::epoched::NestedEpoched<
     LazySet<Address>,
     crate::epoched::OffsetPipelineLen,

--- a/proof_of_stake/src/types.rs
+++ b/proof_of_stake/src/types.rs
@@ -103,14 +103,14 @@ pub type TotalConsensusStakes = crate::epoched::Epoched<
 /// Epoched validator's deltas.
 pub type ValidatorDeltas = crate::epoched::EpochedDelta<
     token::Change,
-    crate::epoched::OffsetUnbondingLen,
+    crate::epoched::OffsetPipelineLen,
     crate::epoched::OffsetMaxProposalPeriodOrSlashProcessingLenPlus,
 >;
 
 /// Epoched total deltas.
 pub type TotalDeltas = crate::epoched::EpochedDelta<
     token::Change,
-    crate::epoched::OffsetUnbondingLen,
+    crate::epoched::OffsetPipelineLen,
     crate::epoched::OffsetMaxProposalPeriodOrSlashProcessingLenPlus,
 >;
 
@@ -146,7 +146,7 @@ pub type ValidatorSlashes = NestedMap<Address, Slashes>;
 /// slashes earlier than `cubic_window_width` epochs behind the current
 pub type EpochedSlashes = crate::epoched::NestedEpoched<
     ValidatorSlashes,
-    crate::epoched::OffsetUnbondingLen,
+    crate::epoched::OffsetPipelineLen,
     crate::epoched::OffsetSlashProcessingLenPlus,
 >;
 


### PR DESCRIPTION
## Describe your changes
Closes #17, closes #1270. Some other things addressed in this PR:
- rename `store_total_consensus_stake` to `compute_and_store_total_consensus_stake`
- Improves docstrings, comments, and logging
- Removes outdated TODOs in PoS
- `is_delegator` issue

## Indicate on which release or other PRs this topic is based on
v0.26.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
