### PR TITLE
Removed uses of lifetimes in the SDKs Namada trait and implementation

### DIFF
--- a/.changelog/unreleased/SDK/2225-remove-sdk-lifetimes.md
+++ b/.changelog/unreleased/SDK/2225-remove-sdk-lifetimes.md
@@ -1,0 +1,2 @@
+- Removed uses of lifetimes in the SDKs Namada trait and implementation
+  ([\#2225](https://github.com/anoma/namada/pull/2225))

--- a/apps/src/bin/namada-client/main.rs
+++ b/apps/src/bin/namada-client/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
     CliApi::handle_client_command::<HttpClient, _>(
         None,
         cli::namada_client_cli()?,
-        &CliIo,
+        CliIo,
     )
     .await
 }

--- a/apps/src/bin/namada-relayer/main.rs
+++ b/apps/src/bin/namada-relayer/main.rs
@@ -14,5 +14,5 @@ async fn main() -> Result<()> {
 
     let cmd = cli::namada_relayer_cli()?;
     // run the CLI
-    CliApi::handle_relayer_command::<HttpClient>(None, cmd, &CliIo).await
+    CliApi::handle_relayer_command::<HttpClient>(None, cmd, CliIo).await
 }

--- a/apps/src/lib/cli/client.rs
+++ b/apps/src/lib/cli/client.rs
@@ -12,7 +12,7 @@ impl CliApi {
     pub async fn handle_client_command<C, IO: Io>(
         client: Option<C>,
         cmd: cli::NamadaClient,
-        io: &IO,
+        io: IO,
     ) -> Result<()>
     where
         C: CliClient,
@@ -29,9 +29,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         let dry_run =
                             args.tx.dry_run || args.tx.dry_run_wrapper;
                         tx::submit_custom(&namada, args).await?;
@@ -42,7 +42,7 @@ impl CliApi {
                                 .save()
                                 .unwrap_or_else(|err| eprintln!("{}", err));
                         } else {
-                            io.println(
+                            namada.io().println(
                                 "Transaction dry run. No addresses have been \
                                  saved.",
                             )
@@ -54,9 +54,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_transfer(&namada, args).await?;
                     }
                     Sub::TxIbcTransfer(TxIbcTransfer(mut args)) => {
@@ -65,9 +65,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_ibc_transfer(&namada, args).await?;
                     }
                     Sub::TxUpdateAccount(TxUpdateAccount(mut args)) => {
@@ -76,9 +76,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_update_account(&namada, args).await?;
                     }
                     Sub::TxInitAccount(TxInitAccount(mut args)) => {
@@ -87,9 +87,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         let dry_run =
                             args.tx.dry_run || args.tx.dry_run_wrapper;
                         tx::submit_init_account(&namada, args).await?;
@@ -100,7 +100,7 @@ impl CliApi {
                                 .save()
                                 .unwrap_or_else(|err| eprintln!("{}", err));
                         } else {
-                            io.println(
+                            namada.io().println(
                                 "Transaction dry run. No addresses have been \
                                  saved.",
                             )
@@ -112,18 +112,18 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
                         let cli::context::ChainContext {
-                            mut wallet,
+                            wallet,
                             mut config,
-                            mut shielded,
+                            shielded,
                             native_token,
                         } = ctx.take_chain_or_exit();
                         let namada = NamadaImpl::native_new(
-                            &client,
-                            &mut wallet,
-                            &mut shielded,
+                            client,
+                            wallet,
+                            shielded,
                             io,
                             native_token,
                         );
@@ -136,9 +136,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_init_proposal(&namada, args).await?;
                     }
                     Sub::TxVoteProposal(TxVoteProposal(mut args)) => {
@@ -147,9 +147,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_vote_proposal(&namada, args).await?;
                     }
                     Sub::TxRevealPk(TxRevealPk(mut args)) => {
@@ -158,9 +158,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_reveal_pk(&namada, args).await?;
                     }
                     Sub::Bond(Bond(mut args)) => {
@@ -169,9 +169,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_bond(&namada, args).await?;
                     }
                     Sub::Unbond(Unbond(mut args)) => {
@@ -180,9 +180,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_unbond(&namada, args).await?;
                     }
                     Sub::Withdraw(Withdraw(mut args)) => {
@@ -191,9 +191,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_withdraw(&namada, args).await?;
                     }
                     Sub::ClaimRewards(ClaimRewards(mut args)) => {
@@ -202,9 +202,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_claim_rewards(&namada, args).await?;
                     }
                     Sub::Redelegate(Redelegate(mut args)) => {
@@ -213,9 +213,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_redelegate(&namada, args).await?;
                     }
                     Sub::TxCommissionRateChange(TxCommissionRateChange(
@@ -226,9 +226,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_validator_commission_change(&namada, args)
                             .await?;
                     }
@@ -240,18 +240,18 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
                         let cli::context::ChainContext {
-                            mut wallet,
+                            wallet,
                             mut config,
-                            mut shielded,
+                            shielded,
                             native_token,
                         } = ctx.take_chain_or_exit();
                         let namada = NamadaImpl::native_new(
-                            &client,
-                            &mut wallet,
-                            &mut shielded,
+                            client,
+                            wallet,
+                            shielded,
                             io,
                             native_token,
                         );
@@ -268,9 +268,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_validator_metadata_change(&namada, args)
                             .await?;
                     }
@@ -282,9 +282,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_bridge_pool_tx(&namada, args).await?;
                     }
                     Sub::TxUnjailValidator(TxUnjailValidator(mut args)) => {
@@ -293,9 +293,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_unjail_validator(&namada, args).await?;
                     }
                     Sub::TxDeactivateValidator(TxDeactivateValidator(
@@ -306,9 +306,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_deactivate_validator(&namada, args).await?;
                     }
                     Sub::TxReactivateValidator(TxReactivateValidator(
@@ -319,9 +319,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_reactivate_validator(&namada, args).await?;
                     }
                     Sub::TxUpdateStewardCommission(
@@ -332,9 +332,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_update_steward_commission(&namada, args)
                             .await?;
                     }
@@ -344,9 +344,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::submit_resign_steward(&namada, args).await?;
                     }
                     // Ledger queries
@@ -354,8 +354,8 @@ impl CliApi {
                         let client = client.unwrap_or_else(|| {
                             C::from_tendermint_address(&mut args.ledger_address)
                         });
-                        client.wait_until_node_is_synced(io).await?;
-                        let namada = ctx.to_sdk(&client, io);
+                        client.wait_until_node_is_synced(&io).await?;
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_and_print_epoch(&namada).await;
                     }
                     Sub::QueryValidatorState(QueryValidatorState(mut args)) => {
@@ -364,9 +364,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_and_print_validator_state(&namada, args)
                             .await;
                     }
@@ -376,9 +376,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_transfers(&namada, args).await;
                     }
                     Sub::QueryConversions(QueryConversions(mut args)) => {
@@ -387,17 +387,17 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_conversions(&namada, args).await;
                     }
                     Sub::QueryBlock(QueryBlock(mut args)) => {
                         let client = client.unwrap_or_else(|| {
                             C::from_tendermint_address(&mut args.ledger_address)
                         });
-                        client.wait_until_node_is_synced(io).await?;
-                        let namada = ctx.to_sdk(&client, io);
+                        client.wait_until_node_is_synced(&io).await?;
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_block(&namada).await;
                     }
                     Sub::QueryBalance(QueryBalance(mut args)) => {
@@ -406,9 +406,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_balance(&namada, args).await;
                     }
                     Sub::QueryBonds(QueryBonds(mut args)) => {
@@ -417,9 +417,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_bonds(&namada, args)
                             .await
                             .expect("expected successful query of bonds");
@@ -430,9 +430,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_bonded_stake(&namada, args).await;
                     }
                     Sub::QueryCommissionRate(QueryCommissionRate(mut args)) => {
@@ -441,9 +441,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_and_print_commission_rate(&namada, args)
                             .await;
                     }
@@ -453,9 +453,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_and_print_metadata(&namada, args).await;
                     }
                     Sub::QuerySlashes(QuerySlashes(mut args)) => {
@@ -464,9 +464,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_slashes(&namada, args).await;
                     }
                     Sub::QueryDelegations(QueryDelegations(mut args)) => {
@@ -475,9 +475,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_delegations(&namada, args).await;
                     }
                     Sub::QueryFindValidator(QueryFindValidator(mut args)) => {
@@ -486,9 +486,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_find_validator(&namada, args).await;
                     }
                     Sub::QueryResult(QueryResult(mut args)) => {
@@ -497,9 +497,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_result(&namada, args).await;
                     }
                     Sub::QueryRawBytes(QueryRawBytes(mut args)) => {
@@ -508,9 +508,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_raw_bytes(&namada, args).await;
                     }
                     Sub::QueryProposal(QueryProposal(mut args)) => {
@@ -519,9 +519,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_proposal(&namada, args).await;
                     }
                     Sub::QueryProposalResult(QueryProposalResult(mut args)) => {
@@ -530,9 +530,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_proposal_result(&namada, args).await;
                     }
                     Sub::QueryProtocolParameters(QueryProtocolParameters(
@@ -543,9 +543,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_protocol_parameters(&namada, args).await;
                     }
                     Sub::QueryPgf(QueryPgf(mut args)) => {
@@ -554,9 +554,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_pgf(&namada, args).await;
                     }
                     Sub::QueryAccount(QueryAccount(mut args)) => {
@@ -565,9 +565,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         rpc::query_account(&namada, args).await;
                     }
                     Sub::SignTx(SignTx(mut args)) => {
@@ -576,9 +576,9 @@ impl CliApi {
                                 &mut args.tx.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::sign_tx(&namada, args).await?;
                     }
                     Sub::GenIbcShieldedTransafer(GenIbcShieldedTransafer(
@@ -589,9 +589,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         tx::gen_ibc_shielded_transfer(&namada, args).await?;
                     }
                 }
@@ -625,9 +625,9 @@ impl CliApi {
                     let mut ledger_address = args.ledger_address.clone();
                     let client =
                         C::from_tendermint_address(&mut ledger_address);
-                    client.wait_until_node_is_synced(io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
                     let args = args.to_sdk(&mut ctx);
-                    let namada = ctx.to_sdk(&client, io);
+                    let namada = ctx.to_sdk(client, io);
                     rpc::epoch_sleep(&namada, args).await;
                 }
                 Utils::ValidateGenesisTemplates(ValidateGenesisTemplates(

--- a/apps/src/lib/cli/context.rs
+++ b/apps/src/lib/cli/context.rs
@@ -165,22 +165,18 @@ impl Context {
     }
 
     /// Make an implementation of Namada from this object and parameters.
-    pub fn to_sdk<'a, C, IO>(
-        &'a mut self,
-        client: &'a C,
-        io: &'a IO,
-    ) -> impl Namada
+    pub fn to_sdk<C, IO>(self, client: C, io: IO) -> impl Namada
     where
         C: namada::ledger::queries::Client + Sync,
         IO: Io,
     {
-        let chain_ctx = self.borrow_mut_chain_or_exit();
+        let chain_ctx = self.take_chain_or_exit();
         NamadaImpl::native_new(
             client,
-            &mut chain_ctx.wallet,
-            &mut chain_ctx.shielded,
+            chain_ctx.wallet,
+            chain_ctx.shielded,
             io,
-            chain_ctx.native_token.clone(),
+            chain_ctx.native_token,
         )
     }
 }

--- a/apps/src/lib/cli/relayer.rs
+++ b/apps/src/lib/cli/relayer.rs
@@ -12,7 +12,7 @@ impl CliApi {
     pub async fn handle_relayer_command<C>(
         client: Option<C>,
         cmd: cli::NamadaRelayer,
-        io: &impl Io,
+        io: impl Io,
     ) -> Result<()>
     where
         C: CliClient,
@@ -29,9 +29,9 @@ impl CliApi {
                                 &mut args.query.ledger_address,
                             )
                         });
-                        client.wait_until_node_is_synced(io).await?;
+                        client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
-                        let namada = ctx.to_sdk(&client, io);
+                        let namada = ctx.to_sdk(client, io);
                         bridge_pool::recommend_batch(&namada, args).await?;
                     }
                 }
@@ -45,9 +45,9 @@ impl CliApi {
                             &mut args.query.ledger_address,
                         )
                     });
-                    client.wait_until_node_is_synced(io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
                     let args = args.to_sdk_ctxless();
-                    bridge_pool::construct_proof(&client, io, args).await?;
+                    bridge_pool::construct_proof(&client, &io, args).await?;
                 }
                 EthBridgePoolWithoutCtx::RelayProof(RelayProof(mut args)) => {
                     let client = client.unwrap_or_else(|| {
@@ -55,12 +55,12 @@ impl CliApi {
                             &mut args.query.ledger_address,
                         )
                     });
-                    client.wait_until_node_is_synced(io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
                     let eth_client =
                         get_eth_rpc_client(&args.eth_rpc_endpoint).await;
                     let args = args.to_sdk_ctxless();
                     bridge_pool::relay_bridge_pool_proof(
-                        eth_client, &client, io, args,
+                        eth_client, &client, &io, args,
                     )
                     .await?;
                 }
@@ -70,8 +70,8 @@ impl CliApi {
                     let client = client.unwrap_or_else(|| {
                         C::from_tendermint_address(&mut query.ledger_address)
                     });
-                    client.wait_until_node_is_synced(io).await?;
-                    bridge_pool::query_bridge_pool(&client, io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
+                    bridge_pool::query_bridge_pool(&client, &io).await?;
                 }
                 EthBridgePoolWithoutCtx::QuerySigned(
                     QuerySignedBridgePool(mut query),
@@ -79,8 +79,8 @@ impl CliApi {
                     let client = client.unwrap_or_else(|| {
                         C::from_tendermint_address(&mut query.ledger_address)
                     });
-                    client.wait_until_node_is_synced(io).await?;
-                    bridge_pool::query_signed_bridge_pool(&client, io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
+                    bridge_pool::query_signed_bridge_pool(&client, &io).await?;
                 }
                 EthBridgePoolWithoutCtx::QueryRelays(QueryRelayProgress(
                     mut query,
@@ -88,8 +88,8 @@ impl CliApi {
                     let client = client.unwrap_or_else(|| {
                         C::from_tendermint_address(&mut query.ledger_address)
                     });
-                    client.wait_until_node_is_synced(io).await?;
-                    bridge_pool::query_relay_progress(&client, io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
+                    bridge_pool::query_relay_progress(&client, &io).await?;
                 }
             },
             cli::NamadaRelayer::ValidatorSet(sub) => match sub {
@@ -101,10 +101,10 @@ impl CliApi {
                             &mut args.query.ledger_address,
                         )
                     });
-                    client.wait_until_node_is_synced(io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
                     let args = args.to_sdk_ctxless();
                     validator_set::query_bridge_validator_set(
-                        &client, io, args,
+                        &client, &io, args,
                     )
                     .await?;
                 }
@@ -116,10 +116,10 @@ impl CliApi {
                             &mut args.query.ledger_address,
                         )
                     });
-                    client.wait_until_node_is_synced(io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
                     let args = args.to_sdk_ctxless();
                     validator_set::query_governnace_validator_set(
-                        &client, io, args,
+                        &client, &io, args,
                     )
                     .await?;
                 }
@@ -131,10 +131,10 @@ impl CliApi {
                             &mut args.query.ledger_address,
                         )
                     });
-                    client.wait_until_node_is_synced(io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
                     let args = args.to_sdk_ctxless();
                     validator_set::query_validator_set_update_proof(
-                        &client, io, args,
+                        &client, &io, args,
                     )
                     .await?;
                 }
@@ -146,12 +146,12 @@ impl CliApi {
                             &mut args.query.ledger_address,
                         )
                     });
-                    client.wait_until_node_is_synced(io).await?;
+                    client.wait_until_node_is_synced(&io).await?;
                     let eth_client =
                         get_eth_rpc_client(&args.eth_rpc_endpoint).await;
                     let args = args.to_sdk_ctxless();
                     validator_set::relay_validator_set_update(
-                        eth_client, &client, io, args,
+                        eth_client, &client, &io, args,
                     )
                     .await?;
                 }

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -65,8 +65,8 @@ use crate::facade::tendermint_rpc::error::Error as TError;
 ///
 /// If a response is not delivered until `deadline`, we exit the cli with an
 /// error.
-pub async fn query_tx_status<'a>(
-    namada: &impl Namada<'a>,
+pub async fn query_tx_status(
+    namada: &impl Namada,
     status: namada_sdk::rpc::TxEventQuery<'_>,
     deadline: Instant,
 ) -> Event {
@@ -76,14 +76,14 @@ pub async fn query_tx_status<'a>(
 }
 
 /// Query and print the epoch of the last committed block
-pub async fn query_and_print_epoch<'a>(context: &impl Namada<'a>) -> Epoch {
+pub async fn query_and_print_epoch(context: &impl Namada) -> Epoch {
     let epoch = rpc::query_epoch(context.client()).await.unwrap();
     display_line!(context.io(), "Last committed epoch: {}", epoch);
     epoch
 }
 
 /// Query the last committed block
-pub async fn query_block<'a>(context: &impl Namada<'a>) {
+pub async fn query_block(context: &impl Namada) {
     let block = namada_sdk::rpc::query_block(context.client())
         .await
         .unwrap();
@@ -114,8 +114,8 @@ pub async fn query_results<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query the specified accepted transfers from the ledger
-pub async fn query_transfers<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_transfers(
+    context: &impl Namada,
     args: args::QueryTransfers,
 ) {
     let query_token = args.token;
@@ -250,7 +250,7 @@ pub async fn query_transfers<'a>(
 }
 
 /// Query the raw bytes of given storage key
-pub async fn query_raw_bytes<'a, N: Namada<'a>>(
+pub async fn query_raw_bytes<N: Namada>(
     context: &N,
     args: args::QueryRawBytes,
 ) {
@@ -281,10 +281,7 @@ pub async fn query_raw_bytes<'a, N: Namada<'a>>(
 }
 
 /// Query token balance(s)
-pub async fn query_balance<'a>(
-    context: &impl Namada<'a>,
-    args: args::QueryBalance,
-) {
+pub async fn query_balance(context: &impl Namada, args: args::QueryBalance) {
     // Query the balances of shielded or transparent account types depending on
     // the CLI arguments
     match &args.owner {
@@ -309,8 +306,8 @@ pub async fn query_balance<'a>(
 }
 
 /// Query token balance(s)
-pub async fn query_transparent_balance<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_transparent_balance(
+    context: &impl Namada,
     args: args::QueryBalance,
 ) {
     let prefix = Key::from(
@@ -386,8 +383,8 @@ pub async fn query_transparent_balance<'a>(
 }
 
 /// Query the token pinned balance(s)
-pub async fn query_pinned_balance<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_pinned_balance(
+    context: &impl Namada,
     args: args::QueryBalance,
 ) {
     // Map addresses to token names
@@ -549,8 +546,8 @@ pub async fn query_pinned_balance<'a>(
     }
 }
 
-async fn print_balances<'a>(
-    context: &impl Namada<'a>,
+async fn print_balances(
+    context: &impl Namada,
     balances: impl Iterator<Item = (storage::Key, token::Amount)>,
     token: Option<&Address>,
     target: Option<&Address>,
@@ -629,8 +626,8 @@ async fn print_balances<'a>(
     }
 }
 
-async fn lookup_token_alias<'a>(
-    context: &impl Namada<'a>,
+async fn lookup_token_alias(
+    context: &impl Namada,
     token: &Address,
     owner: &Address,
 ) -> String {
@@ -649,8 +646,8 @@ async fn lookup_token_alias<'a>(
 }
 
 /// Returns pairs of token alias and token address
-async fn query_tokens<'a>(
-    context: &impl Namada<'a>,
+async fn query_tokens(
+    context: &impl Namada,
     base_token: Option<&Address>,
     owner: Option<&Address>,
 ) -> BTreeMap<String, Address> {
@@ -708,8 +705,8 @@ async fn query_tokens<'a>(
     tokens
 }
 
-async fn get_ibc_denom_alias<'a>(
-    context: &impl Namada<'a>,
+async fn get_ibc_denom_alias(
+    context: &impl Namada,
     ibc_denom: impl AsRef<str>,
 ) -> String {
     let wallet = context.wallet().await;
@@ -729,10 +726,7 @@ async fn get_ibc_denom_alias<'a>(
 }
 
 /// Query Proposals
-pub async fn query_proposal<'a>(
-    context: &impl Namada<'a>,
-    args: args::QueryProposal,
-) {
+pub async fn query_proposal(context: &impl Namada, args: args::QueryProposal) {
     let current_epoch = query_and_print_epoch(context).await;
 
     if let Some(id) = args.proposal_id {
@@ -781,8 +775,8 @@ pub async fn query_proposal_by_id<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query token shielded balance(s)
-pub async fn query_shielded_balance<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_shielded_balance(
+    context: &impl Namada,
     args: args::QueryBalance,
 ) {
     // Used to control whether balances for all keys or a specific key are
@@ -1050,8 +1044,8 @@ pub async fn query_shielded_balance<'a>(
     }
 }
 
-pub async fn print_decoded_balance<'a>(
-    context: &impl Namada<'a>,
+pub async fn print_decoded_balance(
+    context: &impl Namada,
     decoded_balance: MaspAmount,
     epoch: Epoch,
 ) {
@@ -1072,8 +1066,8 @@ pub async fn print_decoded_balance<'a>(
     }
 }
 
-pub async fn print_decoded_balance_with_epoch<'a>(
-    context: &impl Namada<'a>,
+pub async fn print_decoded_balance_with_epoch(
+    context: &impl Namada,
     decoded_balance: MaspAmount,
 ) {
     let tokens = context
@@ -1110,8 +1104,8 @@ pub async fn get_token_balance<C: namada::ledger::queries::Client + Sync>(
         .unwrap()
 }
 
-pub async fn query_proposal_result<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_proposal_result(
+    context: &impl Namada,
     args: args::QueryProposalResult,
 ) {
     if args.proposal_id.is_some() {
@@ -1250,10 +1244,7 @@ pub async fn query_proposal_result<'a>(
     }
 }
 
-pub async fn query_account<'a>(
-    context: &impl Namada<'a>,
-    args: args::QueryAccount,
-) {
+pub async fn query_account(context: &impl Namada, args: args::QueryAccount) {
     let account = rpc::get_account_info(context.client(), &args.owner)
         .await
         .unwrap();
@@ -1269,7 +1260,7 @@ pub async fn query_account<'a>(
     }
 }
 
-pub async fn query_pgf<'a>(context: &impl Namada<'a>, _args: args::QueryPgf) {
+pub async fn query_pgf(context: &impl Namada, _args: args::QueryPgf) {
     let stewards = query_pgf_stewards(context.client()).await;
     let fundings = query_pgf_fundings(context.client()).await;
 
@@ -1320,8 +1311,8 @@ pub async fn query_pgf<'a>(context: &impl Namada<'a>, _args: args::QueryPgf) {
     }
 }
 
-pub async fn query_protocol_parameters<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_protocol_parameters(
+    context: &impl Namada,
     _args: args::QueryProtocolParameters,
 ) {
     let governance_parameters =
@@ -1578,8 +1569,8 @@ pub async fn query_pgf_parameters<C: namada::ledger::queries::Client + Sync>(
     unwrap_client_response::<C, _>(RPC.vp().pgf().parameters(client).await)
 }
 
-pub async fn query_and_print_unbonds<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_and_print_unbonds(
+    context: &impl Namada,
     source: &Address,
     validator: &Address,
 ) {
@@ -1634,8 +1625,8 @@ pub async fn query_withdrawable_tokens<
 }
 
 /// Query PoS bond(s) and unbond(s)
-pub async fn query_bonds<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_bonds(
+    context: &impl Namada,
     args: args::QueryBonds,
 ) -> std::io::Result<()> {
     let epoch = query_and_print_epoch(context).await;
@@ -1758,7 +1749,7 @@ pub async fn query_bonds<'a>(
 }
 
 /// Query PoS bonded stake
-pub async fn query_bonded_stake<'a, N: Namada<'a>>(
+pub async fn query_bonded_stake<N: Namada>(
     context: &N,
     args: args::QueryBondedStake,
 ) {
@@ -1896,8 +1887,8 @@ pub async fn query_validator_state<
 }
 
 /// Query a validator's state information
-pub async fn query_and_print_validator_state<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_and_print_validator_state(
+    context: &impl Namada,
     args: args::QueryValidatorState,
 ) {
     let validator = args.validator;
@@ -1941,8 +1932,8 @@ pub async fn query_and_print_validator_state<'a>(
 }
 
 /// Query PoS validator's commission rate information
-pub async fn query_and_print_commission_rate<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_and_print_commission_rate(
+    context: &impl Namada,
     args: args::QueryCommissionRate,
 ) {
     let validator = args.validator;
@@ -1974,8 +1965,8 @@ pub async fn query_and_print_commission_rate<'a>(
 }
 
 /// Query PoS validator's metadata
-pub async fn query_and_print_metadata<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_and_print_metadata(
+    context: &impl Namada,
     args: args::QueryMetaData,
 ) {
     let validator = args.validator;
@@ -2051,10 +2042,7 @@ pub async fn query_and_print_metadata<'a>(
 }
 
 /// Query PoS slashes
-pub async fn query_slashes<'a, N: Namada<'a>>(
-    context: &N,
-    args: args::QuerySlashes,
-) {
+pub async fn query_slashes<N: Namada>(context: &N, args: args::QuerySlashes) {
     match args.validator {
         Some(validator) => {
             let validator = validator;
@@ -2206,7 +2194,7 @@ pub async fn query_slashes<'a, N: Namada<'a>>(
     }
 }
 
-pub async fn query_delegations<'a, N: Namada<'a>>(
+pub async fn query_delegations<N: Namada>(
     context: &N,
     args: args::QueryDelegations,
 ) {
@@ -2227,7 +2215,7 @@ pub async fn query_delegations<'a, N: Namada<'a>>(
     }
 }
 
-pub async fn query_find_validator<'a, N: Namada<'a>>(
+pub async fn query_find_validator<N: Namada>(
     context: &N,
     args: args::QueryFindValidator,
 ) {
@@ -2264,7 +2252,7 @@ pub async fn query_find_validator<'a, N: Namada<'a>>(
 }
 
 /// Dry run a transaction
-pub async fn dry_run_tx<'a, N: Namada<'a>>(
+pub async fn dry_run_tx<N: Namada>(
     context: &N,
     tx_bytes: Vec<u8>,
 ) -> Result<(), error::Error>
@@ -2331,8 +2319,8 @@ pub async fn known_address<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query for all conversions.
-pub async fn query_conversions<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_conversions(
+    context: &impl Namada,
     args: args::QueryConversions,
 ) {
     // The chosen token type of the conversions
@@ -2408,8 +2396,8 @@ pub async fn query_conversion<C: namada::ledger::queries::Client + Sync>(
 }
 
 /// Query a wasm code hash
-pub async fn query_wasm_code_hash<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_wasm_code_hash(
+    context: &impl Namada,
     code_path: impl AsRef<str>,
 ) -> Result<Hash, error::Error> {
     rpc::query_wasm_code_hash(context, code_path).await
@@ -2443,8 +2431,8 @@ pub async fn query_storage_value_bytes<
 /// Query a range of storage values with a matching prefix and decode them with
 /// [`BorshDeserialize`]. Returns an iterator of the storage keys paired with
 /// their associated values.
-pub async fn query_storage_prefix<'a, 'b, T>(
-    context: &'b impl Namada<'a>,
+pub async fn query_storage_prefix<'b, T>(
+    context: &'b impl Namada,
     key: &storage::Key,
 ) -> Option<impl 'b + Iterator<Item = (storage::Key, T)>>
 where
@@ -2488,10 +2476,7 @@ pub async fn query_tx_response<C: namada::ledger::queries::Client + Sync>(
 
 /// Lookup the results of applying the specified transaction to the
 /// blockchain.
-pub async fn query_result<'a>(
-    context: &impl Namada<'a>,
-    args: args::QueryResult,
-) {
+pub async fn query_result(context: &impl Namada, args: args::QueryResult) {
     // First try looking up application event pertaining to given hash.
     let tx_response = query_tx_response(
         context.client(),
@@ -2529,7 +2514,7 @@ pub async fn query_result<'a>(
     }
 }
 
-pub async fn epoch_sleep<'a>(context: &impl Namada<'a>, _args: args::Query) {
+pub async fn epoch_sleep(context: &impl Namada, _args: args::Query) {
     let start_epoch = query_and_print_epoch(context).await;
     loop {
         tokio::time::sleep(core::time::Duration::from_secs(1)).await;
@@ -2634,8 +2619,8 @@ fn unwrap_client_response<C: namada::ledger::queries::Client, T>(
     })
 }
 
-pub async fn compute_offline_proposal_votes<'a>(
-    context: &impl Namada<'a>,
+pub async fn compute_offline_proposal_votes(
+    context: &impl Namada,
     proposal: &OfflineSignedProposal,
     votes: Vec<OfflineVote>,
 ) -> ProposalVotes {

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -39,8 +39,8 @@ use crate::wallet::{gen_validator_keys, read_and_confirm_encryption_password};
 
 /// Wrapper around `signing::aux_signing_data` that stores the optional
 /// disposable address to the wallet
-pub async fn aux_signing_data<'a>(
-    context: &impl Namada<'a>,
+pub async fn aux_signing_data(
+    context: &impl Namada,
     args: &args::Tx,
     owner: Option<Address>,
     default_signer: Option<Address>,
@@ -69,8 +69,8 @@ pub async fn aux_signing_data<'a>(
 }
 
 // Sign the given transaction using a hardware wallet as a backup
-pub async fn sign<'a>(
-    context: &impl Namada<'a>,
+pub async fn sign(
+    context: &impl Namada,
     tx: &mut Tx,
     args: &args::Tx,
     signing_data: SigningTxData,
@@ -200,8 +200,8 @@ pub async fn sign<'a>(
 }
 
 // Build a transaction to reveal the signer of the given transaction.
-pub async fn submit_reveal_aux<'a>(
-    context: &impl Namada<'a>,
+pub async fn submit_reveal_aux(
+    context: &impl Namada,
     args: args::Tx,
     address: &Address,
 ) -> Result<(), error::Error> {
@@ -239,7 +239,7 @@ pub async fn submit_reveal_aux<'a>(
     Ok(())
 }
 
-pub async fn submit_bridge_pool_tx<'a, N: Namada<'a>>(
+pub async fn submit_bridge_pool_tx<N: Namada>(
     namada: &N,
     args: args::EthereumBridgePool,
 ) -> Result<(), error::Error> {
@@ -263,7 +263,7 @@ pub async fn submit_bridge_pool_tx<'a, N: Namada<'a>>(
     Ok(())
 }
 
-pub async fn submit_custom<'a, N: Namada<'a>>(
+pub async fn submit_custom<N: Namada>(
     namada: &N,
     args: args::TxCustom,
 ) -> Result<(), error::Error>
@@ -289,7 +289,7 @@ where
     Ok(())
 }
 
-pub async fn submit_update_account<'a, N: Namada<'a>>(
+pub async fn submit_update_account<N: Namada>(
     namada: &N,
     args: args::TxUpdateAccount,
 ) -> Result<(), error::Error>
@@ -313,7 +313,7 @@ where
     Ok(())
 }
 
-pub async fn submit_init_account<'a, N: Namada<'a>>(
+pub async fn submit_init_account<N: Namada>(
     namada: &N,
     args: args::TxInitAccount,
 ) -> Result<(), error::Error>
@@ -338,8 +338,8 @@ where
     Ok(())
 }
 
-pub async fn submit_change_consensus_key<'a>(
-    namada: &impl Namada<'a>,
+pub async fn submit_change_consensus_key(
+    namada: &impl Namada,
     config: &mut crate::config::Config,
     args::ConsensusKeyChange {
         tx: tx_args,
@@ -482,8 +482,8 @@ pub async fn submit_change_consensus_key<'a>(
     Ok(())
 }
 
-pub async fn submit_init_validator<'a>(
-    namada: &impl Namada<'a>,
+pub async fn submit_init_validator(
+    namada: &impl Namada,
     config: &mut crate::config::Config,
     args::TxInitValidator {
         tx: tx_args,
@@ -629,7 +629,7 @@ pub async fn submit_init_validator<'a>(
     }
     // Generate the validator keys
     let validator_keys = gen_validator_keys(
-        *namada.wallet_mut().await,
+        &mut *namada.wallet_mut().await,
         Some(eth_hot_pk.clone()),
         protocol_key,
         scheme,
@@ -857,8 +857,8 @@ pub async fn submit_init_validator<'a>(
     Ok(())
 }
 
-pub async fn submit_transfer<'a>(
-    namada: &impl Namada<'a>,
+pub async fn submit_transfer(
+    namada: &impl Namada,
     args: args::TxTransfer,
 ) -> Result<(), error::Error> {
     for _ in 0..2 {
@@ -911,7 +911,7 @@ pub async fn submit_transfer<'a>(
     Ok(())
 }
 
-pub async fn submit_ibc_transfer<'a, N: Namada<'a>>(
+pub async fn submit_ibc_transfer<N: Namada>(
     namada: &N,
     args: args::TxIbcTransfer,
 ) -> Result<(), error::Error>
@@ -935,7 +935,7 @@ where
     Ok(())
 }
 
-pub async fn submit_init_proposal<'a, N: Namada<'a>>(
+pub async fn submit_init_proposal<N: Namada>(
     namada: &N,
     args: args::InitProposal,
 ) -> Result<(), error::Error>
@@ -1064,7 +1064,7 @@ where
     Ok(())
 }
 
-pub async fn submit_vote_proposal<'a, N: Namada<'a>>(
+pub async fn submit_vote_proposal<N: Namada>(
     namada: &N,
     args: args::VoteProposal,
 ) -> Result<(), error::Error>
@@ -1144,7 +1144,7 @@ where
     Ok(())
 }
 
-pub async fn sign_tx<'a, N: Namada<'a>>(
+pub async fn sign_tx<N: Namada>(
     namada: &N,
     args::SignTx {
         tx: tx_args,
@@ -1225,7 +1225,7 @@ where
     Ok(())
 }
 
-pub async fn submit_reveal_pk<'a, N: Namada<'a>>(
+pub async fn submit_reveal_pk<N: Namada>(
     namada: &N,
     args: args::RevealPk,
 ) -> Result<(), error::Error>
@@ -1237,7 +1237,7 @@ where
     Ok(())
 }
 
-pub async fn submit_bond<'a, N: Namada<'a>>(
+pub async fn submit_bond<N: Namada>(
     namada: &N,
     args: args::Bond,
 ) -> Result<(), error::Error>
@@ -1264,7 +1264,7 @@ where
     Ok(())
 }
 
-pub async fn submit_unbond<'a, N: Namada<'a>>(
+pub async fn submit_unbond<N: Namada>(
     namada: &N,
     args: args::Unbond,
 ) -> Result<(), error::Error>
@@ -1290,7 +1290,7 @@ where
     Ok(())
 }
 
-pub async fn submit_withdraw<'a, N: Namada<'a>>(
+pub async fn submit_withdraw<N: Namada>(
     namada: &N,
     args: args::Withdraw,
 ) -> Result<(), error::Error>
@@ -1314,7 +1314,7 @@ where
     Ok(())
 }
 
-pub async fn submit_claim_rewards<'a, N: Namada<'a>>(
+pub async fn submit_claim_rewards<N: Namada>(
     namada: &N,
     args: args::ClaimRewards,
 ) -> Result<(), error::Error>
@@ -1338,7 +1338,7 @@ where
     Ok(())
 }
 
-pub async fn submit_redelegate<'a, N: Namada<'a>>(
+pub async fn submit_redelegate<N: Namada>(
     namada: &N,
     args: args::Redelegate,
 ) -> Result<(), error::Error>
@@ -1361,7 +1361,7 @@ where
     Ok(())
 }
 
-pub async fn submit_validator_commission_change<'a, N: Namada<'a>>(
+pub async fn submit_validator_commission_change<N: Namada>(
     namada: &N,
     args: args::CommissionRateChange,
 ) -> Result<(), error::Error>
@@ -1385,7 +1385,7 @@ where
     Ok(())
 }
 
-pub async fn submit_validator_metadata_change<'a, N: Namada<'a>>(
+pub async fn submit_validator_metadata_change<N: Namada>(
     namada: &N,
     args: args::MetaDataChange,
 ) -> Result<(), error::Error>
@@ -1409,7 +1409,7 @@ where
     Ok(())
 }
 
-// pub async fn submit_change_consensus_key<'a, N: Namada<'a>>(
+// pub async fn submit_change_consensus_key<N: Namada>(
 //     namada: &N,
 //     args: args::ConsensusKeyChange,
 // ) -> Result<(), error::Error>
@@ -1431,7 +1431,7 @@ where
 //     Ok(())
 // }
 
-pub async fn submit_unjail_validator<'a, N: Namada<'a>>(
+pub async fn submit_unjail_validator<N: Namada>(
     namada: &N,
     args: args::TxUnjailValidator,
 ) -> Result<(), error::Error>
@@ -1455,7 +1455,7 @@ where
     Ok(())
 }
 
-pub async fn submit_deactivate_validator<'a, N: Namada<'a>>(
+pub async fn submit_deactivate_validator<N: Namada>(
     namada: &N,
     args: args::TxDeactivateValidator,
 ) -> Result<(), error::Error>
@@ -1479,7 +1479,7 @@ where
     Ok(())
 }
 
-pub async fn submit_reactivate_validator<'a, N: Namada<'a>>(
+pub async fn submit_reactivate_validator<N: Namada>(
     namada: &N,
     args: args::TxReactivateValidator,
 ) -> Result<(), error::Error>
@@ -1503,7 +1503,7 @@ where
     Ok(())
 }
 
-pub async fn submit_update_steward_commission<'a, N: Namada<'a>>(
+pub async fn submit_update_steward_commission<N: Namada>(
     namada: &N,
     args: args::UpdateStewardCommission,
 ) -> Result<(), error::Error>
@@ -1528,7 +1528,7 @@ where
     Ok(())
 }
 
-pub async fn submit_resign_steward<'a, N: Namada<'a>>(
+pub async fn submit_resign_steward<N: Namada>(
     namada: &N,
     args: args::ResignSteward,
 ) -> Result<(), error::Error>
@@ -1553,8 +1553,8 @@ where
 }
 
 /// Save accounts initialized from a tx into the wallet, if any.
-pub async fn save_initialized_accounts<'a>(
-    namada: &impl Namada<'a>,
+pub async fn save_initialized_accounts(
+    namada: &impl Namada,
     args: &args::Tx,
     initialized_accounts: Vec<Address>,
 ) {
@@ -1565,8 +1565,8 @@ pub async fn save_initialized_accounts<'a>(
 /// the tx has been successfully included into the mempool of a validator
 ///
 /// In the case of errors in any of those stages, an error message is returned
-pub async fn broadcast_tx<'a>(
-    namada: &impl Namada<'a>,
+pub async fn broadcast_tx(
+    namada: &impl Namada,
     to_broadcast: &TxBroadcastData,
 ) -> Result<Response, error::Error> {
     tx::broadcast_tx(namada, to_broadcast).await
@@ -1580,15 +1580,15 @@ pub async fn broadcast_tx<'a>(
 /// 3. The decrypted payload of the tx has been included on the blockchain.
 ///
 /// In the case of errors in any of those stages, an error message is returned
-pub async fn submit_tx<'a>(
-    namada: &impl Namada<'a>,
+pub async fn submit_tx(
+    namada: &impl Namada,
     to_broadcast: TxBroadcastData,
 ) -> Result<TxResponse, error::Error> {
     tx::submit_tx(namada, to_broadcast).await
 }
 
-pub async fn gen_ibc_shielded_transfer<'a>(
-    context: &impl Namada<'a>,
+pub async fn gen_ibc_shielded_transfer(
+    context: &impl Namada,
     args: args::GenIbcShieldedTransafer,
 ) -> Result<(), error::Error> {
     if let Some(shielded_transfer) =

--- a/apps/src/lib/node/ledger/shell/testing/client.rs
+++ b/apps/src/lib/node/ledger/shell/testing/client.rs
@@ -48,7 +48,7 @@ pub fn run(
             rt.block_on(CliApi::handle_client_command(
                 Some(node),
                 cmd,
-                &TestingIo,
+                TestingIo,
             ))
         }
         Bin::Wallet => {
@@ -84,7 +84,7 @@ pub fn run(
             rt.block_on(CliApi::handle_relayer_command(
                 Some(node),
                 cmd,
-                &TestingIo,
+                TestingIo,
             ))
         }
     }

--- a/benches/native_vps.rs
+++ b/benches/native_vps.rs
@@ -495,7 +495,7 @@ fn setup_storage_for_masp_verification(
         .to_owned();
 
     // Shield some tokens for Albert
-    let shield_tx = shielded_ctx.generate_masp_tx(
+    let (mut shielded_ctx, shield_tx) = shielded_ctx.generate_masp_tx(
         amount,
         TransferSource::Address(defaults::albert_address()),
         TransferTarget::PaymentAddress(albert_payment_addr),
@@ -504,7 +504,7 @@ fn setup_storage_for_masp_verification(
     shielded_ctx.shell.wl_storage.commit_tx();
     shielded_ctx.shell.commit();
 
-    let signed_tx = match bench_name {
+    let (mut shielded_ctx, signed_tx) = match bench_name {
         "shielding" => shielded_ctx.generate_masp_tx(
             amount,
             TransferSource::Address(defaults::albert_address()),

--- a/benches/txs.rs
+++ b/benches/txs.rs
@@ -83,16 +83,17 @@ fn transfer(c: &mut Criterion) {
                         .to_owned();
 
                     // Shield some tokens for Albert
-                    let shield_tx = shielded_ctx.generate_masp_tx(
-                        amount,
-                        TransferSource::Address(defaults::albert_address()),
-                        TransferTarget::PaymentAddress(albert_payment_addr),
-                    );
+                    let (mut shielded_ctx, shield_tx) = shielded_ctx
+                        .generate_masp_tx(
+                            amount,
+                            TransferSource::Address(defaults::albert_address()),
+                            TransferTarget::PaymentAddress(albert_payment_addr),
+                        );
                     shielded_ctx.shell.execute_tx(&shield_tx);
                     shielded_ctx.shell.wl_storage.commit_tx();
                     shielded_ctx.shell.commit();
 
-                    let signed_tx = match bench_name {
+                    let (shielded_ctx, signed_tx) = match bench_name {
                         "transparent" => shielded_ctx.generate_masp_tx(
                             amount,
                             TransferSource::Address(defaults::albert_address()),

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -175,9 +175,9 @@ impl<C: NamadaTypes> TxCustom<C> {
 
 impl TxCustom {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_custom(context, self).await
@@ -281,9 +281,9 @@ impl<C: NamadaTypes> TxTransfer<C> {
 
 impl TxTransfer {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &mut self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_transfer(context, self).await
@@ -395,9 +395,9 @@ impl<C: NamadaTypes> TxIbcTransfer<C> {
 
 impl TxIbcTransfer {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_ibc_transfer(context, self).await
@@ -484,9 +484,9 @@ impl<C: NamadaTypes> InitProposal<C> {
 
 impl InitProposal {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         let current_epoch = rpc::query_epoch(context.client()).await?;
@@ -641,9 +641,9 @@ impl<C: NamadaTypes> VoteProposal<C> {
 
 impl VoteProposal {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         let current_epoch = rpc::query_epoch(context.client()).await?;
@@ -714,9 +714,9 @@ impl<C: NamadaTypes> TxInitAccount<C> {
 
 impl TxInitAccount {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_init_account(context, self).await
@@ -832,9 +832,9 @@ impl<C: NamadaTypes> TxUpdateAccount<C> {
 
 impl TxUpdateAccount {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_update_account(context, self).await
@@ -910,9 +910,9 @@ impl<C: NamadaTypes> Bond<C> {
 
 impl Bond {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_bond(context, self).await
@@ -937,9 +937,9 @@ pub struct Unbond<C: NamadaTypes = SdkTypes> {
 
 impl Unbond {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(
         crate::proto::Tx,
         SigningTxData,
@@ -1010,9 +1010,9 @@ pub struct Redelegate<C: NamadaTypes = SdkTypes> {
 
 impl Redelegate {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_redelegation(context, self).await
     }
@@ -1091,9 +1091,9 @@ impl<C: NamadaTypes> RevealPk<C> {
 
 impl RevealPk {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_reveal_pk(context, &self.tx, &self.public_key).await
@@ -1175,9 +1175,9 @@ impl<C: NamadaTypes> Withdraw<C> {
 
 impl Withdraw {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_withdraw(context, self).await
@@ -1212,9 +1212,9 @@ impl<C: NamadaTypes> TxBuilder<C> for ClaimRewards<C> {
 
 impl ClaimRewards {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_claim_rewards(context, self).await
@@ -1345,9 +1345,9 @@ impl<C: NamadaTypes> CommissionRateChange<C> {
 
 impl CommissionRateChange {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_validator_commission_change(context, self).await
@@ -1404,9 +1404,9 @@ pub struct ConsensusKeyChange<C: NamadaTypes = SdkTypes> {
 
 // impl ConsensusKeyChange {
 //     /// Build a transaction from this builder
-//     pub async fn build<'a>(
+//     pub async fn build(
 //         &self,
-//         context: &impl Namada<'a>,
+//         context: &impl Namada,
 //     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData,
 // Option<Epoch>)>     {
 //         tx::build_change_consensus_key(context, self).await
@@ -1463,9 +1463,9 @@ impl<C: NamadaTypes> MetaDataChange<C> {
 
 impl MetaDataChange {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_validator_metadata_change(context, self).await
@@ -1519,9 +1519,9 @@ impl<C: NamadaTypes> UpdateStewardCommission<C> {
 
 impl UpdateStewardCommission {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_update_steward_commission(context, self).await
@@ -1568,9 +1568,9 @@ impl<C: NamadaTypes> ResignSteward<C> {
 
 impl ResignSteward {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_resign_steward(context, self).await
@@ -1617,9 +1617,9 @@ impl<C: NamadaTypes> TxUnjailValidator<C> {
 
 impl TxUnjailValidator {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_unjail_validator(context, self).await
@@ -1666,9 +1666,9 @@ impl<C: NamadaTypes> TxDeactivateValidator<C> {
 
 impl TxDeactivateValidator {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_deactivate_validator(context, self).await
@@ -1715,9 +1715,9 @@ impl<C: NamadaTypes> TxReactivateValidator<C> {
 
 impl TxReactivateValidator {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         &self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         tx::build_reactivate_validator(context, self).await
@@ -2288,9 +2288,9 @@ impl<C: NamadaTypes> EthereumBridgePool<C> {
 
 impl EthereumBridgePool {
     /// Build a transaction from this builder
-    pub async fn build<'a>(
+    pub async fn build(
         self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
     ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
     {
         bridge_pool::build_bridge_pool_tx(context, self).await

--- a/sdk/src/eth_bridge/bridge_pool.rs
+++ b/sdk/src/eth_bridge/bridge_pool.rs
@@ -47,7 +47,7 @@ use crate::{
 
 /// Craft a transaction that adds a transfer to the Ethereum bridge pool.
 pub async fn build_bridge_pool_tx(
-    context: &impl Namada<'_>,
+    context: &impl Namada,
     args::EthereumBridgePool {
         tx: tx_args,
         nut,
@@ -113,7 +113,7 @@ pub async fn build_bridge_pool_tx(
 /// Perform client validation checks on a Bridge pool transfer.
 #[allow(clippy::too_many_arguments)]
 async fn validate_bridge_pool_tx(
-    context: &impl Namada<'_>,
+    context: &impl Namada,
     force: bool,
     nut: bool,
     asset: EthAddress,
@@ -316,7 +316,7 @@ struct BridgePoolResponse<'pool> {
 
 /// Query the contents of the Ethereum bridge pool.
 /// Prints out a json payload.
-pub async fn query_bridge_pool<'a>(
+pub async fn query_bridge_pool(
     client: &(impl Client + Sync),
     io: &impl Io,
 ) -> Result<HashMap<String, PendingTransfer>, Error> {
@@ -353,7 +353,7 @@ pub async fn query_bridge_pool<'a>(
 /// Query the contents of the Ethereum bridge pool that
 /// is covered by the latest signed root.
 /// Prints out a json payload.
-pub async fn query_signed_bridge_pool<'a>(
+pub async fn query_signed_bridge_pool(
     client: &(impl Client + Sync),
     io: &impl Io,
 ) -> Result<HashMap<String, PendingTransfer>, Error> {
@@ -392,7 +392,7 @@ pub async fn query_signed_bridge_pool<'a>(
 /// backing each `TransferToEthereum` event.
 ///
 /// Prints a json payload.
-pub async fn query_relay_progress<'a>(
+pub async fn query_relay_progress(
     client: &(impl Client + Sync),
     io: &impl Io,
 ) -> Result<(), Error> {
@@ -417,7 +417,7 @@ pub async fn query_relay_progress<'a>(
 
 /// Internal methdod to construct a proof that a set of transfers are in the
 /// bridge pool.
-async fn construct_bridge_pool_proof<'a>(
+async fn construct_bridge_pool_proof(
     client: &(impl Client + Sync),
     io: &impl Io,
     args: GenBridgePoolProofReq<'_, '_>,
@@ -513,7 +513,7 @@ struct BridgePoolProofResponse {
 /// Construct a merkle proof of a batch of transfers in
 /// the bridge pool and return it to the user (as opposed
 /// to relaying it to ethereum).
-pub async fn construct_proof<'a>(
+pub async fn construct_proof(
     client: &(impl Client + Sync),
     io: &impl Io,
     args: args::BridgePoolProof,
@@ -562,7 +562,7 @@ pub async fn construct_proof<'a>(
 }
 
 /// Relay a validator set update, signed off for a given epoch.
-pub async fn relay_bridge_pool_proof<'a, E>(
+pub async fn relay_bridge_pool_proof<E>(
     eth_client: Arc<E>,
     client: &(impl Client + Sync),
     io: &impl Io,
@@ -794,8 +794,8 @@ mod recommendations {
     /// Recommend the most economical batch of transfers to relay based
     /// on a conversion rate estimates from NAM to ETH and gas usage
     /// heuristics.
-    pub async fn recommend_batch<'a>(
-        context: &impl Namada<'a>,
+    pub async fn recommend_batch(
+        context: &impl Namada,
         args: args::RecommendBatch,
     ) -> Result<(), Error> {
         // get transfers that can already been relayed but are awaiting a quorum

--- a/sdk/src/eth_bridge/validator_set.rs
+++ b/sdk/src/eth_bridge/validator_set.rs
@@ -270,7 +270,7 @@ impl From<Option<TransactionReceipt>> for RelayResult {
 
 /// Query an ABI encoding of the validator set to be installed
 /// at the given epoch, and its associated proof.
-pub async fn query_validator_set_update_proof<'a>(
+pub async fn query_validator_set_update_proof(
     client: &(impl Client + Sync),
     io: &impl Io,
     args: args::ValidatorSetProof,
@@ -298,7 +298,7 @@ pub async fn query_validator_set_update_proof<'a>(
 }
 
 /// Query an ABI encoding of the Bridge validator set at a given epoch.
-pub async fn query_bridge_validator_set<'a>(
+pub async fn query_bridge_validator_set(
     client: &(impl Client + Sync),
     io: &impl Io,
     args: args::BridgeValidatorSet,
@@ -326,7 +326,7 @@ pub async fn query_bridge_validator_set<'a>(
 }
 
 /// Query an ABI encoding of the Governance validator set at a given epoch.
-pub async fn query_governnace_validator_set<'a>(
+pub async fn query_governnace_validator_set(
     client: &(impl Client + Sync),
     io: &impl Io,
     args: args::GovernanceValidatorSet,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -66,42 +66,38 @@ use crate::wallet::{Wallet, WalletIo, WalletStorage};
 
 #[async_trait::async_trait(?Send)]
 /// An interface for high-level interaction with the Namada SDK
-pub trait Namada<'a>: Sized {
+pub trait Namada: Sized {
     /// A client with async request dispatcher method
-    type Client: 'a + queries::Client + Sync;
+    type Client: queries::Client + Sync;
     /// Captures the interactive parts of the wallet's functioning
-    type WalletUtils: 'a + WalletIo + WalletStorage;
+    type WalletUtils: WalletIo + WalletStorage;
     /// Abstracts platform specific details away from the logic of shielded pool
     /// operations.
-    type ShieldedUtils: 'a + ShieldedUtils;
+    type ShieldedUtils: ShieldedUtils;
     /// Captures the input/output streams used by this object
-    type Io: 'a + Io;
+    type Io: Io;
 
     /// Obtain the client for communicating with the ledger
-    fn client(&self) -> &'a Self::Client;
+    fn client(&self) -> &Self::Client;
 
     /// Obtain the input/output handle for this context
-    fn io(&self) -> &'a Self::Io;
+    fn io(&self) -> &Self::Io;
 
     /// Obtain read guard on the wallet
-    async fn wallet(
-        &self,
-    ) -> RwLockReadGuard<&'a mut Wallet<Self::WalletUtils>>;
+    async fn wallet(&self) -> RwLockReadGuard<Wallet<Self::WalletUtils>>;
 
     /// Obtain write guard on the wallet
-    async fn wallet_mut(
-        &self,
-    ) -> RwLockWriteGuard<&'a mut Wallet<Self::WalletUtils>>;
+    async fn wallet_mut(&self) -> RwLockWriteGuard<Wallet<Self::WalletUtils>>;
 
     /// Obtain read guard on the shielded context
     async fn shielded(
         &self,
-    ) -> RwLockReadGuard<&'a mut ShieldedContext<Self::ShieldedUtils>>;
+    ) -> RwLockReadGuard<ShieldedContext<Self::ShieldedUtils>>;
 
     /// Obtain write guard on the shielded context
     async fn shielded_mut(
         &self,
-    ) -> RwLockWriteGuard<&'a mut ShieldedContext<Self::ShieldedUtils>>;
+    ) -> RwLockWriteGuard<ShieldedContext<Self::ShieldedUtils>>;
 
     /// Return the native token
     fn native_token(&self) -> Address;
@@ -537,7 +533,7 @@ pub trait Namada<'a>: Sized {
 }
 
 /// Provides convenience methods for common Namada interactions
-pub struct NamadaImpl<'a, C, U, V, I>
+pub struct NamadaImpl<C, U, V, I>
 where
     C: queries::Client + Sync,
     U: WalletIo,
@@ -545,20 +541,20 @@ where
     I: Io,
 {
     /// Used to send and receive messages from the ledger
-    pub client: &'a C,
+    pub client: C,
     /// Stores the addresses and keys required for ledger interactions
-    pub wallet: RwLock<&'a mut Wallet<U>>,
+    pub wallet: RwLock<Wallet<U>>,
     /// Stores the current state of the shielded pool
-    pub shielded: RwLock<&'a mut ShieldedContext<V>>,
+    pub shielded: RwLock<ShieldedContext<V>>,
     /// Captures the input/output streams used by this object
-    pub io: &'a I,
+    pub io: I,
     /// The address of the native token
     native_token: Address,
     /// The default builder for a Tx
     prototype: args::Tx,
 }
 
-impl<'a, C, U, V, I> NamadaImpl<'a, C, U, V, I>
+impl<C, U, V, I> NamadaImpl<C, U, V, I>
 where
     C: queries::Client + Sync,
     U: WalletIo,
@@ -567,10 +563,10 @@ where
 {
     /// Construct a new Namada context with the given native token address
     pub fn native_new(
-        client: &'a C,
-        wallet: &'a mut Wallet<U>,
-        shielded: &'a mut ShieldedContext<V>,
-        io: &'a I,
+        client: C,
+        wallet: Wallet<U>,
+        shielded: ShieldedContext<V>,
+        io: I,
         native_token: Address,
     ) -> Self {
         NamadaImpl {
@@ -609,12 +605,12 @@ where
 
     /// Construct a new Namada context looking up the native token address
     pub async fn new(
-        client: &'a C,
-        wallet: &'a mut Wallet<U>,
-        shielded: &'a mut ShieldedContext<V>,
-        io: &'a I,
-    ) -> crate::error::Result<NamadaImpl<'a, C, U, V, I>> {
-        let native_token = query_native_token(client).await?;
+        client: C,
+        wallet: Wallet<U>,
+        shielded: ShieldedContext<V>,
+        io: I,
+    ) -> crate::error::Result<NamadaImpl<C, U, V, I>> {
+        let native_token = query_native_token(&client).await?;
         Ok(NamadaImpl::native_new(
             client,
             wallet,
@@ -626,7 +622,7 @@ where
 }
 
 #[async_trait::async_trait(?Send)]
-impl<'a, C, U, V, I> Namada<'a> for NamadaImpl<'a, C, U, V, I>
+impl<C, U, V, I> Namada for NamadaImpl<C, U, V, I>
 where
     C: queries::Client + Sync,
     U: WalletIo + WalletStorage,
@@ -647,41 +643,37 @@ where
         self.native_token.clone()
     }
 
-    fn io(&self) -> &'a Self::Io {
-        self.io
+    fn io(&self) -> &Self::Io {
+        &self.io
     }
 
-    fn client(&self) -> &'a Self::Client {
-        self.client
+    fn client(&self) -> &Self::Client {
+        &self.client
     }
 
-    async fn wallet(
-        &self,
-    ) -> RwLockReadGuard<&'a mut Wallet<Self::WalletUtils>> {
+    async fn wallet(&self) -> RwLockReadGuard<Wallet<Self::WalletUtils>> {
         self.wallet.read().await
     }
 
-    async fn wallet_mut(
-        &self,
-    ) -> RwLockWriteGuard<&'a mut Wallet<Self::WalletUtils>> {
+    async fn wallet_mut(&self) -> RwLockWriteGuard<Wallet<Self::WalletUtils>> {
         self.wallet.write().await
     }
 
     async fn shielded(
         &self,
-    ) -> RwLockReadGuard<&'a mut ShieldedContext<Self::ShieldedUtils>> {
+    ) -> RwLockReadGuard<ShieldedContext<Self::ShieldedUtils>> {
         self.shielded.read().await
     }
 
     async fn shielded_mut(
         &self,
-    ) -> RwLockWriteGuard<&'a mut ShieldedContext<Self::ShieldedUtils>> {
+    ) -> RwLockWriteGuard<ShieldedContext<Self::ShieldedUtils>> {
         self.shielded.write().await
     }
 }
 
 /// Allow the prototypical Tx builder to be modified
-impl<'a, C, U, V, I> args::TxBuilder<SdkTypes> for NamadaImpl<'a, C, U, V, I>
+impl<C, U, V, I> args::TxBuilder<SdkTypes> for NamadaImpl<C, U, V, I>
 where
     C: queries::Client + Sync,
     U: WalletIo,

--- a/sdk/src/masp.rs
+++ b/sdk/src/masp.rs
@@ -1220,9 +1220,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// of the specified asset type. Return the total value accumulated plus
     /// notes and the corresponding diversifiers/merkle paths that were used to
     /// achieve the total value.
-    pub async fn collect_unspent_notes<'a>(
+    pub async fn collect_unspent_notes(
         &mut self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
         vk: &ViewingKey,
         target: I128Sum,
         target_epoch: Epoch,
@@ -1407,9 +1407,9 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// the epoch of the transaction or even before, so exchange all these
     /// amounts to the epoch of the transaction in order to get the value that
     /// would have been displayed in the epoch of the transaction.
-    pub async fn compute_exchanged_pinned_balance<'a>(
+    pub async fn compute_exchanged_pinned_balance(
         &mut self,
-        context: &impl Namada<'a>,
+        context: &impl Namada,
         owner: PaymentAddress,
         viewing_key: &ViewingKey,
     ) -> Result<(MaspAmount, Epoch), Error> {
@@ -1497,8 +1497,8 @@ impl<U: ShieldedUtils> ShieldedContext<U> {
     /// UTXOs are sometimes used to make transactions balanced, but it is
     /// understood that transparent account changes are effected only by the
     /// amounts and signatures specified by the containing Transfer object.
-    pub async fn gen_shielded_transfer<'a>(
-        context: &impl Namada<'a>,
+    pub async fn gen_shielded_transfer(
+        context: &impl Namada,
         source: &TransferSource,
         target: &TransferTarget,
         token: &Address,

--- a/sdk/src/rpc.rs
+++ b/sdk/src/rpc.rs
@@ -52,8 +52,8 @@ use crate::{display_line, edisplay_line, error, Namada};
 ///
 /// If a response is not delivered until `deadline`, we exit the cli with an
 /// error.
-pub async fn query_tx_status<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_tx_status(
+    context: &impl Namada,
     status: TxEventQuery<'_>,
     deadline: time::Instant,
 ) -> Result<Event, Error> {
@@ -276,8 +276,8 @@ pub async fn query_conversions<C: crate::queries::Client + Sync>(
 }
 
 /// Query a wasm code hash
-pub async fn query_wasm_code_hash<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_wasm_code_hash(
+    context: &impl Namada,
     code_path: impl AsRef<str>,
 ) -> Result<Hash, error::Error> {
     let hash_key = Key::wasm_hash(code_path.as_ref());
@@ -360,7 +360,7 @@ pub async fn query_storage_value_bytes<C: crate::queries::Client + Sync>(
 /// Query a range of storage values with a matching prefix and decode them with
 /// [`BorshDeserialize`]. Returns an iterator of the storage keys paired with
 /// their associated values.
-pub async fn query_storage_prefix<'a, 'b, N: Namada<'a>, T>(
+pub async fn query_storage_prefix<'a, 'b, N: Namada, T>(
     context: &'b N,
     key: &storage::Key,
 ) -> Result<Option<impl 'b + Iterator<Item = (storage::Key, T)>>, error::Error>
@@ -464,7 +464,7 @@ pub async fn query_tx_events<C: crate::queries::Client + Sync>(
 }
 
 /// Dry run a transaction
-pub async fn dry_run_tx<'a, N: Namada<'a>>(
+pub async fn dry_run_tx<N: Namada>(
     context: &N,
     tx_bytes: Vec<u8>,
 ) -> Result<namada_core::types::transaction::TxResult, Error> {
@@ -842,8 +842,8 @@ pub async fn get_public_key_at<C: crate::queries::Client + Sync>(
 }
 
 /// Query a validator's unbonds for a given epoch
-pub async fn query_and_print_unbonds<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_and_print_unbonds(
+    context: &impl Namada,
     source: &Address,
     validator: &Address,
 ) -> Result<(), error::Error> {
@@ -982,7 +982,7 @@ pub async fn enriched_bonds_and_unbonds<C: crate::queries::Client + Sync>(
 }
 
 /// Get the correct representation of the amount given the token type.
-pub async fn validate_amount<'a, N: Namada<'a>>(
+pub async fn validate_amount<N: Namada>(
     context: &N,
     amount: InputAmount,
     token: &Address,
@@ -1043,7 +1043,7 @@ pub async fn validate_amount<'a, N: Namada<'a>>(
 }
 
 /// Wait for a first block and node to be synced.
-pub async fn wait_until_node_is_synched<'a>(
+pub async fn wait_until_node_is_synched(
     client: &(impl Client + Sync),
     io: &impl Io,
 ) -> Result<(), Error> {
@@ -1140,7 +1140,7 @@ pub async fn format_denominated_amount(
 }
 
 /// Look up the IBC denomination from a IbcToken.
-pub async fn query_ibc_denom<'a, N: Namada<'a>>(
+pub async fn query_ibc_denom<N: Namada>(
     context: &N,
     token: &Address,
     owner: Option<&Address>,

--- a/sdk/src/signing.rs
+++ b/sdk/src/signing.rs
@@ -86,8 +86,8 @@ pub struct SigningTxData {
 /// for it from the wallet. If the keypair is encrypted but a password is not
 /// supplied, then it is interactively prompted. Errors if the key cannot be
 /// found or loaded.
-pub async fn find_pk<'a>(
-    context: &impl Namada<'a>,
+pub async fn find_pk(
+    context: &impl Namada,
     addr: &Address,
 ) -> Result<common::PublicKey, Error> {
     match addr {
@@ -167,8 +167,8 @@ pub fn find_key_by_pk<U: WalletIo>(
 /// signer. Return the given signing key or public key of the given signer if
 /// possible. If no explicit signer given, use the `default`. If no `default`
 /// is given, an `Error` is returned.
-pub async fn tx_signers<'a>(
-    context: &impl Namada<'a>,
+pub async fn tx_signers(
+    context: &impl Namada,
     args: &args::Tx<SdkTypes>,
     default: Option<Address>,
 ) -> Result<Vec<common::PublicKey>, Error> {
@@ -226,8 +226,8 @@ pub async fn default_sign(
 /// hashes needed for monitoring the tx on chain.
 ///
 /// If it is a dry run, it is not put in a wrapper, but returned as is.
-pub async fn sign_tx<'a, F: std::future::Future<Output = Result<Tx, Error>>>(
-    context: &impl Namada<'a>,
+pub async fn sign_tx<F: std::future::Future<Output = Result<Tx, Error>>>(
+    context: &impl Namada,
     args: &args::Tx,
     tx: &mut Tx,
     signing_data: SigningTxData,
@@ -260,7 +260,7 @@ pub async fn sign_tx<'a, F: std::future::Future<Output = Result<Tx, Error>>>(
                 if used_pubkeys.contains(public_key) {
                     None
                 } else {
-                    match find_key_by_pk(*wallet, args, public_key) {
+                    match find_key_by_pk(&mut wallet, args, public_key) {
                         Ok(secret_key) => {
                             used_pubkeys.insert(public_key.clone());
                             Some(secret_key)
@@ -301,7 +301,7 @@ pub async fn sign_tx<'a, F: std::future::Future<Output = Result<Tx, Error>>>(
         // Lock the wallet just long enough to extract a key from it without
         // interfering with the sign closure call
         let mut wallet = context.wallet_mut().await;
-        find_key_by_pk(*wallet, args, &signing_data.fee_payer)
+        find_key_by_pk(&mut wallet, args, &signing_data.fee_payer)
     };
     match key {
         Ok(fee_payer_keypair) => {
@@ -321,8 +321,8 @@ pub async fn sign_tx<'a, F: std::future::Future<Output = Result<Tx, Error>>>(
 
 /// Return the necessary data regarding an account to be able to generate a
 /// multisignature section
-pub async fn aux_signing_data<'a>(
-    context: &impl Namada<'a>,
+pub async fn aux_signing_data(
+    context: &impl Namada,
     args: &args::Tx<SdkTypes>,
     owner: Option<Address>,
     default_signer: Option<Address>,
@@ -390,8 +390,8 @@ pub async fn aux_signing_data<'a>(
     })
 }
 
-pub async fn init_validator_signing_data<'a>(
-    context: &impl Namada<'a>,
+pub async fn init_validator_signing_data(
+    context: &impl Namada,
     args: &args::Tx<SdkTypes>,
     validator_keys: Vec<common::PublicKey>,
 ) -> Result<SigningTxData, Error> {
@@ -450,7 +450,7 @@ pub struct TxSourcePostBalance {
 /// wrapper and its payload which is needed for monitoring its
 /// progress on chain.
 #[allow(clippy::too_many_arguments)]
-pub async fn wrap_tx<'a, N: Namada<'a>>(
+pub async fn wrap_tx<N: Namada>(
     context: &N,
     tx: &mut Tx,
     args: &args::Tx<SdkTypes>,
@@ -734,8 +734,8 @@ fn make_ledger_amount_addr(
 
 /// Adds a Ledger output line describing a given transaction amount and asset
 /// type
-async fn make_ledger_amount_asset<'a>(
-    context: &impl Namada<'a>,
+async fn make_ledger_amount_asset(
+    context: &impl Namada,
     tokens: &HashMap<Address, String>,
     output: &mut Vec<String>,
     amount: u64,
@@ -829,8 +829,8 @@ fn format_outputs(output: &mut Vec<String>) {
 
 /// Adds a Ledger output for the sender and destination for transparent and MASP
 /// transactions
-pub async fn make_ledger_masp_endpoints<'a>(
-    context: &impl Namada<'a>,
+pub async fn make_ledger_masp_endpoints(
+    context: &impl Namada,
     tokens: &HashMap<Address, String>,
     output: &mut Vec<String>,
     transfer: &Transfer,
@@ -904,8 +904,8 @@ pub async fn make_ledger_masp_endpoints<'a>(
 
 /// Internal method used to generate transaction test vectors
 #[cfg(feature = "std")]
-pub async fn generate_test_vector<'a>(
-    context: &impl Namada<'a>,
+pub async fn generate_test_vector(
+    context: &impl Namada,
     tx: &Tx,
 ) -> Result<(), Error> {
     use std::env;
@@ -1014,8 +1014,8 @@ impl<'a> Display for LedgerProposalType<'a> {
 
 /// Converts the given transaction to the form that is displayed on the Ledger
 /// device
-pub async fn to_ledger_vector<'a>(
-    context: &impl Namada<'a>,
+pub async fn to_ledger_vector(
+    context: &impl Namada,
     tx: &Tx,
 ) -> Result<LedgerVector, Error> {
     // To facilitate lookups of human-readable token names

--- a/sdk/src/tx.rs
+++ b/sdk/src/tx.rs
@@ -173,8 +173,8 @@ pub fn dump_tx<IO: Io>(io: &IO, args: &args::Tx, tx: Tx) {
 /// Prepare a transaction for signing and submission by adding a wrapper header
 /// to it.
 #[allow(clippy::too_many_arguments)]
-pub async fn prepare_tx<'a>(
-    context: &impl Namada<'a>,
+pub async fn prepare_tx(
+    context: &impl Namada,
     args: &args::Tx,
     tx: &mut Tx,
     fee_payer: common::PublicKey,
@@ -192,8 +192,8 @@ pub async fn prepare_tx<'a>(
 
 /// Submit transaction and wait for result. Returns a list of addresses
 /// initialized in the transaction if any. In dry run, this is always empty.
-pub async fn process_tx<'a>(
-    context: &impl Namada<'a>,
+pub async fn process_tx(
+    context: &impl Namada,
     args: &args::Tx,
     tx: Tx,
 ) -> Result<ProcessTxResponse> {
@@ -266,8 +266,8 @@ pub async fn has_revealed_pk<C: crate::queries::Client + Sync>(
 }
 
 /// Submit transaction to reveal the given public key
-pub async fn build_reveal_pk<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_reveal_pk(
+    context: &impl Namada,
     args: &args::Tx,
     public_key: &common::PublicKey,
 ) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
@@ -292,8 +292,8 @@ pub async fn build_reveal_pk<'a>(
 /// the tx has been successfully included into the mempool of a node
 ///
 /// In the case of errors in any of those stages, an error message is returned
-pub async fn broadcast_tx<'a>(
-    context: &impl Namada<'a>,
+pub async fn broadcast_tx(
+    context: &impl Namada,
     to_broadcast: &TxBroadcastData,
 ) -> Result<Response> {
     let (tx, wrapper_tx_hash, decrypted_tx_hash) = match to_broadcast {
@@ -355,8 +355,8 @@ pub async fn broadcast_tx<'a>(
 /// 3. The decrypted payload of the tx has been included on the blockchain.
 ///
 /// In the case of errors in any of those stages, an error message is returned
-pub async fn submit_tx<'a>(
-    context: &impl Namada<'a>,
+pub async fn submit_tx(
+    context: &impl Namada,
     to_broadcast: TxBroadcastData,
 ) -> Result<TxResponse> {
     let (_, wrapper_hash, decrypted_hash) = match &to_broadcast {
@@ -446,7 +446,7 @@ pub fn decode_component<K, F>(
 }
 
 /// Save accounts initialized from a tx into the wallet, if any.
-pub async fn save_initialized_accounts<'a, N: Namada<'a>>(
+pub async fn save_initialized_accounts<N: Namada>(
     context: &N,
     args: &args::Tx,
     initialized_accounts: Vec<Address>,
@@ -506,8 +506,8 @@ pub async fn save_initialized_accounts<'a, N: Namada<'a>>(
 }
 
 /// Submit validator comission rate change
-pub async fn build_validator_commission_change<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_validator_commission_change(
+    context: &impl Namada,
     args::CommissionRateChange {
         tx: tx_args,
         validator,
@@ -618,8 +618,8 @@ pub async fn build_validator_commission_change<'a>(
 }
 
 /// Submit validator metadata change
-pub async fn build_validator_metadata_change<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_validator_metadata_change(
+    context: &impl Namada,
     args::MetaDataChange {
         tx: tx_args,
         validator,
@@ -747,8 +747,8 @@ pub async fn build_validator_metadata_change<'a>(
 }
 
 /// Craft transaction to update a steward commission
-pub async fn build_update_steward_commission<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_update_steward_commission(
+    context: &impl Namada,
     args::UpdateStewardCommission {
         tx: tx_args,
         steward,
@@ -806,8 +806,8 @@ pub async fn build_update_steward_commission<'a>(
 }
 
 /// Craft transaction to resign as a steward
-pub async fn build_resign_steward<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_resign_steward(
+    context: &impl Namada,
     args::ResignSteward {
         tx: tx_args,
         steward,
@@ -846,8 +846,8 @@ pub async fn build_resign_steward<'a>(
 }
 
 /// Submit transaction to unjail a jailed validator
-pub async fn build_unjail_validator<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_unjail_validator(
+    context: &impl Namada,
     args::TxUnjailValidator {
         tx: tx_args,
         validator,
@@ -953,8 +953,8 @@ pub async fn build_unjail_validator<'a>(
 }
 
 /// Submit transaction to deactivate a validator
-pub async fn build_deactivate_validator<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_deactivate_validator(
+    context: &impl Namada,
     args::TxDeactivateValidator {
         tx: tx_args,
         validator,
@@ -1024,8 +1024,8 @@ pub async fn build_deactivate_validator<'a>(
 }
 
 /// Submit transaction to deactivate a validator
-pub async fn build_reactivate_validator<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_reactivate_validator(
+    context: &impl Namada,
     args::TxReactivateValidator {
         tx: tx_args,
         validator,
@@ -1094,8 +1094,8 @@ pub async fn build_reactivate_validator<'a>(
 }
 
 /// Redelegate bonded tokens from one validator to another
-pub async fn build_redelegation<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_redelegation(
+    context: &impl Namada,
     args::Redelegate {
         tx: tx_args,
         src_validator,
@@ -1274,8 +1274,8 @@ pub async fn build_redelegation<'a>(
 }
 
 /// Submit transaction to withdraw an unbond
-pub async fn build_withdraw<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_withdraw(
+    context: &impl Namada,
     args::Withdraw {
         tx: tx_args,
         validator,
@@ -1357,8 +1357,8 @@ pub async fn build_withdraw<'a>(
 }
 
 /// Submit transaction to withdraw an unbond
-pub async fn build_claim_rewards<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_claim_rewards(
+    context: &impl Namada,
     args::ClaimRewards {
         tx: tx_args,
         validator,
@@ -1405,8 +1405,8 @@ pub async fn build_claim_rewards<'a>(
 }
 
 /// Submit a transaction to unbond
-pub async fn build_unbond<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_unbond(
+    context: &impl Namada,
     args::Unbond {
         tx: tx_args,
         validator,
@@ -1512,8 +1512,8 @@ pub async fn build_unbond<'a>(
 }
 
 /// Query the unbonds post-tx
-pub async fn query_unbonds<'a>(
-    context: &impl Namada<'a>,
+pub async fn query_unbonds(
+    context: &impl Namada,
     args: args::Unbond,
     latest_withdrawal_pre: Option<(Epoch, token::Amount)>,
 ) -> Result<()> {
@@ -1583,8 +1583,8 @@ pub async fn query_unbonds<'a>(
 }
 
 /// Submit a transaction to bond
-pub async fn build_bond<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_bond(
+    context: &impl Namada,
     args::Bond {
         tx: tx_args,
         validator,
@@ -1697,8 +1697,8 @@ pub async fn build_bond<'a>(
 }
 
 /// Build a default proposal governance
-pub async fn build_default_proposal<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_default_proposal(
+    context: &impl Namada,
     args::InitProposal {
         tx,
         proposal_data: _,
@@ -1750,8 +1750,8 @@ pub async fn build_default_proposal<'a>(
 }
 
 /// Build a proposal vote
-pub async fn build_vote_proposal<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_vote_proposal(
+    context: &impl Namada,
     args::VoteProposal {
         tx,
         proposal_id,
@@ -1837,8 +1837,8 @@ pub async fn build_vote_proposal<'a>(
 }
 
 /// Build a pgf funding proposal governance
-pub async fn build_pgf_funding_proposal<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_pgf_funding_proposal(
+    context: &impl Namada,
     args::InitProposal {
         tx,
         proposal_data: _,
@@ -1882,8 +1882,8 @@ pub async fn build_pgf_funding_proposal<'a>(
 }
 
 /// Build a pgf funding proposal governance
-pub async fn build_pgf_stewards_proposal<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_pgf_stewards_proposal(
+    context: &impl Namada,
     args::InitProposal {
         tx,
         proposal_data: _,
@@ -1928,8 +1928,8 @@ pub async fn build_pgf_stewards_proposal<'a>(
 }
 
 /// Submit an IBC transfer
-pub async fn build_ibc_transfer<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_ibc_transfer(
+    context: &impl Namada,
     args: &args::TxIbcTransfer,
 ) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
     let default_signer = Some(args.source.clone());
@@ -2057,8 +2057,8 @@ pub async fn build_ibc_transfer<'a>(
 
 /// Abstraction for helping build transactions
 #[allow(clippy::too_many_arguments)]
-pub async fn build<'a, F, D>(
-    context: &impl Namada<'a>,
+pub async fn build<F, D>(
+    context: &impl Namada,
     tx_args: &crate::args::Tx,
     path: PathBuf,
     data: D,
@@ -2083,8 +2083,8 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn build_pow_flag<'a, F, D>(
-    context: &impl Namada<'a>,
+async fn build_pow_flag<F, D>(
+    context: &impl Namada,
     tx_args: &crate::args::Tx,
     path: PathBuf,
     mut data: D,
@@ -2126,9 +2126,9 @@ where
 
 /// Try to decode the given asset type and add its decoding to the supplied set.
 /// Returns true only if a new decoding has been added to the given set.
-async fn add_asset_type<'a>(
+async fn add_asset_type(
     asset_types: &mut HashSet<(Address, MaspDenom, Epoch)>,
-    context: &impl Namada<'a>,
+    context: &impl Namada,
     asset_type: AssetType,
 ) -> bool {
     if let Some(asset_type) = context
@@ -2146,8 +2146,8 @@ async fn add_asset_type<'a>(
 /// Collect the asset types used in the given Builder and decode them. This
 /// function provides the data necessary for offline wallets to present asset
 /// type information.
-async fn used_asset_types<'a, P, R, K, N>(
-    context: &impl Namada<'a>,
+async fn used_asset_types<P, R, K, N>(
+    context: &impl Namada,
     builder: &Builder<P, R, K, N>,
 ) -> std::result::Result<HashSet<(Address, MaspDenom, Epoch)>, RpcError> {
     let mut asset_types = HashSet::new();
@@ -2180,7 +2180,7 @@ async fn used_asset_types<'a, P, R, K, N>(
 }
 
 /// Submit an ordinary transfer
-pub async fn build_transfer<'a, N: Namada<'a>>(
+pub async fn build_transfer<N: Namada>(
     context: &N,
     args: &mut args::TxTransfer,
 ) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
@@ -2351,8 +2351,8 @@ pub async fn build_transfer<'a, N: Namada<'a>>(
 }
 
 /// Submit a transaction to initialize an account
-pub async fn build_init_account<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_init_account(
+    context: &impl Namada,
     args::TxInitAccount {
         tx: tx_args,
         vp_code_path,
@@ -2406,8 +2406,8 @@ pub async fn build_init_account<'a>(
 }
 
 /// Submit a transaction to update a VP
-pub async fn build_update_account<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_update_account(
+    context: &impl Namada,
     args::TxUpdateAccount {
         tx: tx_args,
         vp_code_path,
@@ -2488,8 +2488,8 @@ pub async fn build_update_account<'a>(
 }
 
 /// Submit a custom transaction
-pub async fn build_custom<'a>(
-    context: &impl Namada<'a>,
+pub async fn build_custom(
+    context: &impl Namada,
     args::TxCustom {
         tx: tx_args,
         code_path,
@@ -2539,7 +2539,7 @@ pub async fn build_custom<'a>(
 }
 
 /// Generate IBC shielded transfer
-pub async fn gen_ibc_shielded_transfer<'a, N: Namada<'a>>(
+pub async fn gen_ibc_shielded_transfer<N: Namada>(
     context: &N,
     args: args::GenIbcShieldedTransafer,
 ) -> Result<Option<IbcShieldedTransfer>> {
@@ -2612,8 +2612,8 @@ pub async fn gen_ibc_shielded_transfer<'a, N: Namada<'a>>(
     }
 }
 
-async fn get_ibc_src_port_channel<'a>(
-    context: &impl Namada<'a>,
+async fn get_ibc_src_port_channel(
+    context: &impl Namada,
     dest_port_id: &PortId,
     dest_channel_id: &ChannelId,
 ) -> Result<(PortId, ChannelId)> {
@@ -2654,9 +2654,9 @@ async fn get_ibc_src_port_channel<'a>(
         })
 }
 
-async fn expect_dry_broadcast<'a>(
+async fn expect_dry_broadcast(
     to_broadcast: TxBroadcastData,
-    context: &impl Namada<'a>,
+    context: &impl Namada,
 ) -> Result<ProcessTxResponse> {
     match to_broadcast {
         TxBroadcastData::DryRun(tx) => {
@@ -2678,10 +2678,10 @@ fn lift_rpc_error<T>(res: std::result::Result<T, RpcError>) -> Result<T> {
 /// Returns the given validator if the given address is a validator,
 /// otherwise returns an error, force forces the address through even
 /// if it isn't a validator
-async fn known_validator_or_err<'a>(
+async fn known_validator_or_err(
     validator: Address,
     force: bool,
-    context: &impl Namada<'a>,
+    context: &impl Namada,
 ) -> Result<Address> {
     // Check that the validator address exists on chain
     let is_validator = rpc::is_validator(context.client(), &validator).await?;
@@ -2704,10 +2704,10 @@ async fn known_validator_or_err<'a>(
 /// general pattern for checking if an address exists on the chain, or
 /// throwing an error if it's not forced. Takes a generic error
 /// message and the error type.
-async fn address_exists_or_err<'a, F>(
+async fn address_exists_or_err<F>(
     addr: Address,
     force: bool,
-    context: &impl Namada<'a>,
+    context: &impl Namada,
     message: String,
     err: F,
 ) -> Result<Address>
@@ -2730,10 +2730,10 @@ where
 /// Returns the given source address if the given address exists on chain
 /// otherwise returns an error, force forces the address through even
 /// if it isn't on chain
-async fn source_exists_or_err<'a>(
+async fn source_exists_or_err(
     token: Address,
     force: bool,
-    context: &impl Namada<'a>,
+    context: &impl Namada,
 ) -> Result<Address> {
     let message =
         format!("The source address {} doesn't exist on chain.", token);
@@ -2746,10 +2746,10 @@ async fn source_exists_or_err<'a>(
 /// Returns the given target address if the given address exists on chain
 /// otherwise returns an error, force forces the address through even
 /// if it isn't on chain
-async fn target_exists_or_err<'a>(
+async fn target_exists_or_err(
     token: Address,
     force: bool,
-    context: &impl Namada<'a>,
+    context: &impl Namada,
 ) -> Result<Address> {
     let message =
         format!("The target address {} doesn't exist on chain.", token);
@@ -2762,7 +2762,7 @@ async fn target_exists_or_err<'a>(
 /// Checks the balance at the given address is enough to transfer the
 /// given amount, along with the balance even existing. Force
 /// overrides this. Returns the updated balance for fee check if necessary
-async fn check_balance_too_low_err<'a, N: Namada<'a>>(
+async fn check_balance_too_low_err<N: Namada>(
     token: &Address,
     source: &Address,
     amount: token::Amount,
@@ -2825,8 +2825,8 @@ async fn check_balance_too_low_err<'a, N: Namada<'a>>(
     }
 }
 
-async fn query_wasm_code_hash_buf<'a>(
-    context: &impl Namada<'a>,
+async fn query_wasm_code_hash_buf(
+    context: &impl Namada,
     path: &Path,
 ) -> Result<Hash> {
     query_wasm_code_hash(context, path.to_string_lossy()).await


### PR DESCRIPTION
## Describe your changes
Modified the `Namada` trait and implementation to own its their clients, streams, wallet, and shielded utilities. Then removed all the redundant lifetimes. This was relatively straightforward because it was rare that after a `NamadaImpl` has been instantiated that any other object would want to own the client, streams, wallet, or shielded utilities.

## Indicate on which release or other PRs this topic is based on
Namada 0.27.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
