### PR TITLE
WIP CLI revamp

### DIFF
--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -557,9 +557,11 @@ pub mod cmds {
             App::new(Self::CMD)
                 .about("Generates a new transparent / shielded secret key.")
                 .long_about(
-                    "Generates a keypair with a given alias and derives the \
-                     implicit address from its public key. The address will \
-                     be stored with the same alias. TODO shielded",
+                    "In the transparent setting, generates a keypair with a \
+                     given alias and derives the implicit address from its \
+                     public key. The address will be stored with the same \
+                     alias. In the shielded setting, generates a new spending \
+                     key.",
                 )
                 .add_args::<args::KeyGen>()
         }
@@ -5704,7 +5706,7 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let scheme = SCHEME.parse(matches);
             let shielded = SHIELDED.parse(matches);
-            let alias = ALIAS_OPT.parse(matches);
+            let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             let use_device = USE_DEVICE.parse(matches);
@@ -5732,7 +5734,7 @@ pub mod args {
                     .def()
                     .help("Derive a spending key for the shielded pool."),
             )
-            .arg(ALIAS_OPT.def().help(
+            .arg(ALIAS.def().help(
                 "The key and address alias. If none provided, the alias will \
                  be the public key hash.",
             ))
@@ -5765,7 +5767,7 @@ pub mod args {
             let scheme = SCHEME.parse(matches);
             let shielded = SHIELDED.parse(matches);
             let raw = RAW_KEY_GEN.parse(matches);
-            let alias = ALIAS_OPT.parse(matches);
+            let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
             let is_pre_genesis = PRE_GENESIS.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
@@ -5803,7 +5805,7 @@ pub mod args {
                          mnemonic code is generated.",
                     ),
             )
-            .arg(ALIAS_OPT.def().help(
+            .arg(ALIAS.def().help(
                 "The key and address alias. If none provided, the alias will \
                  be the public key hash.",
             ))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -471,10 +471,8 @@ pub mod cmds {
         KeyDerive(WalletDerive),
         /// Key / address list
         KeyAddrList(WalletListKeysAddresses),
-        /// Key search
-        KeyFind(WalletFindKeys),
-        /// Address search
-        AddrFind(WalletFindAddresses),
+        /// Key / address search
+        KeyAddrFind(WalletFindKeysAddresses),
         /// Key export
         KeyExport(WalletExportKey),
         /// Key import
@@ -490,8 +488,7 @@ pub mod cmds {
             app.subcommand(WalletGen::def())
                 .subcommand(WalletDerive::def())
                 .subcommand(WalletListKeysAddresses::def())
-                .subcommand(WalletFindKeys::def())
-                .subcommand(WalletFindAddresses::def())
+                .subcommand(WalletFindKeysAddresses::def())
                 .subcommand(WalletExportKey::def())
                 .subcommand(WalletImportKey::def())
                 .subcommand(WalletAddKeyAddress::def())
@@ -502,16 +499,14 @@ pub mod cmds {
             let gen = SubCmd::parse(matches).map(Self::KeyGen);
             let derive = SubCmd::parse(matches).map(Self::KeyDerive);
             let key_addr_list = SubCmd::parse(matches).map(Self::KeyAddrList);
-            let key_find = SubCmd::parse(matches).map(Self::KeyFind);
-            let addr_find = SubCmd::parse(matches).map(Self::AddrFind);
+            let key_addr_find = SubCmd::parse(matches).map(Self::KeyAddrFind);
             let export = SubCmd::parse(matches).map(Self::KeyExport);
             let import = SubCmd::parse(matches).map(Self::KeyImport);
             let key_addr_add = SubCmd::parse(matches).map(Self::KeyAddrAdd);
             let pay_addr_gen = SubCmd::parse(matches).map(Self::PayAddrGen);
             gen.or(derive)
                 .or(key_addr_list)
-                .or(key_find)
-                .or(addr_find)
+                .or(key_addr_find)
                 .or(export)
                 .or(import)
                 .or(key_addr_add)
@@ -628,52 +623,31 @@ pub mod cmds {
         }
     }
 
-    /// TODO Find a keypair in the wallet store
-    /// TODO Find the given shielded address or key
+    /// Find known keys and addresses
     #[derive(Clone, Debug)]
-    pub struct WalletFindKeys(pub args::KeyFind);
+    pub struct WalletFindKeysAddresses(pub args::KeyAddressFind);
 
-    impl SubCmd for WalletFindKeys {
-        const CMD: &'static str = "find-keys";
+    impl SubCmd for WalletFindKeysAddresses {
+        const CMD: &'static str = "find";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches
                 .subcommand_matches(Self::CMD)
-                .map(|matches| (Self(args::KeyFind::parse(matches))))
+                .map(|matches| Self(args::KeyAddressFind::parse(matches)))
         }
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Key search")
+                .about("Find known keys and addresses in the wallet.")
                 .long_about(
-                    "In the transparent setting, searches for a keypair from \
-                     a public key or an alias.\nIn the shielded setting, \
-                     searches for the given payment address or key in the \
-                     wallet.",
+                    "In the transparent setting, searches for a keypair / \
+                     address by a given alias, public key, or a public key \
+                     hash. Looks up an alias of the given address.\nIn the \
+                     shielded setting, searches for a spending / viewing key \
+                     and payment address by a given alias. Looks up an alias \
+                     of the given payment address.",
                 )
-                .add_args::<args::KeyAddressList>()
-        }
-    }
-
-    /// Find an address by its alias
-    #[derive(Clone, Debug)]
-    pub struct WalletFindAddresses(pub args::AddressFind);
-
-    impl SubCmd for WalletFindAddresses {
-        const CMD: &'static str = "find-addr";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches
-                .subcommand_matches(Self::CMD)
-                .map(|matches| Self(args::AddressFind::parse(matches)))
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about(
-                    "Find an address by its alias or an alias by its address.",
-                )
-                .add_args::<args::AddressFind>()
+                .add_args::<args::KeyAddressFind>()
         }
     }
 
@@ -2590,7 +2564,7 @@ pub mod args {
     use namada::types::ethereum_events::EthAddress;
     use namada::types::keccak::KeccakHash;
     use namada::types::key::*;
-    use namada::types::masp::MaspValue;
+    use namada::types::masp::PaymentAddress;
     use namada::types::storage::{self, BlockHeight, Epoch};
     use namada::types::time::DateTimeUtc;
     use namada::types::token;
@@ -2752,10 +2726,9 @@ pub mod args {
             TendermintAddress::from_str(raw).unwrap()
         }));
     pub const LEDGER_ADDRESS: Arg<TendermintAddress> = arg("node");
-    pub const LIST_ADDRESSES_ONLY: ArgFlag = flag("addr");
-    pub const LIST_KEYS_ONLY: ArgFlag = flag("keys");
+    pub const LIST_FIND_ADDRESSES_ONLY: ArgFlag = flag("addr");
+    pub const LIST_FIND_KEYS_ONLY: ArgFlag = flag("keys");
     pub const LOCALHOST: ArgFlag = flag("localhost");
-    pub const MASP_VALUE_OPT: ArgOpt<MaspValue> = arg_opt("shielded-value");
     pub const MAX_COMMISSION_RATE_CHANGE: Arg<Dec> =
         arg("max-commission-rate-change");
     pub const MAX_ETH_GAS: ArgOpt<u64> = arg_opt("max_eth-gas");
@@ -2793,9 +2766,15 @@ pub mod args {
     pub const RAW_ADDRESS: Arg<Address> = arg("address");
     pub const RAW_ADDRESS_OPT: ArgOpt<Address> = RAW_ADDRESS.opt();
     pub const RAW_KEY_GEN: ArgFlag = flag("raw");
+    pub const RAW_PAYMENT_ADDRESS: Arg<PaymentAddress> = arg("payment-address");
+    pub const RAW_PAYMENT_ADDRESS_OPT: ArgOpt<PaymentAddress> =
+        RAW_PAYMENT_ADDRESS.opt();
     pub const RAW_PUBLIC_KEY: Arg<common::PublicKey> = arg("public-key");
     pub const RAW_PUBLIC_KEY_OPT: ArgOpt<common::PublicKey> =
-        arg_opt("public-key");
+        RAW_PUBLIC_KEY.opt();
+    pub const RAW_PUBLIC_KEY_HASH: Arg<String> = arg("public-key-hash");
+    pub const RAW_PUBLIC_KEY_HASH_OPT: ArgOpt<String> =
+        RAW_PUBLIC_KEY_HASH.opt();
     pub const RAW_SOURCE: Arg<String> = arg("source");
     pub const RECEIVER: Arg<String> = arg("receiver");
     pub const RELAYER: Arg<Address> = arg("relayer");
@@ -2847,7 +2826,6 @@ pub mod args {
     pub const VALIDATOR_ETH_HOT_KEY: ArgOpt<WalletKeypair> =
         arg_opt("eth-hot-key");
     pub const VALUE: Arg<String> = arg("value");
-    pub const VALUE_OPT: ArgOpt<String> = VALUE.opt();
     pub const VERIFICATION_KEY: ArgOpt<WalletPublicKey> =
         arg_opt("verification-key");
     pub const VIEWING_KEY: Arg<WalletViewingKey> = arg("key");
@@ -5841,8 +5819,8 @@ pub mod args {
             let shielded = SHIELDED.parse(matches);
             let decrypt = DECRYPT.parse(matches);
             let is_pre_genesis = PRE_GENESIS.parse(matches);
-            let keys_only = LIST_KEYS_ONLY.parse(matches);
-            let addresses_only = LIST_ADDRESSES_ONLY.parse(matches);
+            let keys_only = LIST_FIND_KEYS_ONLY.parse(matches);
+            let addresses_only = LIST_FIND_ADDRESSES_ONLY.parse(matches);
             let unsafe_show_secret = UNSAFE_SHOW_SECRET.parse(matches);
             Self {
                 shielded,
@@ -5864,8 +5842,12 @@ pub mod args {
                 "Use pre-genesis wallet, instead of for the current chain, if \
                  any.",
             ))
-            .arg(LIST_KEYS_ONLY.def().help("List only keys."))
-            .arg(LIST_ADDRESSES_ONLY.def().help("List only addresses."))
+            .arg(LIST_FIND_KEYS_ONLY.def().help("List keys only."))
+            .arg(LIST_FIND_ADDRESSES_ONLY.def().help("List addresses only."))
+            .group(ArgGroup::new("only_group").args([
+                LIST_FIND_KEYS_ONLY.name,
+                LIST_FIND_ADDRESSES_ONLY.name,
+            ]))
             .arg(
                 UNSAFE_SHOW_SECRET
                     .def()
@@ -5874,20 +5856,27 @@ pub mod args {
         }
     }
 
-    impl Args for KeyFind {
+    impl Args for KeyAddressFind {
         fn parse(matches: &ArgMatches) -> Self {
             let shielded = SHIELDED.parse(matches);
             let alias = ALIAS_OPT.parse(matches);
+            let address = RAW_ADDRESS_OPT.parse(matches);
             let public_key = RAW_PUBLIC_KEY_OPT.parse(matches);
-            let value = VALUE_OPT.parse(matches);
+            let public_key_hash = RAW_PUBLIC_KEY_HASH_OPT.parse(matches);
+            let payment_address = RAW_PAYMENT_ADDRESS_OPT.parse(matches);
+            let keys_only = LIST_FIND_KEYS_ONLY.parse(matches);
+            let addresses_only = LIST_FIND_ADDRESSES_ONLY.parse(matches);
             let is_pre_genesis = PRE_GENESIS.parse(matches);
             let unsafe_show_secret = UNSAFE_SHOW_SECRET.parse(matches);
-
             Self {
                 shielded,
                 alias,
+                address,
                 public_key,
-                value,
+                public_key_hash,
+                payment_address,
+                keys_only,
+                addresses_only,
                 is_pre_genesis,
                 unsafe_show_secret,
             }
@@ -5895,42 +5884,57 @@ pub mod args {
 
         fn def(app: App) -> App {
             app.arg(
-                SHIELDED
-                    .def()
-                    .help("Find spending key for the shielded pool.")
-                    .conflicts_with_all([
-                        VALUE_OPT.name,
-                        RAW_PUBLIC_KEY_OPT.name,
-                    ]),
+                SHIELDED.def().help(
+                    "Find keys and payment addresses for the shielded pool.",
+                ),
             )
             .arg(
                 ALIAS_OPT
                     .def()
+                    .help("An alias associated with the keys / addresses."),
+            )
+            .arg(
+                RAW_ADDRESS_OPT
+                    .def()
                     .help(
-                        "TODO An alias associated with the keypair. The alias \
-                         that is to be found.",
+                        "The bech32m encoded string of a transparent address.",
                     )
-                    .conflicts_with(VALUE_OPT.name),
+                    .conflicts_with(SHIELDED.name),
             )
             .arg(
-                RAW_PUBLIC_KEY_OPT
-                    .def()
-                    .help("A public key associated with the keypair."),
+                RAW_PUBLIC_KEY_OPT.def().help(
+                    "A public key associated with the transparent keypair.",
+                ),
             )
+            .arg(RAW_PUBLIC_KEY_HASH_OPT.def().help(
+                "A public key hash associated with the transparent keypair.",
+            ))
             .arg(
-                VALUE_OPT
+                RAW_PAYMENT_ADDRESS_OPT
                     .def()
-                    .help("A public key or alias associated with the keypair."),
+                    .help(
+                        "The bech32m encoded string of a shielded payment \
+                         address.",
+                    )
+                    .conflicts_with(SHIELDED.name),
             )
             .group(
-                ArgGroup::new("key_find_args")
+                ArgGroup::new("addr_find_args")
                     .args([
                         ALIAS_OPT.name,
+                        RAW_ADDRESS_OPT.name,
                         RAW_PUBLIC_KEY_OPT.name,
-                        VALUE_OPT.name,
+                        RAW_PUBLIC_KEY_HASH_OPT.name,
+                        RAW_PAYMENT_ADDRESS_OPT.name,
                     ])
                     .required(true),
             )
+            .arg(LIST_FIND_KEYS_ONLY.def().help("Find keys only."))
+            .arg(LIST_FIND_ADDRESSES_ONLY.def().help("List addresses only."))
+            .group(ArgGroup::new("only_group").args([
+                LIST_FIND_KEYS_ONLY.name,
+                LIST_FIND_ADDRESSES_ONLY.name,
+            ]))
             .arg(PRE_GENESIS.def().help(
                 "Use pre-genesis wallet, instead of for the current chain, if \
                  any.",
@@ -5939,41 +5943,6 @@ pub mod args {
                 UNSAFE_SHOW_SECRET
                     .def()
                     .help("UNSAFE: Print the secret / spending key."),
-            )
-        }
-    }
-
-    impl Args for AddressFind {
-        fn parse(matches: &ArgMatches) -> Self {
-            let alias = ALIAS_OPT.parse(matches);
-            let address = RAW_ADDRESS_OPT.parse(matches);
-            let is_pre_genesis = PRE_GENESIS.parse(matches);
-            Self {
-                alias,
-                address,
-                is_pre_genesis,
-            }
-        }
-
-        fn def(app: App) -> App {
-            app.arg(
-                ALIAS_OPT
-                    .def()
-                    .help("An alias associated with the address."),
-            )
-            .arg(
-                RAW_ADDRESS_OPT
-                    .def()
-                    .help("The bech32m encoded address string."),
-            )
-            .arg(PRE_GENESIS.def().help(
-                "Use pre-genesis wallet, instead of for the current chain, if \
-                 any.",
-            ))
-            .group(
-                ArgGroup::new("addr_find_args")
-                    .args([ALIAS_OPT.name, RAW_ADDRESS_OPT.name])
-                    .required(true),
             )
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -465,8 +465,6 @@ pub mod cmds {
     #[allow(clippy::large_enum_variant)]
     #[derive(Clone, Debug)]
     pub enum NamadaWallet {
-        /// Key management commands
-        Key(WalletKey),
         /// Address management commands
         Address(WalletAddress),
         /// MASP key, address management commands
@@ -483,12 +481,13 @@ pub mod cmds {
         NewAddrList(WalletNewAddressList),
         /// TODO
         NewAddrFind(WalletNewAddressFind),
+        /// TODO
+        NewKeyExport(WalletNewExportKey),
     }
 
     impl Cmd for NamadaWallet {
         fn add_sub(app: App) -> App {
-            app.subcommand(WalletKey::def())
-                .subcommand(WalletAddress::def())
+            app.subcommand(WalletAddress::def())
                 .subcommand(WalletMasp::def())
                 .subcommand(WalletNewGen::def())
                 .subcommand(WalletNewDerive::def())
@@ -496,10 +495,10 @@ pub mod cmds {
                 .subcommand(WalletNewKeyFind::def())
                 .subcommand(WalletNewAddressList::def())
                 .subcommand(WalletNewAddressFind::def())
+                .subcommand(WalletNewExportKey::def())
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            let key = SubCmd::parse(matches).map(Self::Key);
             let address = SubCmd::parse(matches).map(Self::Address);
             let masp = SubCmd::parse(matches).map(Self::Masp);
             let gen_new = SubCmd::parse(matches).map(Self::NewGen);
@@ -508,7 +507,8 @@ pub mod cmds {
             let key_find_new = SubCmd::parse(matches).map(Self::NewKeyFind);
             let addr_list_new = SubCmd::parse(matches).map(Self::NewAddrList);
             let addr_find_new = SubCmd::parse(matches).map(Self::NewAddrFind);
-            key.or(address)
+            let export_new = SubCmd::parse(matches).map(Self::NewKeyExport);
+            address
                 .or(masp)
                 .or(gen_new)
                 .or(derive_new)
@@ -516,6 +516,7 @@ pub mod cmds {
                 .or(key_find_new)
                 .or(addr_list_new)
                 .or(addr_find_new)
+                .or(export_new)
         }
     }
 
@@ -535,34 +536,6 @@ pub mod cmds {
                     .subcommand_required(true)
                     .arg_required_else_help(true),
             )
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    #[allow(clippy::large_enum_variant)]
-    pub enum WalletKey {
-        Export(Export),
-    }
-
-    impl SubCmd for WalletKey {
-        const CMD: &'static str = "key";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).and_then(|matches| {
-                let export = SubCmd::parse(matches).map(Self::Export);
-                export
-            })
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about(
-                    "Keypair management, including methods to generate and \
-                     look-up keys.",
-                )
-                .subcommand_required(true)
-                .arg_required_else_help(true)
-                .subcommand(Export::def())
         }
     }
 
@@ -718,10 +691,11 @@ pub mod cmds {
         }
     }
 
+    /// Export key
     #[derive(Clone, Debug)]
-    pub struct Export(pub args::KeyExport);
+    pub struct WalletNewExportKey(pub args::KeyExport);
 
-    impl SubCmd for Export {
+    impl SubCmd for WalletNewExportKey {
         const CMD: &'static str = "export";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1787,7 +1787,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Change commission raate.")
+                .about("Change commission rate.")
                 .add_args::<args::CommissionRateChange<args::CliTypes>>()
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -735,10 +735,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about(
-                    "Adds the given transparent / payment address or key to \
-                     the wallet.",
-                )
+                .about("Adds the given key or address to the wallet.")
                 .add_args::<args::KeyAddressAdd>()
         }
     }
@@ -2844,7 +2841,8 @@ pub mod args {
         arg_opt("eth-cold-key");
     pub const VALIDATOR_ETH_HOT_KEY: ArgOpt<WalletKeypair> =
         arg_opt("eth-hot-key");
-    pub const VALUE: ArgOpt<String> = arg_opt("value");
+    pub const VALUE: Arg<String> = arg("value");
+    pub const VALUE_OPT: ArgOpt<String> = VALUE.opt();
     pub const VERIFICATION_KEY: ArgOpt<WalletPublicKey> =
         arg_opt("verification-key");
     pub const VIEWING_KEY: Arg<WalletViewingKey> = arg("key");
@@ -5871,7 +5869,7 @@ pub mod args {
             let shielded = SHIELDED.parse(matches);
             let alias = ALIAS_OPT.parse(matches);
             let public_key = RAW_PUBLIC_KEY_OPT.parse(matches);
-            let value = VALUE.parse(matches);
+            let value = VALUE_OPT.parse(matches);
             let is_pre_genesis = PRE_GENESIS.parse(matches);
             let unsafe_show_secret = UNSAFE_SHOW_SECRET.parse(matches);
 
@@ -5890,7 +5888,10 @@ pub mod args {
                 SHIELDED
                     .def()
                     .help("Find spending key for the shielded pool.")
-                    .conflicts_with_all([VALUE.name, RAW_PUBLIC_KEY_OPT.name]),
+                    .conflicts_with_all([
+                        VALUE_OPT.name,
+                        RAW_PUBLIC_KEY_OPT.name,
+                    ]),
             )
             .arg(
                 ALIAS_OPT
@@ -5899,7 +5900,7 @@ pub mod args {
                         "TODO An alias associated with the keypair. The alias \
                          that is to be found.",
                     )
-                    .conflicts_with(VALUE.name),
+                    .conflicts_with(VALUE_OPT.name),
             )
             .arg(
                 RAW_PUBLIC_KEY_OPT
@@ -5907,13 +5908,17 @@ pub mod args {
                     .help("A public key associated with the keypair."),
             )
             .arg(
-                VALUE
+                VALUE_OPT
                     .def()
                     .help("A public key or alias associated with the keypair."),
             )
             .group(
                 ArgGroup::new("key_find_args")
-                    .args([ALIAS_OPT.name, RAW_PUBLIC_KEY_OPT.name, VALUE.name])
+                    .args([
+                        ALIAS_OPT.name,
+                        RAW_PUBLIC_KEY_OPT.name,
+                        VALUE_OPT.name,
+                    ])
                     .required(true),
             )
             .arg(PRE_GENESIS.def().help(
@@ -5984,14 +5989,12 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
-            let address = RAW_ADDRESS_OPT.parse(matches);
-            let value = MASP_VALUE_OPT.parse(matches);
+            let value = VALUE.parse(matches);
             let is_pre_genesis = PRE_GENESIS.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             Self {
                 alias,
                 alias_force,
-                address,
                 value,
                 is_pre_genesis,
                 unsafe_dont_encrypt,
@@ -6007,20 +6010,12 @@ pub mod args {
             .arg(ALIAS_FORCE.def().help(
                 "Override the alias without confirmation if it already exists.",
             ))
-            .arg(
-                RAW_ADDRESS_OPT
-                    .def()
-                    .help("The bech32m encoded transparent address string."),
-            )
-            .arg(MASP_VALUE_OPT.def().help(
-                "A spending key, viewing key, or payment address of the \
-                 shielded pool.",
+            .arg(VALUE.def().help(
+                "Any value of the following:\n- transparent pool secret key \
+                 string\n- the bech32m encoded transparent address string\n- \
+                 shielded pool spending key\n- shielded pool viewing key\n- \
+                 shielded pool payment address ",
             ))
-            .group(
-                ArgGroup::new("key_address_add_args")
-                    .args([RAW_ADDRESS_OPT.name, MASP_VALUE_OPT.name])
-                    .required(true),
-            )
             .arg(PRE_GENESIS.def().help(
                 "Use pre-genesis wallet, instead of for the current chain, if \
                  any.",

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -608,7 +608,7 @@ pub mod cmds {
         }
     }
 
-    /// TODO List all known shielded keys
+    /// List all known keys
     #[derive(Clone, Debug)]
     pub struct WalletListKeys(pub args::KeyList);
 
@@ -623,10 +623,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about(
-                    "TODO List all known keys. Lists all shielded keys in the \
-                     wallet.",
-                )
+                .about("List all known secret / shielded keys in the wallet.")
                 .add_args::<args::KeyList>()
         }
     }
@@ -647,9 +644,11 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about(
-                    "TODO Searches for a keypair from a public key or an \
-                     alias. Find the given shielded address or key in the \
+                .about("Key search")
+                .long_about(
+                    "In the transparent setting, searches for a keypair from \
+                     a public key or an alias.\nIn the shielded setting, \
+                     searches for the given payment address or key in the \
                      wallet.",
                 )
                 .add_args::<args::KeyList>()
@@ -657,7 +656,6 @@ pub mod cmds {
     }
 
     /// List known addresses
-    /// TODO List all known payment addresses
     #[derive(Clone, Debug)]
     pub struct WalletListAddresses(pub args::AddressList);
 
@@ -673,7 +671,7 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about(
-                    "TODO List all known addresses. Lists all payment \
+                    "List all known transparent addresses / shielded payment \
                      addresses in the wallet",
                 )
                 .add_args::<args::AddressList>()
@@ -702,7 +700,7 @@ pub mod cmds {
         }
     }
 
-    /// Export key
+    /// Export key to a file
     #[derive(Clone, Debug)]
     pub struct WalletExportKey(pub args::KeyExport);
 
@@ -5954,10 +5952,11 @@ pub mod args {
                 "Use pre-genesis wallet, instead of for the current chain, if \
                  any.",
             ))
-            .arg(UNSAFE_SHOW_SECRET.def().help(
-                "TODO UNSAFE: Print the secret key.Print the spending key \
-                 values.",
-            ))
+            .arg(
+                UNSAFE_SHOW_SECRET
+                    .def()
+                    .help("UNSAFE: Print the secret / spending key."),
+            )
         }
     }
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -466,48 +466,48 @@ pub mod cmds {
     #[derive(Clone, Debug)]
     pub enum NamadaWallet {
         /// Key generation
-        NewGen(WalletNewGen),
+        KeyGen(WalletGen),
         /// Key derivation
-        NewDerive(WalletNewDerive),
+        KeyDerive(WalletDerive),
         /// Key list
-        NewKeyList(WalletNewKeyList),
+        KeyList(WalletListKeys),
         /// Key search
-        NewKeyFind(WalletNewKeyFind),
+        KeyFind(WalletFindKeys),
         /// Address list
-        NewAddrList(WalletNewAddressList),
+        AddrList(WalletListAddresses),
         /// Address search
-        NewAddrFind(WalletNewAddressFind),
+        AddrFind(WalletFindAddresses),
         /// Key export
-        NewKeyExport(WalletNewExportKey),
+        KeyExport(WalletExportKey),
         /// Key import
-        NewKeyAddrAdd(WalletNewKeyAddressAdd),
+        KeyAddrAdd(WalletAddKeyAddress),
         /// Payment address generation
-        NewPayAddrGen(WalletNewPaymentAddressGen),
+        PayAddrGen(WalletGenPaymentAddress),
     }
 
     impl Cmd for NamadaWallet {
         fn add_sub(app: App) -> App {
-            app.subcommand(WalletNewGen::def())
-                .subcommand(WalletNewDerive::def())
-                .subcommand(WalletNewKeyList::def())
-                .subcommand(WalletNewKeyFind::def())
-                .subcommand(WalletNewAddressList::def())
-                .subcommand(WalletNewAddressFind::def())
-                .subcommand(WalletNewExportKey::def())
-                .subcommand(WalletNewKeyAddressAdd::def())
-                .subcommand(WalletNewPaymentAddressGen::def())
+            app.subcommand(WalletGen::def())
+                .subcommand(WalletDerive::def())
+                .subcommand(WalletListKeys::def())
+                .subcommand(WalletFindKeys::def())
+                .subcommand(WalletListAddresses::def())
+                .subcommand(WalletFindAddresses::def())
+                .subcommand(WalletExportKey::def())
+                .subcommand(WalletAddKeyAddress::def())
+                .subcommand(WalletGenPaymentAddress::def())
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            let gen_new = SubCmd::parse(matches).map(Self::NewGen);
-            let derive_new = SubCmd::parse(matches).map(Self::NewDerive);
-            let key_list_new = SubCmd::parse(matches).map(Self::NewKeyList);
-            let key_find_new = SubCmd::parse(matches).map(Self::NewKeyFind);
-            let addr_list_new = SubCmd::parse(matches).map(Self::NewAddrList);
-            let addr_find_new = SubCmd::parse(matches).map(Self::NewAddrFind);
-            let export_new = SubCmd::parse(matches).map(Self::NewKeyExport);
-            let key_addr_add = SubCmd::parse(matches).map(Self::NewKeyAddrAdd);
-            let pay_addr_gen = SubCmd::parse(matches).map(Self::NewPayAddrGen);
+            let gen_new = SubCmd::parse(matches).map(Self::KeyGen);
+            let derive_new = SubCmd::parse(matches).map(Self::KeyDerive);
+            let key_list_new = SubCmd::parse(matches).map(Self::KeyList);
+            let key_find_new = SubCmd::parse(matches).map(Self::KeyFind);
+            let addr_list_new = SubCmd::parse(matches).map(Self::AddrList);
+            let addr_find_new = SubCmd::parse(matches).map(Self::AddrFind);
+            let export_new = SubCmd::parse(matches).map(Self::KeyExport);
+            let key_addr_add = SubCmd::parse(matches).map(Self::KeyAddrAdd);
+            let pay_addr_gen = SubCmd::parse(matches).map(Self::PayAddrGen);
             gen_new
                 .or(derive_new)
                 .or(key_list_new)
@@ -543,9 +543,9 @@ pub mod cmds {
     /// address derived from it. In the shielded setting, generate a new
     /// spending key.
     #[derive(Clone, Debug)]
-    pub struct WalletNewGen(pub args::KeyGen);
+    pub struct WalletGen(pub args::KeyGen);
 
-    impl SubCmd for WalletNewGen {
+    impl SubCmd for WalletGen {
         const CMD: &'static str = "gen";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -570,9 +570,9 @@ pub mod cmds {
     /// the mnemonic code.
     /// In the shielded setting, derive a spending key from the mnemonic code.
     #[derive(Clone, Debug)]
-    pub struct WalletNewDerive(pub args::KeyDerive);
+    pub struct WalletDerive(pub args::KeyDerive);
 
-    impl SubCmd for WalletNewDerive {
+    impl SubCmd for WalletDerive {
         const CMD: &'static str = "derive";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -599,9 +599,9 @@ pub mod cmds {
 
     /// TODO List all known shielded keys
     #[derive(Clone, Debug)]
-    pub struct WalletNewKeyList(pub args::KeyList);
+    pub struct WalletListKeys(pub args::KeyList);
 
-    impl SubCmd for WalletNewKeyList {
+    impl SubCmd for WalletListKeys {
         const CMD: &'static str = "list-keys";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -623,10 +623,10 @@ pub mod cmds {
     /// TODO Find a keypair in the wallet store
     /// TODO Find the given shielded address or key
     #[derive(Clone, Debug)]
-    pub struct WalletNewKeyFind(pub args::KeyFind);
+    pub struct WalletFindKeys(pub args::KeyFind);
 
-    impl SubCmd for WalletNewKeyFind {
-        const CMD: &'static str = "find-key";
+    impl SubCmd for WalletFindKeys {
+        const CMD: &'static str = "find-keys";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches
@@ -648,9 +648,9 @@ pub mod cmds {
     /// List known addresses
     /// TODO List all known payment addresses
     #[derive(Clone, Debug)]
-    pub struct WalletNewAddressList(pub args::AddressList);
+    pub struct WalletListAddresses(pub args::AddressList);
 
-    impl SubCmd for WalletNewAddressList {
+    impl SubCmd for WalletListAddresses {
         const CMD: &'static str = "list-addr";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -671,9 +671,9 @@ pub mod cmds {
 
     /// Find an address by its alias
     #[derive(Clone, Debug)]
-    pub struct WalletNewAddressFind(pub args::AddressFind);
+    pub struct WalletFindAddresses(pub args::AddressFind);
 
-    impl SubCmd for WalletNewAddressFind {
+    impl SubCmd for WalletFindAddresses {
         const CMD: &'static str = "find-addr";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -693,9 +693,9 @@ pub mod cmds {
 
     /// Export key
     #[derive(Clone, Debug)]
-    pub struct WalletNewExportKey(pub args::KeyExport);
+    pub struct WalletExportKey(pub args::KeyExport);
 
-    impl SubCmd for WalletNewExportKey {
+    impl SubCmd for WalletExportKey {
         const CMD: &'static str = "export";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -713,9 +713,9 @@ pub mod cmds {
 
     /// Add public / payment address to the wallet
     #[derive(Clone, Debug)]
-    pub struct WalletNewKeyAddressAdd(pub args::KeyAddressAdd);
+    pub struct WalletAddKeyAddress(pub args::KeyAddressAdd);
 
-    impl SubCmd for WalletNewKeyAddressAdd {
+    impl SubCmd for WalletAddKeyAddress {
         const CMD: &'static str = "add";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -736,11 +736,9 @@ pub mod cmds {
 
     /// Generate a payment address from a viewing key or payment address
     #[derive(Clone, Debug)]
-    pub struct WalletNewPaymentAddressGen(
-        pub args::PayAddressGen<args::CliTypes>,
-    );
+    pub struct WalletGenPaymentAddress(pub args::PayAddressGen<args::CliTypes>);
 
-    impl SubCmd for WalletNewPaymentAddressGen {
+    impl SubCmd for WalletGenPaymentAddress {
         const CMD: &'static str = "gen-payment-addr";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -560,8 +560,10 @@ pub mod cmds {
                     "In the transparent setting, generates a keypair with a \
                      given alias and derives the implicit address from its \
                      public key. The address will be stored with the same \
-                     alias. In the shielded setting, generates a new spending \
-                     key.",
+                     alias.\nIn the shielded setting, generates a new \
+                     spending key with a given alias.\nIn both settings, by \
+                     default, an HD-key with a default derivation path is \
+                     generated, with a random mnemonic code.",
                 )
                 .add_args::<args::KeyGen>()
         }
@@ -585,14 +587,17 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about(
-                    "Derive transparent / shielded key from the mnemonic code.",
+                    "Derive transparent / shielded key from the mnemonic code \
+                     or a seed stored on the hardware wallet device.",
                 )
                 .long_about(
-                    "Derives a keypair from the given mnemonic code and HD \
-                     derivation path and derives the implicit address from \
-                     its public key. Stores the keypair and the address with \
-                     the given alias. A hardware wallet can be used, in which \
-                     case a private key is not derivable. TODO shielded",
+                    "In the transparent setting, derives a keypair from the \
+                     given mnemonic code and HD derivation path and derives \
+                     the implicit address from its public key. Stores the \
+                     keypair and the address with the given alias.\nIn the \
+                     shielded setting, derives a spending key.\nA hardware \
+                     wallet can be used, in which case the private key is not \
+                     derivable.",
                 )
                 .add_args::<args::KeyDerive>()
         }
@@ -5734,10 +5739,7 @@ pub mod args {
                     .def()
                     .help("Derive a spending key for the shielded pool."),
             )
-            .arg(ALIAS.def().help(
-                "The key and address alias. If none provided, the alias will \
-                 be the public key hash.",
-            ))
+            .arg(ALIAS.def().help("The key and address alias."))
             .arg(
                 ALIAS_FORCE
                     .def()
@@ -5805,10 +5807,7 @@ pub mod args {
                          mnemonic code is generated.",
                     ),
             )
-            .arg(ALIAS.def().help(
-                "The key and address alias. If none provided, the alias will \
-                 be the public key hash.",
-            ))
+            .arg(ALIAS.def().help("The key and address alias."))
             .arg(ALIAS_FORCE.def().help(
                 "Override the alias without confirmation if it already exists.",
             ))
@@ -5821,12 +5820,12 @@ pub mod args {
                  used in a live network.",
             ))
             .arg(HD_WALLET_DERIVATION_PATH.def().help(
-                "Generate a new key and wallet using BIP39 mnemonic code and \
-                 HD derivation path. Use keyword `default` to refer to a \
+                "HD key derivation path. Use keyword `default` to refer to a \
                  scheme default path:\n- m/44'/60'/0'/0/0 for secp256k1 \
                  scheme\n- m/44'/877'/0'/0'/0' for ed25519 scheme.\nFor \
                  ed25519, all path indices will be promoted to hardened \
-                 indexes. TODO",
+                 indexes. If none is specified, the scheme default path is \
+                 used.",
             ))
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -499,22 +499,21 @@ pub mod cmds {
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            let gen_new = SubCmd::parse(matches).map(Self::KeyGen);
-            let derive_new = SubCmd::parse(matches).map(Self::KeyDerive);
-            let key_list_new = SubCmd::parse(matches).map(Self::KeyList);
-            let key_find_new = SubCmd::parse(matches).map(Self::KeyFind);
-            let addr_list_new = SubCmd::parse(matches).map(Self::AddrList);
-            let addr_find_new = SubCmd::parse(matches).map(Self::AddrFind);
-            let export_new = SubCmd::parse(matches).map(Self::KeyExport);
+            let gen = SubCmd::parse(matches).map(Self::KeyGen);
+            let derive = SubCmd::parse(matches).map(Self::KeyDerive);
+            let key_list = SubCmd::parse(matches).map(Self::KeyList);
+            let key_find = SubCmd::parse(matches).map(Self::KeyFind);
+            let addr_list = SubCmd::parse(matches).map(Self::AddrList);
+            let addr_find = SubCmd::parse(matches).map(Self::AddrFind);
+            let export = SubCmd::parse(matches).map(Self::KeyExport);
             let key_addr_add = SubCmd::parse(matches).map(Self::KeyAddrAdd);
             let pay_addr_gen = SubCmd::parse(matches).map(Self::PayAddrGen);
-            gen_new
-                .or(derive_new)
-                .or(key_list_new)
-                .or(key_find_new)
-                .or(addr_list_new)
-                .or(addr_find_new)
-                .or(export_new)
+            gen.or(derive)
+                .or(key_list)
+                .or(key_find)
+                .or(addr_list)
+                .or(addr_find)
+                .or(export)
                 .or(key_addr_add)
                 .or(pay_addr_gen)
         }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -712,7 +712,10 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Exports a keypair / spending key to a file.")
+                .about(
+                    "Exports a transparent keypair / shielded spending key to \
+                     a file.",
+                )
                 .add_args::<args::KeyExport>()
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -622,7 +622,7 @@ pub mod cmds {
                 .long_about(
                     "In the transparent setting, list known keypairs and \
                      addresses.\nIn the shielded setting, list known spending \
-                     keys and payment addresses.",
+                     / viewing keys and payment addresses.",
                 )
                 .add_args::<args::KeyAddressList>()
         }
@@ -759,7 +759,7 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about(
-                    "Generates a payment address from the given spending key",
+                    "Generates a payment address from the given spending key.",
                 )
                 .add_args::<args::PayAddressGen<args::CliTypes>>()
         }
@@ -5856,8 +5856,8 @@ pub mod args {
 
         fn def(app: App) -> App {
             app.arg(SHIELDED.def().help(
-                "List spending keys and payment addresses for the shielded \
-                 pool.",
+                "List viewing / spending keys and payment addresses for the \
+                 shielded pool.",
             ))
             .arg(DECRYPT.def().help("Decrypt keys that are encrypted."))
             .arg(PRE_GENESIS.def().help(

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -480,6 +480,8 @@ pub mod cmds {
         /// Key export
         KeyExport(WalletExportKey),
         /// Key import
+        KeyImport(WalletImportKey),
+        /// Key / address add
         KeyAddrAdd(WalletAddKeyAddress),
         /// Payment address generation
         PayAddrGen(WalletGenPaymentAddress),
@@ -494,6 +496,7 @@ pub mod cmds {
                 .subcommand(WalletListAddresses::def())
                 .subcommand(WalletFindAddresses::def())
                 .subcommand(WalletExportKey::def())
+                .subcommand(WalletImportKey::def())
                 .subcommand(WalletAddKeyAddress::def())
                 .subcommand(WalletGenPaymentAddress::def())
         }
@@ -506,6 +509,7 @@ pub mod cmds {
             let addr_list = SubCmd::parse(matches).map(Self::AddrList);
             let addr_find = SubCmd::parse(matches).map(Self::AddrFind);
             let export = SubCmd::parse(matches).map(Self::KeyExport);
+            let import = SubCmd::parse(matches).map(Self::KeyImport);
             let key_addr_add = SubCmd::parse(matches).map(Self::KeyAddrAdd);
             let pay_addr_gen = SubCmd::parse(matches).map(Self::PayAddrGen);
             gen.or(derive)
@@ -514,6 +518,7 @@ pub mod cmds {
                 .or(addr_list)
                 .or(addr_find)
                 .or(export)
+                .or(import)
                 .or(key_addr_add)
                 .or(pay_addr_gen)
         }
@@ -717,6 +722,29 @@ pub mod cmds {
                      a file.",
                 )
                 .add_args::<args::KeyExport>()
+        }
+    }
+
+    /// Import key from a file
+    #[derive(Clone, Debug)]
+    pub struct WalletImportKey(pub args::KeyImport);
+
+    impl SubCmd for WalletImportKey {
+        const CMD: &'static str = "import";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches
+                .subcommand_matches(Self::CMD)
+                .map(|matches| (Self(args::KeyImport::parse(matches))))
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about(
+                    "Imports a transparent keypair / shielded spending key \
+                     from a file.",
+                )
+                .add_args::<args::KeyImport>()
         }
     }
 
@@ -2716,6 +2744,7 @@ pub mod args {
     pub const FEE_AMOUNT_OPT: ArgOpt<token::DenominatedAmount> =
         arg_opt("gas-price");
     pub const FEE_PAYER_OPT: ArgOpt<WalletKeypair> = arg_opt("gas-payer");
+    pub const FILE_PATH: Arg<String> = arg("file");
     pub const FORCE: ArgFlag = flag("force");
     pub const GAS_LIMIT: ArgDefault<GasLimit> =
         arg_default("gas-limit", DefaultFn(|| GasLimit::from(25_000)));
@@ -6049,6 +6078,43 @@ pub mod args {
             .arg(PRE_GENESIS.def().help(
                 "Use pre-genesis wallet, instead of for the current chain, if \
                  any.",
+            ))
+        }
+    }
+
+    impl Args for KeyImport {
+        fn parse(matches: &ArgMatches) -> Self {
+            let file_path = FILE_PATH.parse(matches);
+            let alias = ALIAS.parse(matches);
+            let alias_force = ALIAS_FORCE.parse(matches);
+            let is_pre_genesis = PRE_GENESIS.parse(matches);
+            let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
+            Self {
+                alias,
+                alias_force,
+                file_path,
+                is_pre_genesis,
+                unsafe_dont_encrypt,
+            }
+        }
+
+        fn def(app: App) -> App {
+            app.arg(FILE_PATH.def().help(
+                "Path to the file containing the key you wish to import.",
+            ))
+            .arg(ALIAS.def().help("The alias assigned to the."))
+            .arg(
+                ALIAS_FORCE
+                    .def()
+                    .help("An alias to be associated with the imported entry."),
+            )
+            .arg(PRE_GENESIS.def().help(
+                "Use pre-genesis wallet, instead of for the current chain, if \
+                 any.",
+            ))
+            .arg(UNSAFE_DONT_ENCRYPT.def().help(
+                "UNSAFE: Do not encrypt the added keys. Do not use this for \
+                 keys used in a live network.",
             ))
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -712,7 +712,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Exports a keypair to a file.")
+                .about("Exports a keypair / spending key to a file.")
                 .add_args::<args::KeyExport>()
         }
     }
@@ -6031,9 +6031,11 @@ pub mod args {
 
     impl Args for KeyExport {
         fn parse(matches: &ArgMatches) -> Self {
+            let shielded = SHIELDED.parse(matches);
             let alias = ALIAS.parse(matches);
             let is_pre_genesis = PRE_GENESIS.parse(matches);
             Self {
+                shielded,
                 alias,
                 is_pre_genesis,
             }
@@ -6041,8 +6043,11 @@ pub mod args {
 
         fn def(app: App) -> App {
             app.arg(
-                ALIAS.def().help("The alias of the key you wish to export."),
+                SHIELDED
+                    .def()
+                    .help("Whether to export the shielded spending key."),
             )
+            .arg(ALIAS.def().help("The alias of the key you wish to export."))
             .arg(PRE_GENESIS.def().help(
                 "Use pre-genesis wallet, instead of for the current chain, if \
                  any.",

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -471,6 +471,8 @@ pub mod cmds {
         Address(WalletAddress),
         /// MASP key, address management commands
         Masp(WalletMasp),
+        /// TODO
+        NewGen(WalletNewGen),
     }
 
     impl Cmd for NamadaWallet {
@@ -478,13 +480,15 @@ pub mod cmds {
             app.subcommand(WalletKey::def())
                 .subcommand(WalletAddress::def())
                 .subcommand(WalletMasp::def())
+                .subcommand(WalletNewGen::def())
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             let key = SubCmd::parse(matches).map(Self::Key);
             let address = SubCmd::parse(matches).map(Self::Address);
             let masp = SubCmd::parse(matches).map(Self::Masp);
-            key.or(address).or(masp)
+            let gen_new = SubCmd::parse(matches).map(Self::NewGen);
+            key.or(address).or(masp).or(gen_new)
         }
     }
 
@@ -511,7 +515,6 @@ pub mod cmds {
     #[allow(clippy::large_enum_variant)]
     pub enum WalletKey {
         Derive(KeyDerive),
-        Gen(KeyGen),
         Find(KeyFind),
         List(KeyList),
         Export(Export),
@@ -522,12 +525,11 @@ pub mod cmds {
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).and_then(|matches| {
-                let generate = SubCmd::parse(matches).map(Self::Gen);
                 let restore = SubCmd::parse(matches).map(Self::Derive);
                 let lookup = SubCmd::parse(matches).map(Self::Find);
                 let list = SubCmd::parse(matches).map(Self::List);
                 let export = SubCmd::parse(matches).map(Self::Export);
-                generate.or(restore).or(lookup).or(list).or(export)
+                restore.or(lookup).or(list).or(export)
             })
         }
 
@@ -540,7 +542,6 @@ pub mod cmds {
                 .subcommand_required(true)
                 .arg_required_else_help(true)
                 .subcommand(KeyDerive::def())
-                .subcommand(KeyGen::def())
                 .subcommand(KeyFind::def())
                 .subcommand(KeyList::def())
                 .subcommand(Export::def())
@@ -573,17 +574,19 @@ pub mod cmds {
         }
     }
 
-    /// Generate a new keypair and an implicit address derived from it
+    /// In the transparent setting, generate a new keypair and an implicit
+    /// address derived from it. In the shielded setting, generate a new
+    /// spending key.
     #[derive(Clone, Debug)]
-    pub struct KeyGen(pub args::KeyAndAddressGen);
+    pub struct WalletNewGen(pub args::KeyGen);
 
-    impl SubCmd for KeyGen {
+    impl SubCmd for WalletNewGen {
         const CMD: &'static str = "gen";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches
                 .subcommand_matches(Self::CMD)
-                .map(|matches| Self(args::KeyAndAddressGen::parse(matches)))
+                .map(|matches| Self(args::KeyGen::parse(matches)))
         }
 
         fn def() -> App {
@@ -591,9 +594,9 @@ pub mod cmds {
                 .about(
                     "Generates a keypair with a given alias and derives the \
                      implicit address from its public key. The address will \
-                     be stored with the same alias.",
+                     be stored with the same alias. TODO shielded",
                 )
-                .add_args::<args::KeyAndAddressGen>()
+                .add_args::<args::KeyGen>()
         }
     }
 
@@ -658,7 +661,6 @@ pub mod cmds {
     #[derive(Clone, Debug)]
     pub enum WalletMasp {
         GenPayAddr(MaspGenPayAddr),
-        GenSpendKey(MaspGenSpendKey),
         AddAddrKey(MaspAddAddrKey),
         ListPayAddrs(MaspListPayAddrs),
         ListKeys(MaspListKeys),
@@ -671,12 +673,11 @@ pub mod cmds {
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).and_then(|matches| {
                 let genpa = SubCmd::parse(matches).map(Self::GenPayAddr);
-                let gensk = SubCmd::parse(matches).map(Self::GenSpendKey);
                 let addak = SubCmd::parse(matches).map(Self::AddAddrKey);
                 let listpa = SubCmd::parse(matches).map(Self::ListPayAddrs);
                 let listsk = SubCmd::parse(matches).map(Self::ListKeys);
                 let findak = SubCmd::parse(matches).map(Self::FindAddrKey);
-                gensk.or(genpa).or(addak).or(listpa).or(listsk).or(findak)
+                genpa.or(addak).or(listpa).or(listsk).or(findak)
             })
         }
 
@@ -689,7 +690,6 @@ pub mod cmds {
                 )
                 .subcommand_required(true)
                 .arg_required_else_help(true)
-                .subcommand(MaspGenSpendKey::def())
                 .subcommand(MaspGenPayAddr::def())
                 .subcommand(MaspAddAddrKey::def())
                 .subcommand(MaspListPayAddrs::def())
@@ -822,7 +822,6 @@ pub mod cmds {
 
     #[derive(Clone, Debug)]
     pub enum WalletAddress {
-        Gen(AddressGen),
         Derive(AddressDerive),
         Find(AddressOrAliasFind),
         List(AddressList),
@@ -834,12 +833,11 @@ pub mod cmds {
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).and_then(|matches| {
-                let gen = SubCmd::parse(matches).map(Self::Gen);
                 let restore = SubCmd::parse(matches).map(Self::Derive);
                 let find = SubCmd::parse(matches).map(Self::Find);
                 let list = SubCmd::parse(matches).map(Self::List);
                 let add = SubCmd::parse(matches).map(Self::Add);
-                gen.or(restore).or(find).or(list).or(add)
+                restore.or(find).or(list).or(add)
             })
         }
 
@@ -851,35 +849,10 @@ pub mod cmds {
                 )
                 .subcommand_required(true)
                 .arg_required_else_help(true)
-                .subcommand(AddressGen::def())
                 .subcommand(AddressDerive::def())
                 .subcommand(AddressOrAliasFind::def())
                 .subcommand(AddressList::def())
                 .subcommand(AddressAdd::def())
-        }
-    }
-
-    /// Generate a new keypair and an implicit address derived from it
-    #[derive(Clone, Debug)]
-    pub struct AddressGen(pub args::KeyAndAddressGen);
-
-    impl SubCmd for AddressGen {
-        const CMD: &'static str = "gen";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).map(|matches| {
-                AddressGen(args::KeyAndAddressGen::parse(matches))
-            })
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about(
-                    "Generates a keypair with a given alias and derives the \
-                     implicit address from its public key. The address will \
-                     be stored with the same alias.",
-                )
-                .add_args::<args::KeyAndAddressGen>()
         }
     }
 
@@ -2996,6 +2969,7 @@ pub mod args {
     pub const PROPOSAL_VOTE: Arg<String> = arg("vote");
     pub const RAW_ADDRESS: Arg<Address> = arg("address");
     pub const RAW_ADDRESS_OPT: ArgOpt<Address> = RAW_ADDRESS.opt();
+    pub const RAW_KEY_GEN: ArgFlag = flag("raw");
     pub const RAW_PUBLIC_KEY: Arg<common::PublicKey> = arg("public-key");
     pub const RAW_PUBLIC_KEY_OPT: ArgOpt<common::PublicKey> =
         arg_opt("public-key");
@@ -3008,6 +2982,7 @@ pub mod args {
     pub const SELF_BOND_AMOUNT: Arg<token::DenominatedAmount> =
         arg("self-bond-amount");
     pub const SENDER: Arg<String> = arg("sender");
+    pub const SHIELDED: ArgFlag = flag("shielded");
     pub const SIGNER: ArgOpt<WalletAddress> = arg_opt("signer");
     pub const SIGNING_KEY_OPT: ArgOpt<WalletKeypair> = SIGNING_KEY.opt();
     pub const SIGNING_KEY: Arg<WalletKeypair> = arg("signing-key");
@@ -6041,9 +6016,11 @@ pub mod args {
         }
     }
 
-    impl Args for KeyAndAddressGen {
+    impl Args for KeyGen {
         fn parse(matches: &ArgMatches) -> Self {
             let scheme = SCHEME.parse(matches);
+            let shielded = SHIELDED.parse(matches);
+            let raw = RAW_KEY_GEN.parse(matches);
             let alias = ALIAS_OPT.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
             let is_pre_genesis = PRE_GENESIS.parse(matches);
@@ -6051,6 +6028,8 @@ pub mod args {
             let derivation_path = HD_WALLET_DERIVATION_PATH.parse(matches);
             Self {
                 scheme,
+                shielded,
+                raw,
                 alias,
                 alias_force,
                 is_pre_genesis,
@@ -6060,11 +6039,26 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(SCHEME.def().help(
-                "The type of key that should be generated. Argument must be \
-                 either ed25519 or secp256k1. If none provided, the default \
-                 key scheme is ed25519.",
+            app.arg(SCHEME.def().conflicts_with(SHIELDED.name).help(
+                "For the transparent pool, the type of key that should be \
+                 generated. Argument must be either ed25519 or secp256k1. If \
+                 none provided, the default key scheme is ed25519.\nNot \
+                 applicable for the shielded pool.",
             ))
+            .arg(
+                SHIELDED
+                    .def()
+                    .help("Generate a spending key for the shielded pool."),
+            )
+            .arg(
+                RAW_KEY_GEN
+                    .def()
+                    .conflicts_with(HD_WALLET_DERIVATION_PATH.name)
+                    .help(
+                        "Generate a random non-HD secret / spending key. No \
+                         mnemonic code is generated.",
+                    ),
+            )
             .arg(ALIAS_OPT.def().help(
                 "The key and address alias. If none provided, the alias will \
                  be the public key hash.",

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -168,8 +168,8 @@ fn payment_addresses_list(
     if known_addresses.is_empty() {
         display_line!(
             io,
-            "No known payment addresses. Try `masp gen-addr --alias my-addr` \
-             to generate a new payment address.",
+            "TODO No known payment addresses. Try `masp gen-addr --alias \
+             my-addr` to generate a new payment address.",
         );
     } else {
         let stdout = io::stdout();

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -49,12 +49,9 @@ impl CliApi {
             cmds::NamadaWallet::KeyAddrList(cmds::WalletListKeysAddresses(
                 args,
             )) => key_address_list(ctx, io, args),
-            cmds::NamadaWallet::KeyFind(cmds::WalletFindKeys(args)) => {
-                key_find(ctx, io, args)
-            }
-            cmds::NamadaWallet::AddrFind(cmds::WalletFindAddresses(args)) => {
-                address_or_alias_find(ctx, io, args)
-            }
+            cmds::NamadaWallet::KeyAddrFind(cmds::WalletFindKeysAddresses(
+                args,
+            )) => key_address_find(ctx, io, args),
             cmds::NamadaWallet::KeyExport(cmds::WalletExportKey(args)) => {
                 key_export(ctx, io, args)
             }
@@ -676,23 +673,20 @@ fn key_address_add(
 }
 
 /// Find a keypair in the wallet store.
-fn transparent_key_address_find(
+fn transparent_key_find(
     ctx: Context,
     io: &impl Io,
-    args::KeyFind {
-        public_key,
-        alias,
-        value,
-        is_pre_genesis,
-        unsafe_show_secret,
-        ..
-    }: args::KeyFind,
+    alias: Option<String>,
+    public_key: Option<common::PublicKey>,
+    public_key_hash: Option<String>,
+    is_pre_genesis: bool,
+    unsafe_show_secret: bool,
 ) {
     let mut wallet = load_wallet(ctx, is_pre_genesis);
     let found_keypair = match public_key {
         Some(pk) => wallet.find_key_by_pk(&pk, None),
         None => {
-            let alias = alias.or(value);
+            let alias = alias.or(public_key_hash);
             match alias {
                 None => {
                     edisplay_line!(
@@ -723,28 +717,144 @@ fn transparent_key_address_find(
     }
 }
 
-/// Find shielded address or key
-/// TODO this works for both keys and addresses
-/// TODO split to enable finding alias by payment key
-fn shielded_key_address_find(
+/// Find address (alias) by its alias (address).
+fn transparent_address_or_alias_find(
     ctx: Context,
     io: &impl Io,
-    args::KeyFind {
-        alias,
-        unsafe_show_secret,
-        is_pre_genesis,
-        ..
-    }: args::KeyFind,
+    alias: Option<String>,
+    address: Option<Address>,
+    is_pre_genesis: bool,
+) {
+    let wallet = load_wallet(ctx, is_pre_genesis);
+    if address.is_some() && alias.is_some() {
+        panic!(
+            "This should not be happening: clap should emit its own error \
+             message."
+        );
+    } else if alias.is_some() {
+        let alias = alias.unwrap().to_lowercase();
+        if let Some(address) = wallet.find_address(&alias) {
+            display_line!(io, "Found address {}", address.to_pretty_string());
+        } else {
+            display_line!(
+                io,
+                "No address with alias {} found. Use the command `list \
+                 --addr` to see all the known transparent addresses.",
+                alias
+            );
+        }
+    } else if address.is_some() {
+        if let Some(alias) = wallet.find_alias(address.as_ref().unwrap()) {
+            display_line!(io, "Found alias {}", alias);
+        } else {
+            display_line!(
+                io,
+                "No address with alias {} found. Use the command `list \
+                 --addr` to see all the known transparent addresses.",
+                address.unwrap()
+            );
+        }
+    }
+}
+
+/// Find payment address (alias) by its alias (payment address).
+fn payment_address_or_alias_find(
+    ctx: Context,
+    io: &impl Io,
+    alias: Option<String>,
+    payment_address: Option<PaymentAddress>,
+    is_pre_genesis: bool,
+) {
+    let wallet = load_wallet(ctx, is_pre_genesis);
+    if payment_address.is_some() && alias.is_some() {
+        panic!(
+            "This should not be happening: clap should emit its own error \
+             message."
+        );
+    } else if alias.is_some() {
+        let alias = alias.unwrap().to_lowercase();
+        if let Some(payment_addr) = wallet.find_payment_addr(&alias) {
+            display_line!(io, "Found payment address {}", payment_addr);
+        } else {
+            display_line!(
+                io,
+                "No payment address with alias {} found. Use the command \
+                 `list --shielded --addr` to see all the known payment \
+                 addresses.",
+                alias
+            );
+        }
+    } else if payment_address.is_some() {
+        if let Some(alias) =
+            wallet.find_alias_by_payment_addr(payment_address.as_ref().unwrap())
+        {
+            display_line!(io, "Found alias {}", alias);
+        } else {
+            display_line!(
+                io,
+                "No address with alias {} found. Use the command `list \
+                 --shielded --addr` to see all the known payment addresses.",
+                payment_address.unwrap()
+            );
+        }
+    }
+}
+
+/// Find transparent addresses and keys by alias
+fn transparent_key_address_find_by_alias(
+    ctx: Context,
+    io: &impl Io,
+    alias: String,
+    keys_only: bool,
+    addresses_only: bool,
+    is_pre_genesis: bool,
+    unsafe_show_secret: bool,
 ) {
     let mut wallet = load_wallet(ctx, is_pre_genesis);
-    // TODO
-    let alias = alias.unwrap_or_else(|| {
-        display_line!(io, "Missing alias.");
-        display_line!(io, "No changes are persisted. Exiting.");
-        cli::safe_exit(1)
-    });
     let alias = alias.to_lowercase();
-    if let Ok(viewing_key) = wallet.find_viewing_key(&alias) {
+    if let Some(keypair) = (!addresses_only)
+        .then_some(())
+        .and_then(|_| wallet.find_secret_key(&alias, None).ok())
+    {
+        let pkh: PublicKeyHash = (&keypair.ref_to()).into();
+        display_line!(io, "Public key hash: {}", pkh);
+        display_line!(io, "Public key: {}", keypair.ref_to());
+        if unsafe_show_secret {
+            display_line!(io, "Secret key: {}", keypair);
+        }
+    } else if let Some(address) = (!keys_only)
+        .then_some(())
+        .and_then(|_| wallet.find_address(&alias))
+    {
+        display_line!(io, "Found address {}", address.to_pretty_string());
+    } else if !addresses_only && !keys_only {
+        // Otherwise alias cannot be referring to any shielded value
+        display_line!(
+            io,
+            "No transparent address or key with alias {} found. Use the \
+             command `list` to see all the known transparent addresses and \
+             keys.",
+            alias
+        );
+    }
+}
+
+/// Find shielded payment address and keys by alias
+fn shielded_key_address_find_by_alias(
+    ctx: Context,
+    io: &impl Io,
+    alias: String,
+    keys_only: bool,
+    addresses_only: bool,
+    is_pre_genesis: bool,
+    unsafe_show_secret: bool,
+) {
+    let mut wallet = load_wallet(ctx, is_pre_genesis);
+    let alias = alias.to_lowercase();
+    if let Some(viewing_key) = (!addresses_only)
+        .then_some(())
+        .and_then(|_| wallet.find_viewing_key(&alias).ok())
+    {
         // Check if alias is a viewing key
         display_line!(io, "Viewing key: {}", viewing_key);
         if unsafe_show_secret {
@@ -757,17 +867,20 @@ fn shielded_key_address_find(
                 Err(err) => edisplay_line!(io, "{}", err),
             }
         }
-    } else if let Some(payment_addr) = wallet.find_payment_addr(&alias) {
+    } else if let Some(payment_addr) = (!keys_only)
+        .then_some(())
+        .and_then(|_| wallet.find_payment_addr(&alias))
+    {
         // Failing that, check if alias is a payment address
         display_line!(io, "Payment address: {}", payment_addr);
-    } else {
+    } else if !addresses_only && !keys_only {
         // Otherwise alias cannot be referring to any shielded value
         display_line!(
             io,
-            "No shielded address or key with alias {} found. Use the commands \
-             `list-addr --shielded` and `list-keys --shielded` to see all the \
-             known shielded addresses and keys.",
-            alias.to_lowercase()
+            "No shielded payment address or key with alias {} found. Use the \
+             command `list --shielded` to see all the known shielded \
+             addresses and keys.",
+            alias
         );
     }
 }
@@ -933,46 +1046,34 @@ fn transparent_addresses_list(
     }
 }
 
-/// Find address (alias) by its alias (address).
-fn address_or_alias_find(
+/// Add a transparent secret key to the wallet.
+fn transparent_secret_key_add(
     ctx: Context,
     io: &impl Io,
-    args::AddressFind {
-        alias,
-        address,
-        is_pre_genesis,
-    }: args::AddressFind,
+    alias: String,
+    alias_force: bool,
+    sk: common::SecretKey,
+    is_pre_genesis: bool,
+    unsafe_dont_encrypt: bool,
 ) {
-    let wallet = load_wallet(ctx, is_pre_genesis);
-    if address.is_some() && alias.is_some() {
-        panic!(
-            "This should not be happening: clap should emit its own error \
-             message."
-        );
-    } else if alias.is_some() {
-        let alias = alias.unwrap().to_lowercase();
-        if let Some(address) = wallet.find_address(&alias) {
-            display_line!(io, "Found address {}", address.to_pretty_string());
-        } else {
-            display_line!(
-                io,
-                "No address with alias {} found. Use the command `address \
-                 list` to see all the known addresses.",
-                alias
-            );
-        }
-    } else if address.is_some() {
-        if let Some(alias) = wallet.find_alias(address.as_ref().unwrap()) {
-            display_line!(io, "Found alias {}", alias);
-        } else {
-            display_line!(
-                io,
-                "No alias with address {} found. Use the command `address \
-                 list` to see all the known addresses.",
-                address.unwrap()
-            );
-        }
-    }
+    let mut wallet = load_wallet(ctx, is_pre_genesis);
+    let encryption_password =
+        read_and_confirm_encryption_password(unsafe_dont_encrypt);
+    let alias = wallet
+        .insert_keypair(alias, alias_force, sk, encryption_password, None, None)
+        .unwrap_or_else(|err| {
+            edisplay_line!(io, "{}", err);
+            display_line!(io, "No changes are persisted. Exiting.");
+            cli::safe_exit(1);
+        });
+    wallet
+        .save()
+        .unwrap_or_else(|err| edisplay_line!(io, "{}", err));
+    display_line!(
+        io,
+        "Successfully added a key and an address with alias: \"{}\"",
+        alias
+    );
 }
 
 /// Add an address to the wallet.

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -342,6 +342,7 @@ async fn transparent_key_and_address_derive(
             edisplay_line!(io, "{}", err);
             cli::safe_exit(1)
         });
+    let alias = alias.to_lowercase();
     let alias = if !use_device {
         let encryption_password =
             read_and_confirm_encryption_password(unsafe_dont_encrypt);
@@ -433,6 +434,7 @@ fn transparent_key_and_address_gen(
         ..
     }: args::KeyGen,
 ) {
+    let alias = alias.to_lowercase();
     let mut wallet = load_wallet(ctx, is_pre_genesis);
     let encryption_password =
         read_and_confirm_encryption_password(unsafe_dont_encrypt);
@@ -615,6 +617,7 @@ fn shielded_key_address_find(
     }: args::KeyFind,
 ) {
     let mut wallet = load_wallet(ctx, is_pre_genesis);
+    // TODO
     let alias = alias.unwrap_or_else(|| {
         display_line!(io, "Missing alias.");
         display_line!(io, "No changes are persisted. Exiting.");
@@ -727,12 +730,13 @@ fn key_export(
         is_pre_genesis,
     }: args::KeyExport,
 ) {
+    let alias = alias.to_lowercase();
     let mut wallet = load_wallet(ctx, is_pre_genesis);
     wallet
-        .find_secret_key(alias.to_lowercase(), None)
+        .find_secret_key(&alias, None)
         .map(|keypair| {
             let file_data = keypair.serialize_to_vec();
-            let file_name = format!("key_{}", alias.to_lowercase());
+            let file_name = format!("key_{}", alias);
             let mut file = File::create(&file_name).unwrap();
 
             file.write_all(file_data.as_ref()).unwrap();
@@ -789,14 +793,15 @@ fn address_or_alias_find(
              message."
         );
     } else if alias.is_some() {
-        if let Some(address) = wallet.find_address(alias.as_ref().unwrap()) {
+        let alias = alias.unwrap().to_lowercase();
+        if let Some(address) = wallet.find_address(&alias) {
             display_line!(io, "Found address {}", address.to_pretty_string());
         } else {
             display_line!(
                 io,
                 "No address with alias {} found. Use the command `address \
                  list` to see all the known addresses.",
-                alias.unwrap().to_lowercase()
+                alias
             );
         }
     } else if address.is_some() {
@@ -825,10 +830,11 @@ fn transparent_address_add(
         ..
     }: args::KeyAddressAdd,
 ) {
+    let alias = alias.to_lowercase();
     let address = address.unwrap(); // this should not fail
     let mut wallet = load_wallet(ctx, is_pre_genesis);
     if wallet
-        .insert_address(alias.to_lowercase(), address, alias_force)
+        .insert_address(&alias, address, alias_force)
         .is_none()
     {
         edisplay_line!(io, "Address not added");
@@ -840,7 +846,7 @@ fn transparent_address_add(
     display_line!(
         io,
         "Successfully added a key and an address with alias: \"{}\"",
-        alias.to_lowercase()
+        alias
     );
 }
 

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -40,33 +40,33 @@ impl CliApi {
         io: &impl Io,
     ) -> Result<()> {
         match cmd {
-            cmds::NamadaWallet::NewGen(cmds::WalletNewGen(args)) => {
+            cmds::NamadaWallet::KeyGen(cmds::WalletGen(args)) => {
                 key_gen(ctx, io, args)
             }
-            cmds::NamadaWallet::NewDerive(cmds::WalletNewDerive(args)) => {
+            cmds::NamadaWallet::KeyDerive(cmds::WalletDerive(args)) => {
                 key_derive(ctx, io, args).await
             }
-            cmds::NamadaWallet::NewKeyList(cmds::WalletNewKeyList(args)) => {
+            cmds::NamadaWallet::KeyList(cmds::WalletListKeys(args)) => {
                 key_list(ctx, io, args)
             }
-            cmds::NamadaWallet::NewKeyFind(cmds::WalletNewKeyFind(args)) => {
+            cmds::NamadaWallet::KeyFind(cmds::WalletFindKeys(args)) => {
                 key_find(ctx, io, args)
             }
-            cmds::NamadaWallet::NewAddrList(cmds::WalletNewAddressList(
+            cmds::NamadaWallet::AddrList(cmds::WalletListAddresses(args)) => {
+                address_list(ctx, io, args)
+            }
+            cmds::NamadaWallet::AddrFind(cmds::WalletFindAddresses(args)) => {
+                address_or_alias_find(ctx, io, args)
+            }
+            cmds::NamadaWallet::KeyExport(cmds::WalletExportKey(args)) => {
+                key_export(ctx, io, args)
+            }
+            cmds::NamadaWallet::KeyAddrAdd(cmds::WalletAddKeyAddress(args)) => {
+                key_address_add(ctx, io, args)
+            }
+            cmds::NamadaWallet::PayAddrGen(cmds::WalletGenPaymentAddress(
                 args,
-            )) => address_list(ctx, io, args),
-            cmds::NamadaWallet::NewAddrFind(cmds::WalletNewAddressFind(
-                args,
-            )) => address_or_alias_find(ctx, io, args),
-            cmds::NamadaWallet::NewKeyExport(cmds::WalletNewExportKey(
-                args,
-            )) => key_export(ctx, io, args),
-            cmds::NamadaWallet::NewKeyAddrAdd(
-                cmds::WalletNewKeyAddressAdd(args),
-            ) => key_address_add(ctx, io, args),
-            cmds::NamadaWallet::NewPayAddrGen(
-                cmds::WalletNewPaymentAddressGen(args),
-            ) => {
+            )) => {
                 let args = args.to_sdk(&mut ctx);
                 payment_address_gen(
                     &mut ctx.borrow_mut_chain_or_exit().wallet,

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -12,7 +12,7 @@ use ledger_namada_rs::{BIP44Path, NamadaApp};
 use ledger_transport_hid::hidapi::HidApi;
 use ledger_transport_hid::TransportNativeHID;
 use masp_primitives::zip32::ExtendedFullViewingKey;
-use namada::types::address::Address;
+use namada::types::address::{Address, DecodeError};
 use namada::types::io::Io;
 use namada::types::key::*;
 use namada::types::masp::{MaspValue, PaymentAddress};
@@ -248,19 +248,15 @@ fn payment_address_gen(
 fn shielded_key_address_add(
     ctx: Context,
     io: &impl Io,
-    args::KeyAddressAdd {
-        alias,
-        alias_force,
-        value,
-        is_pre_genesis,
-        unsafe_dont_encrypt,
-        ..
-    }: args::KeyAddressAdd,
+    alias: String,
+    alias_force: bool,
+    masp_value: MaspValue,
+    is_pre_genesis: bool,
+    unsafe_dont_encrypt: bool,
 ) {
-    let value = value.unwrap(); // this should not fail
     let alias = alias.to_lowercase();
     let mut wallet = load_wallet(ctx, is_pre_genesis);
-    let (alias, typ) = match value {
+    let (alias, typ) = match masp_value {
         MaspValue::FullViewingKey(viewing_key) => {
             let alias = wallet
                 .insert_viewing_key(alias, viewing_key, alias_force)
@@ -510,7 +506,7 @@ async fn key_derive(
     }
 }
 
-/// TODO
+/// List keys
 fn key_list(ctx: Context, io: &impl Io, args_key_list: args::KeyList) {
     if !args_key_list.shielded {
         transparent_keys_list(ctx, io, args_key_list)
@@ -519,7 +515,7 @@ fn key_list(ctx: Context, io: &impl Io, args_key_list: args::KeyList) {
     }
 }
 
-/// TODO
+/// Find key or address
 fn key_find(ctx: Context, io: &impl Io, args_key_find: args::KeyFind) {
     if !args_key_find.shielded {
         transparent_key_address_find(ctx, io, args_key_find)
@@ -528,7 +524,7 @@ fn key_find(ctx: Context, io: &impl Io, args_key_find: args::KeyFind) {
     }
 }
 
-/// TODO
+/// List addresses
 fn address_list(ctx: Context, io: &impl Io, args_key_list: args::AddressList) {
     if !args_key_list.shielded {
         transparent_addresses_list(ctx, io, args_key_list)
@@ -537,21 +533,85 @@ fn address_list(ctx: Context, io: &impl Io, args_key_list: args::AddressList) {
     }
 }
 
-/// TODO
+/// Value for add command
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum KeyAddrAddValue {
+    /// Transparent secret key
+    TranspSecretKey(common::SecretKey),
+    /// Transparent address
+    TranspAddress(Address),
+    /// Masp value
+    MASPValue(MaspValue),
+}
+
+impl FromStr for KeyAddrAddValue {
+    type Err = DecodeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Try to decode this value first as a secret key, then as an address,
+        // then as a MASP value
+        common::SecretKey::from_str(s)
+            .map(Self::TranspSecretKey)
+            .or_else(|_| Address::from_str(s).map(Self::TranspAddress))
+            .or_else(|_| MaspValue::from_str(s).map(Self::MASPValue))
+    }
+}
+
+/// Add key or address
 fn key_address_add(
     ctx: Context,
     io: &impl Io,
-    args_key_addr_add: args::KeyAddressAdd,
+    args::KeyAddressAdd {
+        alias,
+        alias_force,
+        value,
+        is_pre_genesis,
+        unsafe_dont_encrypt,
+        ..
+    }: args::KeyAddressAdd,
 ) {
-    if args_key_addr_add.address.is_some() {
-        transparent_address_add(ctx, io, args_key_addr_add)
-    } else if args_key_addr_add.value.is_some() {
-        shielded_key_address_add(ctx, io, args_key_addr_add)
-    } else {
-        unreachable!(
-            "This should not happen as the group of address and value is \
-             required."
-        )
+    match KeyAddrAddValue::from_str(&value).unwrap_or_else(|err| {
+        edisplay_line!(io, "{}", err);
+        display_line!(io, "No changes are persisted. Exiting.");
+        cli::safe_exit(1)
+    }) {
+        KeyAddrAddValue::TranspSecretKey(sk) => {
+            let mut wallet = load_wallet(ctx, is_pre_genesis);
+            let encryption_password =
+                read_and_confirm_encryption_password(unsafe_dont_encrypt);
+            wallet
+                .insert_keypair(
+                    alias,
+                    alias_force,
+                    sk,
+                    encryption_password,
+                    None,
+                    None,
+                )
+                .unwrap_or_else(|err| {
+                    edisplay_line!(io, "{}", err);
+                    display_line!(io, "No changes are persisted. Exiting.");
+                    cli::safe_exit(1);
+                });
+        }
+        KeyAddrAddValue::TranspAddress(address) => transparent_address_add(
+            ctx,
+            io,
+            alias,
+            alias_force,
+            address,
+            is_pre_genesis,
+        ),
+        KeyAddrAddValue::MASPValue(masp_value) => shielded_key_address_add(
+            ctx,
+            io,
+            alias,
+            alias_force,
+            masp_value,
+            is_pre_genesis,
+            unsafe_dont_encrypt,
+        ),
     }
 }
 
@@ -829,16 +889,12 @@ fn address_or_alias_find(
 fn transparent_address_add(
     ctx: Context,
     io: &impl Io,
-    args::KeyAddressAdd {
-        alias,
-        alias_force,
-        address,
-        is_pre_genesis,
-        ..
-    }: args::KeyAddressAdd,
+    alias: String,
+    alias_force: bool,
+    address: Address,
+    is_pre_genesis: bool,
 ) {
     let alias = alias.to_lowercase();
-    let address = address.unwrap(); // this should not fail
     let mut wallet = load_wallet(ctx, is_pre_genesis);
     if wallet
         .insert_address(&alias, address, alias_force)

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -363,7 +363,7 @@ async fn transparent_key_and_address_derive(
             .0
     } else {
         let hidapi = HidApi::new().unwrap_or_else(|err| {
-            edisplay_line!(io, "Failed to create Hidapi: {}", err);
+            edisplay_line!(io, "Failed to create HidApi: {}", err);
             cli::safe_exit(1)
         });
         let app = NamadaApp::new(

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -193,11 +193,6 @@ fn spending_key_gen(
         ..
     }: args::KeyGen,
 ) {
-    let alias = alias.unwrap_or_else(|| {
-        display_line!(io, "Missing alias.");
-        display_line!(io, "No changes are persisted. Exiting.");
-        cli::safe_exit(1)
-    });
     let mut wallet = load_wallet(ctx, is_pre_genesis);
     let alias = alias.to_lowercase();
     let password = read_and_confirm_encryption_password(unsafe_dont_encrypt);
@@ -353,7 +348,7 @@ async fn transparent_key_and_address_derive(
         wallet
             .derive_key_from_mnemonic_code(
                 scheme,
-                alias,
+                Some(alias),
                 alias_force,
                 derivation_path,
                 None,
@@ -396,13 +391,12 @@ async fn transparent_key_and_address_derive(
 
         let pubkey = common::PublicKey::try_from_slice(&response.public_key)
             .expect("unable to decode public key from hardware wallet");
-        let pkh = PublicKeyHash::from(&pubkey);
         let address = Address::from_str(&response.address_str)
             .expect("unable to decode address from hardware wallet");
 
         wallet
             .insert_public_key(
-                alias.unwrap_or_else(|| pkh.to_string()),
+                alias,
                 pubkey,
                 Some(address),
                 Some(derivation_path),
@@ -445,7 +439,7 @@ fn transparent_key_and_address_gen(
     let alias = if raw {
         wallet.gen_store_secret_key(
             scheme,
-            alias,
+            Some(alias),
             alias_force,
             encryption_password,
             &mut OsRng,
@@ -464,7 +458,7 @@ fn transparent_key_and_address_gen(
                 });
         wallet.derive_store_hd_secret_key(
             scheme,
-            alias,
+            Some(alias),
             alias_force,
             seed,
             derivation_path,

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -40,16 +40,6 @@ impl CliApi {
         io: &impl Io,
     ) -> Result<()> {
         match cmd {
-            cmds::NamadaWallet::Key(sub) => match sub {
-                cmds::WalletKey::Export(cmds::Export(args)) => {
-                    key_export(ctx, io, args)
-                }
-            },
-            cmds::NamadaWallet::Address(sub) => match sub {
-                cmds::WalletAddress::Add(cmds::AddressAdd(args)) => {
-                    address_add(ctx, io, args)
-                }
-            },
             cmds::NamadaWallet::Masp(sub) => match sub {
                 cmds::WalletMasp::GenPayAddr(cmds::MaspGenPayAddr(args)) => {
                     let args = args.to_sdk(&mut ctx);
@@ -58,9 +48,6 @@ impl CliApi {
                         io,
                         args,
                     )
-                }
-                cmds::WalletMasp::AddAddrKey(cmds::MaspAddAddrKey(args)) => {
-                    address_key_add(ctx, io, args)
                 }
             },
             cmds::NamadaWallet::NewGen(cmds::WalletNewGen(args)) => {
@@ -81,6 +68,12 @@ impl CliApi {
             cmds::NamadaWallet::NewAddrFind(cmds::WalletNewAddressFind(
                 args,
             )) => address_or_alias_find(ctx, io, args),
+            cmds::NamadaWallet::NewKeyExport(cmds::WalletNewExportKey(
+                args,
+            )) => key_export(ctx, io, args),
+            cmds::NamadaWallet::NewKeyAddrAdd(
+                cmds::WalletNewKeyAddressAdd(args),
+            ) => key_address_add(ctx, io, args),
         }
         Ok(())
     }
@@ -257,17 +250,19 @@ fn payment_address_gen(
 }
 
 /// Add a viewing key, spending key, or payment address to wallet.
-fn address_key_add(
+fn shielded_key_address_add(
     ctx: Context,
     io: &impl Io,
-    args::MaspAddrKeyAdd {
+    args::KeyAddressAdd {
         alias,
         alias_force,
         value,
         is_pre_genesis,
         unsafe_dont_encrypt,
-    }: args::MaspAddrKeyAdd,
+        ..
+    }: args::KeyAddressAdd,
 ) {
+    let value = value.unwrap(); // this should not fail
     let alias = alias.to_lowercase();
     let mut wallet = load_wallet(ctx, is_pre_genesis);
     let (alias, typ) = match value {
@@ -538,6 +533,24 @@ fn address_list(ctx: Context, io: &impl Io, args_key_list: args::AddressList) {
     }
 }
 
+/// TODO
+fn key_address_add(
+    ctx: Context,
+    io: &impl Io,
+    args_key_addr_add: args::KeyAddressAdd,
+) {
+    if args_key_addr_add.address.is_some() {
+        transparent_address_add(ctx, io, args_key_addr_add)
+    } else if args_key_addr_add.value.is_some() {
+        shielded_key_address_add(ctx, io, args_key_addr_add)
+    } else {
+        unreachable!(
+            "This should not happen as the group of address and value is \
+             required."
+        )
+    }
+}
+
 /// Find a keypair in the wallet store.
 fn transparent_key_address_find(
     ctx: Context,
@@ -703,7 +716,7 @@ fn transparent_keys_list(
     }
 }
 
-/// Export a keypair to a file.
+/// Export a transparent keypair to a file.
 fn key_export(
     ctx: Context,
     io: &impl Io,
@@ -799,16 +812,18 @@ fn address_or_alias_find(
 }
 
 /// Add an address to the wallet.
-fn address_add(
+fn transparent_address_add(
     ctx: Context,
     io: &impl Io,
-    args::AddressAdd {
+    args::KeyAddressAdd {
         alias,
         alias_force,
         address,
         is_pre_genesis,
-    }: args::AddressAdd,
+        ..
+    }: args::KeyAddressAdd,
 ) {
+    let address = address.unwrap(); // this should not fail
     let mut wallet = load_wallet(ctx, is_pre_genesis);
     if wallet
         .insert_address(alias.to_lowercase(), address, alias_force)

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -44,9 +44,6 @@ impl CliApi {
                 cmds::WalletKey::Find(cmds::KeyFind(args)) => {
                     key_find(ctx, io, args)
                 }
-                cmds::WalletKey::List(cmds::KeyList(args)) => {
-                    key_list(ctx, io, args)
-                }
                 cmds::WalletKey::Export(cmds::Export(args)) => {
                     key_export(ctx, io, args)
                 }
@@ -77,9 +74,6 @@ impl CliApi {
                 cmds::WalletMasp::ListPayAddrs(cmds::MaspListPayAddrs(
                     args,
                 )) => payment_addresses_list(ctx, io, args),
-                cmds::WalletMasp::ListKeys(cmds::MaspListKeys(args)) => {
-                    spending_keys_list(ctx, io, args)
-                }
                 cmds::WalletMasp::FindAddrKey(cmds::MaspFindAddrKey(args)) => {
                     address_key_find(ctx, io, args)
                 }
@@ -89,6 +83,9 @@ impl CliApi {
             }
             cmds::NamadaWallet::NewDerive(cmds::WalletNewDerive(args)) => {
                 key_derive(ctx, io, args).await
+            }
+            cmds::NamadaWallet::NewKeyList(cmds::WalletNewKeyList(args)) => {
+                key_list(ctx, io, args)
             }
         }
         Ok(())
@@ -139,11 +136,12 @@ fn address_key_find(
 fn spending_keys_list(
     ctx: Context,
     io: &impl Io,
-    args::MaspKeysList {
+    args::KeyList {
         decrypt,
         is_pre_genesis,
         unsafe_show_secret,
-    }: args::MaspKeysList,
+        ..
+    }: args::KeyList,
 ) {
     let wallet = load_wallet(ctx, is_pre_genesis);
     let known_view_keys = wallet.get_viewing_keys();
@@ -559,6 +557,15 @@ async fn key_derive(
     }
 }
 
+/// TODO
+fn key_list(ctx: Context, io: &impl Io, args_key_list: args::KeyList) {
+    if !args_key_list.shielded {
+        transparent_keys_list(ctx, io, args_key_list)
+    } else {
+        spending_keys_list(ctx, io, args_key_list)
+    }
+}
+
 /// Find a keypair in the wallet store.
 fn key_find(
     ctx: Context,
@@ -607,13 +614,14 @@ fn key_find(
 }
 
 /// List all known keys.
-fn key_list(
+fn transparent_keys_list(
     ctx: Context,
     io: &impl Io,
     args::KeyList {
         decrypt,
         is_pre_genesis,
         unsafe_show_secret,
+        ..
     }: args::KeyList,
 ) {
     let wallet = load_wallet(ctx, is_pre_genesis);
@@ -621,8 +629,7 @@ fn key_list(
     if known_public_keys.is_empty() {
         display_line!(
             io,
-            "No known keys. Try `key gen --alias my-key` to generate a new \
-             key.",
+            "No known keys. Try `gen --alias my-key` to generate a new key.",
         );
     } else {
         let stdout = io::stdout();

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -94,7 +94,8 @@ fn spending_keys_list(
         display_line!(
             io,
             "No known keys. Try `add --alias my-addr --value ...` to add a \
-             new key to the wallet, or `gen --shielded` to generate a new key.",
+             new key to the wallet, or `gen --shielded --alias my-key` to \
+             generate a new key.",
         );
     } else {
         let stdout = io::stdout();

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -492,7 +492,7 @@ fn key_gen(ctx: Context, io: &impl Io, args_key_gen: args::KeyGen) {
     }
 }
 
-/// TODO
+/// HD key derivation from mnemonic code
 async fn key_derive(
     mut ctx: Context,
     io: &impl Io,

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -721,31 +721,38 @@ fn transparent_keys_list(
     }
 }
 
-/// Export a transparent keypair to a file.
+/// Export a transparent keypair / MASP spending key to a file.
 fn key_export(
     ctx: Context,
     io: &impl Io,
     args::KeyExport {
+        shielded,
         alias,
         is_pre_genesis,
     }: args::KeyExport,
 ) {
     let alias = alias.to_lowercase();
     let mut wallet = load_wallet(ctx, is_pre_genesis);
-    wallet
-        .find_secret_key(&alias, None)
-        .map(|keypair| {
-            let file_data = keypair.serialize_to_vec();
-            let file_name = format!("key_{}", alias);
-            let mut file = File::create(&file_name).unwrap();
-
-            file.write_all(file_data.as_ref()).unwrap();
-            display_line!(io, "Exported to file {}", file_name);
-        })
-        .unwrap_or_else(|err| {
-            edisplay_line!(io, "{}", err);
-            cli::safe_exit(1)
-        })
+    if !shielded {
+        wallet
+            .find_secret_key(&alias, None)
+            .map(|sk| Box::new(sk) as Box<dyn BorshSerializeExt>)
+    } else {
+        wallet
+            .find_spending_key(&alias, None)
+            .map(|spk| Box::new(spk) as Box<dyn BorshSerializeExt>)
+    }
+    .map(|key| {
+        let file_data = key.serialize_to_vec();
+        let file_name = format!("key_{}", alias);
+        let mut file = File::create(&file_name).unwrap();
+        file.write_all(file_data.as_ref()).unwrap();
+        display_line!(io, "Exported to file {}", file_name);
+    })
+    .unwrap_or_else(|err| {
+        edisplay_line!(io, "{}", err);
+        cli::safe_exit(1)
+    })
 }
 
 /// List all known transparent addresses.

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -99,8 +99,8 @@ fn spending_keys_list(
     if known_view_keys.is_empty() {
         display_line!(
             io,
-            "TODO No known keys. Try `masp add --alias my-addr --value ...` \
-             to add a new key to the wallet.",
+            "No known keys. Try `add --alias my-addr --value ...` to add a \
+             new key to the wallet, or `gen --shielded` to generate a new key.",
         );
     } else {
         let stdout = io::stdout();
@@ -171,7 +171,7 @@ fn payment_addresses_list(
     if known_addresses.is_empty() {
         display_line!(
             io,
-            "TODO No known payment addresses. Try `masp gen-addr --alias \
+            "No known payment addresses. Try `masp gen-payment-addr --alias \
              my-addr` to generate a new payment address.",
         );
     } else {
@@ -536,7 +536,7 @@ fn address_list(ctx: Context, io: &impl Io, args_key_list: args::AddressList) {
     }
 }
 
-/// Value for add command
+/// Value for wallet `add` command
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum KeyAddrAddValue {
@@ -736,9 +736,9 @@ fn shielded_key_address_find(
         // Otherwise alias cannot be referring to any shielded value
         display_line!(
             io,
-            "TODO No shielded address or key with alias {} found. Use the \
-             commands `masp list-addrs` and `masp list-keys` to see all the \
-             known addresses and keys.",
+            "No shielded address or key with alias {} found. Use the commands \
+             `list-addr --shielded` and `list-keys --shielded` to see all the \
+             known shielded addresses and keys.",
             alias.to_lowercase()
         );
     }

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -1141,7 +1141,7 @@ fn transparent_secret_key_add(
     );
 }
 
-/// Add an address to the wallet.
+/// Add a transparent address to the wallet.
 fn transparent_address_add(
     ctx: Context,
     io: &impl Io,

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -40,16 +40,6 @@ impl CliApi {
         io: &impl Io,
     ) -> Result<()> {
         match cmd {
-            cmds::NamadaWallet::Masp(sub) => match sub {
-                cmds::WalletMasp::GenPayAddr(cmds::MaspGenPayAddr(args)) => {
-                    let args = args.to_sdk(&mut ctx);
-                    payment_address_gen(
-                        &mut ctx.borrow_mut_chain_or_exit().wallet,
-                        io,
-                        args,
-                    )
-                }
-            },
             cmds::NamadaWallet::NewGen(cmds::WalletNewGen(args)) => {
                 key_gen(ctx, io, args)
             }
@@ -74,6 +64,16 @@ impl CliApi {
             cmds::NamadaWallet::NewKeyAddrAdd(
                 cmds::WalletNewKeyAddressAdd(args),
             ) => key_address_add(ctx, io, args),
+            cmds::NamadaWallet::NewPayAddrGen(
+                cmds::WalletNewPaymentAddressGen(args),
+            ) => {
+                let args = args.to_sdk(&mut ctx);
+                payment_address_gen(
+                    &mut ctx.borrow_mut_chain_or_exit().wallet,
+                    io,
+                    args,
+                )
+            }
         }
         Ok(())
     }
@@ -217,13 +217,13 @@ fn spending_key_gen(
 fn payment_address_gen(
     wallet: &mut Wallet<impl WalletStorage + WalletIo>,
     io: &impl Io,
-    args::MaspPayAddrGen {
+    args::PayAddressGen {
         alias,
         alias_force,
         viewing_key,
         pin,
         ..
-    }: args::MaspPayAddrGen,
+    }: args::PayAddressGen,
 ) {
     let alias = alias.to_lowercase();
     let viewing_key = ExtendedFullViewingKey::from(viewing_key).fvk.vk;

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -160,7 +160,7 @@ fn payment_addresses_list(ctx: Context, io: &impl Io, is_pre_genesis: bool) {
         display_line!(
             io,
             "No known payment addresses. Try `gen-payment-addr --alias \
-             my-addr` to generate a new payment address.",
+             my-payment-addr` to generate a new payment address.",
         );
     } else {
         let stdout = io::stdout();

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -41,14 +41,6 @@ impl CliApi {
     ) -> Result<()> {
         match cmd {
             cmds::NamadaWallet::Key(sub) => match sub {
-                cmds::WalletKey::Derive(cmds::KeyDerive(args)) => {
-                    key_and_address_derive(
-                        &mut ctx.borrow_mut_chain_or_exit().wallet,
-                        io,
-                        args,
-                    )
-                    .await
-                }
                 cmds::WalletKey::Find(cmds::KeyFind(args)) => {
                     key_find(ctx, io, args)
                 }
@@ -60,14 +52,6 @@ impl CliApi {
                 }
             },
             cmds::NamadaWallet::Address(sub) => match sub {
-                cmds::WalletAddress::Derive(cmds::AddressDerive(args)) => {
-                    key_and_address_derive(
-                        &mut ctx.borrow_mut_chain_or_exit().wallet,
-                        io,
-                        args,
-                    )
-                    .await
-                }
                 cmds::WalletAddress::Find(cmds::AddressOrAliasFind(args)) => {
                     address_or_alias_find(ctx, io, args)
                 }
@@ -102,6 +86,9 @@ impl CliApi {
             },
             cmds::NamadaWallet::NewGen(cmds::WalletNewGen(args)) => {
                 key_gen(ctx, io, args)
+            }
+            cmds::NamadaWallet::NewDerive(cmds::WalletNewDerive(args)) => {
+                key_derive(ctx, io, args).await
             }
         }
         Ok(())
@@ -398,14 +385,15 @@ pub fn decode_derivation_path(
 async fn key_and_address_derive(
     wallet: &mut Wallet<impl WalletStorage + WalletIo>,
     io: &impl Io,
-    args::KeyAndAddressDerive {
+    args::KeyDerive {
         scheme,
         alias,
         alias_force,
         unsafe_dont_encrypt,
         derivation_path,
         use_device,
-    }: args::KeyAndAddressDerive,
+        ..
+    }: args::KeyDerive,
 ) {
     let derivation_path = decode_derivation_path(scheme, derivation_path)
         .unwrap_or_else(|err| {
@@ -551,6 +539,24 @@ fn key_and_address_gen(
         "Successfully added a key and an address with alias: \"{}\"",
         alias
     );
+}
+
+/// TODO
+async fn key_derive(
+    mut ctx: Context,
+    io: &impl Io,
+    args_key_derive: args::KeyDerive,
+) {
+    if !args_key_derive.shielded {
+        key_and_address_derive(
+            &mut ctx.borrow_mut_chain_or_exit().wallet,
+            io,
+            args_key_derive,
+        )
+        .await
+    } else {
+        todo!()
+    }
 }
 
 /// Find a keypair in the wallet store.

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -759,8 +759,8 @@ fn transparent_addresses_list(
     if known_addresses.is_empty() {
         display_line!(
             io,
-            "No known addresses. Try `address gen --alias my-addr` to \
-             generate a new implicit address.",
+            "No known addresses. Try `gen --alias my-addr` to generate a new \
+             implicit address.",
         );
     } else {
         let stdout = io::stdout();

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1955,26 +1955,21 @@ pub struct KeyFind {
     pub unsafe_show_secret: bool,
 }
 
-/// Wallet list keys arguments
+/// Wallet list arguments
 #[derive(Clone, Debug)]
-pub struct KeyList {
+pub struct KeyAddressList {
     /// Whether to list MASP spending keys
     pub shielded: bool,
     /// Don't decrypt keys
     pub decrypt: bool,
     /// List keys pre-genesis instead of a current chain
     pub is_pre_genesis: bool,
+    /// List keys only
+    pub keys_only: bool,
+    /// List addresses only
+    pub addresses_only: bool,
     /// Show secret keys to user
     pub unsafe_show_secret: bool,
-}
-
-/// List addresses arguments
-#[derive(Clone, Debug)]
-pub struct AddressList {
-    /// Whether to list MASP payment addresses
-    pub shielded: bool,
-    /// List addresses pre-genesis instead of current chain
-    pub is_pre_genesis: bool,
 }
 
 /// Wallet address lookup arguments

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2048,7 +2048,9 @@ pub struct MaspListPayAddrs {
 /// Wallet list keys arguments
 #[derive(Clone, Debug)]
 pub struct KeyList {
-    /// Don't decrypt keypairs
+    /// Whether to list spending keys of the shielded pool
+    pub shielded: bool,
+    /// Don't decrypt keys
     pub decrypt: bool,
     /// List keys pre-genesis instead of a current chain
     pub is_pre_genesis: bool,

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1925,7 +1925,7 @@ pub struct KeyGen {
 pub struct KeyDerive {
     /// Scheme type
     pub scheme: SchemeType,
-    /// Whether to generate a spending key for the shielded pool
+    /// Whether to generate a MASP spending key
     pub shielded: bool,
     /// Key alias
     pub alias: String,
@@ -1942,7 +1942,7 @@ pub struct KeyDerive {
 /// Wallet key lookup arguments
 #[derive(Clone, Debug)]
 pub struct KeyFind {
-    /// Whether to find shielded address by alias
+    /// Whether to find a MASP address by alias
     pub shielded: bool,
     /// Key alias to lookup keypair with
     pub alias: Option<String>,
@@ -1959,7 +1959,7 @@ pub struct KeyFind {
 /// Wallet list keys arguments
 #[derive(Clone, Debug)]
 pub struct KeyList {
-    /// Whether to list spending keys of the shielded pool
+    /// Whether to list MASP spending keys
     pub shielded: bool,
     /// Don't decrypt keys
     pub decrypt: bool,
@@ -1972,7 +1972,7 @@ pub struct KeyList {
 /// List addresses arguments
 #[derive(Clone, Debug)]
 pub struct AddressList {
-    /// Whether to list payment addresses of the shielded pool
+    /// Whether to list MASP payment addresses
     pub shielded: bool,
     /// List addresses pre-genesis instead of current chain
     pub is_pre_genesis: bool,

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -13,6 +13,7 @@ use namada_core::types::dec::Dec;
 use namada_core::types::ethereum_events::EthAddress;
 use namada_core::types::keccak::KeccakHash;
 use namada_core::types::key::{common, SchemeType};
+use namada_core::types::masp::PaymentAddress;
 use namada_core::types::storage::Epoch;
 use namada_core::types::time::DateTimeUtc;
 use namada_core::types::transaction::GasLimit;
@@ -1938,23 +1939,6 @@ pub struct KeyDerive {
     pub use_device: bool,
 }
 
-/// Wallet key lookup arguments
-#[derive(Clone, Debug)]
-pub struct KeyFind {
-    /// Whether to find a MASP address by alias
-    pub shielded: bool,
-    /// Key alias to lookup keypair with
-    pub alias: Option<String>,
-    /// Public key to lookup keypair with
-    pub public_key: Option<common::PublicKey>,
-    /// Public key hash to lookup keypair with
-    pub value: Option<String>,
-    /// Find a key pre-genesis instead of a current chain
-    pub is_pre_genesis: bool,
-    /// Show secret keys to user
-    pub unsafe_show_secret: bool,
-}
-
 /// Wallet list arguments
 #[derive(Clone, Debug)]
 pub struct KeyAddressList {
@@ -1972,17 +1956,30 @@ pub struct KeyAddressList {
     pub unsafe_show_secret: bool,
 }
 
-/// Wallet address lookup arguments
+/// Wallet key / address lookup arguments
 #[derive(Clone, Debug)]
-pub struct AddressFind {
+pub struct KeyAddressFind {
+    /// Whether to find MASP keys / addresses
+    pub shielded: bool,
     /// Alias to find
     pub alias: Option<String>,
     /// Address to find
     pub address: Option<Address>,
+    /// Public key to lookup keypair with
+    pub public_key: Option<common::PublicKey>,
+    /// Public key hash to lookup keypair with
+    pub public_key_hash: Option<String>,
+    /// Payment address to find
+    pub payment_address: Option<PaymentAddress>,
+    /// Find keys only
+    pub keys_only: bool,
+    /// Find addresses only
+    pub addresses_only: bool,
     /// Lookup address pre-genesis instead of a current chain
     pub is_pre_genesis: bool,
+    /// Show secret keys to user
+    pub unsafe_show_secret: bool,
 }
-
 /// Wallet key export arguments
 #[derive(Clone, Debug)]
 pub struct KeyExport {

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1999,6 +1999,21 @@ pub struct KeyExport {
     pub is_pre_genesis: bool,
 }
 
+/// Wallet key import arguments
+#[derive(Clone, Debug)]
+pub struct KeyImport {
+    /// File name
+    pub file_path: String,
+    /// Key alias
+    pub alias: String,
+    /// Whether to force overwrite the alias
+    pub alias_force: bool,
+    /// Export key pre-genesis instead of a current chain
+    pub is_pre_genesis: bool,
+    /// Don't encrypt the key
+    pub unsafe_dont_encrypt: bool,
+}
+
 /// Wallet key / address add arguments
 #[derive(Clone, Debug)]
 pub struct KeyAddressAdd {

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2040,7 +2040,7 @@ pub struct MaspKeysList {
 /// Wallet list shielded payment addresses arguments
 #[derive(Clone, Debug)]
 pub struct MaspListPayAddrs {
-    /// List sheilded payment address pre-genesis instead
+    /// List shielded payment address pre-genesis instead
     /// of a current chain
     pub is_pre_genesis: bool,
 }

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1945,9 +1945,13 @@ pub struct MaspPayAddrGen<C: NamadaTypes = SdkTypes> {
 
 /// Wallet generate key and implicit address arguments
 #[derive(Clone, Debug)]
-pub struct KeyAndAddressGen {
+pub struct KeyGen {
     /// Scheme type
     pub scheme: SchemeType,
+    /// Whether to generate a spending key for the shielded pool
+    pub shielded: bool,
+    /// Whether to generate a raw non-hd key
+    pub raw: bool,
     /// Key alias
     pub alias: Option<String>,
     /// Whether to force overwrite the alias, if provided

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -13,7 +13,6 @@ use namada_core::types::dec::Dec;
 use namada_core::types::ethereum_events::EthAddress;
 use namada_core::types::keccak::KeccakHash;
 use namada_core::types::key::{common, SchemeType};
-use namada_core::types::masp::MaspValue;
 use namada_core::types::storage::Epoch;
 use namada_core::types::time::DateTimeUtc;
 use namada_core::types::transaction::GasLimit;
@@ -2007,10 +2006,8 @@ pub struct KeyAddressAdd {
     pub alias: String,
     /// Whether to force overwrite the alias
     pub alias_force: bool,
-    /// Transparent address to add
-    pub address: Option<Address>,
-    /// Any shielded value
-    pub value: Option<MaspValue>,
+    /// Any supported value
+    pub value: String,
     /// Add key / address pre-genesis instead of current chain
     pub is_pre_genesis: bool,
     /// Don't encrypt the keys

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1916,7 +1916,7 @@ pub struct KeyGen {
     pub is_pre_genesis: bool,
     /// Don't encrypt the keypair
     pub unsafe_dont_encrypt: bool,
-    /// BIP44 derivation path
+    /// BIP44 / ZIP32 derivation path
     pub derivation_path: String,
 }
 

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1992,6 +1992,8 @@ pub struct AddressFind {
 /// Wallet key export arguments
 #[derive(Clone, Debug)]
 pub struct KeyExport {
+    /// Whether to export a MASP spending key
+    pub shielded: bool,
     /// Key alias
     pub alias: String,
     /// Export key pre-genesis instead of a current chain

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1983,66 +1983,22 @@ pub struct KeyDerive {
     pub use_device: bool,
 }
 
-/// Wallet restore key and implicit address arguments
-#[derive(Clone, Debug)]
-pub struct KeyAndAddressDerive {
-    /// Scheme type
-    pub scheme: SchemeType,
-    /// Key alias
-    pub alias: Option<String>,
-    /// Whether to force overwrite the alias, if provided
-    pub alias_force: bool,
-    /// Don't encrypt the keypair
-    pub unsafe_dont_encrypt: bool,
-    /// BIP44 derivation path
-    pub derivation_path: String,
-    /// Use device to generate key and address
-    pub use_device: bool,
-}
-
-/// Wallet key lookup arguments
+/// Wallet find shielded address or key arguments
+/// TODO Wallet key lookup arguments
 #[derive(Clone, Debug)]
 pub struct KeyFind {
-    /// Public key to lookup keypair with
-    pub public_key: Option<common::PublicKey>,
+    /// Whether to find shielded address by alias
+    pub shielded: bool,
     /// Key alias to lookup keypair with
     pub alias: Option<String>,
+    /// Public key to lookup keypair with
+    pub public_key: Option<common::PublicKey>,
     /// Public key hash to lookup keypair with
     pub value: Option<String>,
     /// Find a key pre-genesis instead of a current chain
     pub is_pre_genesis: bool,
     /// Show secret keys to user
     pub unsafe_show_secret: bool,
-}
-
-/// Wallet find shielded address or key arguments
-#[derive(Clone, Debug)]
-pub struct AddrKeyFind {
-    /// Address/key alias
-    pub alias: String,
-    /// Show secret keys to user
-    pub unsafe_show_secret: bool,
-    /// Find shielded address / key pre-genesis instead of a current chain
-    pub is_pre_genesis: bool,
-}
-
-/// Wallet list shielded keys arguments
-#[derive(Clone, Debug)]
-pub struct MaspKeysList {
-    /// Don't decrypt spending keys
-    pub decrypt: bool,
-    /// List shielded keys pre-genesis instead of a current chain
-    pub is_pre_genesis: bool,
-    /// Show secret keys to user
-    pub unsafe_show_secret: bool,
-}
-
-/// Wallet list shielded payment addresses arguments
-#[derive(Clone, Debug)]
-pub struct MaspListPayAddrs {
-    /// List shielded payment address pre-genesis instead
-    /// of a current chain
-    pub is_pre_genesis: bool,
 }
 
 /// Wallet list keys arguments
@@ -2058,18 +2014,18 @@ pub struct KeyList {
     pub unsafe_show_secret: bool,
 }
 
-/// Wallet key export arguments
+/// List transparent wallet addresses / shielded payment addresses
 #[derive(Clone, Debug)]
-pub struct KeyExport {
-    /// Key alias
-    pub alias: String,
-    /// Export key pre-genesis instead of a current chain
+pub struct AddressList {
+    /// Whether to list payment addresses of the shielded pool
+    pub shielded: bool,
+    /// List addresses pre-genesis instead of current chain
     pub is_pre_genesis: bool,
 }
 
 /// Wallet address lookup arguments
 #[derive(Clone, Debug)]
-pub struct AddressOrAliasFind {
+pub struct AddressFind {
     /// Alias to find
     pub alias: Option<String>,
     /// Address to find
@@ -2078,10 +2034,12 @@ pub struct AddressOrAliasFind {
     pub is_pre_genesis: bool,
 }
 
-/// List wallet address
+/// Wallet key export arguments
 #[derive(Clone, Debug)]
-pub struct AddressList {
-    /// List addresses pre-genesis instead of current chain
+pub struct KeyExport {
+    /// Key alias
+    pub alias: String,
+    /// Export key pre-genesis instead of a current chain
     pub is_pre_genesis: bool,
 }
 

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1899,50 +1899,6 @@ impl<C: NamadaTypes> TxBuilder<C> for Tx<C> {
     }
 }
 
-/// MASP add key or address arguments
-#[derive(Clone, Debug)]
-pub struct MaspAddrKeyAdd {
-    /// Key alias
-    pub alias: String,
-    /// Whether to force overwrite the alias
-    pub alias_force: bool,
-    /// Any MASP value
-    pub value: MaspValue,
-    /// Add a MASP key / address pre-genesis instead
-    /// of a current chain
-    pub is_pre_genesis: bool,
-    /// Don't encrypt the keypair
-    pub unsafe_dont_encrypt: bool,
-}
-
-/// MASP generate spending key arguments
-#[derive(Clone, Debug)]
-pub struct MaspSpendKeyGen {
-    /// Key alias
-    pub alias: String,
-    /// Whether to force overwrite the alias
-    pub alias_force: bool,
-    /// Generate spending key pre-genesis instead of a current chain
-    pub is_pre_genesis: bool,
-    /// Don't encrypt the keypair
-    pub unsafe_dont_encrypt: bool,
-}
-
-/// MASP generate payment address arguments
-#[derive(Clone, Debug)]
-pub struct MaspPayAddrGen<C: NamadaTypes = SdkTypes> {
-    /// Key alias
-    pub alias: String,
-    /// Whether to force overwrite the alias
-    pub alias_force: bool,
-    /// Viewing key
-    pub viewing_key: C::ViewingKey,
-    /// Pin
-    pub pin: bool,
-    /// Generate an address pre-genesis instead of a current chain
-    pub is_pre_genesis: bool,
-}
-
 /// Wallet generate key and implicit address arguments
 #[derive(Clone, Debug)]
 pub struct KeyGen {
@@ -1983,8 +1939,7 @@ pub struct KeyDerive {
     pub use_device: bool,
 }
 
-/// Wallet find shielded address or key arguments
-/// TODO Wallet key lookup arguments
+/// Wallet key lookup arguments
 #[derive(Clone, Debug)]
 pub struct KeyFind {
     /// Whether to find shielded address by alias
@@ -2014,7 +1969,7 @@ pub struct KeyList {
     pub unsafe_show_secret: bool,
 }
 
-/// List transparent wallet addresses / shielded payment addresses
+/// List addresses arguments
 #[derive(Clone, Debug)]
 pub struct AddressList {
     /// Whether to list payment addresses of the shielded pool
@@ -2058,6 +2013,21 @@ pub struct KeyAddressAdd {
     pub is_pre_genesis: bool,
     /// Don't encrypt the keys
     pub unsafe_dont_encrypt: bool,
+}
+
+/// Generate payment address arguments
+#[derive(Clone, Debug)]
+pub struct PayAddressGen<C: NamadaTypes = SdkTypes> {
+    /// Key alias
+    pub alias: String,
+    /// Whether to force overwrite the alias
+    pub alias_force: bool,
+    /// Viewing key
+    pub viewing_key: C::ViewingKey,
+    /// Pin
+    pub pin: bool,
+    /// Generate an address pre-genesis instead of a current chain
+    pub is_pre_genesis: bool,
 }
 
 /// Bridge pool batch recommendation.

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1909,7 +1909,7 @@ pub struct KeyGen {
     /// Whether to generate a raw non-hd key
     pub raw: bool,
     /// Key alias
-    pub alias: Option<String>,
+    pub alias: String,
     /// Whether to force overwrite the alias, if provided
     pub alias_force: bool,
     /// Generate a key for pre-genesis, instead of a current chain
@@ -1928,7 +1928,7 @@ pub struct KeyDerive {
     /// Whether to generate a spending key for the shielded pool
     pub shielded: bool,
     /// Key alias
-    pub alias: Option<String>,
+    pub alias: String,
     /// Whether to force overwrite the alias, if provided
     pub alias_force: bool,
     /// Don't encrypt the keypair

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1909,7 +1909,7 @@ pub struct KeyGen {
     pub raw: bool,
     /// Key alias
     pub alias: String,
-    /// Whether to force overwrite the alias, if provided
+    /// Whether to force overwrite the alias
     pub alias_force: bool,
     /// Generate a key for pre-genesis, instead of a current chain
     pub is_pre_genesis: bool,
@@ -1928,7 +1928,7 @@ pub struct KeyDerive {
     pub shielded: bool,
     /// Key alias
     pub alias: String,
-    /// Whether to force overwrite the alias, if provided
+    /// Whether to force overwrite the alias
     pub alias_force: bool,
     /// Don't encrypt the keypair
     pub unsafe_dont_encrypt: bool,
@@ -2025,7 +2025,7 @@ pub struct KeyAddressAdd {
     pub value: String,
     /// Add key / address pre-genesis instead of current chain
     pub is_pre_genesis: bool,
-    /// Don't encrypt the keys
+    /// Don't encrypt the key
     pub unsafe_dont_encrypt: bool,
 }
 

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1966,6 +1966,25 @@ pub struct KeyGen {
 
 /// Wallet restore key and implicit address arguments
 #[derive(Clone, Debug)]
+pub struct KeyDerive {
+    /// Scheme type
+    pub scheme: SchemeType,
+    /// Whether to generate a spending key for the shielded pool
+    pub shielded: bool,
+    /// Key alias
+    pub alias: Option<String>,
+    /// Whether to force overwrite the alias, if provided
+    pub alias_force: bool,
+    /// Don't encrypt the keypair
+    pub unsafe_dont_encrypt: bool,
+    /// BIP44 derivation path
+    pub derivation_path: String,
+    /// Use device to generate key and address
+    pub use_device: bool,
+}
+
+/// Wallet restore key and implicit address arguments
+#[derive(Clone, Debug)]
 pub struct KeyAndAddressDerive {
     /// Scheme type
     pub scheme: SchemeType,

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2043,17 +2043,21 @@ pub struct KeyExport {
     pub is_pre_genesis: bool,
 }
 
-/// Wallet address add arguments
+/// Wallet key / address add arguments
 #[derive(Clone, Debug)]
-pub struct AddressAdd {
+pub struct KeyAddressAdd {
     /// Address alias
     pub alias: String,
     /// Whether to force overwrite the alias
     pub alias_force: bool,
-    /// Address to add
-    pub address: Address,
-    /// Add an address pre-genesis instead of current chain
+    /// Transparent address to add
+    pub address: Option<Address>,
+    /// Any shielded value
+    pub value: Option<MaspValue>,
+    /// Add key / address pre-genesis instead of current chain
     pub is_pre_genesis: bool,
+    /// Don't encrypt the keys
+    pub unsafe_dont_encrypt: bool,
 }
 
 /// Bridge pool batch recommendation.

--- a/sdk/src/wallet/mod.rs
+++ b/sdk/src/wallet/mod.rs
@@ -417,6 +417,14 @@ impl<U> Wallet<U> {
         self.store.find_payment_addr(alias.as_ref())
     }
 
+    /// Find an alias by the payment address if it's in the wallet.
+    pub fn find_alias_by_payment_addr(
+        &self,
+        payment_address: &PaymentAddress,
+    ) -> Option<&Alias> {
+        self.store.find_alias_by_payment_addr(payment_address)
+    }
+
     /// Get all known keys by their alias, paired with PKH, if known.
     pub fn get_secret_keys(
         &self,


### PR DESCRIPTION
This PR introduces a revamped structure of the wallet CLI.

- [ ] describe the new structure here

The following changes were additionally introduced.

- For consistency, `--alias` argument is made obligatory for `gen` / `derive` commands.
- Raw (non-HD) key generation functionality is restored, hidden under `--raw` flag.
  Example: `namadaw gen --raw --alias key1`
- Fix alias string normalization
- Implemented `export` for MASP spending keys
- Implement `add` for secret keys
- Implemented import from file
- Simplified interface of `add` command. Example: `namadaw add --alias my_entry --value val`. The supported values: secret key, namada address, MASP spending key / viewing key / payment address
- Introduced bi-map for the alias-payment address book
- Implemented alias lookup by MASP payment key

TODOs

- [x] check how `--raw` and `--hd-path` interact
- [x] restore raw key generation functionality from #2183 
- [x] rename the constructors for subcommands
- [x] check that `_new` suffix is removed
- [x] make alias obligatory for key gen / derive
- [x] make sure aliases are normalized appropriately (`to_lower()`) everywhere
- [x] implement export for shielded keys
- [x] implement key import functionality
- [x] merge `list-key` and `list-addr`
- [x] merge `find-key` and `find-addr`
- [x] update help messages for `gen`
- [x] update help messages for `derive`
- [x] update help messages for `list`
- [x] update help messages for `find`
- [x] update help messages for `export`
- [x] update help messages for `add`
- [x] update help messages for `gen-payment-addr`
- [x] fix `TODO`s in the code
- [x] rebase onto the recent `main`
- [ ] implement ZIP32 functionality for spending key generation
- [ ] use `Alias` struct everywhere in order to force alias normalization?

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
