### PR TITLE
Fix pruning BridgePool Merkle tree

### DIFF
--- a/.changelog/unreleased/bug-fixes/2264-fix-bp-tree-pruning.md
+++ b/.changelog/unreleased/bug-fixes/2264-fix-bp-tree-pruning.md
@@ -1,0 +1,2 @@
+- Fix to skip pruning BridgePool Merkle trees when no signed nonce
+  ([\#2264](https://github.com/anoma/namada/issues/2264))

--- a/apps/src/lib/node/ledger/storage/mod.proptest-regressions
+++ b/apps/src/lib/node/ledger/storage/mod.proptest-regressions
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 94189e4348e711536bd368fb077d15a64d5591b88bded0cedce7abf6035b7083 # shrinks to blocks_write_type = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 3, 3, 0, 2, 1, 4, 0, 0, 0, 4, 0, 3, 0, 4, 4, 1, 3, 3, 3, 3, 1, 1, 0, 2, 2, 4, 3, 1, 4, 3, 0, 2, 4, 1, 4, 1]

--- a/apps/src/lib/node/ledger/storage/mod.proptest-regressions
+++ b/apps/src/lib/node/ledger/storage/mod.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 94189e4348e711536bd368fb077d15a64d5591b88bded0cedce7abf6035b7083 # shrinks to blocks_write_type = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 3, 3, 0, 2, 1, 4, 0, 0, 0, 4, 0, 3, 0, 4, 4, 1, 3, 3, 3, 3, 1, 1, 0, 2, 2, 4, 3, 1, 4, 3, 0, 2, 4, 1, 4, 1]

--- a/apps/src/lib/node/ledger/storage/mod.rs
+++ b/apps/src/lib/node/ledger/storage/mod.rs
@@ -591,11 +591,8 @@ mod tests {
         );
         let new_epoch_start = BlockHeight(1);
         let signed_root_key = bridge_pool::get_signed_root_key();
+        // the first nonce isn't written for a test skipping pruning
         let nonce = Uint::default();
-        let root_proof =
-            BridgePoolRootProof::new((KeccakHash::default(), nonce));
-        let bytes = types::encode(&root_proof);
-        storage.write(&signed_root_key, bytes).unwrap();
 
         storage
             .begin_block(BlockHash::default(), new_epoch_start)
@@ -622,11 +619,8 @@ mod tests {
             .write(&key, types::encode(&value))
             .expect("write failed");
 
+        // the second nonce isn't written for a test skipping pruning
         let nonce = nonce + 1;
-        let root_proof =
-            BridgePoolRootProof::new((KeccakHash::default(), nonce));
-        let bytes = types::encode(&root_proof);
-        storage.write(&signed_root_key, bytes).unwrap();
 
         storage.block.epoch = storage.block.epoch.next();
         storage.block.pred_epochs.new_epoch(new_epoch_start);

--- a/core/src/ledger/storage/mockdb.rs
+++ b/core/src/ledger/storage/mockdb.rs
@@ -593,8 +593,8 @@ impl DB for MockDB {
         &self,
         _height: BlockHeight,
         _last_height: BlockHeight,
-    ) -> Result<Uint> {
-        Ok(Uint::default())
+    ) -> Result<Option<Uint>> {
+        Ok(None)
     }
 
     fn write_replay_protection_entry(


### PR DESCRIPTION
## Describe your changes
When a signed nonce wasn't stored, the pruning failed.
To fix it, it skips when there is no signed root.

## Indicate on which release or other PRs this topic is based on
`0.28.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
