### PR TITLE
cache masp verifying keys

### DIFF
--- a/.changelog/unreleased/improvements/2272-cache-masp-keys.md
+++ b/.changelog/unreleased/improvements/2272-cache-masp-keys.md
@@ -1,0 +1,2 @@
+- Preload and cache MASP verifying keys on ledger start-up.
+  ([\#2272](https://github.com/anoma/namada/pull/2272))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,6 +4440,7 @@ dependencies = [
  "fd-lock",
  "futures",
  "itertools 0.10.5",
+ "lazy_static",
  "masp_primitives",
  "masp_proofs",
  "namada_core",

--- a/apps/src/lib/node/ledger/mod.rs
+++ b/apps/src/lib/node/ledger/mod.rs
@@ -259,6 +259,10 @@ async fn run_aux(config: config::Ledger, wasm_dir: PathBuf) {
             }
         };
 
+    tracing::info!("Loading MASP verifying keys.");
+    let _ = namada_sdk::masp::preload_verifying_keys();
+    tracing::info!("Done loading MASP verifying keys.");
+
     // Start ABCI server and broadcaster (the latter only if we are a validator
     // node)
     let (abci, broadcaster, shell_handler) = start_abci_broadcaster_shell(

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -67,6 +67,7 @@ ethers.workspace = true
 fd-lock = { workspace = true, optional = true }
 futures.workspace = true
 itertools.workspace = true
+lazy_static.workspace= true
 masp_primitives.workspace = true
 masp_proofs.workspace = true
 namada_core = {path = "../core", default-features = false, features = ["rand"]}

--- a/sdk/src/masp.rs
+++ b/sdk/src/masp.rs
@@ -2050,8 +2050,8 @@ mod tests {
             .expect("expected a temp dir")
             .into_path();
         let fake_params_paths =
-            [SPEND_NAME, CONVERT_NAME, OUTPUT_NAME].map(|p| tempdir.join(p));
-        for path in fake_params_paths {
+            [SPEND_NAME, OUTPUT_NAME, CONVERT_NAME].map(|p| tempdir.join(p));
+        for path in &fake_params_paths {
             let mut f =
                 std::fs::File::create(path).expect("expected a temp file");
             f.write_all(b"fake params")
@@ -2062,7 +2062,11 @@ mod tests {
 
         std::env::set_var(super::ENV_VAR_MASP_PARAMS_DIR, tempdir.as_os_str());
         // should panic here
-        super::load_pvks();
+        masp_proofs::load_parameters(
+            &fake_params_paths[0],
+            &fake_params_paths[1],
+            &fake_params_paths[2],
+        );
     }
 
     /// a more involved test, using dummy parameters with the right
@@ -2114,11 +2118,11 @@ mod tests {
         // TODO: get masp to export these consts
         let fake_params_paths = [
             (SPEND_NAME, 49848572u64),
-            (CONVERT_NAME, 22570940u64),
             (OUTPUT_NAME, 16398620u64),
+            (CONVERT_NAME, 22570940u64),
         ]
         .map(|(p, s)| (tempdir.join(p), s));
-        for (path, size) in fake_params_paths {
+        for (path, size) in &fake_params_paths {
             let mut f =
                 std::fs::File::create(path).expect("expected a temp file");
             fake_params
@@ -2128,14 +2132,19 @@ mod tests {
             // params should always be smaller than the large masp
             // circuit params. so this truncate extends the file, and
             // extra bytes at the end do not make it invalid.
-            f.set_len(size).expect("expected to truncate the temp file");
+            f.set_len(*size)
+                .expect("expected to truncate the temp file");
             f.sync_all()
                 .expect("expected a writable temp file (on sync)");
         }
 
         std::env::set_var(super::ENV_VAR_MASP_PARAMS_DIR, tempdir.as_os_str());
         // should panic here
-        super::load_pvks();
+        masp_proofs::load_parameters(
+            &fake_params_paths[0].0,
+            &fake_params_paths[1].0,
+            &fake_params_paths[2].0,
+        );
     }
 }
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3476,6 +3476,7 @@ dependencies = [
  "ethers",
  "futures",
  "itertools 0.10.5",
+ "lazy_static",
  "masp_primitives",
  "masp_proofs",
  "namada_core",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -3476,6 +3476,7 @@ dependencies = [
  "ethers",
  "futures",
  "itertools 0.10.5",
+ "lazy_static",
  "masp_primitives",
  "masp_proofs",
  "namada_core",


### PR DESCRIPTION
## Describe your changes

Preload MASP params on start up, derive verifying keys and cache them in-memory (using `lazy_static`).

## Indicate on which release or other PRs this topic is based on

0.28.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
