### PR TITLE
Fix liveness unjailing

### DIFF
--- a/.changelog/unreleased/improvements/2246-fix-liveness.md
+++ b/.changelog/unreleased/improvements/2246-fix-liveness.md
@@ -1,0 +1,3 @@
+- Fix bug in client to allow for unjailing a validator
+  that was jailed for missing liveness requirements
+  ([\#2246](https://github.com/anoma/namada/pull/2246))

--- a/proof_of_stake/src/lib.rs
+++ b/proof_of_stake/src/lib.rs
@@ -5778,6 +5778,12 @@ where
         .collect::<HashSet<_>>();
 
     for validator in &validators_to_jail {
+        let state_jail_epoch = validator_state_handle(validator)
+            .get(storage, jail_epoch, params)?
+            .expect("Validator should have a state for the jail epoch");
+        if state_jail_epoch == ValidatorState::Jailed {
+            continue;
+        }
         tracing::info!(
             "Jailing validator {} starting in epoch {} for missing too many \
              votes to ensure liveness",

--- a/sdk/src/queries/vp/pos.rs
+++ b/sdk/src/queries/vp/pos.rs
@@ -24,10 +24,10 @@ use namada_proof_of_stake::{
     read_consensus_validator_set_addresses_with_stake, read_pos_params,
     read_total_stake, read_validator_description,
     read_validator_discord_handle, read_validator_email,
-    read_validator_max_commission_rate_change, read_validator_stake,
-    read_validator_website, unbond_handle, validator_commission_rate_handle,
-    validator_incoming_redelegations_handle, validator_slashes_handle,
-    validator_state_handle,
+    read_validator_last_slash_epoch, read_validator_max_commission_rate_change,
+    read_validator_stake, read_validator_website, unbond_handle,
+    validator_commission_rate_handle, validator_incoming_redelegations_handle,
+    validator_slashes_handle, validator_state_handle,
 };
 
 use crate::queries::types::RequestCtx;
@@ -57,6 +57,9 @@ router! {POS,
 
         ( "incoming_redelegation" / [src_validator: Address] / [delegator: Address] )
             -> Option<Epoch> = validator_incoming_redelegation,
+
+        ( "last_infraction_epoch" / [validator: Address] )
+            -> Option<Epoch> = validator_last_infraction_epoch,
     },
 
     ( "validator_set" ) = {
@@ -283,6 +286,18 @@ where
         &params,
     )?;
     Ok(state)
+}
+
+/// Get the validator state
+fn validator_last_infraction_epoch<D, H, V, T>(
+    ctx: RequestCtx<'_, D, H, V, T>,
+    validator: Address,
+) -> storage_api::Result<Option<Epoch>>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    read_validator_last_slash_epoch(ctx.wl_storage, &validator)
 }
 
 /// Get the total stake of a validator at the given epoch or current when

--- a/sdk/src/rpc.rs
+++ b/sdk/src/rpc.rs
@@ -807,6 +807,19 @@ pub async fn query_bond<C: crate::queries::Client + Sync>(
     )
 }
 
+/// Query a validator's bonds for a given epoch
+pub async fn query_last_infraction_epoch<C: crate::queries::Client + Sync>(
+    client: &C,
+    validator: &Address,
+) -> Result<Option<Epoch>, error::Error> {
+    convert_response::<C, _>(
+        RPC.vp()
+            .pos()
+            .validator_last_infraction_epoch(client, validator)
+            .await,
+    )
+}
+
 /// Query the accunt substorage space of an address
 pub async fn get_account_info<C: crate::queries::Client + Sync>(
     client: &C,

--- a/sdk/src/tx.rs
+++ b/sdk/src/tx.rs
@@ -900,23 +900,20 @@ pub async fn build_unjail_validator<'a>(
         }
     }
 
-    let last_slash_epoch_key =
-        namada_proof_of_stake::storage::validator_last_slash_key(validator);
-    let last_slash_epoch = rpc::query_storage_value::<_, Epoch>(
-        context.client(),
-        &last_slash_epoch_key,
-    )
-    .await;
+    let last_slash_epoch =
+        rpc::query_last_infraction_epoch(context.client(), validator).await;
     match last_slash_epoch {
-        Ok(last_slash_epoch) => {
+        Ok(Some(last_slash_epoch)) => {
+            // Jailed due to slashing
             let eligible_epoch =
                 last_slash_epoch + params.slash_processing_epoch_offset();
             if current_epoch < eligible_epoch {
                 edisplay_line!(
                     context.io(),
                     "The given validator address {} is currently frozen and \
-                     not yet eligible to be unjailed.",
-                    &validator
+                     will be eligible to be unjailed starting at epoch {}.",
+                    &validator,
+                    eligible_epoch
                 );
                 if !tx_args.force {
                     return Err(Error::from(
@@ -927,16 +924,14 @@ pub async fn build_unjail_validator<'a>(
                 }
             }
         }
-        Err(Error::Query(
-            QueryError::NoSuchKey(_) | QueryError::General(_),
-        )) => {
-            return Err(Error::from(TxError::Other(format!(
-                "The given validator address {} is currently frozen and not \
-                 yet eligible to be unjailed.",
-                &validator
-            ))));
+        Ok(None) => {
+            // Jailed due to liveness only. No checks needed.
         }
-        Err(err) => return Err(err),
+        Err(err) => {
+            if !tx_args.force {
+                return Err(err);
+            }
+        }
     }
 
     build(


### PR DESCRIPTION
## Describe your changes
The client checks for submitting an unjail tx were not updated to consider jailing due to liveness only. More specifically, now an unjail tx should be allowed if no data is found for the last infraction epoch of a currently jailed validator, since the validator can be jailed due to liveness requirements. This is resolved in the PR.

## Indicate on which release or other PRs this topic is based on
v0.27.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
