### PR TITLE
MASP nullifier uniqueness

### DIFF
--- a/.changelog/unreleased/bug-fixes/2240-nullifier-uniqueness.md
+++ b/.changelog/unreleased/bug-fixes/2240-nullifier-uniqueness.md
@@ -1,0 +1,2 @@
+- Prevents double-spending in masp by adding a nullifier set.
+  ([\#2240](https://github.com/anoma/namada/pull/2240))

--- a/core/src/ledger/masp_utils.rs
+++ b/core/src/ledger/masp_utils.rs
@@ -1,0 +1,30 @@
+//! MASP utilities
+
+use masp_primitives::transaction::Transaction;
+
+use super::storage_api::StorageWrite;
+use crate::ledger::storage_api::Result;
+use crate::types::address::MASP;
+use crate::types::hash::Hash;
+use crate::types::storage::{Key, KeySeg};
+use crate::types::token::MASP_NULLIFIERS_KEY_PREFIX;
+
+/// Writes the nullifiers of the provided masp transaction to storage
+pub fn reveal_nullifiers(
+    ctx: &mut impl StorageWrite,
+    transaction: &Transaction,
+) -> Result<()> {
+    for description in transaction
+        .sapling_bundle()
+        .map_or(&vec![], |description| &description.shielded_spends)
+    {
+        let nullifier_key = Key::from(MASP.to_db_key())
+            .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
+            .expect("Cannot obtain a storage key")
+            .push(&Hash(description.nullifier.0))
+            .expect("Cannot obtain a storage key");
+        ctx.write(&nullifier_key, ())?;
+    }
+
+    Ok(())
+}

--- a/core/src/ledger/masp_utils.rs
+++ b/core/src/ledger/masp_utils.rs
@@ -2,15 +2,18 @@
 
 use masp_primitives::transaction::Transaction;
 
-use super::storage_api::StorageWrite;
+use super::storage_api::{StorageRead, StorageWrite};
 use crate::ledger::storage_api::Result;
 use crate::types::address::MASP;
 use crate::types::hash::Hash;
-use crate::types::storage::{Key, KeySeg};
-use crate::types::token::MASP_NULLIFIERS_KEY_PREFIX;
+use crate::types::storage::{BlockHeight, Epoch, Key, KeySeg, TxIndex};
+use crate::types::token::{
+    Transfer, HEAD_TX_KEY, MASP_NULLIFIERS_KEY_PREFIX, PIN_KEY_PREFIX,
+    TX_KEY_PREFIX,
+};
 
-/// Writes the nullifiers of the provided masp transaction to storage
-pub fn reveal_nullifiers(
+// Writes the nullifiers of the provided masp transaction to storage
+fn reveal_nullifiers(
     ctx: &mut impl StorageWrite,
     transaction: &Transaction,
 ) -> Result<()> {
@@ -24,6 +27,46 @@ pub fn reveal_nullifiers(
             .push(&Hash(description.nullifier.0))
             .expect("Cannot obtain a storage key");
         ctx.write(&nullifier_key, ())?;
+    }
+
+    Ok(())
+}
+
+/// Handle a MASP transaction.
+pub fn handle_masp_tx(
+    ctx: &mut (impl StorageRead + StorageWrite),
+    transfer: &Transfer,
+    shielded: &Transaction,
+) -> Result<()> {
+    let masp_addr = MASP;
+    let head_tx_key = Key::from(masp_addr.to_db_key())
+        .push(&HEAD_TX_KEY.to_owned())
+        .expect("Cannot obtain a storage key");
+    let current_tx_idx: u64 =
+        ctx.read(&head_tx_key).unwrap_or(None).unwrap_or(0);
+    let current_tx_key = Key::from(masp_addr.to_db_key())
+        .push(&(TX_KEY_PREFIX.to_owned() + &current_tx_idx.to_string()))
+        .expect("Cannot obtain a storage key");
+    // Save the Transfer object and its location within the blockchain
+    // so that clients do not have to separately look these
+    // up
+    let record: (Epoch, BlockHeight, TxIndex, Transfer, Transaction) = (
+        ctx.get_block_epoch()?,
+        ctx.get_block_height()?,
+        ctx.get_tx_index()?,
+        transfer.clone(),
+        shielded.clone(),
+    );
+    ctx.write(&current_tx_key, record)?;
+    ctx.write(&head_tx_key, current_tx_idx + 1)?;
+    reveal_nullifiers(ctx, shielded)?;
+
+    // If storage key has been supplied, then pin this transaction to it
+    if let Some(key) = &transfer.key {
+        let pin_key = Key::from(masp_addr.to_db_key())
+            .push(&(PIN_KEY_PREFIX.to_owned() + key))
+            .expect("Cannot obtain a storage key");
+        ctx.write(&pin_key, current_tx_idx)?;
     }
 
     Ok(())

--- a/core/src/ledger/mod.rs
+++ b/core/src/ledger/mod.rs
@@ -6,6 +6,7 @@ pub mod governance;
 pub mod ibc;
 pub mod inflation;
 pub mod masp_conversions;
+pub mod masp_utils;
 pub mod parameters;
 pub mod pgf;
 pub mod replay_protection;

--- a/core/src/ledger/storage/write_log.rs
+++ b/core/src/ledger/storage/write_log.rs
@@ -182,7 +182,6 @@ impl WriteLog {
         &self,
         key: &storage::Key,
     ) -> (Option<&StorageModification>, u64) {
-        // try to read from tx write log first
         match self.block_write_log.get(key) {
             Some(v) => {
                 let gas = match v {

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -1130,6 +1130,15 @@ pub fn is_masp_key(key: &Key) -> bool {
                     || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)))
 }
 
+/// Check if the given storage key is a masp nullifier key
+pub fn is_masp_nullifier_key(key: &Key) -> bool {
+    matches!(&key.segments[..],
+    [DbKeySeg::AddressSeg(addr),
+             DbKeySeg::StringSeg(prefix),
+             ..
+        ] if *addr == MASP && prefix == MASP_NULLIFIERS_KEY_PREFIX)
+}
+
 /// Obtain the storage key for the last locked ratio of a token
 pub fn masp_last_locked_ratio_key(token_address: &Address) -> Key {
     key_of_token(

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -900,6 +900,8 @@ pub const HEAD_TX_KEY: &str = "head-tx";
 pub const TX_KEY_PREFIX: &str = "tx-";
 /// Key segment prefix for pinned shielded transactions
 pub const PIN_KEY_PREFIX: &str = "pin-";
+/// Key segment prefix for the nullifiers
+pub const MASP_NULLIFIERS_KEY_PREFIX: &str = "nullifiers";
 /// Last calculated inflation value handed out
 pub const MASP_LAST_INFLATION_KEY: &str = "last_inflation";
 /// The last locked ratio
@@ -1124,7 +1126,8 @@ pub fn is_masp_key(key: &Key) -> bool {
             if *addr == MASP
                 && (key == HEAD_TX_KEY
                     || key.starts_with(TX_KEY_PREFIX)
-                    || key.starts_with(PIN_KEY_PREFIX)))
+                    || key.starts_with(PIN_KEY_PREFIX)
+                    || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)))
 }
 
 /// Obtain the storage key for the last locked ratio of a token

--- a/shared/src/ledger/native_vp/ibc/context.rs
+++ b/shared/src/ledger/native_vp/ibc/context.rs
@@ -5,8 +5,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use borsh_ext::BorshSerializeExt;
 use masp_primitives::transaction::Transaction;
 use namada_core::ledger::ibc::{IbcCommonContext, IbcStorageContext};
-use namada_core::types::hash::Hash;
-use namada_core::types::token::MASP_NULLIFIERS_KEY_PREFIX;
+use namada_core::ledger::masp_utils;
 
 use crate::ledger::ibc::storage::is_ibc_key;
 use crate::ledger::native_vp::CtxPreStorageRead;
@@ -239,19 +238,7 @@ where
         );
         self.write(&current_tx_key, record.serialize_to_vec())?;
         self.write(&head_tx_key, (current_tx_idx + 1).serialize_to_vec())?;
-        for description in shielded
-            .masp_tx
-            .sapling_bundle()
-            .map_or(&vec![], |description| &description.shielded_spends)
-        {
-            // Reveal the nullifier to prevent double spending
-            let nullifier_key = Key::from(masp_addr.to_db_key())
-                .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
-                .expect("Cannot obtain a storage key")
-                .push(&Hash(description.nullifier.0))
-                .expect("Cannot obtain a storage key");
-            self.write(&nullifier_key, ())?;
-        }
+        masp_utils::reveal_nullifiers(self, &shielded.masp_tx)?;
         // If storage key has been supplied, then pin this transaction to it
         if let Some(key) = &shielded.transfer.key {
             let pin_key = Key::from(masp_addr.to_db_key())

--- a/shared/src/ledger/native_vp/ibc/context.rs
+++ b/shared/src/ledger/native_vp/ibc/context.rs
@@ -3,7 +3,6 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use borsh_ext::BorshSerializeExt;
-use masp_primitives::transaction::Transaction;
 use namada_core::ledger::ibc::{IbcCommonContext, IbcStorageContext};
 use namada_core::ledger::masp_utils;
 
@@ -12,15 +11,12 @@ use crate::ledger::native_vp::CtxPreStorageRead;
 use crate::ledger::storage::write_log::StorageModification;
 use crate::ledger::storage::{self as ledger_storage, StorageHasher};
 use crate::ledger::storage_api::{self, StorageRead, StorageWrite};
-use crate::types::address::{Address, InternalAddress, MASP};
+use crate::types::address::{Address, InternalAddress};
 use crate::types::ibc::{IbcEvent, IbcShieldedTransfer};
 use crate::types::storage::{
-    BlockHash, BlockHeight, Epoch, Header, Key, KeySeg, TxIndex,
+    BlockHash, BlockHeight, Epoch, Header, Key, TxIndex,
 };
-use crate::types::token::{
-    self, Amount, DenominatedAmount, Transfer, HEAD_TX_KEY, PIN_KEY_PREFIX,
-    TX_KEY_PREFIX,
-};
+use crate::types::token::{self, Amount, DenominatedAmount};
 use crate::vm::WasmCacheAccess;
 
 /// Result of a storage API call.
@@ -217,36 +213,7 @@ where
     }
 
     fn handle_masp_tx(&mut self, shielded: &IbcShieldedTransfer) -> Result<()> {
-        let masp_addr = MASP;
-        let head_tx_key = Key::from(masp_addr.to_db_key())
-            .push(&HEAD_TX_KEY.to_owned())
-            .expect("Cannot obtain a storage key");
-        let current_tx_idx: u64 =
-            self.ctx.read(&head_tx_key).unwrap_or(None).unwrap_or(0);
-        let current_tx_key = Key::from(masp_addr.to_db_key())
-            .push(&(TX_KEY_PREFIX.to_owned() + &current_tx_idx.to_string()))
-            .expect("Cannot obtain a storage key");
-        // Save the Transfer object and its location within the blockchain
-        // so that clients do not have to separately look these
-        // up
-        let record: (Epoch, BlockHeight, TxIndex, Transfer, Transaction) = (
-            self.ctx.get_block_epoch()?,
-            self.ctx.get_block_height()?,
-            self.ctx.get_tx_index()?,
-            shielded.transfer.clone(),
-            shielded.masp_tx.clone(),
-        );
-        self.write(&current_tx_key, record.serialize_to_vec())?;
-        self.write(&head_tx_key, (current_tx_idx + 1).serialize_to_vec())?;
-        masp_utils::reveal_nullifiers(self, &shielded.masp_tx)?;
-        // If storage key has been supplied, then pin this transaction to it
-        if let Some(key) = &shielded.transfer.key {
-            let pin_key = Key::from(masp_addr.to_db_key())
-                .push(&(PIN_KEY_PREFIX.to_owned() + key))
-                .expect("Cannot obtain a storage key");
-            self.write(&pin_key, current_tx_idx.serialize_to_vec())?;
-        }
-        Ok(())
+        masp_utils::handle_masp_tx(self, &shielded.transfer, &shielded.masp_tx)
     }
 
     fn mint_token(

--- a/shared/src/ledger/native_vp/masp.rs
+++ b/shared/src/ledger/native_vp/masp.rs
@@ -189,6 +189,16 @@ where
                     );
                     return Ok(false);
                 }
+
+                // Check that the nullifier is indeed committed (no temp write
+                // and no delete) and carries no associated data (the latter not
+                // strictly necessary for validation, but we don't expect any
+                // value for this key anyway)
+                match self.ctx.read_bytes_post(&nullifier_key)? {
+                    Some(value) if value.is_empty() => (),
+                    _ => return Ok(false),
+                }
+
                 revealed_nullifiers.insert(nullifier_key);
             }
 

--- a/shared/src/vm/host_env.rs
+++ b/shared/src/vm/host_env.rs
@@ -13,6 +13,7 @@ use namada_core::ledger::gas::{
 use namada_core::types::address::{ESTABLISHED_ADDRESS_BYTES_LEN, MASP};
 use namada_core::types::internal::KeyVal;
 use namada_core::types::storage::TX_INDEX_LENGTH;
+use namada_core::types::token::MASP_NULLIFIERS_KEY_PREFIX;
 use namada_core::types::transaction::TxSentinel;
 use namada_core::types::validity_predicate::VpSentinel;
 use thiserror::Error;
@@ -2541,6 +2542,19 @@ where
         );
         self.write(&current_tx_key, record)?;
         self.write(&head_tx_key, current_tx_idx + 1)?;
+        for description in shielded
+            .masp_tx
+            .sapling_bundle()
+            .map_or(&vec![], |description| &description.shielded_spends)
+        {
+            // Reveal the nullifier to prevent double spending
+            let nullifier_key = Key::from(masp_addr.to_db_key())
+                .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
+                .expect("Cannot obtain a storage key")
+                .push(&Hash(description.nullifier.0))
+                .expect("Cannot obtain a storage key");
+            self.write(&nullifier_key, ())?;
+        }
         // If storage key has been supplied, then pin this transaction to it
         if let Some(key) = &shielded.transfer.key {
             let pin_key = Key::from(masp_addr.to_db_key())

--- a/tx_prelude/src/ibc.rs
+++ b/tx_prelude/src/ibc.rs
@@ -6,12 +6,13 @@ use std::rc::Rc;
 pub use namada_core::ledger::ibc::{
     IbcActions, IbcCommonContext, IbcStorageContext, ProofSpec, TransferModule,
 };
+use namada_core::ledger::masp_utils;
 use namada_core::ledger::tx_env::TxEnv;
 use namada_core::types::address::{Address, InternalAddress};
 pub use namada_core::types::ibc::{IbcEvent, IbcShieldedTransfer};
 use namada_core::types::token::DenominatedAmount;
 
-use crate::token::{burn, handle_masp_tx, mint, transfer};
+use crate::token::{burn, mint, transfer};
 use crate::{Ctx, Error};
 
 /// IBC actions to handle an IBC message
@@ -52,7 +53,7 @@ impl IbcStorageContext for Ctx {
         &mut self,
         shielded: &IbcShieldedTransfer,
     ) -> Result<(), Error> {
-        handle_masp_tx(self, &shielded.transfer, &shielded.masp_tx)
+        masp_utils::handle_masp_tx(self, &shielded.transfer, &shielded.masp_tx)
     }
 
     fn mint_token(

--- a/tx_prelude/src/token.rs
+++ b/tx_prelude/src/token.rs
@@ -1,5 +1,6 @@
 use masp_primitives::transaction::Transaction;
 use namada_core::types::address::{Address, MASP};
+use namada_core::types::hash::Hash;
 use namada_core::types::storage::KeySeg;
 use namada_core::types::token;
 pub use namada_core::types::token::*;
@@ -60,6 +61,18 @@ pub fn handle_masp_tx(
     );
     ctx.write(&current_tx_key, record)?;
     ctx.write(&head_tx_key, current_tx_idx + 1)?;
+    for description in shielded
+        .sapling_bundle()
+        .map_or(&vec![], |description| &description.shielded_spends)
+    {
+        // Reveal the nullifier to prevent double spending
+        let nullifier_key = storage::Key::from(masp_addr.to_db_key())
+            .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
+            .expect("Cannot obtain a storage key")
+            .push(&Hash(description.nullifier.0))
+            .expect("Cannot obtain a storage key");
+        ctx.write(&nullifier_key, ())?;
+    }
     // If storage key has been supplied, then pin this transaction to it
     if let Some(key) = &transfer.key {
         let pin_key = storage::Key::from(masp_addr.to_db_key())

--- a/tx_prelude/src/token.rs
+++ b/tx_prelude/src/token.rs
@@ -1,7 +1,5 @@
-use masp_primitives::transaction::Transaction;
-use namada_core::ledger::masp_utils;
-use namada_core::types::address::{Address, MASP};
-use namada_core::types::storage::KeySeg;
+pub use namada_core::ledger::masp_utils;
+use namada_core::types::address::Address;
 use namada_core::types::token;
 pub use namada_core::types::token::*;
 
@@ -29,45 +27,6 @@ pub fn transfer(
         dest_bal.receive(&amount.amount);
         ctx.write(&src_key, src_bal)?;
         ctx.write(&dest_key, dest_bal)?;
-    }
-    Ok(())
-}
-
-/// Handle a MASP transaction.
-pub fn handle_masp_tx(
-    ctx: &mut Ctx,
-    transfer: &Transfer,
-    shielded: &Transaction,
-) -> TxResult {
-    let masp_addr = MASP;
-    ctx.insert_verifier(&masp_addr)?;
-    let head_tx_key = storage::Key::from(masp_addr.to_db_key())
-        .push(&HEAD_TX_KEY.to_owned())
-        .expect("Cannot obtain a storage key");
-    let current_tx_idx: u64 =
-        ctx.read(&head_tx_key).unwrap_or(None).unwrap_or(0);
-    let current_tx_key = storage::Key::from(masp_addr.to_db_key())
-        .push(&(TX_KEY_PREFIX.to_owned() + &current_tx_idx.to_string()))
-        .expect("Cannot obtain a storage key");
-    // Save the Transfer object and its location within the blockchain
-    // so that clients do not have to separately look these
-    // up
-    let record: (Epoch, BlockHeight, TxIndex, Transfer, Transaction) = (
-        ctx.get_block_epoch()?,
-        ctx.get_block_height()?,
-        ctx.get_tx_index()?,
-        transfer.clone(),
-        shielded.clone(),
-    );
-    ctx.write(&current_tx_key, record)?;
-    ctx.write(&head_tx_key, current_tx_idx + 1)?;
-    masp_utils::reveal_nullifiers(ctx, shielded)?;
-    // If storage key has been supplied, then pin this transaction to it
-    if let Some(key) = &transfer.key {
-        let pin_key = storage::Key::from(masp_addr.to_db_key())
-            .push(&(PIN_KEY_PREFIX.to_owned() + key))
-            .expect("Cannot obtain a storage key");
-        ctx.write(&pin_key, current_tx_idx)?;
     }
     Ok(())
 }

--- a/wasm/wasm_source/src/tx_transfer.rs
+++ b/wasm/wasm_source/src/tx_transfer.rs
@@ -38,7 +38,7 @@ fn apply_tx(ctx: &mut Ctx, tx_data: Tx) -> TxResult {
         })
         .transpose()?;
     if let Some(shielded) = shielded {
-        token::handle_masp_tx(ctx, &transfer, &shielded)?;
+        token::masp_utils::handle_masp_tx(ctx, &transfer, &shielded)?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Describe your changes

Addresses #1373.

Implements a nullifier set to prevent double spending in masp transactions. Updates the masp VP to check that the transactions writes the correct nullifiers and that these haven't already been revealed.

**NOTE**: testing this with an integration or e2e test is impossible cause we cannot force the submission of the tx if the builder fails to construct the shielded `Transaction`. We'd need to test this with a unit test (which I think would be the correct way regardless of the `force` issue) but at the moment we don't have the tools to write unit tests for the masp vp (at least to my knowledge)

## Indicate on which release or other PRs this topic is based on

v0.27.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
