### PR TITLE
CLI revamp - 0.28.0

### DIFF
--- a/.changelog/unreleased/features/2260-wallet-cli-revamping-main-rebased.md
+++ b/.changelog/unreleased/features/2260-wallet-cli-revamping-main-rebased.md
@@ -1,0 +1,7 @@
+- The wallet CLI structure has been significantly reworked and simplified.
+  Alias argument is now obligatory for key generation / derivation
+  commands. Feature of raw (non-HD) key generation has been restored,
+  which was removed in the previous release. Key export / import
+  functionality for both transparent and shielded key kinds has been
+  implemented. Additionally, several other improvements have been made.
+  ([\#2260](https://github.com/anoma/namada/pull/2260))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -6111,57 +6111,54 @@ pub mod args {
 
     impl Args for KeyAddressList {
         fn parse(matches: &ArgMatches) -> Self {
-            let decrypt = DECRYPT.parse(matches);
             let transparent_only = TRANSPARENT.parse(matches);
             let shielded_only = SHIELDED.parse(matches);
             let keys_only = LIST_FIND_KEYS_ONLY.parse(matches);
             let addresses_only = LIST_FIND_ADDRESSES_ONLY.parse(matches);
+            let decrypt = DECRYPT.parse(matches);
             let unsafe_show_secret = UNSAFE_SHOW_SECRET.parse(matches);
             Self {
-                decrypt,
                 transparent_only,
                 shielded_only,
                 keys_only,
                 addresses_only,
+                decrypt,
                 unsafe_show_secret,
             }
         }
 
         fn def(app: App) -> App {
-            app.arg(DECRYPT.def().help("Decrypt keys that are encrypted."))
-                .arg(
-                    TRANSPARENT
-                        .def()
-                        .help("List transparent keys / addresses only."),
-                )
-                .arg(
-                    SHIELDED.def().help(
-                        "List keys / addresses of the shielded pool only.",
-                    ),
-                )
-                .group(
-                    ArgGroup::new("only_group_1")
-                        .args([TRANSPARENT.name, SHIELDED.name]),
-                )
-                .arg(LIST_FIND_KEYS_ONLY.def().help("List keys only."))
-                .arg(
-                    LIST_FIND_ADDRESSES_ONLY.def().help("List addresses only."),
-                )
-                .group(ArgGroup::new("only_group_2").args([
-                    LIST_FIND_KEYS_ONLY.name,
-                    LIST_FIND_ADDRESSES_ONLY.name,
-                ]))
-                .arg(
-                    UNSAFE_SHOW_SECRET
-                        .def()
-                        .help("UNSAFE: Print the secret / spending keys."),
-                )
+            app.arg(
+                TRANSPARENT
+                    .def()
+                    .help("List transparent keys / addresses only."),
+            )
+            .arg(
+                SHIELDED
+                    .def()
+                    .help("List keys / addresses of the shielded pool only."),
+            )
+            .group(
+                ArgGroup::new("only_group_1")
+                    .args([TRANSPARENT.name, SHIELDED.name]),
+            )
+            .arg(LIST_FIND_KEYS_ONLY.def().help("List keys only."))
+            .arg(LIST_FIND_ADDRESSES_ONLY.def().help("List addresses only."))
+            .group(ArgGroup::new("only_group_2").args([
+                LIST_FIND_KEYS_ONLY.name,
+                LIST_FIND_ADDRESSES_ONLY.name,
+            ]))
+            .arg(DECRYPT.def().help("Decrypt keys that are encrypted."))
+            .arg(
+                UNSAFE_SHOW_SECRET
+                    .def()
+                    .help("UNSAFE: Print the secret / spending keys."),
+            )
         }
     }
 
     impl Args for KeyAddressFind {
         fn parse(matches: &ArgMatches) -> Self {
-            let shielded = SHIELDED.parse(matches);
             let alias = ALIAS_OPT.parse(matches);
             let address = RAW_ADDRESS_OPT.parse(matches);
             let public_key = RAW_PUBLIC_KEY_OPT.parse(matches);
@@ -6169,9 +6166,9 @@ pub mod args {
             let payment_address = RAW_PAYMENT_ADDRESS_OPT.parse(matches);
             let keys_only = LIST_FIND_KEYS_ONLY.parse(matches);
             let addresses_only = LIST_FIND_ADDRESSES_ONLY.parse(matches);
+            let decrypt = DECRYPT.parse(matches);
             let unsafe_show_secret = UNSAFE_SHOW_SECRET.parse(matches);
             Self {
-                shielded,
                 alias,
                 address,
                 public_key,
@@ -6179,28 +6176,21 @@ pub mod args {
                 payment_address,
                 keys_only,
                 addresses_only,
+                decrypt,
                 unsafe_show_secret,
             }
         }
 
         fn def(app: App) -> App {
             app.arg(
-                SHIELDED.def().help(
-                    "Find keys and payment addresses for the shielded pool.",
-                ),
-            )
-            .arg(
                 ALIAS_OPT
                     .def()
                     .help("An alias associated with the keys / addresses."),
             )
             .arg(
-                RAW_ADDRESS_OPT
-                    .def()
-                    .help(
-                        "The bech32m encoded string of a transparent address.",
-                    )
-                    .conflicts_with(SHIELDED.name),
+                RAW_ADDRESS_OPT.def().help(
+                    "The bech32m encoded string of a transparent address.",
+                ),
             )
             .arg(
                 RAW_PUBLIC_KEY_OPT.def().help(
@@ -6210,15 +6200,9 @@ pub mod args {
             .arg(RAW_PUBLIC_KEY_HASH_OPT.def().help(
                 "A public key hash associated with the transparent keypair.",
             ))
-            .arg(
-                RAW_PAYMENT_ADDRESS_OPT
-                    .def()
-                    .help(
-                        "The bech32m encoded string of a shielded payment \
-                         address.",
-                    )
-                    .conflicts_with(SHIELDED.name),
-            )
+            .arg(RAW_PAYMENT_ADDRESS_OPT.def().help(
+                "The bech32m encoded string of a shielded payment address.",
+            ))
             .group(
                 ArgGroup::new("addr_find_args")
                     .args([
@@ -6240,6 +6224,7 @@ pub mod args {
                 "Use pre-genesis wallet, instead of for the current chain, if \
                  any.",
             ))
+            .arg(DECRYPT.def().help("Decrypt keys that are encrypted."))
             .arg(
                 UNSAFE_SHOW_SECRET
                     .def()

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -726,7 +726,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Exports a keypair to a file.")
+                .about("Exports a keypair / spending key to a file.")
                 .add_args::<args::KeyExport>()
         }
     }
@@ -6298,14 +6298,18 @@ pub mod args {
 
     impl Args for KeyExport {
         fn parse(matches: &ArgMatches) -> Self {
+            let shielded = SHIELDED.parse(matches);
             let alias = ALIAS.parse(matches);
-            Self { alias }
+            Self { shielded, alias }
         }
 
         fn def(app: App) -> App {
             app.arg(
-                ALIAS.def().help("The alias of the key you wish to export."),
+                SHIELDED
+                    .def()
+                    .help("Whether to export the shielded spending key."),
             )
+            .arg(ALIAS.def().help("The alias of the key you wish to export."))
         }
     }
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -487,6 +487,8 @@ pub mod cmds {
         Masp(WalletMasp),
         /// TODO
         NewGen(WalletNewGen),
+        /// TODO
+        NewDerive(WalletNewDerive),
     }
 
     impl Cmd for NamadaWallet {
@@ -495,6 +497,7 @@ pub mod cmds {
                 .subcommand(WalletAddress::def())
                 .subcommand(WalletMasp::def())
                 .subcommand(WalletNewGen::def())
+                .subcommand(WalletNewDerive::def())
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -502,7 +505,8 @@ pub mod cmds {
             let address = SubCmd::parse(matches).map(Self::Address);
             let masp = SubCmd::parse(matches).map(Self::Masp);
             let gen_new = SubCmd::parse(matches).map(Self::NewGen);
-            key.or(address).or(masp).or(gen_new)
+            let derive_new = SubCmd::parse(matches).map(Self::NewDerive);
+            key.or(address).or(masp).or(gen_new).or(derive_new)
         }
     }
 
@@ -528,7 +532,6 @@ pub mod cmds {
     #[derive(Clone, Debug)]
     #[allow(clippy::large_enum_variant)]
     pub enum WalletKey {
-        Derive(KeyDerive),
         Find(KeyFind),
         List(KeyList),
         Export(Export),
@@ -539,11 +542,10 @@ pub mod cmds {
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).and_then(|matches| {
-                let restore = SubCmd::parse(matches).map(Self::Derive);
                 let lookup = SubCmd::parse(matches).map(Self::Find);
                 let list = SubCmd::parse(matches).map(Self::List);
                 let export = SubCmd::parse(matches).map(Self::Export);
-                restore.or(lookup).or(list).or(export)
+                lookup.or(list).or(export)
             })
         }
 
@@ -555,7 +557,6 @@ pub mod cmds {
                 )
                 .subcommand_required(true)
                 .arg_required_else_help(true)
-                .subcommand(KeyDerive::def())
                 .subcommand(KeyFind::def())
                 .subcommand(KeyList::def())
                 .subcommand(Export::def())
@@ -564,7 +565,7 @@ pub mod cmds {
 
     /// Restore a keypair and implicit address from the mnemonic code
     #[derive(Clone, Debug)]
-    pub struct KeyDerive(pub args::KeyAndAddressDerive);
+    pub struct KeyDerive(pub args::KeyDerive);
 
     impl SubCmd for KeyDerive {
         const CMD: &'static str = "derive";
@@ -572,7 +573,7 @@ pub mod cmds {
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches
                 .subcommand_matches(Self::CMD)
-                .map(|matches| Self(args::KeyAndAddressDerive::parse(matches)))
+                .map(|matches| Self(args::KeyDerive::parse(matches)))
         }
 
         fn def() -> App {
@@ -584,7 +585,7 @@ pub mod cmds {
                      the given alias. A hardware wallet can be used, in which \
                      case a private key is not derivable.",
                 )
-                .add_args::<args::KeyAndAddressDerive>()
+                .add_args::<args::KeyDerive>()
         }
     }
 
@@ -611,6 +612,34 @@ pub mod cmds {
                      be stored with the same alias. TODO shielded",
                 )
                 .add_args::<args::KeyGen>()
+        }
+    }
+
+    /// In the transparent setting, derive a keypair and implicit address from
+    /// the mnemonic code.
+    /// In the shielded setting, derive a spending key from the mnemonic code.
+    #[derive(Clone, Debug)]
+    pub struct WalletNewDerive(pub args::KeyDerive);
+
+    impl SubCmd for WalletNewDerive {
+        const CMD: &'static str = "derive";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches
+                .subcommand_matches(Self::CMD)
+                .map(|matches| Self(args::KeyDerive::parse(matches)))
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about(
+                    "Derives a keypair from the given mnemonic code and HD \
+                     derivation path and derives the implicit address from \
+                     its public key. Stores the keypair and the address with \
+                     the given alias. A hardware wallet can be used, in which \
+                     case a private key is not derivable. TODO shielded",
+                )
+                .add_args::<args::KeyDerive>()
         }
     }
 
@@ -834,7 +863,6 @@ pub mod cmds {
 
     #[derive(Clone, Debug)]
     pub enum WalletAddress {
-        Derive(AddressDerive),
         Find(AddressOrAliasFind),
         List,
         Add(AddressAdd),
@@ -845,12 +873,11 @@ pub mod cmds {
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).and_then(|matches| {
-                let restore = SubCmd::parse(matches).map(Self::Derive);
                 let find = SubCmd::parse(matches).map(Self::Find);
                 let list =
                     <AddressList as SubCmd>::parse(matches).map(|_| Self::List);
                 let add = SubCmd::parse(matches).map(Self::Add);
-                restore.or(find).or(list).or(add)
+                find.or(list).or(add)
             })
         }
 
@@ -862,36 +889,9 @@ pub mod cmds {
                 )
                 .subcommand_required(true)
                 .arg_required_else_help(true)
-                .subcommand(AddressDerive::def())
                 .subcommand(AddressOrAliasFind::def())
                 .subcommand(AddressList::def())
                 .subcommand(AddressAdd::def())
-        }
-    }
-
-    /// Restore a keypair and an implicit address from the mnemonic code
-    #[derive(Clone, Debug)]
-    pub struct AddressDerive(pub args::KeyAndAddressDerive);
-
-    impl SubCmd for AddressDerive {
-        const CMD: &'static str = "derive";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).map(|matches| {
-                AddressDerive(args::KeyAndAddressDerive::parse(matches))
-            })
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about(
-                    "Derives a keypair from the given mnemonic code and HD \
-                     derivation path and derives the implicit address from \
-                     its public key. Stores the keypair and the address with \
-                     the given alias. A hardware wallet can be used, in which \
-                     case a private key is not derivable.",
-                )
-                .add_args::<args::KeyAndAddressDerive>()
         }
     }
 
@@ -6247,9 +6247,10 @@ pub mod args {
         }
     }
 
-    impl Args for KeyAndAddressDerive {
+    impl Args for KeyDerive {
         fn parse(matches: &ArgMatches) -> Self {
             let scheme = SCHEME.parse(matches);
+            let shielded = SHIELDED.parse(matches);
             let alias = ALIAS_OPT.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
@@ -6257,6 +6258,7 @@ pub mod args {
             let derivation_path = HD_WALLET_DERIVATION_PATH.parse(matches);
             Self {
                 scheme,
+                shielded,
                 alias,
                 alias_force,
                 unsafe_dont_encrypt,
@@ -6266,11 +6268,17 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(SCHEME.def().help(
-                "The type of key that should be added. Argument must be \
-                 either ed25519 or secp256k1. If none provided, the default \
-                 key scheme is ed25519.",
+            app.arg(SCHEME.def().conflicts_with(SHIELDED.name).help(
+                "For the transparent pool, the type of key that should be \
+                 derived. Argument must be either ed25519 or secp256k1. If \
+                 none provided, the default key scheme is ed25519.\nNot \
+                 applicable for the shielded pool.",
             ))
+            .arg(
+                SHIELDED
+                    .def()
+                    .help("Derive a spending key for the shielded pool."),
+            )
             .arg(ALIAS_OPT.def().help(
                 "The key and address alias. If none provided, the alias will \
                  be the public key hash.",
@@ -6357,8 +6365,7 @@ pub mod args {
                  scheme default path:\n- m/44'/60'/0'/0/0 for secp256k1 \
                  scheme\n- m/44'/877'/0'/0'/0' for ed25519 scheme.\nFor \
                  ed25519, all path indices will be promoted to hardened \
-                 indexes. If none specified, mnemonic code and derivation \
-                 path are not used.",
+                 indexes. TODO",
             ))
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -6257,10 +6257,10 @@ pub mod args {
                 "Override the alias without confirmation if it already exists.",
             ))
             .arg(VALUE.def().help(
-                "Any value of the following:\n- transparent pool secret key \
-                 string\n- the bech32m encoded transparent address string\n- \
-                 shielded pool spending key\n- shielded pool viewing key\n- \
-                 shielded pool payment address ",
+                "Any value of the following:\n- transparent pool secret \
+                 key\n- transparent pool public key\n- transparent pool \
+                 address\n- shielded pool spending key\n- shielded pool \
+                 viewing key\n- shielded pool payment address ",
             ))
             .arg(UNSAFE_DONT_ENCRYPT.def().help(
                 "UNSAFE: Do not encrypt the added keys. Do not use this for \

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -2948,6 +2948,7 @@ pub mod args {
     pub const TOKEN: Arg<WalletAddress> = arg("token");
     pub const TRANSFER_SOURCE: Arg<WalletTransferSource> = arg("source");
     pub const TRANSFER_TARGET: Arg<WalletTransferTarget> = arg("target");
+    pub const TRANSPARENT: ArgFlag = flag("transparent");
     pub const TX_HASH: Arg<String> = arg("tx-hash");
     pub const THRESHOLD: ArgOpt<u8> = arg_opt("threshold");
     pub const UNSAFE_DONT_ENCRYPT: ArgFlag = flag("unsafe-dont-encrypt");
@@ -6110,14 +6111,16 @@ pub mod args {
 
     impl Args for KeyAddressList {
         fn parse(matches: &ArgMatches) -> Self {
-            let shielded = SHIELDED.parse(matches);
             let decrypt = DECRYPT.parse(matches);
+            let transparent_only = TRANSPARENT.parse(matches);
+            let shielded_only = SHIELDED.parse(matches);
             let keys_only = LIST_FIND_KEYS_ONLY.parse(matches);
             let addresses_only = LIST_FIND_ADDRESSES_ONLY.parse(matches);
             let unsafe_show_secret = UNSAFE_SHOW_SECRET.parse(matches);
             Self {
-                shielded,
                 decrypt,
+                transparent_only,
+                shielded_only,
                 keys_only,
                 addresses_only,
                 unsafe_show_secret,
@@ -6125,22 +6128,34 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(SHIELDED.def().help(
-                "List viewing / spending keys and payment addresses for the \
-                 shielded pool.",
-            ))
-            .arg(DECRYPT.def().help("Decrypt keys that are encrypted."))
-            .arg(LIST_FIND_KEYS_ONLY.def().help("List keys only."))
-            .arg(LIST_FIND_ADDRESSES_ONLY.def().help("List addresses only."))
-            .group(ArgGroup::new("only_group").args([
-                LIST_FIND_KEYS_ONLY.name,
-                LIST_FIND_ADDRESSES_ONLY.name,
-            ]))
-            .arg(
-                UNSAFE_SHOW_SECRET
-                    .def()
-                    .help("UNSAFE: Print the secret / spending keys."),
-            )
+            app.arg(DECRYPT.def().help("Decrypt keys that are encrypted."))
+                .arg(
+                    TRANSPARENT
+                        .def()
+                        .help("List transparent keys / addresses only."),
+                )
+                .arg(
+                    SHIELDED.def().help(
+                        "List keys / addresses of the shielded pool only.",
+                    ),
+                )
+                .group(
+                    ArgGroup::new("only_group_1")
+                        .args([TRANSPARENT.name, SHIELDED.name]),
+                )
+                .arg(LIST_FIND_KEYS_ONLY.def().help("List keys only."))
+                .arg(
+                    LIST_FIND_ADDRESSES_ONLY.def().help("List addresses only."),
+                )
+                .group(ArgGroup::new("only_group_2").args([
+                    LIST_FIND_KEYS_ONLY.name,
+                    LIST_FIND_ADDRESSES_ONLY.name,
+                ]))
+                .arg(
+                    UNSAFE_SHOW_SECRET
+                        .def()
+                        .help("UNSAFE: Print the secret / spending keys."),
+                )
         }
     }
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -480,48 +480,48 @@ pub mod cmds {
     #[derive(Clone, Debug)]
     pub enum NamadaWallet {
         /// Key generation
-        NewGen(WalletNewGen),
+        KeyGen(WalletGen),
         /// Key derivation
-        NewDerive(WalletNewDerive),
+        KeyDerive(WalletDerive),
         /// Key list
-        NewKeyList(WalletNewKeyList),
+        KeyList(WalletListKeys),
         /// Key search
-        NewKeyFind(WalletNewKeyFind),
+        KeyFind(WalletFindKeys),
         /// Address list
-        NewAddrList(WalletNewAddressList),
+        AddrList(WalletListAddresses),
         /// Address search
-        NewAddrFind(WalletNewAddressFind),
+        AddrFind(WalletFindAddresses),
         /// Key export
-        NewKeyExport(WalletNewExportKey),
+        KeyExport(WalletExportKey),
         /// Key import
-        NewKeyAddrAdd(WalletNewKeyAddressAdd),
+        KeyAddrAdd(WalletAddKeyAddress),
         /// Payment address generation
-        NewPayAddrGen(WalletNewPaymentAddressGen),
+        PayAddrGen(WalletGenPaymentAddress),
     }
 
     impl Cmd for NamadaWallet {
         fn add_sub(app: App) -> App {
-            app.subcommand(WalletNewGen::def())
-                .subcommand(WalletNewDerive::def())
-                .subcommand(WalletNewKeyList::def())
-                .subcommand(WalletNewKeyFind::def())
-                .subcommand(WalletNewAddressList::def())
-                .subcommand(WalletNewAddressFind::def())
-                .subcommand(WalletNewExportKey::def())
-                .subcommand(WalletNewKeyAddressAdd::def())
-                .subcommand(WalletNewPaymentAddressGen::def())
+            app.subcommand(WalletGen::def())
+                .subcommand(WalletDerive::def())
+                .subcommand(WalletListKeys::def())
+                .subcommand(WalletFindKeys::def())
+                .subcommand(WalletListAddresses::def())
+                .subcommand(WalletFindAddresses::def())
+                .subcommand(WalletExportKey::def())
+                .subcommand(WalletAddKeyAddress::def())
+                .subcommand(WalletGenPaymentAddress::def())
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            let gen_new = SubCmd::parse(matches).map(Self::NewGen);
-            let derive_new = SubCmd::parse(matches).map(Self::NewDerive);
-            let key_list_new = SubCmd::parse(matches).map(Self::NewKeyList);
-            let key_find_new = SubCmd::parse(matches).map(Self::NewKeyFind);
-            let addr_list_new = SubCmd::parse(matches).map(Self::NewAddrList);
-            let addr_find_new = SubCmd::parse(matches).map(Self::NewAddrFind);
-            let export_new = SubCmd::parse(matches).map(Self::NewKeyExport);
-            let key_addr_add = SubCmd::parse(matches).map(Self::NewKeyAddrAdd);
-            let pay_addr_gen = SubCmd::parse(matches).map(Self::NewPayAddrGen);
+            let gen_new = SubCmd::parse(matches).map(Self::KeyGen);
+            let derive_new = SubCmd::parse(matches).map(Self::KeyDerive);
+            let key_list_new = SubCmd::parse(matches).map(Self::KeyList);
+            let key_find_new = SubCmd::parse(matches).map(Self::KeyFind);
+            let addr_list_new = SubCmd::parse(matches).map(Self::AddrList);
+            let addr_find_new = SubCmd::parse(matches).map(Self::AddrFind);
+            let export_new = SubCmd::parse(matches).map(Self::KeyExport);
+            let key_addr_add = SubCmd::parse(matches).map(Self::KeyAddrAdd);
+            let pay_addr_gen = SubCmd::parse(matches).map(Self::PayAddrGen);
             gen_new
                 .or(derive_new)
                 .or(key_list_new)
@@ -557,9 +557,9 @@ pub mod cmds {
     /// address derived from it. In the shielded setting, generate a new
     /// spending key.
     #[derive(Clone, Debug)]
-    pub struct WalletNewGen(pub args::KeyGen);
+    pub struct WalletGen(pub args::KeyGen);
 
-    impl SubCmd for WalletNewGen {
+    impl SubCmd for WalletGen {
         const CMD: &'static str = "gen";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -584,9 +584,9 @@ pub mod cmds {
     /// the mnemonic code.
     /// In the shielded setting, derive a spending key from the mnemonic code.
     #[derive(Clone, Debug)]
-    pub struct WalletNewDerive(pub args::KeyDerive);
+    pub struct WalletDerive(pub args::KeyDerive);
 
-    impl SubCmd for WalletNewDerive {
+    impl SubCmd for WalletDerive {
         const CMD: &'static str = "derive";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -613,9 +613,9 @@ pub mod cmds {
 
     /// TODO List all known shielded keys
     #[derive(Clone, Debug)]
-    pub struct WalletNewKeyList(pub args::KeyList);
+    pub struct WalletListKeys(pub args::KeyList);
 
-    impl SubCmd for WalletNewKeyList {
+    impl SubCmd for WalletListKeys {
         const CMD: &'static str = "list-keys";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -637,10 +637,10 @@ pub mod cmds {
     /// TODO Find a keypair in the wallet store
     /// TODO Find the given shielded address or key
     #[derive(Clone, Debug)]
-    pub struct WalletNewKeyFind(pub args::KeyFind);
+    pub struct WalletFindKeys(pub args::KeyFind);
 
-    impl SubCmd for WalletNewKeyFind {
-        const CMD: &'static str = "find-key";
+    impl SubCmd for WalletFindKeys {
+        const CMD: &'static str = "find-keys";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches
@@ -662,9 +662,9 @@ pub mod cmds {
     /// List known addresses
     /// TODO List all known payment addresses
     #[derive(Clone, Debug)]
-    pub struct WalletNewAddressList(pub args::AddressList);
+    pub struct WalletListAddresses(pub args::AddressList);
 
-    impl SubCmd for WalletNewAddressList {
+    impl SubCmd for WalletListAddresses {
         const CMD: &'static str = "list-addr";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -685,9 +685,9 @@ pub mod cmds {
 
     /// Find an address by its alias
     #[derive(Clone, Debug)]
-    pub struct WalletNewAddressFind(pub args::AddressFind);
+    pub struct WalletFindAddresses(pub args::AddressFind);
 
-    impl SubCmd for WalletNewAddressFind {
+    impl SubCmd for WalletFindAddresses {
         const CMD: &'static str = "find-addr";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -707,9 +707,9 @@ pub mod cmds {
 
     /// Export key
     #[derive(Clone, Debug)]
-    pub struct WalletNewExportKey(pub args::KeyExport);
+    pub struct WalletExportKey(pub args::KeyExport);
 
-    impl SubCmd for WalletNewExportKey {
+    impl SubCmd for WalletExportKey {
         const CMD: &'static str = "export";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -727,9 +727,9 @@ pub mod cmds {
 
     /// Add public / payment address to the wallet
     #[derive(Clone, Debug)]
-    pub struct WalletNewKeyAddressAdd(pub args::KeyAddressAdd);
+    pub struct WalletAddKeyAddress(pub args::KeyAddressAdd);
 
-    impl SubCmd for WalletNewKeyAddressAdd {
+    impl SubCmd for WalletAddKeyAddress {
         const CMD: &'static str = "add";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
@@ -750,11 +750,9 @@ pub mod cmds {
 
     /// Generate a payment address from a viewing key or payment address
     #[derive(Clone, Debug)]
-    pub struct WalletNewPaymentAddressGen(
-        pub args::PayAddressGen<args::CliTypes>,
-    );
+    pub struct WalletGenPaymentAddress(pub args::PayAddressGen<args::CliTypes>);
 
-    impl SubCmd for WalletNewPaymentAddressGen {
+    impl SubCmd for WalletGenPaymentAddress {
         const CMD: &'static str = "gen-payment-addr";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -513,22 +513,21 @@ pub mod cmds {
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            let gen_new = SubCmd::parse(matches).map(Self::KeyGen);
-            let derive_new = SubCmd::parse(matches).map(Self::KeyDerive);
-            let key_list_new = SubCmd::parse(matches).map(Self::KeyList);
-            let key_find_new = SubCmd::parse(matches).map(Self::KeyFind);
-            let addr_list_new = SubCmd::parse(matches).map(Self::AddrList);
-            let addr_find_new = SubCmd::parse(matches).map(Self::AddrFind);
-            let export_new = SubCmd::parse(matches).map(Self::KeyExport);
+            let gen = SubCmd::parse(matches).map(Self::KeyGen);
+            let derive = SubCmd::parse(matches).map(Self::KeyDerive);
+            let key_list = SubCmd::parse(matches).map(Self::KeyList);
+            let key_find = SubCmd::parse(matches).map(Self::KeyFind);
+            let addr_list = SubCmd::parse(matches).map(Self::AddrList);
+            let addr_find = SubCmd::parse(matches).map(Self::AddrFind);
+            let export = SubCmd::parse(matches).map(Self::KeyExport);
             let key_addr_add = SubCmd::parse(matches).map(Self::KeyAddrAdd);
             let pay_addr_gen = SubCmd::parse(matches).map(Self::PayAddrGen);
-            gen_new
-                .or(derive_new)
-                .or(key_list_new)
-                .or(key_find_new)
-                .or(addr_list_new)
-                .or(addr_find_new)
-                .or(export_new)
+            gen.or(derive)
+                .or(key_list)
+                .or(key_find)
+                .or(addr_list)
+                .or(addr_find)
+                .or(export)
                 .or(key_addr_add)
                 .or(pay_addr_gen)
         }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -571,9 +571,11 @@ pub mod cmds {
             App::new(Self::CMD)
                 .about("Generates a new transparent / shielded secret key.")
                 .long_about(
-                    "Generates a keypair with a given alias and derives the \
-                     implicit address from its public key. The address will \
-                     be stored with the same alias. TODO shielded",
+                    "In the transparent setting, generates a keypair with a \
+                     given alias and derives the implicit address from its \
+                     public key. The address will be stored with the same \
+                     alias. In the shielded setting, generates a new spending \
+                     key.",
                 )
                 .add_args::<args::KeyGen>()
         }
@@ -6004,7 +6006,7 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let scheme = SCHEME.parse(matches);
             let shielded = SHIELDED.parse(matches);
-            let alias = ALIAS_OPT.parse(matches);
+            let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             let use_device = USE_DEVICE.parse(matches);
@@ -6032,7 +6034,7 @@ pub mod args {
                     .def()
                     .help("Derive a spending key for the shielded pool."),
             )
-            .arg(ALIAS_OPT.def().help(
+            .arg(ALIAS.def().help(
                 "The key and address alias. If none provided, the alias will \
                  be the public key hash.",
             ))
@@ -6065,7 +6067,7 @@ pub mod args {
             let scheme = SCHEME.parse(matches);
             let shielded = SHIELDED.parse(matches);
             let raw = RAW_KEY_GEN.parse(matches);
-            let alias = ALIAS_OPT.parse(matches);
+            let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             let derivation_path = HD_WALLET_DERIVATION_PATH.parse(matches);
@@ -6101,7 +6103,7 @@ pub mod args {
                          mnemonic code is generated.",
                     ),
             )
-            .arg(ALIAS_OPT.def().help(
+            .arg(ALIAS.def().help(
                 "The key and address alias. If none provided, the alias will \
                  be the public key hash.",
             ))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -622,7 +622,7 @@ pub mod cmds {
         }
     }
 
-    /// TODO List all known shielded keys
+    /// List all known keys
     #[derive(Clone, Debug)]
     pub struct WalletListKeys(pub args::KeyList);
 
@@ -637,10 +637,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about(
-                    "TODO List all known keys. Lists all shielded keys in the \
-                     wallet.",
-                )
+                .about("List all known secret / shielded keys in the wallet.")
                 .add_args::<args::KeyList>()
         }
     }
@@ -661,9 +658,11 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about(
-                    "TODO Searches for a keypair from a public key or an \
-                     alias. Find the given shielded address or key in the \
+                .about("Key search")
+                .long_about(
+                    "In the transparent setting, searches for a keypair from \
+                     a public key or an alias.\nIn the shielded setting, \
+                     searches for the given payment address or key in the \
                      wallet.",
                 )
                 .add_args::<args::KeyList>()
@@ -671,7 +670,6 @@ pub mod cmds {
     }
 
     /// List known addresses
-    /// TODO List all known payment addresses
     #[derive(Clone, Debug)]
     pub struct WalletListAddresses(pub args::AddressList);
 
@@ -687,7 +685,7 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about(
-                    "TODO List all known addresses. Lists all payment \
+                    "List all known transparent addresses / shielded payment \
                      addresses in the wallet",
                 )
                 .add_args::<args::AddressList>()
@@ -716,7 +714,7 @@ pub mod cmds {
         }
     }
 
-    /// Export key
+    /// Export key to a file
     #[derive(Clone, Debug)]
     pub struct WalletExportKey(pub args::KeyExport);
 
@@ -6240,10 +6238,11 @@ pub mod args {
                 "Use pre-genesis wallet, instead of for the current chain, if \
                  any.",
             ))
-            .arg(UNSAFE_SHOW_SECRET.def().help(
-                "TODO UNSAFE: Print the secret key.Print the spending key \
-                 values.",
-            ))
+            .arg(
+                UNSAFE_SHOW_SECRET
+                    .def()
+                    .help("UNSAFE: Print the secret / spending key."),
+            )
         }
     }
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -479,8 +479,6 @@ pub mod cmds {
     #[allow(clippy::large_enum_variant)]
     #[derive(Clone, Debug)]
     pub enum NamadaWallet {
-        /// Key management commands
-        Key(WalletKey),
         /// Address management commands
         Address(WalletAddress),
         /// MASP key, address management commands
@@ -497,12 +495,13 @@ pub mod cmds {
         NewAddrList(WalletNewAddressList),
         /// TODO
         NewAddrFind(WalletNewAddressFind),
+        /// TODO
+        NewKeyExport(WalletNewExportKey),
     }
 
     impl Cmd for NamadaWallet {
         fn add_sub(app: App) -> App {
-            app.subcommand(WalletKey::def())
-                .subcommand(WalletAddress::def())
+            app.subcommand(WalletAddress::def())
                 .subcommand(WalletMasp::def())
                 .subcommand(WalletNewGen::def())
                 .subcommand(WalletNewDerive::def())
@@ -510,10 +509,10 @@ pub mod cmds {
                 .subcommand(WalletNewKeyFind::def())
                 .subcommand(WalletNewAddressList::def())
                 .subcommand(WalletNewAddressFind::def())
+                .subcommand(WalletNewExportKey::def())
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            let key = SubCmd::parse(matches).map(Self::Key);
             let address = SubCmd::parse(matches).map(Self::Address);
             let masp = SubCmd::parse(matches).map(Self::Masp);
             let gen_new = SubCmd::parse(matches).map(Self::NewGen);
@@ -522,7 +521,8 @@ pub mod cmds {
             let key_find_new = SubCmd::parse(matches).map(Self::NewKeyFind);
             let addr_list_new = SubCmd::parse(matches).map(Self::NewAddrList);
             let addr_find_new = SubCmd::parse(matches).map(Self::NewAddrFind);
-            key.or(address)
+            let export_new = SubCmd::parse(matches).map(Self::NewKeyExport);
+            address
                 .or(masp)
                 .or(gen_new)
                 .or(derive_new)
@@ -530,6 +530,7 @@ pub mod cmds {
                 .or(key_find_new)
                 .or(addr_list_new)
                 .or(addr_find_new)
+                .or(export_new)
         }
     }
 
@@ -549,34 +550,6 @@ pub mod cmds {
                     .subcommand_required(true)
                     .arg_required_else_help(true),
             )
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    #[allow(clippy::large_enum_variant)]
-    pub enum WalletKey {
-        Export(Export),
-    }
-
-    impl SubCmd for WalletKey {
-        const CMD: &'static str = "key";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).and_then(|matches| {
-                let export = SubCmd::parse(matches).map(Self::Export);
-                export
-            })
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about(
-                    "Keypair management, including methods to generate and \
-                     look-up keys.",
-                )
-                .subcommand_required(true)
-                .arg_required_else_help(true)
-                .subcommand(Export::def())
         }
     }
 
@@ -732,10 +705,11 @@ pub mod cmds {
         }
     }
 
+    /// Export key
     #[derive(Clone, Debug)]
-    pub struct Export(pub args::KeyExport);
+    pub struct WalletNewExportKey(pub args::KeyExport);
 
-    impl SubCmd for Export {
+    impl SubCmd for WalletNewExportKey {
         const CMD: &'static str = "export";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -726,7 +726,10 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Exports a keypair / spending key to a file.")
+                .about(
+                    "Exports a transparent keypair / shielded spending key to \
+                     a file.",
+                )
                 .add_args::<args::KeyExport>()
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -483,12 +483,10 @@ pub mod cmds {
         KeyGen(WalletGen),
         /// Key derivation
         KeyDerive(WalletDerive),
-        /// Key list
-        KeyList(WalletListKeys),
+        /// Key / address list
+        KeyAddrList(WalletListKeysAddresses),
         /// Key search
         KeyFind(WalletFindKeys),
-        /// Address list
-        AddrList(WalletListAddresses),
         /// Address search
         AddrFind(WalletFindAddresses),
         /// Key export
@@ -505,9 +503,8 @@ pub mod cmds {
         fn add_sub(app: App) -> App {
             app.subcommand(WalletGen::def())
                 .subcommand(WalletDerive::def())
-                .subcommand(WalletListKeys::def())
+                .subcommand(WalletListKeysAddresses::def())
                 .subcommand(WalletFindKeys::def())
-                .subcommand(WalletListAddresses::def())
                 .subcommand(WalletFindAddresses::def())
                 .subcommand(WalletExportKey::def())
                 .subcommand(WalletImportKey::def())
@@ -518,18 +515,16 @@ pub mod cmds {
         fn parse(matches: &ArgMatches) -> Option<Self> {
             let gen = SubCmd::parse(matches).map(Self::KeyGen);
             let derive = SubCmd::parse(matches).map(Self::KeyDerive);
-            let key_list = SubCmd::parse(matches).map(Self::KeyList);
+            let key_addr_list = SubCmd::parse(matches).map(Self::KeyAddrList);
             let key_find = SubCmd::parse(matches).map(Self::KeyFind);
-            let addr_list = SubCmd::parse(matches).map(Self::AddrList);
             let addr_find = SubCmd::parse(matches).map(Self::AddrFind);
             let export = SubCmd::parse(matches).map(Self::KeyExport);
             let import = SubCmd::parse(matches).map(Self::KeyImport);
             let key_addr_add = SubCmd::parse(matches).map(Self::KeyAddrAdd);
             let pay_addr_gen = SubCmd::parse(matches).map(Self::PayAddrGen);
             gen.or(derive)
-                .or(key_list)
+                .or(key_addr_list)
                 .or(key_find)
-                .or(addr_list)
                 .or(addr_find)
                 .or(export)
                 .or(import)
@@ -622,23 +617,28 @@ pub mod cmds {
         }
     }
 
-    /// List all known keys
+    /// List known keys and addresses
     #[derive(Clone, Debug)]
-    pub struct WalletListKeys(pub args::KeyList);
+    pub struct WalletListKeysAddresses(pub args::KeyAddressList);
 
-    impl SubCmd for WalletListKeys {
-        const CMD: &'static str = "list-keys";
+    impl SubCmd for WalletListKeysAddresses {
+        const CMD: &'static str = "list";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches
                 .subcommand_matches(Self::CMD)
-                .map(|matches| (Self(args::KeyList::parse(matches))))
+                .map(|matches| (Self(args::KeyAddressList::parse(matches))))
         }
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("List all known secret / shielded keys in the wallet.")
-                .add_args::<args::KeyList>()
+                .about("List known keys and addresses in the wallet.")
+                .long_about(
+                    "In the transparent setting, list known keypairs and \
+                     addresses.\nIn the shielded setting, list known spending \
+                     keys and payment addresses.",
+                )
+                .add_args::<args::KeyAddressList>()
         }
     }
 
@@ -665,30 +665,7 @@ pub mod cmds {
                      searches for the given payment address or key in the \
                      wallet.",
                 )
-                .add_args::<args::KeyList>()
-        }
-    }
-
-    /// List known addresses
-    #[derive(Clone, Debug)]
-    pub struct WalletListAddresses(pub args::AddressList);
-
-    impl SubCmd for WalletListAddresses {
-        const CMD: &'static str = "list-addr";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches
-                .subcommand_matches(Self::CMD)
-                .map(|matches| Self(args::AddressList::parse(matches)))
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about(
-                    "List all known transparent addresses / shielded payment \
-                     addresses in the wallet",
-                )
-                .add_args::<args::AddressList>()
+                .add_args::<args::KeyAddressList>()
         }
     }
 
@@ -2918,8 +2895,9 @@ pub mod args {
             let raw = "127.0.0.1:26657";
             TendermintAddress::from_str(raw).unwrap()
         }));
-
     pub const LEDGER_ADDRESS: Arg<TendermintAddress> = arg("node");
+    pub const LIST_ADDRESSES_ONLY: ArgFlag = flag("addr");
+    pub const LIST_KEYS_ONLY: ArgFlag = flag("keys");
     pub const LOCALHOST: ArgFlag = flag("localhost");
     pub const MASP_VALUE_OPT: ArgOpt<MaspValue> = arg_opt("shielded-value");
     pub const MAX_COMMISSION_RATE_CHANGE: Arg<Dec> =
@@ -6152,25 +6130,30 @@ pub mod args {
         }
     }
 
-    impl Args for KeyList {
+    impl Args for KeyAddressList {
         fn parse(matches: &ArgMatches) -> Self {
             let shielded = SHIELDED.parse(matches);
             let decrypt = DECRYPT.parse(matches);
+            let keys_only = LIST_KEYS_ONLY.parse(matches);
+            let addresses_only = LIST_ADDRESSES_ONLY.parse(matches);
             let unsafe_show_secret = UNSAFE_SHOW_SECRET.parse(matches);
             Self {
                 shielded,
                 decrypt,
+                keys_only,
+                addresses_only,
                 unsafe_show_secret,
             }
         }
 
         fn def(app: App) -> App {
-            app.arg(
-                SHIELDED
-                    .def()
-                    .help("List spending keys for the shielded pool."),
-            )
+            app.arg(SHIELDED.def().help(
+                "List spending keys and payment addresses for the shielded \
+                 pool.",
+            ))
             .arg(DECRYPT.def().help("Decrypt keys that are encrypted."))
+            .arg(LIST_KEYS_ONLY.def().help("List only keys."))
+            .arg(LIST_ADDRESSES_ONLY.def().help("List only addresses."))
             .arg(
                 UNSAFE_SHOW_SECRET
                     .def()
@@ -6243,20 +6226,6 @@ pub mod args {
                     .def()
                     .help("UNSAFE: Print the secret / spending key."),
             )
-        }
-    }
-
-    impl Args for AddressList {
-        fn parse(matches: &ArgMatches) -> Self {
-            let shielded = SHIELDED.parse(matches);
-            Self { shielded }
-        }
-
-        fn def(app: App) -> App {
-            app.arg(PRE_GENESIS.def().help(
-                "Use pre-genesis wallet, instead of for the current chain, if \
-                 any.",
-            ))
         }
     }
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -6314,18 +6314,14 @@ pub mod args {
 
     impl Args for KeyExport {
         fn parse(matches: &ArgMatches) -> Self {
-            let shielded = SHIELDED.parse(matches);
             let alias = ALIAS.parse(matches);
-            Self { shielded, alias }
+            Self { alias }
         }
 
         fn def(app: App) -> App {
             app.arg(
-                SHIELDED
-                    .def()
-                    .help("Whether to export the shielded spending key."),
+                ALIAS.def().help("The alias of the key you wish to export."),
             )
-            .arg(ALIAS.def().help("The alias of the key you wish to export."))
         }
     }
 
@@ -6354,8 +6350,8 @@ pub mod args {
                     .help("An alias to be associated with the imported entry."),
             )
             .arg(UNSAFE_DONT_ENCRYPT.def().help(
-                "UNSAFE: Do not encrypt the added keys. Do not use this for \
-                 keys used in a live network.",
+                "UNSAFE: Do not encrypt the imported keys. Do not use this \
+                 for keys used in a live network.",
             ))
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1842,7 +1842,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Change commission raate.")
+                .about("Change commission rate.")
                 .add_args::<args::CommissionRateChange<args::CliTypes>>()
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -479,8 +479,6 @@ pub mod cmds {
     #[allow(clippy::large_enum_variant)]
     #[derive(Clone, Debug)]
     pub enum NamadaWallet {
-        /// MASP key, address management commands
-        Masp(WalletMasp),
         /// Key generation
         NewGen(WalletNewGen),
         /// Key derivation
@@ -497,12 +495,13 @@ pub mod cmds {
         NewKeyExport(WalletNewExportKey),
         /// Key import
         NewKeyAddrAdd(WalletNewKeyAddressAdd),
+        /// Payment address generation
+        NewPayAddrGen(WalletNewPaymentAddressGen),
     }
 
     impl Cmd for NamadaWallet {
         fn add_sub(app: App) -> App {
-            app.subcommand(WalletMasp::def())
-                .subcommand(WalletNewGen::def())
+            app.subcommand(WalletNewGen::def())
                 .subcommand(WalletNewDerive::def())
                 .subcommand(WalletNewKeyList::def())
                 .subcommand(WalletNewKeyFind::def())
@@ -510,10 +509,10 @@ pub mod cmds {
                 .subcommand(WalletNewAddressFind::def())
                 .subcommand(WalletNewExportKey::def())
                 .subcommand(WalletNewKeyAddressAdd::def())
+                .subcommand(WalletNewPaymentAddressGen::def())
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            let masp = SubCmd::parse(matches).map(Self::Masp);
             let gen_new = SubCmd::parse(matches).map(Self::NewGen);
             let derive_new = SubCmd::parse(matches).map(Self::NewDerive);
             let key_list_new = SubCmd::parse(matches).map(Self::NewKeyList);
@@ -522,7 +521,8 @@ pub mod cmds {
             let addr_find_new = SubCmd::parse(matches).map(Self::NewAddrFind);
             let export_new = SubCmd::parse(matches).map(Self::NewKeyExport);
             let key_addr_add = SubCmd::parse(matches).map(Self::NewKeyAddrAdd);
-            masp.or(gen_new)
+            let pay_addr_gen = SubCmd::parse(matches).map(Self::NewPayAddrGen);
+            gen_new
                 .or(derive_new)
                 .or(key_list_new)
                 .or(key_find_new)
@@ -530,6 +530,7 @@ pub mod cmds {
                 .or(addr_find_new)
                 .or(export_new)
                 .or(key_addr_add)
+                .or(pay_addr_gen)
         }
     }
 
@@ -747,66 +748,19 @@ pub mod cmds {
         }
     }
 
-    #[allow(clippy::large_enum_variant)]
-    #[derive(Clone, Debug)]
-    pub enum WalletMasp {
-        GenPayAddr(MaspGenPayAddr),
-    }
-
-    impl SubCmd for WalletMasp {
-        const CMD: &'static str = "masp";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).and_then(|matches| {
-                let genpa = SubCmd::parse(matches).map(Self::GenPayAddr);
-                genpa
-            })
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about(
-                    "Multi-asset shielded pool address and keypair management \
-                     including methods to generate and look-up addresses and \
-                     keys.",
-                )
-                .subcommand_required(true)
-                .arg_required_else_help(true)
-                .subcommand(MaspGenPayAddr::def())
-        }
-    }
-
-    /// Generate a spending key
-    #[derive(Clone, Debug)]
-    pub struct MaspGenSpendKey(pub args::MaspSpendKeyGen);
-
-    impl SubCmd for MaspGenSpendKey {
-        const CMD: &'static str = "gen-key";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).map(|matches| {
-                MaspGenSpendKey(args::MaspSpendKeyGen::parse(matches))
-            })
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about("Generates a random spending key")
-                .add_args::<args::MaspSpendKeyGen>()
-        }
-    }
-
     /// Generate a payment address from a viewing key or payment address
     #[derive(Clone, Debug)]
-    pub struct MaspGenPayAddr(pub args::MaspPayAddrGen<args::CliTypes>);
+    pub struct WalletNewPaymentAddressGen(
+        pub args::PayAddressGen<args::CliTypes>,
+    );
 
-    impl SubCmd for MaspGenPayAddr {
-        const CMD: &'static str = "gen-addr";
+    impl SubCmd for WalletNewPaymentAddressGen {
+        const CMD: &'static str = "gen-payment-addr";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).map(|matches| {
-                MaspGenPayAddr(args::MaspPayAddrGen::parse(matches))
-            })
+            matches
+                .subcommand_matches(Self::CMD)
+                .map(|matches| Self(args::PayAddressGen::parse(matches)))
         }
 
         fn def() -> App {
@@ -814,23 +768,7 @@ pub mod cmds {
                 .about(
                     "Generates a payment address from the given spending key",
                 )
-                .add_args::<args::MaspPayAddrGen<args::CliTypes>>()
-        }
-    }
-
-    /// List known addresses
-    #[derive(Clone, Debug)]
-    pub struct AddressList;
-
-    impl SubCmd for AddressList {
-        const CMD: &'static str = "list";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).map(|_| Self)
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD).about("List all known addresses.")
+                .add_args::<args::PayAddressGen<args::CliTypes>>()
         }
     }
 
@@ -6000,36 +5938,8 @@ pub mod args {
         }
     }
 
-    impl Args for MaspSpendKeyGen {
-        fn parse(matches: &ArgMatches) -> Self {
-            let alias = ALIAS.parse(matches);
-            let alias_force = ALIAS_FORCE.parse(matches);
-            let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
-            Self {
-                alias,
-                alias_force,
-                unsafe_dont_encrypt,
-            }
-        }
-
-        fn def(app: App) -> App {
-            app.arg(
-                ALIAS
-                    .def()
-                    .help("An alias to be associated with the spending key."),
-            )
-            .arg(ALIAS_FORCE.def().help(
-                "Override the alias without confirmation if it already exists.",
-            ))
-            .arg(UNSAFE_DONT_ENCRYPT.def().help(
-                "UNSAFE: Do not encrypt the keypair. Do not use this for keys \
-                 used in a live network.",
-            ))
-        }
-    }
-
-    impl CliToSdk<MaspPayAddrGen<SdkTypes>> for MaspPayAddrGen<CliTypes> {
-        fn to_sdk(self, ctx: &mut Context) -> MaspPayAddrGen<SdkTypes> {
+    impl CliToSdk<PayAddressGen<SdkTypes>> for PayAddressGen<CliTypes> {
+        fn to_sdk(self, ctx: &mut Context) -> PayAddressGen<SdkTypes> {
             use namada_sdk::wallet::Wallet;
 
             use crate::wallet::CliWalletUtils;
@@ -6053,7 +5963,7 @@ pub mod args {
             } else {
                 find_viewing_key(&mut ctx.borrow_mut_chain_or_exit().wallet)
             };
-            MaspPayAddrGen::<SdkTypes> {
+            PayAddressGen::<SdkTypes> {
                 alias: self.alias,
                 alias_force: self.alias_force,
                 viewing_key,
@@ -6062,7 +5972,7 @@ pub mod args {
         }
     }
 
-    impl Args for MaspPayAddrGen<CliTypes> {
+    impl Args for PayAddressGen<CliTypes> {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
@@ -6335,7 +6245,7 @@ pub mod args {
                     .help("The bech32m encoded address string."),
             )
             .group(
-                ArgGroup::new("find_flags")
+                ArgGroup::new("addr_find_args")
                     .args([ALIAS_OPT.name, RAW_ADDRESS_OPT.name])
                     .required(true),
             )

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -749,10 +749,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about(
-                    "Adds the given transparent / payment address or key to \
-                     the wallet.",
-                )
+                .about("Adds the given key or address to the wallet.")
                 .add_args::<args::KeyAddressAdd>()
         }
     }
@@ -2986,7 +2983,8 @@ pub mod args {
         arg_opt("eth-cold-key");
     pub const VALIDATOR_ETH_HOT_KEY: ArgOpt<WalletPublicKey> =
         arg_opt("eth-hot-key");
-    pub const VALUE: ArgOpt<String> = arg_opt("value");
+    pub const VALUE: Arg<String> = arg("value");
+    pub const VALUE_OPT: ArgOpt<String> = VALUE.opt();
     pub const VIEWING_KEY: Arg<WalletViewingKey> = arg("key");
     pub const VP: ArgOpt<String> = arg_opt("vp");
     pub const WALLET_ALIAS_FORCE: ArgFlag = flag("wallet-alias-force");
@@ -6159,7 +6157,7 @@ pub mod args {
             let shielded = SHIELDED.parse(matches);
             let alias = ALIAS_OPT.parse(matches);
             let public_key = RAW_PUBLIC_KEY_OPT.parse(matches);
-            let value = VALUE.parse(matches);
+            let value = VALUE_OPT.parse(matches);
             let unsafe_show_secret = UNSAFE_SHOW_SECRET.parse(matches);
 
             Self {
@@ -6176,7 +6174,10 @@ pub mod args {
                 SHIELDED
                     .def()
                     .help("Find spending key for the shielded pool.")
-                    .conflicts_with_all([VALUE.name, RAW_PUBLIC_KEY_OPT.name]),
+                    .conflicts_with_all([
+                        VALUE_OPT.name,
+                        RAW_PUBLIC_KEY_OPT.name,
+                    ]),
             )
             .arg(
                 ALIAS_OPT
@@ -6185,7 +6186,7 @@ pub mod args {
                         "TODO An alias associated with the keypair. The alias \
                          that is to be found.",
                     )
-                    .conflicts_with(VALUE.name),
+                    .conflicts_with(VALUE_OPT.name),
             )
             .arg(
                 RAW_PUBLIC_KEY_OPT
@@ -6193,13 +6194,17 @@ pub mod args {
                     .help("A public key associated with the keypair."),
             )
             .arg(
-                VALUE
+                VALUE_OPT
                     .def()
                     .help("A public key or alias associated with the keypair."),
             )
             .group(
                 ArgGroup::new("key_find_args")
-                    .args([ALIAS_OPT.name, RAW_PUBLIC_KEY_OPT.name, VALUE.name])
+                    .args([
+                        ALIAS_OPT.name,
+                        RAW_PUBLIC_KEY_OPT.name,
+                        VALUE_OPT.name,
+                    ])
                     .required(true),
             )
             .arg(PRE_GENESIS.def().help(
@@ -6257,13 +6262,11 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
-            let address = RAW_ADDRESS_OPT.parse(matches);
-            let value = MASP_VALUE_OPT.parse(matches);
+            let value = VALUE.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             Self {
                 alias,
                 alias_force,
-                address,
                 value,
                 unsafe_dont_encrypt,
             }
@@ -6278,20 +6281,12 @@ pub mod args {
             .arg(ALIAS_FORCE.def().help(
                 "Override the alias without confirmation if it already exists.",
             ))
-            .arg(
-                RAW_ADDRESS_OPT
-                    .def()
-                    .help("The bech32m encoded transparent address string."),
-            )
-            .arg(MASP_VALUE_OPT.def().help(
-                "A spending key, viewing key, or payment address of the \
-                 shielded pool.",
+            .arg(VALUE.def().help(
+                "Any value of the following:\n- transparent pool secret key \
+                 string\n- the bech32m encoded transparent address string\n- \
+                 shielded pool spending key\n- shielded pool viewing key\n- \
+                 shielded pool payment address ",
             ))
-            .group(
-                ArgGroup::new("key_address_add_args")
-                    .args([RAW_ADDRESS_OPT.name, MASP_VALUE_OPT.name])
-                    .required(true),
-            )
             .arg(UNSAFE_DONT_ENCRYPT.def().help(
                 "UNSAFE: Do not encrypt the added keys. Do not use this for \
                  keys used in a live network.",

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -6216,7 +6216,7 @@ pub mod args {
                     .required(true),
             )
             .arg(LIST_FIND_KEYS_ONLY.def().help("Find keys only."))
-            .arg(LIST_FIND_ADDRESSES_ONLY.def().help("List addresses only."))
+            .arg(LIST_FIND_ADDRESSES_ONLY.def().help("Find addresses only."))
             .group(ArgGroup::new("only_group").args([
                 LIST_FIND_KEYS_ONLY.name,
                 LIST_FIND_ADDRESSES_ONLY.name,

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -636,7 +636,7 @@ pub mod cmds {
                 .long_about(
                     "In the transparent setting, list known keypairs and \
                      addresses.\nIn the shielded setting, list known spending \
-                     keys and payment addresses.",
+                     / viewing keys and payment addresses.",
                 )
                 .add_args::<args::KeyAddressList>()
         }
@@ -773,7 +773,7 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about(
-                    "Generates a payment address from the given spending key",
+                    "Generates a payment address from the given spending key.",
                 )
                 .add_args::<args::PayAddressGen<args::CliTypes>>()
         }
@@ -6148,8 +6148,8 @@ pub mod args {
 
         fn def(app: App) -> App {
             app.arg(SHIELDED.def().help(
-                "List spending keys and payment addresses for the shielded \
-                 pool.",
+                "List viewing / spending keys and payment addresses for the \
+                 shielded pool.",
             ))
             .arg(DECRYPT.def().help("Decrypt keys that are encrypted."))
             .arg(LIST_KEYS_ONLY.def().help("List only keys."))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -479,30 +479,29 @@ pub mod cmds {
     #[allow(clippy::large_enum_variant)]
     #[derive(Clone, Debug)]
     pub enum NamadaWallet {
-        /// Address management commands
-        Address(WalletAddress),
         /// MASP key, address management commands
         Masp(WalletMasp),
-        /// TODO
+        /// Key generation
         NewGen(WalletNewGen),
-        /// TODO
+        /// Key derivation
         NewDerive(WalletNewDerive),
-        /// TODO
+        /// Key list
         NewKeyList(WalletNewKeyList),
-        /// TODO
+        /// Key search
         NewKeyFind(WalletNewKeyFind),
-        /// TODO
+        /// Address list
         NewAddrList(WalletNewAddressList),
-        /// TODO
+        /// Address search
         NewAddrFind(WalletNewAddressFind),
-        /// TODO
+        /// Key export
         NewKeyExport(WalletNewExportKey),
+        /// Key import
+        NewKeyAddrAdd(WalletNewKeyAddressAdd),
     }
 
     impl Cmd for NamadaWallet {
         fn add_sub(app: App) -> App {
-            app.subcommand(WalletAddress::def())
-                .subcommand(WalletMasp::def())
+            app.subcommand(WalletMasp::def())
                 .subcommand(WalletNewGen::def())
                 .subcommand(WalletNewDerive::def())
                 .subcommand(WalletNewKeyList::def())
@@ -510,10 +509,10 @@ pub mod cmds {
                 .subcommand(WalletNewAddressList::def())
                 .subcommand(WalletNewAddressFind::def())
                 .subcommand(WalletNewExportKey::def())
+                .subcommand(WalletNewKeyAddressAdd::def())
         }
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            let address = SubCmd::parse(matches).map(Self::Address);
             let masp = SubCmd::parse(matches).map(Self::Masp);
             let gen_new = SubCmd::parse(matches).map(Self::NewGen);
             let derive_new = SubCmd::parse(matches).map(Self::NewDerive);
@@ -522,15 +521,15 @@ pub mod cmds {
             let addr_list_new = SubCmd::parse(matches).map(Self::NewAddrList);
             let addr_find_new = SubCmd::parse(matches).map(Self::NewAddrFind);
             let export_new = SubCmd::parse(matches).map(Self::NewKeyExport);
-            address
-                .or(masp)
-                .or(gen_new)
+            let key_addr_add = SubCmd::parse(matches).map(Self::NewKeyAddrAdd);
+            masp.or(gen_new)
                 .or(derive_new)
                 .or(key_list_new)
                 .or(key_find_new)
                 .or(addr_list_new)
                 .or(addr_find_new)
                 .or(export_new)
+                .or(key_addr_add)
         }
     }
 
@@ -725,11 +724,33 @@ pub mod cmds {
         }
     }
 
+    /// Add public / payment address to the wallet
+    #[derive(Clone, Debug)]
+    pub struct WalletNewKeyAddressAdd(pub args::KeyAddressAdd);
+
+    impl SubCmd for WalletNewKeyAddressAdd {
+        const CMD: &'static str = "add";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches
+                .subcommand_matches(Self::CMD)
+                .map(|matches| (Self(args::KeyAddressAdd::parse(matches))))
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about(
+                    "Adds the given transparent / payment address or key to \
+                     the wallet.",
+                )
+                .add_args::<args::KeyAddressAdd>()
+        }
+    }
+
     #[allow(clippy::large_enum_variant)]
     #[derive(Clone, Debug)]
     pub enum WalletMasp {
         GenPayAddr(MaspGenPayAddr),
-        AddAddrKey(MaspAddAddrKey),
     }
 
     impl SubCmd for WalletMasp {
@@ -738,8 +759,7 @@ pub mod cmds {
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).and_then(|matches| {
                 let genpa = SubCmd::parse(matches).map(Self::GenPayAddr);
-                let addak = SubCmd::parse(matches).map(Self::AddAddrKey);
-                genpa.or(addak)
+                genpa
             })
         }
 
@@ -753,27 +773,6 @@ pub mod cmds {
                 .subcommand_required(true)
                 .arg_required_else_help(true)
                 .subcommand(MaspGenPayAddr::def())
-                .subcommand(MaspAddAddrKey::def())
-        }
-    }
-
-    /// Add a key or an address
-    #[derive(Clone, Debug)]
-    pub struct MaspAddAddrKey(pub args::MaspAddrKeyAdd);
-
-    impl SubCmd for MaspAddAddrKey {
-        const CMD: &'static str = "add";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).map(|matches| {
-                MaspAddAddrKey(args::MaspAddrKeyAdd::parse(matches))
-            })
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about("Adds the given payment address or key to the wallet")
-                .add_args::<args::MaspAddrKeyAdd>()
         }
     }
 
@@ -819,33 +818,6 @@ pub mod cmds {
         }
     }
 
-    #[derive(Clone, Debug)]
-    pub enum WalletAddress {
-        Add(AddressAdd),
-    }
-
-    impl SubCmd for WalletAddress {
-        const CMD: &'static str = "address";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).and_then(|matches| {
-                let add = SubCmd::parse(matches).map(Self::Add);
-                add
-            })
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about(
-                    "Address management, including methods to generate and \
-                     look-up addresses.",
-                )
-                .subcommand_required(true)
-                .arg_required_else_help(true)
-                .subcommand(AddressAdd::def())
-        }
-    }
-
     /// List known addresses
     #[derive(Clone, Debug)]
     pub struct AddressList;
@@ -859,26 +831,6 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD).about("List all known addresses.")
-        }
-    }
-
-    /// Generate a new keypair and an implicit address derived from it
-    #[derive(Clone, Debug)]
-    pub struct AddressAdd(pub args::AddressAdd);
-
-    impl SubCmd for AddressAdd {
-        const CMD: &'static str = "add";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches
-                .subcommand_matches(Self::CMD)
-                .map(|matches| AddressAdd(args::AddressAdd::parse(matches)))
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about("Store an alias for an address in the wallet.")
-                .add_args::<args::AddressAdd>()
         }
     }
 
@@ -3000,7 +2952,7 @@ pub mod args {
 
     pub const LEDGER_ADDRESS: Arg<TendermintAddress> = arg("node");
     pub const LOCALHOST: ArgFlag = flag("localhost");
-    pub const MASP_VALUE: Arg<MaspValue> = arg("value");
+    pub const MASP_VALUE_OPT: ArgOpt<MaspValue> = arg_opt("shielded-value");
     pub const MAX_COMMISSION_RATE_CHANGE: Arg<Dec> =
         arg("max-commission-rate-change");
     pub const MAX_ETH_GAS: ArgOpt<u64> = arg_opt("max_eth-gas");
@@ -6048,41 +6000,6 @@ pub mod args {
         }
     }
 
-    impl Args for MaspAddrKeyAdd {
-        fn parse(matches: &ArgMatches) -> Self {
-            let alias = ALIAS.parse(matches);
-            let alias_force = ALIAS_FORCE.parse(matches);
-            let value = MASP_VALUE.parse(matches);
-            let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
-            Self {
-                alias,
-                alias_force,
-                value,
-                unsafe_dont_encrypt,
-            }
-        }
-
-        fn def(app: App) -> App {
-            app.arg(
-                ALIAS
-                    .def()
-                    .help("An alias to be associated with the new entry."),
-            )
-            .arg(ALIAS_FORCE.def().help(
-                "Override the alias without confirmation if it already exists.",
-            ))
-            .arg(
-                MASP_VALUE
-                    .def()
-                    .help("A spending key, viewing key, or payment address."),
-            )
-            .arg(UNSAFE_DONT_ENCRYPT.def().help(
-                "UNSAFE: Do not encrypt the keypair. Do not use this for keys \
-                 used in a live network.",
-            ))
-        }
-    }
-
     impl Args for MaspSpendKeyGen {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
@@ -6370,7 +6287,7 @@ pub mod args {
                     .help("A public key or alias associated with the keypair."),
             )
             .group(
-                ArgGroup::new("key_find_flags")
+                ArgGroup::new("key_find_args")
                     .args([ALIAS_OPT.name, RAW_PUBLIC_KEY_OPT.name, VALUE.name])
                     .required(true),
             )
@@ -6425,15 +6342,19 @@ pub mod args {
         }
     }
 
-    impl Args for AddressAdd {
+    impl Args for KeyAddressAdd {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
-            let address = RAW_ADDRESS.parse(matches);
+            let address = RAW_ADDRESS_OPT.parse(matches);
+            let value = MASP_VALUE_OPT.parse(matches);
+            let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             Self {
                 alias,
                 alias_force,
                 address,
+                value,
+                unsafe_dont_encrypt,
             }
         }
 
@@ -6441,16 +6362,29 @@ pub mod args {
             app.arg(
                 ALIAS
                     .def()
-                    .help("An alias to be associated with the address."),
+                    .help("An alias to be associated with the new entry."),
             )
             .arg(ALIAS_FORCE.def().help(
                 "Override the alias without confirmation if it already exists.",
             ))
             .arg(
-                RAW_ADDRESS
+                RAW_ADDRESS_OPT
                     .def()
-                    .help("The bech32m encoded address string."),
+                    .help("The bech32m encoded transparent address string."),
             )
+            .arg(MASP_VALUE_OPT.def().help(
+                "A spending key, viewing key, or payment address of the \
+                 shielded pool.",
+            ))
+            .group(
+                ArgGroup::new("key_address_add_args")
+                    .args([RAW_ADDRESS_OPT.name, MASP_VALUE_OPT.name])
+                    .required(true),
+            )
+            .arg(UNSAFE_DONT_ENCRYPT.def().help(
+                "UNSAFE: Do not encrypt the added keys. Do not use this for \
+                 keys used in a live network.",
+            ))
         }
     }
 

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -574,8 +574,10 @@ pub mod cmds {
                     "In the transparent setting, generates a keypair with a \
                      given alias and derives the implicit address from its \
                      public key. The address will be stored with the same \
-                     alias. In the shielded setting, generates a new spending \
-                     key.",
+                     alias.\nIn the shielded setting, generates a new \
+                     spending key with a given alias.\nIn both settings, by \
+                     default, an HD-key with a default derivation path is \
+                     generated, with a random mnemonic code.",
                 )
                 .add_args::<args::KeyGen>()
         }
@@ -599,14 +601,17 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about(
-                    "Derive transparent / shielded key from the mnemonic code.",
+                    "Derive transparent / shielded key from the mnemonic code \
+                     or a seed stored on the hardware wallet device.",
                 )
                 .long_about(
-                    "Derives a keypair from the given mnemonic code and HD \
-                     derivation path and derives the implicit address from \
-                     its public key. Stores the keypair and the address with \
-                     the given alias. A hardware wallet can be used, in which \
-                     case a private key is not derivable. TODO shielded",
+                    "In the transparent setting, derives a keypair from the \
+                     given mnemonic code and HD derivation path and derives \
+                     the implicit address from its public key. Stores the \
+                     keypair and the address with the given alias.\nIn the \
+                     shielded setting, derives a spending key.\nA hardware \
+                     wallet can be used, in which case the private key is not \
+                     derivable.",
                 )
                 .add_args::<args::KeyDerive>()
         }
@@ -6034,10 +6039,7 @@ pub mod args {
                     .def()
                     .help("Derive a spending key for the shielded pool."),
             )
-            .arg(ALIAS.def().help(
-                "The key and address alias. If none provided, the alias will \
-                 be the public key hash.",
-            ))
+            .arg(ALIAS.def().help("The key and address alias."))
             .arg(
                 ALIAS_FORCE
                     .def()
@@ -6103,10 +6105,7 @@ pub mod args {
                          mnemonic code is generated.",
                     ),
             )
-            .arg(ALIAS.def().help(
-                "The key and address alias. If none provided, the alias will \
-                 be the public key hash.",
-            ))
+            .arg(ALIAS.def().help("The key and address alias."))
             .arg(ALIAS_FORCE.def().help(
                 "Override the alias without confirmation if it already exists.",
             ))
@@ -6115,12 +6114,12 @@ pub mod args {
                  used in a live network.",
             ))
             .arg(HD_WALLET_DERIVATION_PATH.def().help(
-                "Generate a new key and wallet using BIP39 mnemonic code and \
-                 HD derivation path. Use keyword `default` to refer to a \
+                "HD key derivation path. Use keyword `default` to refer to a \
                  scheme default path:\n- m/44'/60'/0'/0/0 for secp256k1 \
                  scheme\n- m/44'/877'/0'/0'/0' for ed25519 scheme.\nFor \
                  ed25519, all path indices will be promoted to hardened \
-                 indexes. TODO",
+                 indexes. If none is specified, the scheme default path is \
+                 used.",
             ))
         }
     }

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -488,7 +488,7 @@ fn key_gen(ctx: Context, io: &impl Io, args_key_gen: args::KeyGen) {
     }
 }
 
-/// TODO
+/// HD key derivation from mnemonic code
 async fn key_derive(
     ctx: Context,
     io: &impl Io,

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -972,6 +972,7 @@ fn shielded_key_address_find_by_alias(
             .unwrap();
         }
     }
+
     found
 }
 

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -88,7 +88,8 @@ fn spending_keys_list(
         display_line!(
             io,
             "No known keys. Try `add --alias my-addr --value ...` to add a \
-             new key to the wallet, or `gen --shielded` to generate a new key.",
+             new key to the wallet, or `gen --shielded --alias my-key` to \
+             generate a new key.",
         );
     } else {
         let stdout = io::stdout();

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -39,12 +39,6 @@ impl CliApi {
         io: &impl Io,
     ) -> Result<()> {
         match cmd {
-            cmds::NamadaWallet::Masp(sub) => match sub {
-                cmds::WalletMasp::GenPayAddr(cmds::MaspGenPayAddr(args)) => {
-                    let args = args.to_sdk(&mut ctx);
-                    payment_address_gen(ctx, io, args)
-                }
-            },
             cmds::NamadaWallet::NewGen(cmds::WalletNewGen(args)) => {
                 key_gen(ctx, io, args)
             }
@@ -69,6 +63,12 @@ impl CliApi {
             cmds::NamadaWallet::NewKeyAddrAdd(
                 cmds::WalletNewKeyAddressAdd(args),
             ) => key_address_add(ctx, io, args),
+            cmds::NamadaWallet::NewPayAddrGen(
+                cmds::WalletNewPaymentAddressGen(args),
+            ) => {
+                let args = args.to_sdk(&mut ctx);
+                payment_address_gen(ctx, io, args)
+            }
         }
         Ok(())
     }
@@ -210,13 +210,13 @@ fn spending_key_gen(
 fn payment_address_gen(
     ctx: Context,
     io: &impl Io,
-    args::MaspPayAddrGen {
+    args::PayAddressGen {
         alias,
         alias_force,
         viewing_key,
         pin,
         ..
-    }: args::MaspPayAddrGen,
+    }: args::PayAddressGen,
 ) {
     let mut wallet = load_wallet(ctx);
     let alias = alias.to_lowercase();

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -162,8 +162,8 @@ fn payment_addresses_list(
     if known_addresses.is_empty() {
         display_line!(
             io,
-            "No known payment addresses. Try `masp gen-addr --alias my-addr` \
-             to generate a new payment address.",
+            "TODO No known payment addresses. Try `masp gen-addr --alias \
+             my-addr` to generate a new payment address.",
         );
     } else {
         let stdout = io::stdout();

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -101,11 +101,11 @@ fn shielded_keys_list(
             // If this alias is associated with a spending key, indicate whether
             // or not the spending key is encrypted
             let encrypted_status = match spending_key_opt {
-                None => "",
-                Some(spend_key) if spend_key.is_encrypted() => "(encrypted)",
-                _ => "(not encrypted)",
+                None => "external",
+                Some(spend_key) if spend_key.is_encrypted() => "encrypted",
+                _ => "not encrypted",
             };
-            display!(io, &mut w_lock; "  Alias \"{}\" {}", alias, encrypted_status).unwrap();
+            display!(io, &mut w_lock; "  Alias \"{}\" ({})", alias, encrypted_status).unwrap();
             // Always print the corresponding viewing key
             display_line!(io, &mut w_lock; "    Viewing Key: {}", key).unwrap();
             // A subset of viewing keys will have corresponding spending keys.

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -40,18 +40,11 @@ impl CliApi {
     ) -> Result<()> {
         match cmd {
             cmds::NamadaWallet::Key(sub) => match sub {
-                cmds::WalletKey::Find(cmds::KeyFind(args)) => {
-                    key_find(ctx, io, args)
-                }
                 cmds::WalletKey::Export(cmds::Export(args)) => {
                     key_export(ctx, io, args)
                 }
             },
             cmds::NamadaWallet::Address(sub) => match sub {
-                cmds::WalletAddress::Find(cmds::AddressOrAliasFind(args)) => {
-                    address_or_alias_find(ctx, io, args)
-                }
-                cmds::WalletAddress::List => address_list(ctx, io),
                 cmds::WalletAddress::Add(cmds::AddressAdd(args)) => {
                     address_add(ctx, io, args)
                 }
@@ -64,12 +57,6 @@ impl CliApi {
                 cmds::WalletMasp::AddAddrKey(cmds::MaspAddAddrKey(args)) => {
                     address_key_add(ctx, io, args)
                 }
-                cmds::WalletMasp::ListPayAddrs => {
-                    payment_addresses_list(ctx, io)
-                }
-                cmds::WalletMasp::FindAddrKey(cmds::MaspFindAddrKey(args)) => {
-                    address_key_find(ctx, io, args)
-                }
             },
             cmds::NamadaWallet::NewGen(cmds::WalletNewGen(args)) => {
                 key_gen(ctx, io, args)
@@ -80,47 +67,17 @@ impl CliApi {
             cmds::NamadaWallet::NewKeyList(cmds::WalletNewKeyList(args)) => {
                 key_list(ctx, io, args)
             }
+            cmds::NamadaWallet::NewKeyFind(cmds::WalletNewKeyFind(args)) => {
+                key_find(ctx, io, args)
+            }
+            cmds::NamadaWallet::NewAddrList(cmds::WalletNewAddressList(
+                args,
+            )) => address_list(ctx, io, args),
+            cmds::NamadaWallet::NewAddrFind(cmds::WalletNewAddressFind(
+                args,
+            )) => address_or_alias_find(ctx, io, args),
         }
         Ok(())
-    }
-}
-
-/// Find shielded address or key
-fn address_key_find(
-    ctx: Context,
-    io: &impl Io,
-    args::AddrKeyFind {
-        alias,
-        unsafe_show_secret,
-    }: args::AddrKeyFind,
-) {
-    let mut wallet = load_wallet(ctx);
-    let alias = alias.to_lowercase();
-    if let Ok(viewing_key) = wallet.find_viewing_key(&alias) {
-        // Check if alias is a viewing key
-        display_line!(io, "Viewing key: {}", viewing_key);
-        if unsafe_show_secret {
-            // Check if alias is also a spending key
-            match wallet.find_spending_key(&alias, None) {
-                Ok(spending_key) => {
-                    display_line!(io, "Spending key: {}", spending_key)
-                }
-                Err(FindKeyError::KeyNotFound(_)) => {}
-                Err(err) => edisplay_line!(io, "{}", err),
-            }
-        }
-    } else if let Some(payment_addr) = wallet.find_payment_addr(&alias) {
-        // Failing that, check if alias is a payment address
-        display_line!(io, "Payment address: {}", payment_addr);
-    } else {
-        // Otherwise alias cannot be referring to any shielded value
-        display_line!(
-            io,
-            "No shielded address or key with alias {} found. Use the commands \
-             `masp list-addrs` and `masp list-keys` to see all the known \
-             addresses and keys.",
-            alias.to_lowercase()
-        );
     }
 }
 
@@ -140,8 +97,8 @@ fn spending_keys_list(
     if known_view_keys.is_empty() {
         display_line!(
             io,
-            "No known keys. Try `masp add --alias my-addr --value ...` to add \
-             a new key to the wallet.",
+            "TODO No known keys. Try `masp add --alias my-addr --value ...` \
+             to add a new key to the wallet.",
         );
     } else {
         let stdout = io::stdout();
@@ -202,7 +159,11 @@ fn spending_keys_list(
 }
 
 /// List payment addresses.
-fn payment_addresses_list(ctx: Context, io: &impl Io) {
+fn payment_addresses_list(
+    ctx: Context,
+    io: &impl Io,
+    // args::AddressList { .. }: args::AddressList,
+) {
     let wallet = load_wallet(ctx);
     let known_addresses = wallet.get_payment_addrs();
     if known_addresses.is_empty() {
@@ -366,7 +327,7 @@ pub fn decode_derivation_path(
 
 /// Derives a keypair and an implicit address from the mnemonic code in the
 /// wallet.
-async fn key_and_address_derive(
+async fn transparent_key_and_address_derive(
     ctx: Context,
     io: &impl Io,
     args::KeyDerive {
@@ -461,18 +422,9 @@ async fn key_and_address_derive(
     );
 }
 
-/// TODO
-fn key_gen(ctx: Context, io: &impl Io, args_key_gen: args::KeyGen) {
-    if !args_key_gen.shielded {
-        key_and_address_gen(ctx, io, args_key_gen)
-    } else {
-        spending_key_gen(ctx, io, args_key_gen)
-    }
-}
-
 /// Generate a new keypair and derive implicit address from it and store them in
 /// the wallet.
-fn key_and_address_gen(
+fn transparent_key_and_address_gen(
     ctx: Context,
     io: &impl Io,
     args::KeyGen {
@@ -528,13 +480,22 @@ fn key_and_address_gen(
 }
 
 /// TODO
+fn key_gen(ctx: Context, io: &impl Io, args_key_gen: args::KeyGen) {
+    if !args_key_gen.shielded {
+        transparent_key_and_address_gen(ctx, io, args_key_gen)
+    } else {
+        spending_key_gen(ctx, io, args_key_gen)
+    }
+}
+
+/// TODO
 async fn key_derive(
     ctx: Context,
     io: &impl Io,
     args_key_derive: args::KeyDerive,
 ) {
     if !args_key_derive.shielded {
-        key_and_address_derive(ctx, io, args_key_derive).await
+        transparent_key_and_address_derive(ctx, io, args_key_derive).await
     } else {
         todo!()
     }
@@ -549,8 +510,26 @@ fn key_list(ctx: Context, io: &impl Io, args_key_list: args::KeyList) {
     }
 }
 
+/// TODO
+fn key_find(ctx: Context, io: &impl Io, args_key_find: args::KeyFind) {
+    if !args_key_find.shielded {
+        transparent_key_address_find(ctx, io, args_key_find)
+    } else {
+        shielded_key_address_find(ctx, io, args_key_find)
+    }
+}
+
+/// TODO
+fn address_list(ctx: Context, io: &impl Io, args_key_list: args::AddressList) {
+    if !args_key_list.shielded {
+        transparent_addresses_list(ctx, io, args_key_list)
+    } else {
+        payment_addresses_list(ctx, io)
+    }
+}
+
 /// Find a keypair in the wallet store.
-fn key_find(
+fn transparent_key_address_find(
     ctx: Context,
     io: &impl Io,
     args::KeyFind {
@@ -558,6 +537,7 @@ fn key_find(
         alias,
         value,
         unsafe_show_secret,
+        ..
     }: args::KeyFind,
 ) {
     let mut wallet = load_wallet(ctx);
@@ -592,6 +572,53 @@ fn key_find(
         Err(err) => {
             edisplay_line!(io, "{}", err);
         }
+    }
+}
+
+/// Find shielded address or key
+/// TODO this works for both keys and addresses
+/// TODO split to enable finding alias by payment key
+fn shielded_key_address_find(
+    ctx: Context,
+    io: &impl Io,
+    args::KeyFind {
+        alias,
+        unsafe_show_secret,
+        ..
+    }: args::KeyFind,
+) {
+    let mut wallet = load_wallet(ctx);
+    let alias = alias.unwrap_or_else(|| {
+        display_line!(io, "Missing alias.");
+        display_line!(io, "No changes are persisted. Exiting.");
+        cli::safe_exit(1)
+    });
+    let alias = alias.to_lowercase();
+    if let Ok(viewing_key) = wallet.find_viewing_key(&alias) {
+        // Check if alias is a viewing key
+        display_line!(io, "Viewing key: {}", viewing_key);
+        if unsafe_show_secret {
+            // Check if alias is also a spending key
+            match wallet.find_spending_key(&alias, None) {
+                Ok(spending_key) => {
+                    display_line!(io, "Spending key: {}", spending_key)
+                }
+                Err(FindKeyError::KeyNotFound(_)) => {}
+                Err(err) => edisplay_line!(io, "{}", err),
+            }
+        }
+    } else if let Some(payment_addr) = wallet.find_payment_addr(&alias) {
+        // Failing that, check if alias is a payment address
+        display_line!(io, "Payment address: {}", payment_addr);
+    } else {
+        // Otherwise alias cannot be referring to any shielded value
+        display_line!(
+            io,
+            "TODO No shielded address or key with alias {} found. Use the \
+             commands `masp list-addrs` and `masp list-keys` to see all the \
+             known addresses and keys.",
+            alias.to_lowercase()
+        );
     }
 }
 
@@ -686,8 +713,13 @@ fn key_export(
         })
 }
 
-/// List all known addresses.
-fn address_list(ctx: Context, io: &impl Io) {
+/// List all known transparent addresses.
+fn transparent_addresses_list(
+    ctx: Context,
+    io: &impl Io,
+    _args: args::AddressList,
+    // args::AddressList { is_pre_genesis, .. }: args::AddressList,
+) {
     let wallet = load_wallet(ctx);
     let known_addresses = wallet.get_addresses();
     if known_addresses.is_empty() {
@@ -714,7 +746,7 @@ fn address_list(ctx: Context, io: &impl Io) {
 fn address_or_alias_find(
     ctx: Context,
     io: &impl Io,
-    args::AddressOrAliasFind { alias, address }: args::AddressOrAliasFind,
+    args::AddressFind { alias, address }: args::AddressFind,
 ) {
     let wallet = load_wallet(ctx);
     if address.is_some() && alias.is_some() {

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -39,33 +39,33 @@ impl CliApi {
         io: &impl Io,
     ) -> Result<()> {
         match cmd {
-            cmds::NamadaWallet::NewGen(cmds::WalletNewGen(args)) => {
+            cmds::NamadaWallet::KeyGen(cmds::WalletGen(args)) => {
                 key_gen(ctx, io, args)
             }
-            cmds::NamadaWallet::NewDerive(cmds::WalletNewDerive(args)) => {
+            cmds::NamadaWallet::KeyDerive(cmds::WalletDerive(args)) => {
                 key_derive(ctx, io, args).await
             }
-            cmds::NamadaWallet::NewKeyList(cmds::WalletNewKeyList(args)) => {
+            cmds::NamadaWallet::KeyList(cmds::WalletListKeys(args)) => {
                 key_list(ctx, io, args)
             }
-            cmds::NamadaWallet::NewKeyFind(cmds::WalletNewKeyFind(args)) => {
+            cmds::NamadaWallet::KeyFind(cmds::WalletFindKeys(args)) => {
                 key_find(ctx, io, args)
             }
-            cmds::NamadaWallet::NewAddrList(cmds::WalletNewAddressList(
+            cmds::NamadaWallet::AddrList(cmds::WalletListAddresses(args)) => {
+                address_list(ctx, io, args)
+            }
+            cmds::NamadaWallet::AddrFind(cmds::WalletFindAddresses(args)) => {
+                address_or_alias_find(ctx, io, args)
+            }
+            cmds::NamadaWallet::KeyExport(cmds::WalletExportKey(args)) => {
+                key_export(ctx, io, args)
+            }
+            cmds::NamadaWallet::KeyAddrAdd(cmds::WalletAddKeyAddress(args)) => {
+                key_address_add(ctx, io, args)
+            }
+            cmds::NamadaWallet::PayAddrGen(cmds::WalletGenPaymentAddress(
                 args,
-            )) => address_list(ctx, io, args),
-            cmds::NamadaWallet::NewAddrFind(cmds::WalletNewAddressFind(
-                args,
-            )) => address_or_alias_find(ctx, io, args),
-            cmds::NamadaWallet::NewKeyExport(cmds::WalletNewExportKey(
-                args,
-            )) => key_export(ctx, io, args),
-            cmds::NamadaWallet::NewKeyAddrAdd(
-                cmds::WalletNewKeyAddressAdd(args),
-            ) => key_address_add(ctx, io, args),
-            cmds::NamadaWallet::NewPayAddrGen(
-                cmds::WalletNewPaymentAddressGen(args),
-            ) => {
+            )) => {
                 let args = args.to_sdk(&mut ctx);
                 payment_address_gen(ctx, io, args)
             }

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -43,9 +43,6 @@ impl CliApi {
                 cmds::WalletKey::Derive(cmds::KeyDerive(args)) => {
                     key_and_address_derive(ctx, io, args).await
                 }
-                cmds::WalletKey::Gen(cmds::KeyGen(args)) => {
-                    key_and_address_gen(ctx, io, args)
-                }
                 cmds::WalletKey::Find(cmds::KeyFind(args)) => {
                     key_find(ctx, io, args)
                 }
@@ -57,9 +54,6 @@ impl CliApi {
                 }
             },
             cmds::NamadaWallet::Address(sub) => match sub {
-                cmds::WalletAddress::Gen(cmds::AddressGen(args)) => {
-                    key_and_address_gen(ctx, io, args)
-                }
                 cmds::WalletAddress::Derive(cmds::AddressDerive(args)) => {
                     key_and_address_derive(ctx, io, args).await
                 }
@@ -72,9 +66,6 @@ impl CliApi {
                 }
             },
             cmds::NamadaWallet::Masp(sub) => match sub {
-                cmds::WalletMasp::GenSpendKey(cmds::MaspGenSpendKey(args)) => {
-                    spending_key_gen(ctx, io, args)
-                }
                 cmds::WalletMasp::GenPayAddr(cmds::MaspGenPayAddr(args)) => {
                     let args = args.to_sdk(&mut ctx);
                     payment_address_gen(ctx, io, args)
@@ -92,6 +83,9 @@ impl CliApi {
                     address_key_find(ctx, io, args)
                 }
             },
+            cmds::NamadaWallet::NewGen(cmds::WalletNewGen(args)) => {
+                key_gen(ctx, io, args)
+            }
         }
         Ok(())
     }
@@ -236,18 +230,26 @@ fn payment_addresses_list(ctx: Context, io: &impl Io) {
 fn spending_key_gen(
     ctx: Context,
     io: &impl Io,
-    args::MaspSpendKeyGen {
+    args::KeyGen {
         alias,
         alias_force,
         unsafe_dont_encrypt,
-    }: args::MaspSpendKeyGen,
+        ..
+    }: args::KeyGen,
 ) {
+    let alias = alias.unwrap_or_else(|| {
+        display_line!(io, "Missing alias.");
+        display_line!(io, "No changes are persisted. Exiting.");
+        cli::safe_exit(1)
+    });
     let mut wallet = load_wallet(ctx);
     let alias = alias.to_lowercase();
     let password = read_and_confirm_encryption_password(unsafe_dont_encrypt);
     let (alias, _key) =
         wallet.gen_store_spending_key(alias, password, alias_force, &mut OsRng);
-    wallet.save().unwrap_or_else(|err| eprintln!("{}", err));
+    wallet
+        .save()
+        .unwrap_or_else(|err| edisplay_line!(io, "{}", err));
     display_line!(
         io,
         "Successfully added a spending key with alias: \"{}\"",
@@ -463,18 +465,28 @@ async fn key_and_address_derive(
     );
 }
 
+/// TODO
+fn key_gen(ctx: Context, io: &impl Io, args_key_gen: args::KeyGen) {
+    if !args_key_gen.shielded {
+        key_and_address_gen(ctx, io, args_key_gen)
+    } else {
+        spending_key_gen(ctx, io, args_key_gen)
+    }
+}
+
 /// Generate a new keypair and derive implicit address from it and store them in
 /// the wallet.
 fn key_and_address_gen(
     ctx: Context,
     io: &impl Io,
-    args::KeyAndAddressGen {
+    args::KeyGen {
         scheme,
         alias,
         alias_force,
         unsafe_dont_encrypt,
         derivation_path,
-    }: args::KeyAndAddressGen,
+        ..
+    }: args::KeyGen,
 ) {
     let mut wallet = load_wallet(ctx);
     let encryption_password =

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -45,14 +45,11 @@ impl CliApi {
             cmds::NamadaWallet::KeyDerive(cmds::WalletDerive(args)) => {
                 key_derive(ctx, io, args).await
             }
-            cmds::NamadaWallet::KeyList(cmds::WalletListKeys(args)) => {
-                key_list(ctx, io, args)
-            }
+            cmds::NamadaWallet::KeyAddrList(cmds::WalletListKeysAddresses(
+                args,
+            )) => key_address_list(ctx, io, args),
             cmds::NamadaWallet::KeyFind(cmds::WalletFindKeys(args)) => {
                 key_find(ctx, io, args)
-            }
-            cmds::NamadaWallet::AddrList(cmds::WalletListAddresses(args)) => {
-                address_list(ctx, io, args)
             }
             cmds::NamadaWallet::AddrFind(cmds::WalletFindAddresses(args)) => {
                 address_or_alias_find(ctx, io, args)
@@ -81,11 +78,8 @@ impl CliApi {
 fn spending_keys_list(
     ctx: Context,
     io: &impl Io,
-    args::KeyList {
-        decrypt,
-        unsafe_show_secret,
-        ..
-    }: args::KeyList,
+    decrypt: bool,
+    unsafe_show_secret: bool,
 ) {
     let wallet = load_wallet(ctx);
     let known_view_keys = wallet.get_viewing_keys();
@@ -155,17 +149,13 @@ fn spending_keys_list(
 }
 
 /// List payment addresses.
-fn payment_addresses_list(
-    ctx: Context,
-    io: &impl Io,
-    // args::AddressList { .. }: args::AddressList,
-) {
+fn payment_addresses_list(ctx: Context, io: &impl Io) {
     let wallet = load_wallet(ctx);
     let known_addresses = wallet.get_payment_addrs();
     if known_addresses.is_empty() {
         display_line!(
             io,
-            "No known payment addresses. Try `masp gen-payment-addr --alias \
+            "No known payment addresses. Try `gen-payment-addr --alias \
              my-addr` to generate a new payment address.",
         );
     } else {
@@ -501,11 +491,46 @@ async fn key_derive(
 }
 
 /// List keys
-fn key_list(ctx: Context, io: &impl Io, args_key_list: args::KeyList) {
-    if !args_key_list.shielded {
-        transparent_keys_list(ctx, io, args_key_list)
+fn key_list(
+    ctx: Context,
+    io: &impl Io,
+    args::KeyAddressList {
+        shielded,
+        decrypt,
+        unsafe_show_secret,
+        ..
+    }: args::KeyAddressList,
+) {
+    if !shielded {
+        transparent_keys_list(ctx, io, decrypt, unsafe_show_secret)
     } else {
-        spending_keys_list(ctx, io, args_key_list)
+        spending_keys_list(ctx, io, decrypt, unsafe_show_secret)
+    }
+}
+
+/// List addresses
+fn address_list(
+    ctx: Context,
+    io: &impl Io,
+    args::KeyAddressList { shielded, .. }: args::KeyAddressList,
+) {
+    if !shielded {
+        transparent_addresses_list(ctx, io)
+    } else {
+        payment_addresses_list(ctx, io)
+    }
+}
+
+/// List keys and addresses
+fn key_address_list(
+    ctx: Context,
+    io: &impl Io,
+    args_key_address_list: args::KeyAddressList,
+) {
+    if !args_key_address_list.addresses_only {
+        key_list(ctx, io, args_key_address_list)
+    } else if !args_key_address_list.keys_only {
+        address_list(ctx, io, args_key_address_list)
     }
 }
 
@@ -515,15 +540,6 @@ fn key_find(ctx: Context, io: &impl Io, args_key_find: args::KeyFind) {
         transparent_key_address_find(ctx, io, args_key_find)
     } else {
         shielded_key_address_find(ctx, io, args_key_find)
-    }
-}
-
-/// List addresses
-fn address_list(ctx: Context, io: &impl Io, args_key_list: args::AddressList) {
-    if !args_key_list.shielded {
-        transparent_addresses_list(ctx, io, args_key_list)
-    } else {
-        payment_addresses_list(ctx, io)
     }
 }
 
@@ -721,11 +737,8 @@ fn shielded_key_address_find(
 fn transparent_keys_list(
     ctx: Context,
     io: &impl Io,
-    args::KeyList {
-        decrypt,
-        unsafe_show_secret,
-        ..
-    }: args::KeyList,
+    decrypt: bool,
+    unsafe_show_secret: bool,
 ) {
     let wallet = load_wallet(ctx);
     let known_public_keys = wallet.get_public_keys();
@@ -840,12 +853,7 @@ fn key_import(
 }
 
 /// List all known transparent addresses.
-fn transparent_addresses_list(
-    ctx: Context,
-    io: &impl Io,
-    _args: args::AddressList,
-    // args::AddressList { is_pre_genesis, .. }: args::AddressList,
-) {
+fn transparent_addresses_list(ctx: Context, io: &impl Io) {
     let wallet = load_wallet(ctx);
     let known_addresses = wallet.get_addresses();
     if known_addresses.is_empty() {

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -745,8 +745,8 @@ fn transparent_addresses_list(
     if known_addresses.is_empty() {
         display_line!(
             io,
-            "No known addresses. Try `address gen --alias my-addr` to \
-             generate a new implicit address.",
+            "No known addresses. Try `gen --alias my-addr` to generate a new \
+             implicit address.",
         );
     } else {
         let stdout = io::stdout();

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -40,9 +40,6 @@ impl CliApi {
     ) -> Result<()> {
         match cmd {
             cmds::NamadaWallet::Key(sub) => match sub {
-                cmds::WalletKey::Derive(cmds::KeyDerive(args)) => {
-                    key_and_address_derive(ctx, io, args).await
-                }
                 cmds::WalletKey::Find(cmds::KeyFind(args)) => {
                     key_find(ctx, io, args)
                 }
@@ -54,9 +51,6 @@ impl CliApi {
                 }
             },
             cmds::NamadaWallet::Address(sub) => match sub {
-                cmds::WalletAddress::Derive(cmds::AddressDerive(args)) => {
-                    key_and_address_derive(ctx, io, args).await
-                }
                 cmds::WalletAddress::Find(cmds::AddressOrAliasFind(args)) => {
                     address_or_alias_find(ctx, io, args)
                 }
@@ -85,6 +79,9 @@ impl CliApi {
             },
             cmds::NamadaWallet::NewGen(cmds::WalletNewGen(args)) => {
                 key_gen(ctx, io, args)
+            }
+            cmds::NamadaWallet::NewDerive(cmds::WalletNewDerive(args)) => {
+                key_derive(ctx, io, args).await
             }
         }
         Ok(())
@@ -374,14 +371,15 @@ pub fn decode_derivation_path(
 async fn key_and_address_derive(
     ctx: Context,
     io: &impl Io,
-    args::KeyAndAddressDerive {
+    args::KeyDerive {
         scheme,
         alias,
         alias_force,
         unsafe_dont_encrypt,
         derivation_path,
         use_device,
-    }: args::KeyAndAddressDerive,
+        ..
+    }: args::KeyDerive,
 ) {
     let mut wallet = load_wallet(ctx);
     let derivation_path = decode_derivation_path(scheme, derivation_path)
@@ -529,6 +527,19 @@ fn key_and_address_gen(
         "Successfully added a key and an address with alias: \"{}\"",
         alias
     );
+}
+
+/// TODO
+async fn key_derive(
+    ctx: Context,
+    io: &impl Io,
+    args_key_derive: args::KeyDerive,
+) {
+    if !args_key_derive.shielded {
+        key_and_address_derive(ctx, io, args_key_derive).await
+    } else {
+        todo!()
+    }
 }
 
 /// Find a keypair in the wallet store.

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -1062,7 +1062,7 @@ fn transparent_secret_key_add(
     );
 }
 
-/// Add an address to the wallet.
+/// Add a transparent address to the wallet.
 fn transparent_address_add(
     ctx: Context,
     io: &impl Io,

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -336,6 +336,7 @@ async fn transparent_key_and_address_derive(
             edisplay_line!(io, "{}", err);
             cli::safe_exit(1)
         });
+    let alias = alias.to_lowercase();
     let alias = if !use_device {
         let encryption_password =
             read_and_confirm_encryption_password(unsafe_dont_encrypt);
@@ -426,6 +427,7 @@ fn transparent_key_and_address_gen(
         ..
     }: args::KeyGen,
 ) {
+    let alias = alias.to_lowercase();
     let mut wallet = load_wallet(ctx);
     let encryption_password =
         read_and_confirm_encryption_password(unsafe_dont_encrypt);
@@ -604,6 +606,7 @@ fn shielded_key_address_find(
     }: args::KeyFind,
 ) {
     let mut wallet = load_wallet(ctx);
+    // TODO
     let alias = alias.unwrap_or_else(|| {
         display_line!(io, "Missing alias.");
         display_line!(io, "No changes are persisted. Exiting.");
@@ -712,12 +715,13 @@ fn key_export(
     io: &impl Io,
     args::KeyExport { alias }: args::KeyExport,
 ) {
+    let alias = alias.to_lowercase();
     let mut wallet = load_wallet(ctx);
     wallet
-        .find_secret_key(alias.to_lowercase(), None)
+        .find_secret_key(&alias, None)
         .map(|keypair| {
             let file_data = keypair.serialize_to_vec();
-            let file_name = format!("key_{}", alias.to_lowercase());
+            let file_name = format!("key_{}", alias);
             let mut file = File::create(&file_name).unwrap();
 
             file.write_all(file_data.as_ref()).unwrap();
@@ -771,14 +775,15 @@ fn address_or_alias_find(
              message."
         );
     } else if alias.is_some() {
-        if let Some(address) = wallet.find_address(alias.as_ref().unwrap()) {
+        let alias = alias.unwrap().to_lowercase();
+        if let Some(address) = wallet.find_address(&alias) {
             display_line!(io, "Found address {}", address.to_pretty_string());
         } else {
             display_line!(
                 io,
                 "No address with alias {} found. Use the command `address \
                  list` to see all the known addresses.",
-                alias.unwrap().to_lowercase()
+                alias
             );
         }
     } else if address.is_some() {
@@ -806,10 +811,11 @@ fn transparent_address_add(
         ..
     }: args::KeyAddressAdd,
 ) {
+    let alias = alias.to_lowercase();
     let address = address.unwrap(); // this should not fail
     let mut wallet = load_wallet(ctx);
     if wallet
-        .insert_address(alias.to_lowercase(), address, alias_force)
+        .insert_address(&alias, address, alias_force)
         .is_none()
     {
         edisplay_line!(io, "Address not added");
@@ -821,7 +827,7 @@ fn transparent_address_add(
     display_line!(
         io,
         "Successfully added a key and an address with alias: \"{}\"",
-        alias.to_lowercase()
+        alias
     );
 }
 

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -60,6 +60,9 @@ impl CliApi {
             cmds::NamadaWallet::KeyAddrAdd(cmds::WalletAddKeyAddress(args)) => {
                 key_address_add(ctx, io, args)
             }
+            cmds::NamadaWallet::KeyAddrRemove(
+                cmds::WalletRemoveKeyAddress(args),
+            ) => key_address_remove(ctx, io, args),
             cmds::NamadaWallet::PayAddrGen(cmds::WalletGenPaymentAddress(
                 args,
             )) => {
@@ -697,6 +700,21 @@ fn key_address_add(
         cli::safe_exit(1)
     });
     add_key_or_address(ctx, io, alias, alias_force, value, unsafe_dont_encrypt)
+}
+
+/// Remove keys and addresses
+fn key_address_remove(
+    ctx: Context,
+    io: &impl Io,
+    args::KeyAddressRemove { alias, .. }: args::KeyAddressRemove,
+) {
+    let alias = alias.to_lowercase();
+    let mut wallet = load_wallet(ctx);
+    wallet.remove_all_by_alias(alias.clone());
+    wallet
+        .save()
+        .unwrap_or_else(|err| edisplay_line!(io, "{}", err));
+    display_line!(io, "Successfully removed alias: \"{}\"", alias);
 }
 
 /// Find a keypair in the wallet store.

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -105,7 +105,7 @@ fn shielded_keys_list(
                 Some(spend_key) if spend_key.is_encrypted() => "encrypted",
                 _ => "not encrypted",
             };
-            display!(io, &mut w_lock; "  Alias \"{}\" ({})", alias, encrypted_status).unwrap();
+            display_line!(io, &mut w_lock; "  Alias \"{}\" ({}):", alias, encrypted_status).unwrap();
             // Always print the corresponding viewing key
             display_line!(io, &mut w_lock; "    Viewing Key: {}", key).unwrap();
             // A subset of viewing keys will have corresponding spending keys.
@@ -1201,7 +1201,7 @@ fn transparent_public_key_add(
         .unwrap_or_else(|err| edisplay_line!(io, "{}", err));
     display_line!(
         io,
-        "Successfully added public key with alias: \"{}\"",
+        "Successfully added a public key with alias: \"{}\"",
         alias
     );
 }
@@ -1226,7 +1226,11 @@ fn transparent_address_add(
     wallet
         .save()
         .unwrap_or_else(|err| edisplay_line!(io, "{}", err));
-    display_line!(io, "Successfully added address with alias: \"{}\"", alias);
+    display_line!(
+        io,
+        "Successfully added an address with alias: \"{}\"",
+        alias
+    );
 }
 
 /// Load wallet for chain when `ctx.chain.is_some()` or pre-genesis wallet when

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -154,7 +154,7 @@ fn payment_addresses_list(ctx: Context, io: &impl Io) {
         display_line!(
             io,
             "No known payment addresses. Try `gen-payment-addr --alias \
-             my-addr` to generate a new payment address.",
+             my-payment-addr` to generate a new payment address.",
         );
     } else {
         let stdout = io::stdout();

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -60,6 +60,9 @@ impl CliApi {
             cmds::NamadaWallet::KeyExport(cmds::WalletExportKey(args)) => {
                 key_export(ctx, io, args)
             }
+            cmds::NamadaWallet::KeyImport(cmds::WalletImportKey(args)) => {
+                key_import(ctx, io, args)
+            }
             cmds::NamadaWallet::KeyAddrAdd(cmds::WalletAddKeyAddress(args)) => {
                 key_address_add(ctx, io, args)
             }
@@ -549,28 +552,20 @@ impl FromStr for KeyAddrAddValue {
     }
 }
 
-/// Add key or address
-fn key_address_add(
+fn add_key_or_address(
     ctx: Context,
     io: &impl Io,
-    args::KeyAddressAdd {
-        alias,
-        alias_force,
-        value,
-        unsafe_dont_encrypt,
-        ..
-    }: args::KeyAddressAdd,
+    alias: String,
+    alias_force: bool,
+    value: KeyAddrAddValue,
+    unsafe_dont_encrypt: bool,
 ) {
-    match KeyAddrAddValue::from_str(&value).unwrap_or_else(|err| {
-        edisplay_line!(io, "{}", err);
-        display_line!(io, "No changes are persisted. Exiting.");
-        cli::safe_exit(1)
-    }) {
+    match value {
         KeyAddrAddValue::TranspSecretKey(sk) => {
             let mut wallet = load_wallet(ctx);
             let encryption_password =
                 read_and_confirm_encryption_password(unsafe_dont_encrypt);
-            wallet
+            let alias = wallet
                 .insert_keypair(
                     alias,
                     alias_force,
@@ -584,6 +579,14 @@ fn key_address_add(
                     display_line!(io, "No changes are persisted. Exiting.");
                     cli::safe_exit(1);
                 });
+            wallet
+                .save()
+                .unwrap_or_else(|err| edisplay_line!(io, "{}", err));
+            display_line!(
+                io,
+                "Successfully added a key and an address with alias: \"{}\"",
+                alias
+            );
         }
         KeyAddrAddValue::TranspAddress(address) => {
             transparent_address_add(ctx, io, alias, alias_force, address)
@@ -597,6 +600,26 @@ fn key_address_add(
             unsafe_dont_encrypt,
         ),
     }
+}
+
+/// Add key or address
+fn key_address_add(
+    ctx: Context,
+    io: &impl Io,
+    args::KeyAddressAdd {
+        alias,
+        alias_force,
+        value,
+        unsafe_dont_encrypt,
+        ..
+    }: args::KeyAddressAdd,
+) {
+    let value = KeyAddrAddValue::from_str(&value).unwrap_or_else(|err| {
+        edisplay_line!(io, "{}", err);
+        display_line!(io, "No changes are persisted. Exiting.");
+        cli::safe_exit(1)
+    });
+    add_key_or_address(ctx, io, alias, alias_force, value, unsafe_dont_encrypt)
 }
 
 /// Find a keypair in the wallet store.
@@ -790,6 +813,30 @@ fn key_export(
         edisplay_line!(io, "{}", err);
         cli::safe_exit(1)
     })
+}
+
+/// Import a transparent keypair / MASP spending key from a file.
+fn key_import(
+    ctx: Context,
+    io: &impl Io,
+    args::KeyImport {
+        file_path,
+        alias,
+        alias_force,
+        unsafe_dont_encrypt,
+    }: args::KeyImport,
+) {
+    let file_data = std::fs::read_to_string(file_path).unwrap_or_else(|err| {
+        edisplay_line!(io, "{}", err);
+        display_line!(io, "No changes are persisted. Exiting.");
+        cli::safe_exit(1)
+    });
+    let value = KeyAddrAddValue::from_str(&file_data).unwrap_or_else(|err| {
+        edisplay_line!(io, "{}", err);
+        display_line!(io, "No changes are persisted. Exiting.");
+        cli::safe_exit(1)
+    });
+    add_key_or_address(ctx, io, alias, alias_force, value, unsafe_dont_encrypt)
 }
 
 /// List all known transparent addresses.

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -93,8 +93,8 @@ fn spending_keys_list(
     if known_view_keys.is_empty() {
         display_line!(
             io,
-            "TODO No known keys. Try `masp add --alias my-addr --value ...` \
-             to add a new key to the wallet.",
+            "No known keys. Try `add --alias my-addr --value ...` to add a \
+             new key to the wallet, or `gen --shielded` to generate a new key.",
         );
     } else {
         let stdout = io::stdout();
@@ -165,7 +165,7 @@ fn payment_addresses_list(
     if known_addresses.is_empty() {
         display_line!(
             io,
-            "TODO No known payment addresses. Try `masp gen-addr --alias \
+            "No known payment addresses. Try `masp gen-payment-addr --alias \
              my-addr` to generate a new payment address.",
         );
     } else {
@@ -527,7 +527,7 @@ fn address_list(ctx: Context, io: &impl Io, args_key_list: args::AddressList) {
     }
 }
 
-/// Value for add command
+/// Value for wallet `add` command
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum KeyAddrAddValue {
@@ -709,9 +709,9 @@ fn shielded_key_address_find(
         // Otherwise alias cannot be referring to any shielded value
         display_line!(
             io,
-            "TODO No shielded address or key with alias {} found. Use the \
-             commands `masp list-addrs` and `masp list-keys` to see all the \
-             known addresses and keys.",
+            "No shielded address or key with alias {} found. Use the commands \
+             `list-addr --shielded` and `list-keys --shielded` to see all the \
+             known shielded addresses and keys.",
             alias.to_lowercase()
         );
     }

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -186,11 +186,6 @@ fn spending_key_gen(
         ..
     }: args::KeyGen,
 ) {
-    let alias = alias.unwrap_or_else(|| {
-        display_line!(io, "Missing alias.");
-        display_line!(io, "No changes are persisted. Exiting.");
-        cli::safe_exit(1)
-    });
     let mut wallet = load_wallet(ctx);
     let alias = alias.to_lowercase();
     let password = read_and_confirm_encryption_password(unsafe_dont_encrypt);
@@ -347,7 +342,7 @@ async fn transparent_key_and_address_derive(
         wallet
             .derive_key_from_mnemonic_code(
                 scheme,
-                alias,
+                Some(alias),
                 alias_force,
                 derivation_path,
                 None,
@@ -390,13 +385,12 @@ async fn transparent_key_and_address_derive(
 
         let pubkey = common::PublicKey::try_from_slice(&response.public_key)
             .expect("unable to decode public key from hardware wallet");
-        let pkh = PublicKeyHash::from(&pubkey);
         let address = Address::from_str(&response.address_str)
             .expect("unable to decode address from hardware wallet");
 
         wallet
             .insert_public_key(
-                alias.unwrap_or_else(|| pkh.to_string()),
+                alias,
                 pubkey,
                 Some(address),
                 Some(derivation_path),
@@ -438,7 +432,7 @@ fn transparent_key_and_address_gen(
     let alias = if raw {
         wallet.gen_store_secret_key(
             scheme,
-            alias,
+            Some(alias),
             alias_force,
             encryption_password,
             &mut OsRng,
@@ -460,7 +454,7 @@ fn transparent_key_and_address_gen(
         });
         wallet.derive_store_hd_secret_key(
             scheme,
-            alias,
+            Some(alias),
             alias_force,
             seed,
             derivation_path,

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -20,7 +20,7 @@ use namada_sdk::masp::find_valid_diversifier;
 use namada_sdk::wallet::{
     DecryptionError, DerivationPath, DerivationPathError, FindKeyError, Wallet,
 };
-use namada_sdk::{display, display_line, edisplay_line};
+use namada_sdk::{display_line, edisplay_line};
 use rand_core::OsRng;
 
 use crate::cli;

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -884,11 +884,15 @@ fn transparent_key_address_find_by_alias(
             if decrypt {
                 // Check if alias is also a secret key. Decrypt and print it if
                 // requested.
-                if let Ok(keypair) = wallet.find_secret_key(&alias, None) {
-                    if unsafe_show_secret {
-                        display_line!(io, &mut w_lock; "    Secret key: {}", keypair)
+                match wallet.find_secret_key(&alias, None) {
+                    Ok(keypair) => {
+                        if unsafe_show_secret {
+                            display_line!(io, &mut w_lock; "    Secret key: {}", keypair)
                         .unwrap();
+                        }
                     }
+                    Err(FindKeyError::KeyNotFound(_)) => {}
+                    Err(err) => edisplay_line!(io, "{}", err),
                 }
             }
         }

--- a/apps/src/lib/cli/wallet.rs
+++ b/apps/src/lib/cli/wallet.rs
@@ -357,7 +357,7 @@ async fn transparent_key_and_address_derive(
             .0
     } else {
         let hidapi = HidApi::new().unwrap_or_else(|err| {
-            edisplay_line!(io, "Failed to create Hidapi: {}", err);
+            edisplay_line!(io, "Failed to create HidApi: {}", err);
             cli::safe_exit(1)
         });
         let app = NamadaApp::new(

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2079,9 +2079,13 @@ pub struct MaspPayAddrGen<C: NamadaTypes = SdkTypes> {
 
 /// Wallet generate key and implicit address arguments
 #[derive(Clone, Debug)]
-pub struct KeyAndAddressGen {
+pub struct KeyGen {
     /// Scheme type
     pub scheme: SchemeType,
+    /// Whether to generate a spending key for the shielded pool
+    pub shielded: bool,
+    /// Whether to generate a raw non-hd key
+    pub raw: bool,
     /// Key alias
     pub alias: Option<String>,
     /// Whether to force overwrite the alias, if provided

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2120,8 +2120,6 @@ pub struct KeyAddressFind {
 /// Wallet key export arguments
 #[derive(Clone, Debug)]
 pub struct KeyExport {
-    /// Whether to export a MASP spending key
-    pub shielded: bool,
     /// Key alias
     pub alias: String,
 }

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2115,53 +2115,29 @@ pub struct KeyDerive {
     pub use_device: bool,
 }
 
-/// Wallet restore key and implicit address arguments
-#[derive(Clone, Debug)]
-pub struct KeyAndAddressDerive {
-    /// Scheme type
-    pub scheme: SchemeType,
-    /// Key alias
-    pub alias: Option<String>,
-    /// Whether to force overwrite the alias, if provided
-    pub alias_force: bool,
-    /// Don't encrypt the keypair
-    pub unsafe_dont_encrypt: bool,
-    /// BIP44 derivation path
-    pub derivation_path: String,
-    /// Use device to generate key and address
-    pub use_device: bool,
-}
-
-/// Wallet key lookup arguments
+/// Wallet find shielded address or key arguments
+/// TODO Wallet key lookup arguments
 #[derive(Clone, Debug)]
 pub struct KeyFind {
-    /// Public key to lookup keypair with
-    pub public_key: Option<common::PublicKey>,
+    /// Whether to find shielded address by alias
+    pub shielded: bool,
     /// Key alias to lookup keypair with
     pub alias: Option<String>,
+    /// Public key to lookup keypair with
+    pub public_key: Option<common::PublicKey>,
     /// Public key hash to lookup keypair with
     pub value: Option<String>,
     /// Show secret keys to user
     pub unsafe_show_secret: bool,
 }
 
-/// Wallet find shielded address or key arguments
-#[derive(Clone, Debug)]
-pub struct AddrKeyFind {
-    /// Address/key alias
-    pub alias: String,
-    /// Show secret keys to user
-    pub unsafe_show_secret: bool,
-}
-
-/// Wallet list shielded keys arguments
-#[derive(Clone, Debug)]
-pub struct MaspKeysList {
-    /// Don't decrypt spending keys
-    pub decrypt: bool,
-    /// Show secret keys to user
-    pub unsafe_show_secret: bool,
-}
+/// Wallet list shielded payment addresses arguments
+// #[derive(Clone, Debug)]
+// pub struct MaspListPayAddrs {
+//     /// List shielded payment address pre-genesis instead
+//     /// of a current chain
+//     pub is_pre_genesis: bool,
+// }
 
 /// Wallet list keys arguments
 #[derive(Clone, Debug)]
@@ -2174,20 +2150,27 @@ pub struct KeyList {
     pub unsafe_show_secret: bool,
 }
 
+/// List transparent wallet addresses / shielded payment addresses
+#[derive(Clone, Debug)]
+pub struct AddressList {
+    /// Whether to list payment addresses of the shielded pool
+    pub shielded: bool,
+}
+
+/// Wallet address lookup arguments
+#[derive(Clone, Debug)]
+pub struct AddressFind {
+    /// Alias to find
+    pub alias: Option<String>,
+    /// Address to find
+    pub address: Option<Address>,
+}
+
 /// Wallet key export arguments
 #[derive(Clone, Debug)]
 pub struct KeyExport {
     /// Key alias
     pub alias: String,
-}
-
-/// Wallet address lookup arguments
-#[derive(Clone, Debug)]
-pub struct AddressOrAliasFind {
-    /// Alias to find
-    pub alias: Option<String>,
-    /// Address to find
-    pub address: Option<Address>,
 }
 
 /// Wallet address add arguments

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2064,7 +2064,7 @@ pub struct KeyGen {
 pub struct KeyDerive {
     /// Scheme type
     pub scheme: SchemeType,
-    /// Whether to generate a spending key for the shielded pool
+    /// Whether to generate a MASP spending key
     pub shielded: bool,
     /// Key alias
     pub alias: String,
@@ -2081,7 +2081,7 @@ pub struct KeyDerive {
 /// Wallet key lookup arguments
 #[derive(Clone, Debug)]
 pub struct KeyFind {
-    /// Whether to find shielded address by alias
+    /// Whether to find a MASP address by alias
     pub shielded: bool,
     /// Key alias to lookup keypair with
     pub alias: Option<String>,
@@ -2104,7 +2104,7 @@ pub struct KeyFind {
 /// Wallet list keys arguments
 #[derive(Clone, Debug)]
 pub struct KeyList {
-    /// Whether to list spending keys of the shielded pool
+    /// Whether to list MASP spending keys
     pub shielded: bool,
     /// Don't decrypt keys
     pub decrypt: bool,
@@ -2115,7 +2115,7 @@ pub struct KeyList {
 /// List addresses arguments
 #[derive(Clone, Debug)]
 pub struct AddressList {
-    /// Whether to list payment addresses of the shielded pool
+    /// Whether to list MASP payment addresses
     pub shielded: bool,
 }
 

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2152,6 +2152,15 @@ pub struct KeyAddressAdd {
     pub unsafe_dont_encrypt: bool,
 }
 
+/// Wallet key / address remove arguments
+#[derive(Clone, Debug)]
+pub struct KeyAddressRemove {
+    /// Address alias
+    pub alias: String,
+    /// Confirmation to remove the alias
+    pub do_it: bool,
+}
+
 /// Generate payment address arguments
 #[derive(Clone, Debug)]
 pub struct PayAddressGen<C: NamadaTypes = SdkTypes> {

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2081,8 +2081,6 @@ pub struct KeyDerive {
 /// Wallet list arguments
 #[derive(Clone, Copy, Debug)]
 pub struct KeyAddressList {
-    /// Whether to decrypt secret / spending keys
-    pub decrypt: bool,
     /// Whether to list transparent secret keys only
     pub transparent_only: bool,
     /// Whether to list MASP spending keys only
@@ -2091,6 +2089,8 @@ pub struct KeyAddressList {
     pub keys_only: bool,
     /// List addresses only
     pub addresses_only: bool,
+    /// Whether to decrypt secret / spending keys
+    pub decrypt: bool,
     /// Show secret keys to user
     pub unsafe_show_secret: bool,
 }
@@ -2098,8 +2098,6 @@ pub struct KeyAddressList {
 /// Wallet key / address lookup arguments
 #[derive(Clone, Debug)]
 pub struct KeyAddressFind {
-    /// Whether to find MASP keys / addresses
-    pub shielded: bool,
     /// Alias to find
     pub alias: Option<String>,
     /// Address to find
@@ -2114,6 +2112,8 @@ pub struct KeyAddressFind {
     pub keys_only: bool,
     /// Find addresses only
     pub addresses_only: bool,
+    /// Whether to decrypt secret / spending keys
+    pub decrypt: bool,
     /// Show secret keys to user
     pub unsafe_show_secret: bool,
 }

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2050,7 +2050,7 @@ pub struct KeyGen {
     /// Whether to generate a raw non-hd key
     pub raw: bool,
     /// Key alias
-    pub alias: Option<String>,
+    pub alias: String,
     /// Whether to force overwrite the alias, if provided
     pub alias_force: bool,
     /// Don't encrypt the keypair
@@ -2067,7 +2067,7 @@ pub struct KeyDerive {
     /// Whether to generate a spending key for the shielded pool
     pub shielded: bool,
     /// Key alias
-    pub alias: Option<String>,
+    pub alias: String,
     /// Whether to force overwrite the alias, if provided
     pub alias_force: bool,
     /// Don't encrypt the keypair

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2079,12 +2079,14 @@ pub struct KeyDerive {
 }
 
 /// Wallet list arguments
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct KeyAddressList {
-    /// Whether to list MASP spending keys
-    pub shielded: bool,
-    /// Don't decrypt keys
+    /// Whether to decrypt secret / spending keys
     pub decrypt: bool,
+    /// Whether to list transparent secret keys only
+    pub transparent_only: bool,
+    /// Whether to list MASP spending keys only
+    pub shielded_only: bool,
     /// List keys only
     pub keys_only: bool,
     /// List addresses only

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -13,6 +13,7 @@ use namada_core::types::dec::Dec;
 use namada_core::types::ethereum_events::EthAddress;
 use namada_core::types::keccak::KeccakHash;
 use namada_core::types::key::{common, SchemeType};
+use namada_core::types::masp::PaymentAddress;
 use namada_core::types::storage::Epoch;
 use namada_core::types::time::DateTimeUtc;
 use namada_core::types::transaction::GasLimit;
@@ -2077,21 +2078,6 @@ pub struct KeyDerive {
     pub use_device: bool,
 }
 
-/// Wallet key lookup arguments
-#[derive(Clone, Debug)]
-pub struct KeyFind {
-    /// Whether to find a MASP address by alias
-    pub shielded: bool,
-    /// Key alias to lookup keypair with
-    pub alias: Option<String>,
-    /// Public key to lookup keypair with
-    pub public_key: Option<common::PublicKey>,
-    /// Public key hash to lookup keypair with
-    pub value: Option<String>,
-    /// Show secret keys to user
-    pub unsafe_show_secret: bool,
-}
-
 /// Wallet list arguments
 #[derive(Clone, Debug)]
 pub struct KeyAddressList {
@@ -2107,15 +2093,28 @@ pub struct KeyAddressList {
     pub unsafe_show_secret: bool,
 }
 
-/// Wallet address lookup arguments
+/// Wallet key / address lookup arguments
 #[derive(Clone, Debug)]
-pub struct AddressFind {
+pub struct KeyAddressFind {
+    /// Whether to find MASP keys / addresses
+    pub shielded: bool,
     /// Alias to find
     pub alias: Option<String>,
     /// Address to find
     pub address: Option<Address>,
+    /// Public key to lookup keypair with
+    pub public_key: Option<common::PublicKey>,
+    /// Public key hash to lookup keypair with
+    pub public_key_hash: Option<String>,
+    /// Payment address to find
+    pub payment_address: Option<PaymentAddress>,
+    /// Find keys only
+    pub keys_only: bool,
+    /// Find addresses only
+    pub addresses_only: bool,
+    /// Show secret keys to user
+    pub unsafe_show_secret: bool,
 }
-
 /// Wallet key export arguments
 #[derive(Clone, Debug)]
 pub struct KeyExport {

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2131,6 +2131,8 @@ pub struct AddressFind {
 /// Wallet key export arguments
 #[derive(Clone, Debug)]
 pub struct KeyExport {
+    /// Whether to export a MASP spending key
+    pub shielded: bool,
     /// Key alias
     pub alias: String,
 }

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2040,43 +2040,6 @@ impl<C: NamadaTypes> TxBuilder<C> for Tx<C> {
     }
 }
 
-/// MASP add key or address arguments
-#[derive(Clone, Debug)]
-pub struct MaspAddrKeyAdd {
-    /// Key alias
-    pub alias: String,
-    /// Whether to force overwrite the alias
-    pub alias_force: bool,
-    /// Any MASP value
-    pub value: MaspValue,
-    /// Don't encrypt the keypair
-    pub unsafe_dont_encrypt: bool,
-}
-
-/// MASP generate spending key arguments
-#[derive(Clone, Debug)]
-pub struct MaspSpendKeyGen {
-    /// Key alias
-    pub alias: String,
-    /// Whether to force overwrite the alias
-    pub alias_force: bool,
-    /// Don't encrypt the keypair
-    pub unsafe_dont_encrypt: bool,
-}
-
-/// MASP generate payment address arguments
-#[derive(Clone, Debug)]
-pub struct MaspPayAddrGen<C: NamadaTypes = SdkTypes> {
-    /// Key alias
-    pub alias: String,
-    /// Whether to force overwrite the alias
-    pub alias_force: bool,
-    /// Viewing key
-    pub viewing_key: C::ViewingKey,
-    /// Pin
-    pub pin: bool,
-}
-
 /// Wallet generate key and implicit address arguments
 #[derive(Clone, Debug)]
 pub struct KeyGen {
@@ -2115,8 +2078,7 @@ pub struct KeyDerive {
     pub use_device: bool,
 }
 
-/// Wallet find shielded address or key arguments
-/// TODO Wallet key lookup arguments
+/// Wallet key lookup arguments
 #[derive(Clone, Debug)]
 pub struct KeyFind {
     /// Whether to find shielded address by alias
@@ -2150,7 +2112,7 @@ pub struct KeyList {
     pub unsafe_show_secret: bool,
 }
 
-/// List transparent wallet addresses / shielded payment addresses
+/// List addresses arguments
 #[derive(Clone, Debug)]
 pub struct AddressList {
     /// Whether to list payment addresses of the shielded pool
@@ -2186,6 +2148,19 @@ pub struct KeyAddressAdd {
     pub value: Option<MaspValue>,
     /// Don't encrypt the keys
     pub unsafe_dont_encrypt: bool,
+}
+
+/// Generate payment address arguments
+#[derive(Clone, Debug)]
+pub struct PayAddressGen<C: NamadaTypes = SdkTypes> {
+    /// Key alias
+    pub alias: String,
+    /// Whether to force overwrite the alias
+    pub alias_force: bool,
+    /// Viewing key
+    pub viewing_key: C::ViewingKey,
+    /// Pin
+    pub pin: bool,
 }
 
 /// Bridge pool batch recommendation.

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2166,7 +2166,9 @@ pub struct MaspKeysList {
 /// Wallet list keys arguments
 #[derive(Clone, Debug)]
 pub struct KeyList {
-    /// Don't decrypt keypairs
+    /// Whether to list spending keys of the shielded pool
+    pub shielded: bool,
+    /// Don't decrypt keys
     pub decrypt: bool,
     /// Show secret keys to user
     pub unsafe_show_secret: bool,

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2092,30 +2092,19 @@ pub struct KeyFind {
     pub unsafe_show_secret: bool,
 }
 
-/// Wallet list shielded payment addresses arguments
-// #[derive(Clone, Debug)]
-// pub struct MaspListPayAddrs {
-//     /// List shielded payment address pre-genesis instead
-//     /// of a current chain
-//     pub is_pre_genesis: bool,
-// }
-
-/// Wallet list keys arguments
+/// Wallet list arguments
 #[derive(Clone, Debug)]
-pub struct KeyList {
+pub struct KeyAddressList {
     /// Whether to list MASP spending keys
     pub shielded: bool,
     /// Don't decrypt keys
     pub decrypt: bool,
+    /// List keys only
+    pub keys_only: bool,
+    /// List addresses only
+    pub addresses_only: bool,
     /// Show secret keys to user
     pub unsafe_show_secret: bool,
-}
-
-/// List addresses arguments
-#[derive(Clone, Debug)]
-pub struct AddressList {
-    /// Whether to list MASP payment addresses
-    pub shielded: bool,
 }
 
 /// Wallet address lookup arguments

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2136,6 +2136,19 @@ pub struct KeyExport {
     pub alias: String,
 }
 
+/// Wallet key import arguments
+#[derive(Clone, Debug)]
+pub struct KeyImport {
+    /// File name
+    pub file_path: String,
+    /// Key alias
+    pub alias: String,
+    /// Whether to force overwrite the alias
+    pub alias_force: bool,
+    /// Don't encrypt the key
+    pub unsafe_dont_encrypt: bool,
+}
+
 /// Wallet key / address add arguments
 #[derive(Clone, Debug)]
 pub struct KeyAddressAdd {

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2098,6 +2098,25 @@ pub struct KeyGen {
 
 /// Wallet restore key and implicit address arguments
 #[derive(Clone, Debug)]
+pub struct KeyDerive {
+    /// Scheme type
+    pub scheme: SchemeType,
+    /// Whether to generate a spending key for the shielded pool
+    pub shielded: bool,
+    /// Key alias
+    pub alias: Option<String>,
+    /// Whether to force overwrite the alias, if provided
+    pub alias_force: bool,
+    /// Don't encrypt the keypair
+    pub unsafe_dont_encrypt: bool,
+    /// BIP44 derivation path
+    pub derivation_path: String,
+    /// Use device to generate key and address
+    pub use_device: bool,
+}
+
+/// Wallet restore key and implicit address arguments
+#[derive(Clone, Debug)]
 pub struct KeyAndAddressDerive {
     /// Scheme type
     pub scheme: SchemeType,

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -13,7 +13,6 @@ use namada_core::types::dec::Dec;
 use namada_core::types::ethereum_events::EthAddress;
 use namada_core::types::keccak::KeccakHash;
 use namada_core::types::key::{common, SchemeType};
-use namada_core::types::masp::MaspValue;
 use namada_core::types::storage::Epoch;
 use namada_core::types::time::DateTimeUtc;
 use namada_core::types::transaction::GasLimit;
@@ -2144,10 +2143,8 @@ pub struct KeyAddressAdd {
     pub alias: String,
     /// Whether to force overwrite the alias
     pub alias_force: bool,
-    /// Transparent address to add
-    pub address: Option<Address>,
-    /// Any shielded value
-    pub value: Option<MaspValue>,
+    /// Any supported value
+    pub value: String,
     /// Don't encrypt the keys
     pub unsafe_dont_encrypt: bool,
 }

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2173,15 +2173,19 @@ pub struct KeyExport {
     pub alias: String,
 }
 
-/// Wallet address add arguments
+/// Wallet key / address add arguments
 #[derive(Clone, Debug)]
-pub struct AddressAdd {
+pub struct KeyAddressAdd {
     /// Address alias
     pub alias: String,
     /// Whether to force overwrite the alias
     pub alias_force: bool,
-    /// Address to add
-    pub address: Address,
+    /// Transparent address to add
+    pub address: Option<Address>,
+    /// Any shielded value
+    pub value: Option<MaspValue>,
+    /// Don't encrypt the keys
+    pub unsafe_dont_encrypt: bool,
 }
 
 /// Bridge pool batch recommendation.

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2050,7 +2050,7 @@ pub struct KeyGen {
     pub raw: bool,
     /// Key alias
     pub alias: String,
-    /// Whether to force overwrite the alias, if provided
+    /// Whether to force overwrite the alias
     pub alias_force: bool,
     /// Don't encrypt the keypair
     pub unsafe_dont_encrypt: bool,
@@ -2067,7 +2067,7 @@ pub struct KeyDerive {
     pub shielded: bool,
     /// Key alias
     pub alias: String,
-    /// Whether to force overwrite the alias, if provided
+    /// Whether to force overwrite the alias
     pub alias_force: bool,
     /// Don't encrypt the keypair
     pub unsafe_dont_encrypt: bool,
@@ -2158,7 +2158,7 @@ pub struct KeyAddressAdd {
     pub alias_force: bool,
     /// Any supported value
     pub value: String,
-    /// Don't encrypt the keys
+    /// Don't encrypt the key
     pub unsafe_dont_encrypt: bool,
 }
 

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2055,7 +2055,7 @@ pub struct KeyGen {
     pub alias_force: bool,
     /// Don't encrypt the keypair
     pub unsafe_dont_encrypt: bool,
-    /// BIP44 derivation path
+    /// BIP44 / ZIP32 derivation path
     pub derivation_path: String,
 }
 

--- a/sdk/src/wallet/mod.rs
+++ b/sdk/src/wallet/mod.rs
@@ -989,4 +989,9 @@ impl<U: WalletIo> Wallet<U> {
     pub fn extend(&mut self, wallet: Self) {
         self.store.extend(wallet.store)
     }
+
+    /// Remove keys and addresses associated with the given alias
+    pub fn remove_all_by_alias(&mut self, alias: String) {
+        self.store.remove_alias(&alias.into())
+    }
 }

--- a/sdk/src/wallet/mod.rs
+++ b/sdk/src/wallet/mod.rs
@@ -485,6 +485,26 @@ impl<U> Wallet<U> {
             .map(|(alias, value)| (alias.into(), value))
             .collect()
     }
+
+    /// Check if alias is an encrypted secret key
+    pub fn is_encrypted_secret_key(
+        &self,
+        alias: impl AsRef<str>,
+    ) -> Option<bool> {
+        self.store
+            .find_secret_key(alias)
+            .map(|stored_keypair| stored_keypair.is_encrypted())
+    }
+
+    /// Check if alias is an encrypted spending key
+    pub fn is_encrypted_spending_key(
+        &self,
+        alias: impl AsRef<str>,
+    ) -> Option<bool> {
+        self.store
+            .find_spending_key(alias)
+            .map(|stored_spend_key| stored_spend_key.is_encrypted())
+    }
 }
 
 impl<U: WalletStorage> Wallet<U> {
@@ -567,9 +587,8 @@ impl<U: WalletIo> Wallet<U> {
     /// the keypair for the alias.
     /// If no encryption password is provided, the keypair will be stored raw
     /// without encryption.
-    /// Stores the key in decrypted key cache and
-    /// returns the alias of the key and a reference-counting pointer to the
-    /// key.
+    /// Stores the key in decrypted key cache and returns the alias of the key
+    /// and a reference-counting pointer to the key.
     pub fn gen_store_secret_key(
         &mut self,
         scheme: SchemeType,

--- a/sdk/src/wallet/mod.rs
+++ b/sdk/src/wallet/mod.rs
@@ -417,6 +417,14 @@ impl<U> Wallet<U> {
         self.store.find_payment_addr(alias.as_ref())
     }
 
+    /// Find an alias by the payment address if it's in the wallet.
+    pub fn find_alias_by_payment_addr(
+        &self,
+        payment_address: &PaymentAddress,
+    ) -> Option<&Alias> {
+        self.store.find_alias_by_payment_addr(payment_address)
+    }
+
     /// Get all known keys by their alias, paired with PKH, if known.
     pub fn get_secret_keys(
         &self,

--- a/sdk/src/wallet/store.rs
+++ b/sdk/src/wallet/store.rs
@@ -576,7 +576,7 @@ impl Store {
     }
 
     /// Completely remove the given alias from all maps in the wallet
-    fn remove_alias(&mut self, alias: &Alias) {
+    pub fn remove_alias(&mut self, alias: &Alias) {
         self.payment_addrs.remove_by_left(alias);
         self.view_keys.remove(alias);
         self.spend_keys.remove(alias);

--- a/tests/src/e2e/helpers.rs
+++ b/tests/src/e2e/helpers.rs
@@ -110,7 +110,8 @@ pub fn find_address(test: &Test, alias: impl AsRef<str>) -> Result<Address> {
         &["find", "--addr", "--alias", alias.as_ref()],
         Some(10)
     )?;
-    let (unread, matched) = find.exp_regex("Found address .*")?;
+    find.exp_string("Found transparent address:")?;
+    let (unread, matched) = find.exp_regex("\".*\": .*")?;
     let address_str = strip_trailing_newline(&matched)
         .trim()
         .rsplit_once(' ')
@@ -249,6 +250,7 @@ pub fn find_keypair(
             "--keys",
             "--alias",
             alias.as_ref(),
+            "--decrypt",
             "--unsafe-show-secret"
         ],
         Some(10)

--- a/tests/src/e2e/helpers.rs
+++ b/tests/src/e2e/helpers.rs
@@ -107,7 +107,7 @@ pub fn find_address(test: &Test, alias: impl AsRef<str>) -> Result<Address> {
     let mut find = run!(
         test,
         Bin::Wallet,
-        &["address", "find", "--alias", alias.as_ref()],
+        &["find", "--addr", "--alias", alias.as_ref()],
         Some(10)
     )?;
     let (unread, matched) = find.exp_regex("Found address .*")?;
@@ -245,8 +245,8 @@ pub fn find_keypair(
         test,
         Bin::Wallet,
         &[
-            "key",
             "find",
+            "--keys",
             "--alias",
             alias.as_ref(),
             "--unsafe-show-secret"

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -2975,7 +2975,7 @@ fn implicit_account_reveal_pk() -> Result<()> {
         let mut cmd = run!(
             test,
             Bin::Wallet,
-            &["key", "gen", "--alias", &key_alias, "--unsafe-dont-encrypt"],
+            &["gen", "--alias", &key_alias, "--unsafe-dont-encrypt"],
             Some(20),
         )?;
         cmd.assert_success();

--- a/tests/src/e2e/wallet_tests.rs
+++ b/tests/src/e2e/wallet_tests.rs
@@ -46,14 +46,19 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &["find", "--keys", "--alias", key_alias],
+        &["find", "--keys", "--alias", key_alias, "--decrypt"],
         Some(20),
     )?;
 
+    cmd.exp_string("Found transparent keys:")?;
+    cmd.exp_string(&format!(
+        "  Alias \"{}\" (encrypted):",
+        key_alias.to_lowercase()
+    ))?;
+    cmd.exp_string("    Public key hash:")?;
+    cmd.exp_string("    Public key:")?;
     cmd.exp_string("Enter your decryption password:")?;
     cmd.send_line(password)?;
-    cmd.exp_string("Public key hash:")?;
-    cmd.exp_string("Public key:")?;
 
     // 3. key list
     let mut cmd = run!(test, Bin::Wallet, &["list", "--keys"], Some(20))?;
@@ -72,7 +77,7 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
 #[test]
 fn wallet_encrypted_key_cmds_env_var() -> Result<()> {
     let test = setup::single_node_net()?;
-    let key_alias = "test_key_1";
+    let key_alias = "Test_Key_1";
     let password = "VeRySeCuR3";
 
     env::set_var("NAMADA_WALLET_PASSWORD", password);
@@ -86,23 +91,31 @@ fn wallet_encrypted_key_cmds_env_var() -> Result<()> {
 
     cmd.exp_string(&format!(
         "Successfully added a key and an address with alias: \"{}\"",
-        key_alias
+        key_alias.to_lowercase()
     ))?;
 
     // 2. key find
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &["find", "--keys", "--alias", key_alias],
+        &["find", "--keys", "--alias", key_alias, "--decrypt"],
         Some(20),
     )?;
 
-    cmd.exp_string("Public key hash:")?;
-    cmd.exp_string("Public key:")?;
+    cmd.exp_string("Found transparent keys:")?;
+    cmd.exp_string(&format!(
+        "  Alias \"{}\" (encrypted):",
+        key_alias.to_lowercase()
+    ))?;
+    cmd.exp_string("    Public key hash:")?;
+    cmd.exp_string("    Public key:")?;
 
     // 3. key list
     let mut cmd = run!(test, Bin::Wallet, &["list", "--keys"], Some(20))?;
-    cmd.exp_string(&format!("Alias \"{}\" (encrypted):", key_alias))?;
+    cmd.exp_string(&format!(
+        "  Alias \"{}\" (encrypted):",
+        key_alias.to_lowercase()
+    ))?;
 
     Ok(())
 }
@@ -114,7 +127,7 @@ fn wallet_encrypted_key_cmds_env_var() -> Result<()> {
 #[test]
 fn wallet_unencrypted_key_cmds() -> Result<()> {
     let test = setup::single_node_net()?;
-    let key_alias = "test_key_1";
+    let key_alias = "Test_Key_1";
 
     // 1. key gen
     let mut cmd = run!(
@@ -125,7 +138,7 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
     )?;
     cmd.exp_string(&format!(
         "Successfully added a key and an address with alias: \"{}\"",
-        key_alias
+        key_alias.to_lowercase()
     ))?;
 
     // 2. key find
@@ -136,12 +149,20 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
         Some(20),
     )?;
 
-    cmd.exp_string("Public key hash:")?;
-    cmd.exp_string("Public key:")?;
+    cmd.exp_string("Found transparent keys:")?;
+    cmd.exp_string(&format!(
+        "  Alias \"{}\" (not encrypted):",
+        key_alias.to_lowercase()
+    ))?;
+    cmd.exp_string("    Public key hash:")?;
+    cmd.exp_string("    Public key:")?;
 
     // 3. key list
     let mut cmd = run!(test, Bin::Wallet, &["list", "--keys"], Some(20))?;
-    cmd.exp_string(&format!("Alias \"{}\" (not encrypted):", key_alias))?;
+    cmd.exp_string(&format!(
+        "  Alias \"{}\" (not encrypted):",
+        key_alias.to_lowercase()
+    ))?;
 
     Ok(())
 }
@@ -154,8 +175,8 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
 #[test]
 fn wallet_address_cmds() -> Result<()> {
     let test = setup::single_node_net()?;
-    let gen_address_alias = "test_address_1";
-    let add_address_alias = "test_address_2";
+    let gen_address_alias = "Test_Address_1";
+    let add_address_alias = "Test_Address_2";
     let add_address = "tnam1q82t25z5f9gmnv5sztyr8ht9tqhrw4u875qjhy56";
 
     // 1. address gen
@@ -167,7 +188,7 @@ fn wallet_address_cmds() -> Result<()> {
     )?;
     cmd.exp_string(&format!(
         "Successfully added a key and an address with alias: \"{}\"",
-        gen_address_alias
+        gen_address_alias.to_lowercase()
     ))?;
 
     // 2. address add
@@ -178,8 +199,8 @@ fn wallet_address_cmds() -> Result<()> {
         Some(20),
     )?;
     cmd.exp_string(&format!(
-        "Successfully added a key and an address with alias: \"{}\"",
-        add_address_alias
+        "Successfully added an address with alias: \"{}\"",
+        add_address_alias.to_lowercase()
     ))?;
 
     // 3. address find
@@ -189,13 +210,14 @@ fn wallet_address_cmds() -> Result<()> {
         &["find", "--addr", "--alias", gen_address_alias],
         Some(20),
     )?;
-    cmd.exp_string("Found address")?;
+    cmd.exp_string("Found transparent address:")?;
 
     // 4. address list
     let mut cmd = run!(test, Bin::Wallet, &["list", "--addr"], Some(20))?;
 
-    cmd.exp_string(&format!("\"{}\":", gen_address_alias))?;
-    cmd.exp_string(&format!("\"{}\":", add_address_alias))?;
+    cmd.exp_string("Known transparent addresses:")?;
+    cmd.exp_string(&format!("\"{}\":", gen_address_alias.to_lowercase()))?;
+    cmd.exp_string(&format!("\"{}\":", add_address_alias.to_lowercase()))?;
 
     Ok(())
 }

--- a/tests/src/e2e/wallet_tests.rs
+++ b/tests/src/e2e/wallet_tests.rs
@@ -28,12 +28,8 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
     let password = "VeRySeCuR3";
 
     // 1. key gen
-    let mut cmd = run!(
-        test,
-        Bin::Wallet,
-        &["key", "gen", "--alias", key_alias],
-        Some(20),
-    )?;
+    let mut cmd =
+        run!(test, Bin::Wallet, &["gen", "--alias", key_alias], Some(20),)?;
 
     cmd.exp_string("Enter your encryption password:")?;
     cmd.send_line(password)?;
@@ -50,7 +46,7 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &["key", "find", "--alias", key_alias],
+        &["find", "--keys", "--alias", key_alias],
         Some(20),
     )?;
 
@@ -60,7 +56,7 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
     cmd.exp_string("Public key:")?;
 
     // 3. key list
-    let mut cmd = run!(test, Bin::Wallet, &["key", "list"], Some(20))?;
+    let mut cmd = run!(test, Bin::Wallet, &["list", "--keys"], Some(20))?;
     cmd.exp_string(&format!(
         "Alias \"{}\" (encrypted):",
         key_alias.to_lowercase()
@@ -82,12 +78,8 @@ fn wallet_encrypted_key_cmds_env_var() -> Result<()> {
     env::set_var("NAMADA_WALLET_PASSWORD", password);
 
     // 1. key gen
-    let mut cmd = run!(
-        test,
-        Bin::Wallet,
-        &["key", "gen", "--alias", key_alias],
-        Some(20),
-    )?;
+    let mut cmd =
+        run!(test, Bin::Wallet, &["gen", "--alias", key_alias], Some(20),)?;
 
     cmd.exp_string("Enter BIP39 passphrase (empty for none): ")?;
     cmd.send_line("")?;
@@ -101,7 +93,7 @@ fn wallet_encrypted_key_cmds_env_var() -> Result<()> {
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &["key", "find", "--alias", key_alias],
+        &["find", "--keys", "--alias", key_alias],
         Some(20),
     )?;
 
@@ -109,7 +101,7 @@ fn wallet_encrypted_key_cmds_env_var() -> Result<()> {
     cmd.exp_string("Public key:")?;
 
     // 3. key list
-    let mut cmd = run!(test, Bin::Wallet, &["key", "list"], Some(20))?;
+    let mut cmd = run!(test, Bin::Wallet, &["list", "--keys"], Some(20))?;
     cmd.exp_string(&format!("Alias \"{}\" (encrypted):", key_alias))?;
 
     Ok(())
@@ -128,7 +120,7 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &["key", "gen", "--alias", key_alias, "--unsafe-dont-encrypt"],
+        &["gen", "--alias", key_alias, "--unsafe-dont-encrypt"],
         Some(20),
     )?;
     cmd.exp_string(&format!(
@@ -140,7 +132,7 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &["key", "find", "--alias", key_alias],
+        &["find", "--keys", "--alias", key_alias],
         Some(20),
     )?;
 
@@ -148,7 +140,7 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
     cmd.exp_string("Public key:")?;
 
     // 3. key list
-    let mut cmd = run!(test, Bin::Wallet, &["key", "list"], Some(20))?;
+    let mut cmd = run!(test, Bin::Wallet, &["list", "--keys"], Some(20))?;
     cmd.exp_string(&format!("Alias \"{}\" (not encrypted):", key_alias))?;
 
     Ok(())
@@ -170,13 +162,7 @@ fn wallet_address_cmds() -> Result<()> {
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &[
-            "address",
-            "gen",
-            "--alias",
-            gen_address_alias,
-            "--unsafe-dont-encrypt",
-        ],
+        &["gen", "--alias", gen_address_alias, "--unsafe-dont-encrypt"],
         Some(20),
     )?;
     cmd.exp_string(&format!(
@@ -188,14 +174,7 @@ fn wallet_address_cmds() -> Result<()> {
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &[
-            "address",
-            "add",
-            "--address",
-            add_address,
-            "--alias",
-            add_address_alias,
-        ],
+        &["add", "--value", add_address, "--alias", add_address_alias],
         Some(20),
     )?;
     cmd.exp_string(&format!(
@@ -207,13 +186,13 @@ fn wallet_address_cmds() -> Result<()> {
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &["address", "find", "--alias", gen_address_alias],
+        &["find", "--addr", "--alias", gen_address_alias],
         Some(20),
     )?;
     cmd.exp_string("Found address")?;
 
     // 4. address list
-    let mut cmd = run!(test, Bin::Wallet, &["address", "list"], Some(20))?;
+    let mut cmd = run!(test, Bin::Wallet, &["list", "--addr"], Some(20))?;
 
     cmd.exp_string(&format!("\"{}\":", gen_address_alias))?;
     cmd.exp_string(&format!("\"{}\":", add_address_alias))?;


### PR DESCRIPTION
This PR introduces a revamped structure of the wallet CLI suggested in #2135. The changes are based on v0.28.0.

The following changes were additionally introduced.

- For consistency, `--alias` argument is made obligatory for `gen` / `derive` commands.
- Raw (non-HD) key generation functionality is restored, hidden under `--raw` flag.
  Example: `namadaw gen --raw --alias key1`
- Fix alias string normalization
- Implemented `export` for MASP spending keys
- Implemented `import` for secret keys / MASP spending keys
- Implement `add` for secret keys
- Simplified interface of `add` command. Example: `namadaw add --alias my_entry --value val`. The supported values: 
  + secret key
  + public key
  + namada address
  + MASP spending key / viewing key / payment address
- Introduced bi-map for the alias-payment address book
- Implemented alias lookup by MASP payment key

Future work:

- implement ZIP32 functionality for spending key generation
- use `Alias` struct everywhere in order to force alias normalization?

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
