### PR TITLE
less permissive VPs

### DIFF
--- a/.changelog/unreleased/improvements/2213-vp-less-permissive.md
+++ b/.changelog/unreleased/improvements/2213-vp-less-permissive.md
@@ -1,0 +1,3 @@
+- The default implicit and established user account VPs now
+  require valid signature(s) for unknown storage changes.
+  ([\#2213](https://github.com/anoma/namada/pull/2213))

--- a/benches/vps.rs
+++ b/benches/vps.rs
@@ -182,8 +182,7 @@ fn vp_implicit(c: &mut Criterion) {
             .try_to_sk()
             .unwrap();
 
-    let foreign_key_write =
-        generate_foreign_key_tx(&defaults::albert_keypair());
+    let foreign_key_write = generate_foreign_key_tx(&implicit_account);
 
     let shell = BenchShell::default();
     let transfer = shell.generate_tx(
@@ -327,7 +326,7 @@ fn vp_validator(c: &mut Criterion) {
     let mut group = c.benchmark_group("vp_validator");
 
     let foreign_key_write =
-        generate_foreign_key_tx(&defaults::albert_keypair());
+        generate_foreign_key_tx(&defaults::validator_keypair());
 
     let transfer = shell.generate_tx(
         TX_TRANSFER_WASM,

--- a/core/src/types/address.rs
+++ b/core/src/types/address.rs
@@ -62,6 +62,8 @@ pub const POS_SLASH_POOL: Address =
 pub const GOV: Address = Address::Internal(InternalAddress::Governance);
 /// Internal MASP address
 pub const MASP: Address = Address::Internal(InternalAddress::Masp);
+/// Internal Multitoken address
+pub const MULTITOKEN: Address = Address::Internal(InternalAddress::Multitoken);
 
 /// Error from decoding address from string
 pub type DecodeError = string_encoding::DecodeError;

--- a/core/src/types/ibc.rs
+++ b/core/src/types/ibc.rs
@@ -15,6 +15,7 @@ use crate::ibc::apps::transfer::types::{Memo, PrefixedDenom, TracePath};
 use crate::ibc::core::handler::types::events::{
     Error as IbcEventError, IbcEvent as RawIbcEvent,
 };
+pub use crate::ledger::ibc::storage::is_ibc_key;
 use crate::tendermint::abci::Event as AbciEvent;
 use crate::types::masp::PaymentAddress;
 

--- a/proof_of_stake/src/storage.rs
+++ b/proof_of_stake/src/storage.rs
@@ -5,7 +5,7 @@ use namada_core::types::address::Address;
 use namada_core::types::storage::{DbKeySeg, Epoch, Key, KeySeg};
 
 use super::ADDRESS;
-use crate::epoched::LAZY_MAP_SUB_KEY;
+use crate::epoched;
 use crate::types::BondId;
 
 const PARAMS_STORAGE_KEY: &str = "params";
@@ -121,19 +121,23 @@ pub fn validator_consensus_key_key(validator: &Address) -> Key {
 
 /// Is storage key for validator's consensus key?
 pub fn is_validator_consensus_key_key(key: &Key) -> Option<&Address> {
-    match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::StringSeg(prefix),
-            DbKeySeg::AddressSeg(validator),
-            DbKeySeg::StringSeg(key),
-        ] if addr == &ADDRESS
-            && prefix == VALIDATOR_STORAGE_PREFIX
-            && key == VALIDATOR_CONSENSUS_KEY_STORAGE_KEY =>
-        {
-            Some(validator)
+    if key.segments.len() >= 4 {
+        match &key.segments[..4] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(prefix),
+                DbKeySeg::AddressSeg(validator),
+                DbKeySeg::StringSeg(key),
+            ] if addr == &ADDRESS
+                && prefix == VALIDATOR_STORAGE_PREFIX
+                && key == VALIDATOR_CONSENSUS_KEY_STORAGE_KEY =>
+            {
+                Some(validator)
+            }
+            _ => None,
         }
-        _ => None,
+    } else {
+        None
     }
 }
 
@@ -146,19 +150,23 @@ pub fn validator_eth_cold_key_key(validator: &Address) -> Key {
 
 /// Is storage key for validator's eth cold key?
 pub fn is_validator_eth_cold_key_key(key: &Key) -> Option<&Address> {
-    match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::StringSeg(prefix),
-            DbKeySeg::AddressSeg(validator),
-            DbKeySeg::StringSeg(key),
-        ] if addr == &ADDRESS
-            && prefix == VALIDATOR_STORAGE_PREFIX
-            && key == VALIDATOR_ETH_COLD_KEY_STORAGE_KEY =>
-        {
-            Some(validator)
+    if key.segments.len() >= 4 {
+        match &key.segments[..4] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(prefix),
+                DbKeySeg::AddressSeg(validator),
+                DbKeySeg::StringSeg(key),
+            ] if addr == &ADDRESS
+                && prefix == VALIDATOR_STORAGE_PREFIX
+                && key == VALIDATOR_ETH_COLD_KEY_STORAGE_KEY =>
+            {
+                Some(validator)
+            }
+            _ => None,
         }
-        _ => None,
+    } else {
+        None
     }
 }
 
@@ -171,19 +179,23 @@ pub fn validator_eth_hot_key_key(validator: &Address) -> Key {
 
 /// Is storage key for validator's eth hot key?
 pub fn is_validator_eth_hot_key_key(key: &Key) -> Option<&Address> {
-    match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::StringSeg(prefix),
-            DbKeySeg::AddressSeg(validator),
-            DbKeySeg::StringSeg(key),
-        ] if addr == &ADDRESS
-            && prefix == VALIDATOR_STORAGE_PREFIX
-            && key == VALIDATOR_ETH_HOT_KEY_STORAGE_KEY =>
-        {
-            Some(validator)
+    if key.segments.len() >= 4 {
+        match &key.segments[..4] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(prefix),
+                DbKeySeg::AddressSeg(validator),
+                DbKeySeg::StringSeg(key),
+            ] if addr == &ADDRESS
+                && prefix == VALIDATOR_STORAGE_PREFIX
+                && key == VALIDATOR_ETH_HOT_KEY_STORAGE_KEY =>
+            {
+                Some(validator)
+            }
+            _ => None,
         }
-        _ => None,
+    } else {
+        None
     }
 }
 
@@ -195,29 +207,24 @@ pub fn validator_commission_rate_key(validator: &Address) -> Key {
 }
 
 /// Is storage key for validator's commission rate?
-pub fn is_validator_commission_rate_key(
-    key: &Key,
-) -> Option<(&Address, Epoch)> {
-    match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::StringSeg(prefix),
-            DbKeySeg::AddressSeg(validator),
-            DbKeySeg::StringSeg(key),
-            DbKeySeg::StringSeg(lazy_map),
-            DbKeySeg::StringSeg(data),
-            DbKeySeg::StringSeg(epoch),
-        ] if addr == &ADDRESS
-            && prefix == VALIDATOR_STORAGE_PREFIX
-            && key == VALIDATOR_COMMISSION_RATE_STORAGE_KEY
-            && lazy_map == LAZY_MAP_SUB_KEY
-            && data == lazy_map::DATA_SUBKEY =>
-        {
-            let epoch = Epoch::parse(epoch.clone())
-                .expect("Should be able to parse the epoch");
-            Some((validator, epoch))
+pub fn is_validator_commission_rate_key(key: &Key) -> Option<&Address> {
+    if key.segments.len() >= 4 {
+        match &key.segments[..4] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(prefix),
+                DbKeySeg::AddressSeg(validator),
+                DbKeySeg::StringSeg(key),
+            ] if addr == &ADDRESS
+                && prefix == VALIDATOR_STORAGE_PREFIX
+                && key == VALIDATOR_COMMISSION_RATE_STORAGE_KEY =>
+            {
+                Some(validator)
+            }
+            _ => None,
         }
-        _ => None,
+    } else {
+        None
     }
 }
 
@@ -313,6 +320,22 @@ pub fn rewards_counter_key(source: &Address, validator: &Address) -> Key {
         .expect("Cannot obtain a storage key")
 }
 
+/// Is the storage key for rewards counter?
+pub fn is_rewards_counter_key(key: &Key) -> Option<BondId> {
+    match &key.segments[..] {
+        [
+            DbKeySeg::AddressSeg(addr),
+            DbKeySeg::StringSeg(key),
+            DbKeySeg::AddressSeg(source),
+            DbKeySeg::AddressSeg(validator),
+        ] if addr == &ADDRESS && key == REWARDS_COUNTER_KEY => Some(BondId {
+            source: source.clone(),
+            validator: validator.clone(),
+        }),
+        _ => None,
+    }
+}
+
 /// Storage key for a validator's incoming redelegations, where the prefixed
 /// validator is the destination validator.
 pub fn validator_incoming_redelegations_key(validator: &Address) -> Key {
@@ -345,6 +368,33 @@ pub fn validator_total_redelegated_unbonded_key(validator: &Address) -> Key {
         .expect("Cannot obtain a storage key")
 }
 
+/// Is the storage key's prefix matching one of validator's:
+///
+/// - incoming or outgoing redelegations
+/// - total redelegated bonded or unbond amounts
+pub fn is_validator_redelegations_key(key: &Key) -> bool {
+    if key.segments.len() >= 4 {
+        match &key.segments[..4] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(val_prefix),
+                DbKeySeg::AddressSeg(_validator),
+                DbKeySeg::StringSeg(prefix),
+            ] => {
+                addr == &ADDRESS
+                    && val_prefix == VALIDATOR_STORAGE_PREFIX
+                    && (prefix == VALIDATOR_INCOMING_REDELEGATIONS_KEY
+                        || prefix == VALIDATOR_OUTGOING_REDELEGATIONS_KEY
+                        || prefix == VALIDATOR_TOTAL_REDELEGATED_BONDED_KEY
+                        || prefix == VALIDATOR_TOTAL_REDELEGATED_UNBONDED_KEY)
+            }
+            _ => false,
+        }
+    } else {
+        false
+    }
+}
+
 /// Storage key prefix for all delegators' redelegated bonds.
 pub fn delegator_redelegated_bonds_prefix() -> Key {
     Key::from(ADDRESS.to_db_key())
@@ -371,6 +421,29 @@ pub fn delegator_redelegated_unbonds_key(delegator: &Address) -> Key {
     delegator_redelegated_unbonds_prefix()
         .push(&delegator.to_db_key())
         .expect("Cannot obtain a storage key")
+}
+
+/// Is the storage key's prefix matching delegator's total redelegated bonded or
+/// unbond amounts? If so, returns the delegator's address.
+pub fn is_delegator_redelegations_key(key: &Key) -> Option<&Address> {
+    if key.segments.len() >= 3 {
+        match &key.segments[..3] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(prefix),
+                DbKeySeg::AddressSeg(delegator),
+            ] if addr == &ADDRESS
+                && (prefix == DELEGATOR_REDELEGATED_BONDS_KEY
+                    || prefix == DELEGATOR_REDELEGATED_UNBONDS_KEY) =>
+            {
+                Some(delegator)
+            }
+
+            _ => None,
+        }
+    } else {
+        None
+    }
 }
 
 /// Storage key for validator's last known rewards product epoch.
@@ -421,7 +494,7 @@ pub fn is_validator_state_key(key: &Key) -> Option<(&Address, Epoch)> {
         ] if addr == &ADDRESS
             && prefix == VALIDATOR_STORAGE_PREFIX
             && key == VALIDATOR_STATE_STORAGE_KEY
-            && lazy_map == LAZY_MAP_SUB_KEY
+            && lazy_map == epoched::LAZY_MAP_SUB_KEY
             && data == lazy_map::DATA_SUBKEY =>
         {
             let epoch = Epoch::parse(epoch.clone())
@@ -429,6 +502,30 @@ pub fn is_validator_state_key(key: &Key) -> Option<(&Address, Epoch)> {
             Some((validator, epoch))
         }
         _ => None,
+    }
+}
+
+/// Is storage key for a validator state's last update or oldest epoch?
+pub fn is_validator_state_epoched_meta_key(key: &Key) -> bool {
+    if key.segments.len() >= 5 {
+        match &key.segments[..5] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(prefix),
+                DbKeySeg::AddressSeg(_validator),
+                DbKeySeg::StringSeg(key),
+                DbKeySeg::StringSeg(data),
+            ] => {
+                addr == &ADDRESS
+                    && prefix == VALIDATOR_STORAGE_PREFIX
+                    && key == VALIDATOR_STATE_STORAGE_KEY
+                    && (data == epoched::LAST_UPDATE_SUB_KEY
+                        || data == epoched::OLDEST_EPOCH_SUB_KEY)
+            }
+            _ => false,
+        }
+    } else {
+        false
     }
 }
 
@@ -440,33 +537,46 @@ pub fn validator_deltas_key(validator: &Address) -> Key {
 }
 
 /// Is storage key for validator's total deltas?
-pub fn is_validator_deltas_key(key: &Key) -> Option<&Address> {
-    match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::StringSeg(prefix),
-            DbKeySeg::AddressSeg(validator),
-            DbKeySeg::StringSeg(key),
-            DbKeySeg::StringSeg(lazy_map),
-            DbKeySeg::StringSeg(data),
-            DbKeySeg::StringSeg(_epoch),
-        ] if addr == &ADDRESS
-            && prefix == VALIDATOR_STORAGE_PREFIX
-            && key == VALIDATOR_DELTAS_STORAGE_KEY
-            && lazy_map == LAZY_MAP_SUB_KEY
-            && data == lazy_map::DATA_SUBKEY =>
-        {
-            Some(validator)
+pub fn is_validator_deltas_key(key: &Key) -> bool {
+    if key.segments.len() >= 4 {
+        match &key.segments[..4] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(prefix),
+                DbKeySeg::AddressSeg(_validator),
+                DbKeySeg::StringSeg(key),
+            ] => {
+                addr == &ADDRESS
+                    && prefix == VALIDATOR_STORAGE_PREFIX
+                    && key == VALIDATOR_DELTAS_STORAGE_KEY
+            }
+            _ => false,
         }
-        _ => None,
+    } else {
+        false
     }
 }
 
-/// Storage prefix for all active validators (consensus, below-capacity, jailed)
+/// Storage prefix for all active validators (consensus, below-capacity,
+/// below-threshold, inactive, jailed)
 pub fn validator_addresses_key() -> Key {
     Key::from(ADDRESS.to_db_key())
         .push(&VALIDATOR_ADDRESSES_KEY.to_owned())
         .expect("Cannot obtain a storage key")
+}
+
+/// Is the storage key a prefix for all active validators?
+pub fn is_validator_addresses_key(key: &Key) -> bool {
+    if key.segments.len() >= 2 {
+        match &key.segments[..2] {
+            [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(prefix)] => {
+                addr == &ADDRESS && prefix == VALIDATOR_ADDRESSES_KEY
+            }
+            _ => false,
+        }
+    } else {
+        false
+    }
 }
 
 /// Storage prefix for slashes.
@@ -494,7 +604,7 @@ pub fn validator_slashes_key(validator: &Address) -> Key {
 /// Is storage key for a validator's slashes
 pub fn is_validator_slashes_key(key: &Key) -> Option<Address> {
     if key.segments.len() >= 5 {
-        match &key.segments[..] {
+        match &key.segments[..5] {
             [
                 DbKeySeg::AddressSeg(addr),
                 DbKeySeg::StringSeg(prefix),
@@ -557,7 +667,7 @@ pub fn is_bond_key(key: &Key) -> Option<(BondId, Epoch)> {
                 DbKeySeg::StringSeg(epoch_str),
             ] if addr == &ADDRESS
                 && prefix == BOND_STORAGE_KEY
-                && lazy_map == crate::epoched::LAZY_MAP_SUB_KEY
+                && lazy_map == epoched::LAZY_MAP_SUB_KEY
                 && data == lazy_map::DATA_SUBKEY =>
             {
                 let start = Epoch::parse(epoch_str.clone()).ok()?;
@@ -576,13 +686,61 @@ pub fn is_bond_key(key: &Key) -> Option<(BondId, Epoch)> {
     }
 }
 
+/// Is storage key for a bond last update or oldest epoch? Returns the bond ID
+/// if so.
+pub fn is_bond_epoched_meta_key(key: &Key) -> Option<BondId> {
+    if key.segments.len() >= 5 {
+        match &key.segments[..5] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(prefix),
+                DbKeySeg::AddressSeg(source),
+                DbKeySeg::AddressSeg(validator),
+                DbKeySeg::StringSeg(data),
+            ] if addr == &ADDRESS
+                && prefix == BOND_STORAGE_KEY
+                && (data == epoched::LAST_UPDATE_SUB_KEY
+                    || data == epoched::OLDEST_EPOCH_SUB_KEY) =>
+            {
+                Some(BondId {
+                    source: source.clone(),
+                    validator: validator.clone(),
+                })
+            }
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
 /// Storage key for the total bonds for a given validator.
 pub fn validator_total_bonded_key(validator: &Address) -> Key {
-    Key::from(ADDRESS.to_db_key())
+    validator_prefix(validator)
         .push(&VALIDATOR_TOTAL_BONDED_STORAGE_KEY.to_owned())
         .expect("Cannot obtain a storage key")
-        .push(&validator.to_db_key())
-        .expect("Cannot obtain a storage key")
+}
+
+/// Is the storage key for the total bonds or unbonds for a validator?
+pub fn is_validator_total_bond_or_unbond_key(key: &Key) -> bool {
+    if key.segments.len() >= 4 {
+        match &key.segments[..4] {
+            [
+                DbKeySeg::AddressSeg(addr),
+                DbKeySeg::StringSeg(val_prefix),
+                DbKeySeg::AddressSeg(_validator),
+                DbKeySeg::StringSeg(prefix),
+            ] => {
+                addr == &ADDRESS
+                    && val_prefix == VALIDATOR_STORAGE_PREFIX
+                    && (prefix == VALIDATOR_TOTAL_BONDED_STORAGE_KEY
+                        || prefix == VALIDATOR_TOTAL_UNBONDED_STORAGE_KEY)
+            }
+            _ => false,
+        }
+    } else {
+        false
+    }
 }
 
 /// Storage key prefix for all unbonds.
@@ -673,12 +831,12 @@ pub fn below_capacity_validator_set_key() -> Key {
 
 /// Is storage key for the consensus validator set?
 pub fn is_consensus_validator_set_key(key: &Key) -> bool {
-    matches!(&key.segments[..], [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(key), DbKeySeg::StringSeg(set_type), DbKeySeg::StringSeg(lazy_map), DbKeySeg::StringSeg(data), DbKeySeg::StringSeg(_epoch), DbKeySeg::StringSeg(_), DbKeySeg::StringSeg(_amount), DbKeySeg::StringSeg(_), DbKeySeg::StringSeg(_position)] if addr == &ADDRESS && key == VALIDATOR_SETS_STORAGE_PREFIX && set_type == CONSENSUS_VALIDATOR_SET_STORAGE_KEY && lazy_map == LAZY_MAP_SUB_KEY && data == lazy_map::DATA_SUBKEY)
+    matches!(&key.segments[..], [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(key), DbKeySeg::StringSeg(set_type), DbKeySeg::StringSeg(lazy_map), DbKeySeg::StringSeg(data), DbKeySeg::StringSeg(_epoch), DbKeySeg::StringSeg(_), DbKeySeg::StringSeg(_amount), DbKeySeg::StringSeg(_), DbKeySeg::StringSeg(_position)] if addr == &ADDRESS && key == VALIDATOR_SETS_STORAGE_PREFIX && set_type == CONSENSUS_VALIDATOR_SET_STORAGE_KEY && lazy_map == epoched::LAZY_MAP_SUB_KEY && data == lazy_map::DATA_SUBKEY)
 }
 
 /// Is storage key for the below-capacity validator set?
 pub fn is_below_capacity_validator_set_key(key: &Key) -> bool {
-    matches!(&key.segments[..], [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(key), DbKeySeg::StringSeg(set_type), DbKeySeg::StringSeg(lazy_map), DbKeySeg::StringSeg(data), DbKeySeg::StringSeg(_epoch), DbKeySeg::StringSeg(_), DbKeySeg::StringSeg(_amount), DbKeySeg::StringSeg(_), DbKeySeg::StringSeg(_position)] if addr == &ADDRESS && key == VALIDATOR_SETS_STORAGE_PREFIX && set_type == BELOW_CAPACITY_VALIDATOR_SET_STORAGE_KEY && lazy_map == LAZY_MAP_SUB_KEY && data == lazy_map::DATA_SUBKEY)
+    matches!(&key.segments[..], [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(key), DbKeySeg::StringSeg(set_type), DbKeySeg::StringSeg(lazy_map), DbKeySeg::StringSeg(data), DbKeySeg::StringSeg(_epoch), DbKeySeg::StringSeg(_), DbKeySeg::StringSeg(_amount), DbKeySeg::StringSeg(_), DbKeySeg::StringSeg(_position)] if addr == &ADDRESS && key == VALIDATOR_SETS_STORAGE_PREFIX && set_type == BELOW_CAPACITY_VALIDATOR_SET_STORAGE_KEY && lazy_map == epoched::LAZY_MAP_SUB_KEY && data == lazy_map::DATA_SUBKEY)
 }
 
 /// Storage key for total consensus stake
@@ -704,22 +862,16 @@ pub fn total_deltas_key() -> Key {
 }
 
 /// Is storage key for total deltas of all validators?
-pub fn is_total_deltas_key(key: &Key) -> Option<&String> {
-    match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::StringSeg(key),
-            DbKeySeg::StringSeg(lazy_map),
-            DbKeySeg::StringSeg(data),
-            DbKeySeg::StringSeg(epoch),
-        ] if addr == &ADDRESS
-            && key == TOTAL_DELTAS_STORAGE_KEY
-            && lazy_map == LAZY_MAP_SUB_KEY
-            && data == lazy_map::DATA_SUBKEY =>
-        {
-            Some(epoch)
+pub fn is_total_deltas_key(key: &Key) -> bool {
+    if key.segments.len() >= 2 {
+        match &key.segments[..2] {
+            [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(prefix)] => {
+                addr == &ADDRESS && prefix == TOTAL_DELTAS_STORAGE_KEY
+            }
+            _ => false,
         }
-        _ => None,
+    } else {
+        false
     }
 }
 
@@ -772,6 +924,25 @@ pub fn last_pos_reward_claim_epoch_key(
         .expect("Cannot obtain a storage key")
 }
 
+/// Is the storage key for epoch at which an account last claimed PoS
+/// inflationary rewards? Return the bond ID if so.
+pub fn is_last_pos_reward_claim_epoch_key(key: &Key) -> Option<BondId> {
+    match &key.segments[..] {
+        [
+            DbKeySeg::AddressSeg(addr),
+            DbKeySeg::StringSeg(key),
+            DbKeySeg::AddressSeg(source),
+            DbKeySeg::AddressSeg(validator),
+        ] if addr == &ADDRESS && key == LAST_REWARD_CLAIM_EPOCH => {
+            Some(BondId {
+                source: source.clone(),
+                validator: validator.clone(),
+            })
+        }
+        _ => None,
+    }
+}
+
 /// Get validator address from bond key
 pub fn get_validator_address_from_bond(key: &Key) -> Option<Address> {
     match key.get_at(3) {
@@ -788,6 +959,20 @@ pub fn validator_set_positions_key() -> Key {
     Key::from(ADDRESS.to_db_key())
         .push(&VALIDATOR_SET_POSITIONS_KEY.to_owned())
         .expect("Cannot obtain a storage key")
+}
+
+/// Is the storage key for validator set positions?
+pub fn is_validator_set_positions_key(key: &Key) -> bool {
+    if key.segments.len() >= 2 {
+        match &key.segments[..2] {
+            [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(prefix)] => {
+                addr == &ADDRESS && prefix == VALIDATOR_SET_POSITIONS_KEY
+            }
+            _ => false,
+        }
+    } else {
+        false
+    }
 }
 
 /// Storage key for consensus keys set.

--- a/wasm/wasm_source/src/vp_implicit.rs
+++ b/wasm/wasm_source/src/vp_implicit.rs
@@ -147,7 +147,7 @@ fn validate_tx(
             }
         };
         if !is_valid {
-            debug_log!("key {} modification failed vp", key);
+            log_string(format!("key {} modification failed vp_implicit", key));
             return reject();
         }
     }

--- a/wasm/wasm_source/src/vp_user.rs
+++ b/wasm/wasm_source/src/vp_user.rs
@@ -21,7 +21,7 @@ enum KeyType<'a> {
     PoS,
     Vp(&'a Address),
     Masp,
-    PgfStward(&'a Address),
+    PgfSteward(&'a Address),
     GovernanceVote(&'a Address),
     Unknown,
 }
@@ -40,7 +40,7 @@ impl<'a> From<&'a storage::Key> for KeyType<'a> {
                 Self::Unknown
             }
         } else if let Some(address) = pgf_storage::keys::is_stewards_key(key) {
-            Self::PgfStward(address)
+            Self::PgfSteward(address)
         } else if let Some(address) = key.is_validity_predicate() {
             Self::Vp(address)
         } else if token::is_masp_key(key) {
@@ -213,7 +213,7 @@ fn validate_tx(
                     true
                 }
             }
-            KeyType::PgfStward(address) => {
+            KeyType::PgfSteward(address) => {
                 if address == &addr {
                     *valid_sig
                 } else {

--- a/wasm/wasm_source/src/vp_user.rs
+++ b/wasm/wasm_source/src/vp_user.rs
@@ -132,7 +132,7 @@ fn validate_tx(
             }
         };
         if !is_valid {
-            debug_log!("key {} modification failed vp", key);
+            log_string(format!("key {} modification failed vp_user", key));
             return reject();
         }
     }

--- a/wasm/wasm_source/src/vp_user.rs
+++ b/wasm/wasm_source/src/vp_user.rs
@@ -11,9 +11,10 @@
 //!
 //! Any other storage key changes are allowed only with a valid signature.
 
+use core::ops::Deref;
+
 use namada_vp_prelude::*;
 use once_cell::unsync::Lazy;
-use proof_of_stake::types::ValidatorState;
 
 enum KeyType<'a> {
     Token { owner: &'a Address },
@@ -106,107 +107,7 @@ fn validate_tx(
                     true
                 }
             }
-            KeyType::PoS => {
-                // Bond or unbond
-                let bond_id = proof_of_stake::storage::is_bond_key(key)
-                    .map(|(bond_id, _)| bond_id)
-                    .or_else(|| {
-                        proof_of_stake::storage::is_unbond_key(key)
-                            .map(|(bond_id, _, _)| bond_id)
-                    });
-                let is_valid_bond_or_unbond_change = match bond_id {
-                    Some(bond_id) => {
-                        // Bonds and unbonds changes for this address
-                        // must be signed
-                        bond_id.source != addr || *valid_sig
-                    }
-                    None => {
-                        // Unknown changes are not allowed
-                        false
-                    }
-                };
-                // Commission rate changes must be signed by the validator
-                let comm =
-                    proof_of_stake::storage::is_validator_commission_rate_key(
-                        key,
-                    );
-                let is_valid_commission_rate_change = match comm {
-                    Some((validator, _epoch)) => {
-                        *validator == addr && *valid_sig
-                    }
-                    None => false,
-                };
-                // Metadata changes must be signed by the validator whose
-                // metadata is manipulated
-                let metadata =
-                    proof_of_stake::storage::is_validator_metadata_key(key);
-                let is_valid_metadata_change = match metadata {
-                    Some(address) => *address == addr && *valid_sig,
-                    None => false,
-                };
-
-                // Changes due to unjailing, deactivating, and reactivating are
-                // marked by changes in validator state
-                let state_change =
-                    proof_of_stake::storage::is_validator_state_key(key);
-                let is_valid_state_change = match state_change {
-                    Some((address, epoch)) => {
-                        let params_pre =
-                            proof_of_stake::read_pos_params(&ctx.pre())?;
-                        let state_pre =
-                            proof_of_stake::validator_state_handle(address)
-                                .get(&ctx.pre(), epoch, &params_pre)?;
-
-                        let params_post =
-                            proof_of_stake::read_pos_params(&ctx.post())?;
-                        let state_post =
-                            proof_of_stake::validator_state_handle(address)
-                                .get(&ctx.post(), epoch, &params_post)?;
-
-                        match (state_pre, state_post) {
-                            (Some(pre), Some(post)) => {
-                                if
-                                // Deactivation case
-                                (matches!(
-                                    pre,
-                                    ValidatorState::Consensus
-                                        | ValidatorState::BelowCapacity
-                                        | ValidatorState::BelowThreshold
-                                ) && post == ValidatorState::Inactive)
-                                // Reactivation case
-                                || pre == ValidatorState::Inactive
-                                    && post != ValidatorState::Inactive
-                                // Unjail case
-                                || pre == ValidatorState::Jailed
-                                    && matches!(
-                                        post,
-                                        ValidatorState::Consensus
-                                            | ValidatorState::BelowCapacity
-                                            | ValidatorState::BelowThreshold
-                                    )
-                                {
-                                    *address == addr && *valid_sig
-                                } else {
-                                    // Unknown state changes are not allowed
-                                    false
-                                }
-                            }
-                            (None, Some(_post)) => {
-                                // Becoming a validator must be authorized
-                                *valid_sig
-                            }
-                            _ => false,
-                        }
-                    }
-                    None => false,
-                };
-
-                is_valid_bond_or_unbond_change
-                    || is_valid_commission_rate_change
-                    || is_valid_state_change
-                    || is_valid_metadata_change
-                    || *valid_sig
-            }
+            KeyType::PoS => validate_pos_changes(ctx, &addr, key, &valid_sig)?,
             KeyType::PgfSteward(address) => address != &addr || *valid_sig,
             KeyType::GovernanceVote(voter) => voter != &addr || *valid_sig,
             KeyType::Vp(owner) => {
@@ -237,6 +138,177 @@ fn validate_tx(
     }
 
     accept()
+}
+
+fn validate_pos_changes(
+    ctx: &Ctx,
+    owner: &Address,
+    key: &storage::Key,
+    valid_sig: &impl Deref<Target = bool>,
+) -> VpResult {
+    use proof_of_stake::storage;
+
+    // Bond or unbond
+    let is_valid_bond_or_unbond_change = || {
+        let bond_id = storage::is_bond_key(key)
+            .map(|(bond_id, _)| bond_id)
+            .or_else(|| storage::is_bond_epoched_meta_key(key))
+            .or_else(|| {
+                storage::is_unbond_key(key).map(|(bond_id, _, _)| bond_id)
+            });
+        if let Some(bond_id) = bond_id {
+            // Bonds and unbonds changes for this address must be signed
+            return &bond_id.source != owner || **valid_sig;
+        };
+        // Unknown changes are not allowed
+        false
+    };
+
+    // Commission rate changes must be signed by the validator
+    let is_valid_commission_rate_change = || {
+        if let Some(validator) = storage::is_validator_commission_rate_key(key)
+        {
+            return validator == owner && **valid_sig;
+        }
+        false
+    };
+
+    // Metadata changes must be signed by the validator whose
+    // metadata is manipulated
+    let is_valid_metadata_change = || {
+        let metadata = storage::is_validator_metadata_key(key);
+        match metadata {
+            Some(address) => address == owner && **valid_sig,
+            None => false,
+        }
+    };
+
+    // Changes in validator state
+    let is_valid_state_change = || {
+        let state_change = storage::is_validator_state_key(key);
+        let is_valid_state = match state_change {
+            Some((address, epoch)) => {
+                let params_pre = proof_of_stake::read_pos_params(&ctx.pre())?;
+                let state_pre = proof_of_stake::validator_state_handle(address)
+                    .get(&ctx.pre(), epoch, &params_pre)?;
+
+                let params_post = proof_of_stake::read_pos_params(&ctx.post())?;
+                let state_post = proof_of_stake::validator_state_handle(
+                    address,
+                )
+                .get(&ctx.post(), epoch, &params_post)?;
+
+                match (state_pre, state_post) {
+                    (Some(pre), Some(post)) => {
+                        use proof_of_stake::types::ValidatorState::*;
+
+                        if (
+                            // Deactivation case
+                            matches!(
+                                    pre,
+                                    Consensus | BelowCapacity | BelowThreshold
+                                ) && post == Inactive)
+                            // Reactivation case
+                            || pre == Inactive && post != Inactive
+                            // Unjail case
+                            || pre == Jailed
+                                && matches!(
+                                    post,
+                                    Consensus
+                                        | BelowCapacity
+                                        | BelowThreshold
+                                )
+                        {
+                            address == owner && **valid_sig
+                        } else if
+                        // Bonding and unbonding may affect validator sets
+                        matches!(
+                            pre,
+                            Consensus | BelowCapacity | BelowThreshold
+                        ) && matches!(
+                            post,
+                            Consensus | BelowCapacity | BelowThreshold
+                        ) {
+                            true
+                        } else {
+                            // Unknown state changes are not allowed
+                            false
+                        }
+                    }
+                    (None, Some(_post)) => {
+                        // Becoming a validator must be authorized
+                        **valid_sig
+                    }
+                    (Some(_pre), None) => {
+                        // Clearing of old epoched data
+                        true
+                    }
+                    _ => false,
+                }
+            }
+            None => false,
+        };
+
+        VpResult::Ok(
+            is_valid_state
+                || storage::is_validator_state_epoched_meta_key(key)
+                || storage::is_consensus_validator_set_key(key)
+                || storage::is_below_capacity_validator_set_key(key),
+        )
+    };
+
+    let is_valid_reward_claim = || {
+        if let Some(bond_id) = storage::is_last_pos_reward_claim_epoch_key(key)
+        {
+            // Claims for this address must be signed
+            return &bond_id.source != owner || **valid_sig;
+        }
+        false
+    };
+
+    let is_valid_redelegation = || {
+        if storage::is_validator_redelegations_key(key) {
+            return true;
+        }
+        if let Some(delegator) = storage::is_delegator_redelegations_key(key) {
+            // Redelegations for this address must be signed
+            return delegator != owner || **valid_sig;
+        }
+        if let Some(bond_id) = storage::is_rewards_counter_key(key) {
+            // Redelegations auto-claim rewards
+            return &bond_id.source != owner || **valid_sig;
+        }
+        false
+    };
+
+    let is_valid_become_validator = || {
+        if storage::is_validator_addresses_key(key)
+            || storage::is_consensus_keys_key(key)
+            || storage::is_validator_eth_cold_key_key(key).is_some()
+            || storage::is_validator_eth_hot_key_key(key).is_some()
+            || storage::is_validator_max_commission_rate_change_key(key)
+                .is_some()
+            || storage::is_validator_address_raw_hash_key(key).is_some()
+        {
+            // A signature is required to become validator
+            return **valid_sig;
+        }
+        false
+    };
+
+    Ok(is_valid_bond_or_unbond_change()
+        || storage::is_total_deltas_key(key)
+        || storage::is_validator_deltas_key(key)
+        || storage::is_validator_total_bond_or_unbond_key(key)
+        || storage::is_validator_set_positions_key(key)
+        || storage::is_total_consensus_stake_key(key)
+        || is_valid_state_change()?
+        || is_valid_reward_claim()
+        || is_valid_redelegation()
+        || is_valid_commission_rate_change()
+        || is_valid_metadata_change()
+        || is_valid_become_validator()
+        || **valid_sig)
 }
 
 #[cfg(test)]

--- a/wasm/wasm_source/src/vp_user.rs
+++ b/wasm/wasm_source/src/vp_user.rs
@@ -248,7 +248,7 @@ fn validate_pos_changes(
                     }
                     (None, Some(_post)) => {
                         // Becoming a validator must be authorized
-                        **valid_sig
+                        address == owner && **valid_sig
                     }
                     (Some(_pre), None) => {
                         // Clearing of old epoched data
@@ -271,6 +271,10 @@ fn validate_pos_changes(
     let is_valid_reward_claim = || {
         if let Some(bond_id) = storage::is_last_pos_reward_claim_epoch_key(key)
         {
+            // Claims for this address must be signed
+            return &bond_id.source != owner || **valid_sig;
+        }
+        if let Some(bond_id) = storage::is_rewards_counter_key(key) {
             // Claims for this address must be signed
             return &bond_id.source != owner || **valid_sig;
         }


### PR DESCRIPTION
## Describe your changes

fixes #408

Unknown changes in vp_user and vp_implicit now require valid signature(s). 

For PoS changes, we have to check against all possible storage changes that can be applied from a tx and require signature(s) for those that have to be authorized by the source (for vp_user it can be both delegator and validator actions, for vp_implicit only delegator actions). If the change within PoS account subspace is not recognized we default to require sig(s).

To ease debugging in vp_user and vp_implicit, I changed the logging of rejected keys to also be be emitted in release build.

## Indicate on which release or other PRs this topic is based on

v0.28.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
