### PR TITLE
fix: sdk async

### DIFF
--- a/.changelog/unreleased/bug-fixes/2261-fix-sdk-0.28.0.md
+++ b/.changelog/unreleased/bug-fixes/2261-fix-sdk-0.28.0.md
@@ -1,0 +1,2 @@
+- Fix sdk compilation when using async-send feature flag.
+  ([\#2261](https://github.com/anoma/namada/pull/2261))

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ check-mainnet:
 check-crates:
 	$(foreach p,$(crates), echo "Checking $(p)" && cargo +$(nightly) check -Z unstable-options --tests -p $(p) && ) \
 		make -C $(wasms_for_tests) check && \
-		cargo check --package namada --target wasm32-unknown-unknown --no-default-features --features "namada-sdk"
+		cargo check --package namada --target wasm32-unknown-unknown --no-default-features --features "namada-sdk" \
+		cargo check --package namada_sdk --all-features
 
 clippy-wasm = $(cargo) +$(nightly) clippy --manifest-path $(wasm)/Cargo.toml --all-targets -- -D warnings
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ check-mainnet:
 check-crates:
 	$(foreach p,$(crates), echo "Checking $(p)" && cargo +$(nightly) check -Z unstable-options --tests -p $(p) && ) \
 		make -C $(wasms_for_tests) check && \
-		cargo check --package namada --target wasm32-unknown-unknown --no-default-features --features "namada-sdk" \
+		cargo check --package namada --target wasm32-unknown-unknown --no-default-features --features "namada-sdk" && \
 		cargo check --package namada_sdk --all-features
 
 clippy-wasm = $(cargo) +$(nightly) clippy --manifest-path $(wasm)/Cargo.toml --all-targets -- -D warnings

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -542,11 +542,13 @@ pub trait Namada: Sized + MaybeSync + MaybeSend {
         tx: &mut Tx,
         args: &args::Tx,
         signing_data: SigningTxData,
-        with: impl Fn(Tx, common::PublicKey, HashSet<signing::Signable>, D) -> F,
+        with: impl Fn(Tx, common::PublicKey, HashSet<signing::Signable>, D) -> F
+        + MaybeSend
+        + MaybeSync,
         user_data: D,
     ) -> crate::error::Result<()>
     where
-        D: Clone,
+        D: Clone + MaybeSend + MaybeSync,
         F: MaybeSend
             + MaybeSync
             + std::future::Future<Output = crate::error::Result<Tx>>,

--- a/sdk/src/signing.rs
+++ b/sdk/src/signing.rs
@@ -58,7 +58,7 @@ use crate::tx::{
 };
 pub use crate::wallet::store::AddressVpType;
 use crate::wallet::{Wallet, WalletIo};
-use crate::{args, display_line, rpc, Namada};
+use crate::{args, display_line, rpc, MaybeSend, Namada};
 
 #[cfg(feature = "std")]
 /// Env. var specifying where to store signing test vectors
@@ -217,7 +217,7 @@ pub async fn sign_tx<'a, D, F, U>(
     user_data: D,
 ) -> Result<(), Error>
 where
-    D: Clone,
+    D: Clone + MaybeSend,
     U: WalletIo,
     F: std::future::Future<Output = Result<Tx, Error>>,
 {


### PR DESCRIPTION
## Describe your changes
Fix the sdk compiling with `async-send` feature flag. 
Added check on Makefile.

## Indicate on which release or other PRs this topic is based on
- 0.28.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
