### PR TITLE
Update README.md

### DIFF
--- a/genesis/README.md
+++ b/genesis/README.md
@@ -1,6 +1,6 @@
 # Genesis templates
 
-An example setup with a single validator used to run a localnet can be found in [localnet](localnet/README.md) directory.
+An example setup with a single validator used for running a localnet can be found in [localnet](localnet/README.md) directory.
 
 [Starter templates](starter/README.md) can be used to configure new networks.
 


### PR DESCRIPTION
Hi,

"An example setup with a single validator used to run a localnet can be found in localnet directory." - "used to run a localnet" may be clearer as "used for running a localnet". So I made that change. 

Thanks.

## Describe your changes

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
