### PR TITLE
Masp miscellaneous fixes

### DIFF
--- a/.changelog/unreleased/SDK/2282-masp-misc-fixes.md
+++ b/.changelog/unreleased/SDK/2282-masp-misc-fixes.md
@@ -1,0 +1,2 @@
+- Removed useless epoch for fee unshielding.
+  ([\#2282](https://github.com/anoma/namada/pull/2282))

--- a/.changelog/unreleased/bug-fixes/2240-nullifier-uniqueness.md
+++ b/.changelog/unreleased/bug-fixes/2240-nullifier-uniqueness.md
@@ -1,0 +1,2 @@
+- Prevents double-spending in masp by adding a nullifier set.
+  ([\#2240](https://github.com/anoma/namada/pull/2240))

--- a/.changelog/unreleased/bug-fixes/2244-spend-description-validation.md
+++ b/.changelog/unreleased/bug-fixes/2244-spend-description-validation.md
@@ -1,0 +1,2 @@
+- Updates masp tx to store the notes and the native vp to validate them and the
+  anchors. ([\#2244](https://github.com/anoma/namada/pull/2244))

--- a/.changelog/unreleased/bug-fixes/2248-convert-description-validation.md
+++ b/.changelog/unreleased/bug-fixes/2248-convert-description-validation.md
@@ -1,0 +1,2 @@
+- Updates the masp vp to validate the convert description's anchor.
+  ([\#2248](https://github.com/anoma/namada/pull/2248))

--- a/.changelog/unreleased/improvements/2282-masp-misc-fixes.md
+++ b/.changelog/unreleased/improvements/2282-masp-misc-fixes.md
@@ -1,0 +1,2 @@
+- Removed useless epoch for fee unshielding and refactored tests.
+  ([\#2282](https://github.com/anoma/namada/pull/2282))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,6 +3896,8 @@ dependencies = [
  "borsh",
  "borsh-ext",
  "criterion",
+ "masp_primitives",
+ "masp_proofs",
  "namada",
  "namada_apps",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,6 +3930,7 @@ dependencies = [
  "itertools 0.10.5",
  "k256",
  "masp_primitives",
+ "masp_proofs",
  "namada_macros",
  "num-integer",
  "num-rational 0.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,7 +3897,6 @@ dependencies = [
  "borsh-ext",
  "criterion",
  "masp_primitives",
- "masp_proofs",
  "namada",
  "namada_apps",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,7 +3930,6 @@ dependencies = [
  "itertools 0.10.5",
  "k256",
  "masp_primitives",
- "masp_proofs",
  "namada_macros",
  "num-integer",
  "num-rational 0.4.1",

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -223,7 +223,7 @@ pub async fn submit_reveal_aux<'a>(
                 "Submitting a tx to reveal the public key for address \
                  {address}..."
             );
-            let (mut tx, signing_data, _epoch) =
+            let (mut tx, signing_data) =
                 tx::build_reveal_pk(context, &args, &public_key).await?;
 
             signing::generate_test_vector(context, &tx).await?;
@@ -244,7 +244,7 @@ pub async fn submit_bridge_pool_tx<'a, N: Namada<'a>>(
     args: args::EthereumBridgePool,
 ) -> Result<(), error::Error> {
     let tx_args = args.tx.clone();
-    let (mut tx, signing_data, _epoch) = args.clone().build(namada).await?;
+    let (mut tx, signing_data) = args.clone().build(namada).await?;
 
     signing::generate_test_vector(namada, &tx).await?;
 
@@ -272,7 +272,7 @@ where
 {
     submit_reveal_aux(namada, args.tx.clone(), &args.owner).await?;
 
-    let (mut tx, signing_data, _epoch) = args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
 
     signing::generate_test_vector(namada, &tx).await?;
 
@@ -296,7 +296,7 @@ pub async fn submit_update_account<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _epoch) = args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
 
     signing::generate_test_vector(namada, &tx).await?;
 
@@ -320,8 +320,7 @@ pub async fn submit_init_account<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _epoch) =
-        tx::build_init_account(namada, &args).await?;
+    let (mut tx, signing_data) = tx::build_init_account(namada, &args).await?;
 
     signing::generate_test_vector(namada, &tx).await?;
 
@@ -919,7 +918,7 @@ where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
     submit_reveal_aux(namada, args.tx.clone(), &args.source).await?;
-    let (mut tx, signing_data, _epoch) = args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
     if args.tx.dump_tx {
@@ -945,8 +944,7 @@ where
     let current_epoch = rpc::query_and_print_epoch(namada).await;
     let governance_parameters =
         rpc::query_governance_parameters(namada.client()).await;
-    let (mut tx_builder, signing_data, _fee_unshield_epoch) = if args.is_offline
-    {
+    let (mut tx_builder, signing_data) = if args.is_offline {
         let proposal = OfflineProposal::try_from(args.proposal_data.as_ref())
             .map_err(|e| {
                 error::TxError::FailedGovernaneProposalDeserialize(
@@ -1071,8 +1069,7 @@ pub async fn submit_vote_proposal<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx_builder, signing_data, _fee_unshield_epoch) = if args.is_offline
-    {
+    let (mut tx_builder, signing_data) = if args.is_offline {
         let default_signer = Some(args.voter.clone());
         let signing_data = aux_signing_data(
             namada,
@@ -1247,8 +1244,7 @@ where
     let default_address = args.source.clone().unwrap_or(args.validator.clone());
     submit_reveal_aux(namada, args.tx.clone(), &default_address).await?;
 
-    let (mut tx, signing_data, _fee_unshield_epoch) =
-        args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
     if args.tx.dump_tx {
@@ -1271,7 +1267,7 @@ pub async fn submit_unbond<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _fee_unshield_epoch, latest_withdrawal_pre) =
+    let (mut tx, signing_data, latest_withdrawal_pre) =
         args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
@@ -1297,8 +1293,7 @@ pub async fn submit_withdraw<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _fee_unshield_epoch) =
-        args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
     if args.tx.dump_tx {
@@ -1321,8 +1316,7 @@ pub async fn submit_claim_rewards<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _fee_unshield_epoch) =
-        args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
     if args.tx.dump_tx {
@@ -1368,8 +1362,7 @@ pub async fn submit_validator_commission_change<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _fee_unshield_epoch) =
-        args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
     if args.tx.dump_tx {
@@ -1392,8 +1385,7 @@ pub async fn submit_validator_metadata_change<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _fee_unshield_epoch) =
-        args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
     if args.tx.dump_tx {
@@ -1438,8 +1430,7 @@ pub async fn submit_unjail_validator<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _fee_unshield_epoch) =
-        args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
     if args.tx.dump_tx {
@@ -1462,8 +1453,7 @@ pub async fn submit_deactivate_validator<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _fee_unshield_epoch) =
-        args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
     if args.tx.dump_tx {
@@ -1486,8 +1476,7 @@ pub async fn submit_reactivate_validator<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _fee_unshield_epoch) =
-        args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 
     if args.tx.dump_tx {
@@ -1510,8 +1499,7 @@ pub async fn submit_update_steward_commission<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _fee_unshield_epoch) =
-        args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
 
     signing::generate_test_vector(namada, &tx).await?;
 
@@ -1535,7 +1523,7 @@ pub async fn submit_resign_steward<'a, N: Namada<'a>>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    let (mut tx, signing_data, _epoch) = args.build(namada).await?;
+    let (mut tx, signing_data) = args.build(namada).await?;
 
     signing::generate_test_vector(namada, &tx).await?;
 

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -27,7 +27,7 @@ use namada::types::dec::Dec;
 use namada::types::key::tm_raw_hash_to_string;
 use namada::types::storage::{BlockHash, BlockResults, Epoch, Header};
 use namada::types::token::{
-    MASP_NOTE_COMMITMENT_ANCHOR_PREFIX, MASP_NOTE_COMMITMENT_TREE,
+    MASP_NOTE_COMMITMENT_ANCHOR_PREFIX, MASP_NOTE_COMMITMENT_TREE_KEY,
 };
 use namada::types::transaction::protocol::{
     ethereum_tx_data_variants, ProtocolTxType,
@@ -568,7 +568,7 @@ where
 
         // Update the MASP commitment tree anchor if the tree was updated
         let tree_key = Key::from(MASP.to_db_key())
-            .push(&MASP_NOTE_COMMITMENT_TREE.to_owned())
+            .push(&MASP_NOTE_COMMITMENT_TREE_KEY.to_owned())
             .expect("Cannot obtain a storage key");
         if let Some(StorageModification::Write { value }) =
             self.wl_storage.write_log.read(&tree_key).0

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -2,6 +2,9 @@
 use std::collections::HashMap;
 use std::hash::Hash;
 
+use masp_primitives::merkle_tree::CommitmentTree;
+use masp_primitives::sapling::Node;
+use masp_proofs::bls12_381;
 use namada::ledger::parameters::Parameters;
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::{DBIter, DB};
@@ -9,10 +12,14 @@ use namada::ledger::storage_api::token::{credit_tokens, write_denom};
 use namada::ledger::storage_api::StorageWrite;
 use namada::ledger::{ibc, pos};
 use namada::proof_of_stake::BecomeValidator;
+use namada::types::address::MASP;
 use namada::types::hash::Hash as CodeHash;
 use namada::types::key::*;
 use namada::types::storage::KeySeg;
 use namada::types::time::{DateTimeUtc, TimeZone, Utc};
+use namada::types::token::{
+    MASP_NOTE_COMMITMENT_ANCHOR_PREFIX, MASP_NOTE_COMMITMENT_TREE,
+};
 use namada::vm::validate_untrusted_wasm;
 use namada_sdk::eth_bridge::EthBridgeStatus;
 use namada_sdk::proof_of_stake::types::ValidatorMetaData;
@@ -171,6 +178,27 @@ where
         .expect("Must be able to copy PoS genesis validator sets");
 
         ibc::init_genesis_storage(&mut self.wl_storage);
+
+        // Init masp commitment tree and anchor
+        let empty_commitment_tree: CommitmentTree<Node> =
+            CommitmentTree::empty();
+        let anchor = empty_commitment_tree.root();
+        let note_commitment_tree_key = Key::from(MASP.to_db_key())
+            .push(&MASP_NOTE_COMMITMENT_TREE.to_owned())
+            .expect("Cannot obtain a storage key");
+        self.wl_storage
+            .write(&note_commitment_tree_key, empty_commitment_tree)
+            .unwrap();
+        let commitment_tree_anchor_key = Key::from(MASP.to_db_key())
+            .push(&MASP_NOTE_COMMITMENT_ANCHOR_PREFIX.to_owned())
+            .expect("Cannot obtain a storage key")
+            .push(&namada::core::types::hash::Hash(
+                bls12_381::Scalar::from(anchor).to_bytes(),
+            ))
+            .expect("Cannot obtain a storage key");
+        self.wl_storage
+            .write(&commitment_tree_anchor_key, ())
+            .unwrap();
 
         // Set the initial validator set
         response.validators = self

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -18,7 +18,7 @@ use namada::types::key::*;
 use namada::types::storage::KeySeg;
 use namada::types::time::{DateTimeUtc, TimeZone, Utc};
 use namada::types::token::{
-    MASP_NOTE_COMMITMENT_ANCHOR_PREFIX, MASP_NOTE_COMMITMENT_TREE,
+    MASP_NOTE_COMMITMENT_ANCHOR_PREFIX, MASP_NOTE_COMMITMENT_TREE_KEY,
 };
 use namada::vm::validate_untrusted_wasm;
 use namada_sdk::eth_bridge::EthBridgeStatus;
@@ -184,7 +184,7 @@ where
             CommitmentTree::empty();
         let anchor = empty_commitment_tree.root();
         let note_commitment_tree_key = Key::from(MASP.to_db_key())
-            .push(&MASP_NOTE_COMMITMENT_TREE.to_owned())
+            .push(&MASP_NOTE_COMMITMENT_TREE_KEY.to_owned())
             .expect("Cannot obtain a storage key");
         self.wl_storage
             .write(&note_commitment_tree_key, empty_commitment_tree)

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -18,7 +18,8 @@ use namada::types::key::*;
 use namada::types::storage::KeySeg;
 use namada::types::time::{DateTimeUtc, TimeZone, Utc};
 use namada::types::token::{
-    MASP_NOTE_COMMITMENT_ANCHOR_PREFIX, MASP_NOTE_COMMITMENT_TREE_KEY,
+    MASP_CONVERT_ANCHOR_KEY, MASP_NOTE_COMMITMENT_ANCHOR_PREFIX,
+    MASP_NOTE_COMMITMENT_TREE_KEY,
 };
 use namada::vm::validate_untrusted_wasm;
 use namada_sdk::eth_bridge::EthBridgeStatus;
@@ -199,6 +200,20 @@ where
         self.wl_storage
             .write(&commitment_tree_anchor_key, ())
             .unwrap();
+
+        // Init masp convert anchor
+        let convert_anchor_key = Key::from(MASP.to_db_key())
+            .push(&MASP_CONVERT_ANCHOR_KEY.to_owned())
+            .expect("Cannot obtain a storage key");
+        self.wl_storage.write(
+            &convert_anchor_key,
+            namada::core::types::hash::Hash(
+                bls12_381::Scalar::from(
+                    self.wl_storage.storage.conversion_state.tree.root(),
+                )
+                .to_bytes(),
+            ),
+        )?;
 
         // Set the initial validator set
         response.validators = self

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -43,7 +43,6 @@ path = "host_env.rs"
 namada = { path = "../shared", features = ["testing"] }
 namada_apps = { path = "../apps", features = ["benches"] }
 masp_primitives.workspace = true
-masp_proofs.workspace = true
 borsh.workspace = true
 borsh-ext.workspace = true
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -42,6 +42,8 @@ path = "host_env.rs"
 [dev-dependencies]
 namada = { path = "../shared", features = ["testing"] }
 namada_apps = { path = "../apps", features = ["benches"] }
+masp_primitives.workspace = true
+masp_proofs.workspace = true
 borsh.workspace = true
 borsh-ext.workspace = true
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/benches/native_vps.rs
+++ b/benches/native_vps.rs
@@ -4,8 +4,8 @@ use std::rc::Rc;
 use std::str::FromStr;
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use masp_primitives::bls12_381;
 use masp_primitives::sapling::Node;
-use masp_proofs::bls12_381;
 use namada::core::ledger::governance::storage::proposal::ProposalType;
 use namada::core::ledger::governance::storage::vote::{
     StorageProposalVote, VoteType,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -51,7 +51,6 @@ index-set.workspace = true
 itertools.workspace = true
 k256.workspace = true
 masp_primitives.workspace = true
-masp_proofs.workspace = true
 num256.workspace = true
 num_enum = "0.7.0"
 num-integer = "0.1.45"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -51,6 +51,7 @@ index-set.workspace = true
 itertools.workspace = true
 k256.workspace = true
 masp_primitives.workspace = true
+masp_proofs.workspace = true
 num256.workspace = true
 num_enum = "0.7.0"
 num-integer = "0.1.45"

--- a/core/src/ledger/masp_conversions.rs
+++ b/core/src/ledger/masp_conversions.rs
@@ -5,6 +5,8 @@ use std::collections::BTreeMap;
 use borsh::{BorshDeserialize, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use masp_primitives::asset_type::AssetType;
+#[cfg(feature = "wasm-runtime")]
+use masp_primitives::bls12_381;
 use masp_primitives::convert::AllowedConversion;
 use masp_primitives::merkle_tree::FrozenCommitmentTree;
 use masp_primitives::sapling::Node;
@@ -16,7 +18,9 @@ use crate::ledger::storage_api::token::read_denom;
 use crate::ledger::storage_api::{StorageRead, StorageWrite};
 use crate::types::address::{Address, MASP};
 use crate::types::dec::Dec;
-use crate::types::storage::{Epoch, Key, KeySeg};
+use crate::types::storage::Epoch;
+#[cfg(feature = "wasm-runtime")]
+use crate::types::storage::{Key, KeySeg};
 use crate::types::token;
 use crate::types::token::MaspDenom;
 use crate::types::uint::Uint;

--- a/core/src/ledger/masp_conversions.rs
+++ b/core/src/ledger/masp_conversions.rs
@@ -215,7 +215,7 @@ where
     use rayon::prelude::ParallelSlice;
 
     use crate::types::address;
-    use crate::types::token::MASP_CONVERT_ANCHOR_PREFIX;
+    use crate::types::token::MASP_CONVERT_ANCHOR_KEY;
 
     // The derived conversions will be placed in MASP address space
     let masp_addr = MASP;
@@ -459,18 +459,19 @@ where
     // obtained
     wl_storage.storage.conversion_state.tree =
         FrozenCommitmentTree::merge(&tree_parts);
-    // Publish the new anchor in storage
+    // Update the anchor in storage
     let anchor_key = Key::from(MASP.to_db_key())
-        .push(&MASP_CONVERT_ANCHOR_PREFIX.to_owned())
-        .expect("Cannot obtain a storage key")
-        .push(&crate::types::hash::Hash(
-            masp_primitives::bls12_381::Scalar::from(
+        .push(&MASP_CONVERT_ANCHOR_KEY.to_owned())
+        .expect("Cannot obtain a storage key");
+    wl_storage.write(
+        &anchor_key,
+        crate::types::hash::Hash(
+            bls12_381::Scalar::from(
                 wl_storage.storage.conversion_state.tree.root(),
             )
             .to_bytes(),
-        ))
-        .expect("Cannot obtain a storage key");
-    wl_storage.write(&anchor_key, ())?;
+        ),
+    )?;
 
     // Add purely decoding entries to the assets map. These will be
     // overwritten before the creation of the next commitment tree

--- a/core/src/ledger/masp_utils.rs
+++ b/core/src/ledger/masp_utils.rs
@@ -1,0 +1,30 @@
+//! MASP utilities
+
+use masp_primitives::transaction::Transaction;
+
+use super::storage_api::StorageWrite;
+use crate::ledger::storage_api::Result;
+use crate::types::address::MASP;
+use crate::types::hash::Hash;
+use crate::types::storage::{Key, KeySeg};
+use crate::types::token::MASP_NULLIFIERS_KEY_PREFIX;
+
+/// Writes the nullifiers of the provided masp transaction to storage
+pub fn reveal_nullifiers(
+    ctx: &mut impl StorageWrite,
+    transaction: &Transaction,
+) -> Result<()> {
+    for description in transaction
+        .sapling_bundle()
+        .map_or(&vec![], |description| &description.shielded_spends)
+    {
+        let nullifier_key = Key::from(MASP.to_db_key())
+            .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
+            .expect("Cannot obtain a storage key")
+            .push(&Hash(description.nullifier.0))
+            .expect("Cannot obtain a storage key");
+        ctx.write(&nullifier_key, ())?;
+    }
+
+    Ok(())
+}

--- a/core/src/ledger/masp_utils.rs
+++ b/core/src/ledger/masp_utils.rs
@@ -2,15 +2,18 @@
 
 use masp_primitives::transaction::Transaction;
 
-use super::storage_api::StorageWrite;
+use super::storage_api::{StorageRead, StorageWrite};
 use crate::ledger::storage_api::Result;
 use crate::types::address::MASP;
 use crate::types::hash::Hash;
-use crate::types::storage::{Key, KeySeg};
-use crate::types::token::MASP_NULLIFIERS_KEY_PREFIX;
+use crate::types::storage::{BlockHeight, Epoch, Key, KeySeg, TxIndex};
+use crate::types::token::{
+    Transfer, HEAD_TX_KEY, MASP_NULLIFIERS_KEY_PREFIX, PIN_KEY_PREFIX,
+    TX_KEY_PREFIX,
+};
 
-/// Writes the nullifiers of the provided masp transaction to storage
-pub fn reveal_nullifiers(
+// Writes the nullifiers of the provided masp transaction to storage
+fn reveal_nullifiers(
     ctx: &mut impl StorageWrite,
     transaction: &Transaction,
 ) -> Result<()> {
@@ -24,6 +27,46 @@ pub fn reveal_nullifiers(
             .push(&Hash(description.nullifier.0))
             .expect("Cannot obtain a storage key");
         ctx.write(&nullifier_key, ())?;
+    }
+
+    Ok(())
+}
+
+/// Handle a MASP transaction.
+pub fn handle_masp_tx(
+    ctx: &mut (impl StorageRead + StorageWrite),
+    transfer: &Transfer,
+    shielded: &Transaction,
+) -> Result<()> {
+    let masp_addr = MASP;
+    let head_tx_key = Key::from(masp_addr.to_db_key())
+        .push(&HEAD_TX_KEY.to_owned())
+        .expect("Cannot obtain a storage key");
+    let current_tx_idx: u64 =
+        ctx.read(&head_tx_key).unwrap_or(None).unwrap_or(0);
+    let current_tx_key = Key::from(masp_addr.to_db_key())
+        .push(&(TX_KEY_PREFIX.to_owned() + &current_tx_idx.to_string()))
+        .expect("Cannot obtain a storage key");
+    // Save the Transfer object and its location within the blockchain
+    // so that clients do not have to separately look these
+    // up
+    let record: (Epoch, BlockHeight, TxIndex, Transfer, Transaction) = (
+        ctx.get_block_epoch()?,
+        ctx.get_block_height()?,
+        ctx.get_tx_index()?,
+        transfer.clone(),
+        shielded.clone(),
+    );
+    ctx.write(&current_tx_key, record)?;
+    ctx.write(&head_tx_key, current_tx_idx + 1)?;
+    reveal_nullifiers(ctx, shielded)?;
+
+    // If storage key has been supplied, then pin this transaction to it
+    if let Some(key) = &transfer.key {
+        let pin_key = Key::from(masp_addr.to_db_key())
+            .push(&(PIN_KEY_PREFIX.to_owned() + key))
+            .expect("Cannot obtain a storage key");
+        ctx.write(&pin_key, current_tx_idx)?;
     }
 
     Ok(())

--- a/core/src/ledger/masp_utils.rs
+++ b/core/src/ledger/masp_utils.rs
@@ -10,11 +10,8 @@ use crate::types::address::MASP;
 use crate::types::hash::Hash;
 use crate::types::storage::{BlockHeight, Epoch, Key, KeySeg, TxIndex};
 use crate::types::token::{
-    Transfer, HEAD_TX_KEY, MASP_NULLIFIERS_KEY_PREFIX, PIN_KEY_PREFIX,
-    TX_KEY_PREFIX,
-};
-use crate::types::token::{
-    MASP_NOTE_COMMITMENT_TREE, MASP_NULLIFIERS_KEY_PREFIX,
+    Transfer, HEAD_TX_KEY, MASP_NOTE_COMMITMENT_TREE_KEY,
+    MASP_NULLIFIERS_KEY_PREFIX, PIN_KEY_PREFIX, TX_KEY_PREFIX,
 };
 
 // Writes the nullifiers of the provided masp transaction to storage
@@ -37,20 +34,21 @@ fn reveal_nullifiers(
     Ok(())
 }
 
-// Appends the note commitments of the provided transaction to the merkle tree
-// and updates the anchor
-fn update_note_commitment_tree(
+/// Appends the note commitments of the provided transaction to the merkle tree
+/// and updates the anchor
+/// NOTE: this function is public as a temporary workaround because of an issue
+/// when running this function in WASM
+pub fn update_note_commitment_tree(
     ctx: &mut (impl StorageRead + StorageWrite),
     transaction: &Transaction,
 ) -> Result<()> {
     if let Some(bundle) = transaction.sapling_bundle() {
         if !bundle.shielded_outputs.is_empty() {
             let tree_key = Key::from(MASP.to_db_key())
-                .push(&MASP_NOTE_COMMITMENT_TREE.to_owned())
+                .push(&MASP_NOTE_COMMITMENT_TREE_KEY.to_owned())
                 .expect("Cannot obtain a storage key");
-            let mut commitment_tree = ctx
-                .read::<CommitmentTree<Node>>(&tree_key)?
-                .ok_or(Error::SimpleMessage(
+            let mut commitment_tree: CommitmentTree<Node> =
+                ctx.read(&tree_key)?.ok_or(Error::SimpleMessage(
                     "Missing note commitment tree in storage",
                 ))?;
 
@@ -97,7 +95,10 @@ pub fn handle_masp_tx(
     );
     ctx.write(&current_tx_key, record)?;
     ctx.write(&head_tx_key, current_tx_idx + 1)?;
-    update_note_commitment_tree(ctx, shielded)?;
+    // TODO: temporarily disabled because of the node aggregation issue in WASM.
+    // Using the host env tx_update_masp_note_commitment_tree or directly the
+    // update_note_commitment_tree function as a  workaround instead
+    // update_note_commitment_tree(ctx, shielded)?;
     reveal_nullifiers(ctx, shielded)?;
 
     // If storage key has been supplied, then pin this transaction to it

--- a/core/src/ledger/masp_utils.rs
+++ b/core/src/ledger/masp_utils.rs
@@ -10,8 +10,8 @@ use crate::types::address::MASP;
 use crate::types::hash::Hash;
 use crate::types::storage::{BlockHeight, Epoch, Key, KeySeg, TxIndex};
 use crate::types::token::{
-    Transfer, HEAD_TX_KEY, MASP_NOTE_COMMITMENT_TREE_KEY,
-    MASP_NULLIFIERS_KEY_PREFIX, PIN_KEY_PREFIX, TX_KEY_PREFIX,
+    Transfer, HEAD_TX_KEY, MASP_NOTE_COMMITMENT_TREE_KEY, MASP_NULLIFIERS_KEY,
+    PIN_KEY_PREFIX, TX_KEY_PREFIX,
 };
 
 // Writes the nullifiers of the provided masp transaction to storage
@@ -24,7 +24,7 @@ fn reveal_nullifiers(
         .map_or(&vec![], |description| &description.shielded_spends)
     {
         let nullifier_key = Key::from(MASP.to_db_key())
-            .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
+            .push(&MASP_NULLIFIERS_KEY.to_owned())
             .expect("Cannot obtain a storage key")
             .push(&Hash(description.nullifier.0))
             .expect("Cannot obtain a storage key");

--- a/core/src/ledger/mod.rs
+++ b/core/src/ledger/mod.rs
@@ -6,6 +6,7 @@ pub mod governance;
 pub mod ibc;
 pub mod inflation;
 pub mod masp_conversions;
+pub mod masp_utils;
 pub mod parameters;
 pub mod pgf;
 pub mod replay_protection;

--- a/core/src/ledger/storage/write_log.rs
+++ b/core/src/ledger/storage/write_log.rs
@@ -182,7 +182,6 @@ impl WriteLog {
         &self,
         key: &storage::Key,
     ) -> (Option<&StorageModification>, u64) {
-        // try to read from tx write log first
         match self.block_write_log.get(key) {
             Some(v) => {
                 let gas = match v {

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -906,6 +906,8 @@ pub const MASP_NULLIFIERS_KEY_PREFIX: &str = "nullifiers";
 pub const MASP_NOTE_COMMITMENT_TREE_KEY: &str = "commitment_tree";
 /// Key segment prefix for the note commitment anchor
 pub const MASP_NOTE_COMMITMENT_ANCHOR_PREFIX: &str = "note_commitment_anchor";
+/// Key segment prefix for the convert anchor
+pub const MASP_CONVERT_ANCHOR_PREFIX: &str = "convert_anchor";
 /// Last calculated inflation value handed out
 pub const MASP_LAST_INFLATION_KEY: &str = "last_inflation";
 /// The last locked ratio
@@ -1133,7 +1135,8 @@ pub fn is_masp_key(key: &Key) -> bool {
                     || key.starts_with(PIN_KEY_PREFIX)
                     || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)
                     || key == MASP_NOTE_COMMITMENT_TREE_KEY
-                    || key.starts_with(MASP_NOTE_COMMITMENT_ANCHOR_PREFIX)))
+                    || key.starts_with(MASP_NOTE_COMMITMENT_ANCHOR_PREFIX)
+                    || key.starts_with(MASP_CONVERT_ANCHOR_PREFIX)))
 }
 
 /// Check if the given storage key is a masp nullifier key

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -907,7 +907,7 @@ pub const MASP_NOTE_COMMITMENT_TREE_KEY: &str = "commitment_tree";
 /// Key segment prefix for the note commitment anchor
 pub const MASP_NOTE_COMMITMENT_ANCHOR_PREFIX: &str = "note_commitment_anchor";
 /// Key segment prefix for the convert anchor
-pub const MASP_CONVERT_ANCHOR_PREFIX: &str = "convert_anchor";
+pub const MASP_CONVERT_ANCHOR_KEY: &str = "convert_anchor";
 /// Last calculated inflation value handed out
 pub const MASP_LAST_INFLATION_KEY: &str = "last_inflation";
 /// The last locked ratio

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -1130,6 +1130,15 @@ pub fn is_masp_key(key: &Key) -> bool {
                     || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)))
 }
 
+/// Check if the given storage key is a masp nullifier key
+pub fn is_masp_nullifier_key(key: &Key) -> bool {
+    matches!(&key.segments[..],
+    [DbKeySeg::AddressSeg(addr),
+             DbKeySeg::StringSeg(prefix),
+             ..
+        ] if *addr == MASP && prefix == MASP_NULLIFIERS_KEY_PREFIX)
+}
+
 /// Obtain the storage key for the last locked ratio of a token
 pub fn masp_last_locked_ratio_key(token_address: &Address) -> Key {
     key_of_token(

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -903,9 +903,9 @@ pub const PIN_KEY_PREFIX: &str = "pin-";
 /// Key segment prefix for the nullifiers
 pub const MASP_NULLIFIERS_KEY_PREFIX: &str = "nullifiers";
 /// Key segment prefix for the note commitment merkle tree
-pub const MASP_NOTE_COMMITMENT_TREE: &str = "spend_tree";
+pub const MASP_NOTE_COMMITMENT_TREE_KEY: &str = "commitment_tree";
 /// Key segment prefix for the note commitment anchor
-pub const MASP_NOTE_COMMITMENT_ANCHOR_PREFIX: &str = "spend_anchor";
+pub const MASP_NOTE_COMMITMENT_ANCHOR_PREFIX: &str = "note_commitment_anchor";
 /// Last calculated inflation value handed out
 pub const MASP_LAST_INFLATION_KEY: &str = "last_inflation";
 /// The last locked ratio
@@ -1132,7 +1132,7 @@ pub fn is_masp_key(key: &Key) -> bool {
                     || key.starts_with(TX_KEY_PREFIX)
                     || key.starts_with(PIN_KEY_PREFIX)
                     || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)
-                    || key == MASP_NOTE_COMMITMENT_TREE
+                    || key == MASP_NOTE_COMMITMENT_TREE_KEY
                     || key.starts_with(MASP_NOTE_COMMITMENT_ANCHOR_PREFIX)))
 }
 

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -900,6 +900,8 @@ pub const HEAD_TX_KEY: &str = "head-tx";
 pub const TX_KEY_PREFIX: &str = "tx-";
 /// Key segment prefix for pinned shielded transactions
 pub const PIN_KEY_PREFIX: &str = "pin-";
+/// Key segment prefix for the nullifiers
+pub const MASP_NULLIFIERS_KEY_PREFIX: &str = "nullifiers";
 /// Last calculated inflation value handed out
 pub const MASP_LAST_INFLATION_KEY: &str = "last_inflation";
 /// The last locked ratio
@@ -1124,7 +1126,8 @@ pub fn is_masp_key(key: &Key) -> bool {
             if *addr == MASP
                 && (key == HEAD_TX_KEY
                     || key.starts_with(TX_KEY_PREFIX)
-                    || key.starts_with(PIN_KEY_PREFIX)))
+                    || key.starts_with(PIN_KEY_PREFIX)
+                    || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)))
 }
 
 /// Obtain the storage key for the last locked ratio of a token

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -1128,33 +1128,47 @@ pub fn is_denom_key(token_addr: &Address, key: &Key) -> bool {
 /// Check if the given storage key is a masp key
 pub fn is_masp_key(key: &Key) -> bool {
     matches!(&key.segments[..],
+        [DbKeySeg::AddressSeg(addr), ..] if *addr == MASP
+    )
+}
+
+/// Check if the given storage key is allowed to be touched by a masp transfer
+pub fn is_masp_allowed_key(key: &Key) -> bool {
+    matches!(&key.segments[..],
         [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(key)]
             if *addr == MASP
                 && (key == HEAD_TX_KEY
                     || key.starts_with(TX_KEY_PREFIX)
                     || key.starts_with(PIN_KEY_PREFIX)
                     || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)
-                    || key == MASP_NOTE_COMMITMENT_TREE_KEY
-                    || key.starts_with(MASP_NOTE_COMMITMENT_ANCHOR_PREFIX)
-                    || key.starts_with(MASP_CONVERT_ANCHOR_PREFIX)))
+                    || key == MASP_NOTE_COMMITMENT_TREE_KEY))
+}
+
+/// Check if the given storage key is a masp tx prefix key
+pub fn is_masp_tx_prefix_key(key: &Key) -> bool {
+    matches!(&key.segments[..],
+        [DbKeySeg::AddressSeg(addr),
+             DbKeySeg::StringSeg(prefix),
+             ..
+        ] if *addr == MASP && prefix.starts_with(TX_KEY_PREFIX))
+}
+
+/// Check if the given storage key is a masp tx pin key
+pub fn is_masp_tx_pin_key(key: &Key) -> bool {
+    matches!(&key.segments[..],
+        [DbKeySeg::AddressSeg(addr),
+             DbKeySeg::StringSeg(prefix),
+             ..
+        ] if *addr == MASP && prefix.starts_with(PIN_KEY_PREFIX))
 }
 
 /// Check if the given storage key is a masp nullifier key
 pub fn is_masp_nullifier_key(key: &Key) -> bool {
     matches!(&key.segments[..],
-    [DbKeySeg::AddressSeg(addr),
+        [DbKeySeg::AddressSeg(addr),
              DbKeySeg::StringSeg(prefix),
              ..
         ] if *addr == MASP && prefix == MASP_NULLIFIERS_KEY_PREFIX)
-}
-
-/// Check if the given storage key is a masp anchor key
-pub fn is_masp_anchor_key(key: &Key) -> bool {
-    matches!(&key.segments[..],
-    [DbKeySeg::AddressSeg(addr),
-             DbKeySeg::StringSeg(prefix),
-             ..
-        ] if *addr == MASP && prefix == MASP_NOTE_COMMITMENT_ANCHOR_PREFIX)
 }
 
 /// Obtain the storage key for the last locked ratio of a token

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -902,6 +902,10 @@ pub const TX_KEY_PREFIX: &str = "tx-";
 pub const PIN_KEY_PREFIX: &str = "pin-";
 /// Key segment prefix for the nullifiers
 pub const MASP_NULLIFIERS_KEY_PREFIX: &str = "nullifiers";
+/// Key segment prefix for the note commitment merkle tree
+pub const MASP_NOTE_COMMITMENT_TREE: &str = "spend_tree";
+/// Key segment prefix for the note commitment anchor
+pub const MASP_NOTE_COMMITMENT_ANCHOR_PREFIX: &str = "spend_anchor";
 /// Last calculated inflation value handed out
 pub const MASP_LAST_INFLATION_KEY: &str = "last_inflation";
 /// The last locked ratio
@@ -1127,7 +1131,9 @@ pub fn is_masp_key(key: &Key) -> bool {
                 && (key == HEAD_TX_KEY
                     || key.starts_with(TX_KEY_PREFIX)
                     || key.starts_with(PIN_KEY_PREFIX)
-                    || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)))
+                    || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)
+                    || key == MASP_NOTE_COMMITMENT_TREE
+                    || key.starts_with(MASP_NOTE_COMMITMENT_ANCHOR_PREFIX)))
 }
 
 /// Check if the given storage key is a masp nullifier key
@@ -1137,6 +1143,15 @@ pub fn is_masp_nullifier_key(key: &Key) -> bool {
              DbKeySeg::StringSeg(prefix),
              ..
         ] if *addr == MASP && prefix == MASP_NULLIFIERS_KEY_PREFIX)
+}
+
+/// Check if the given storage key is a masp anchor key
+pub fn is_masp_anchor_key(key: &Key) -> bool {
+    matches!(&key.segments[..],
+    [DbKeySeg::AddressSeg(addr),
+             DbKeySeg::StringSeg(prefix),
+             ..
+        ] if *addr == MASP && prefix == MASP_NOTE_COMMITMENT_ANCHOR_PREFIX)
 }
 
 /// Obtain the storage key for the last locked ratio of a token

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -901,7 +901,7 @@ pub const TX_KEY_PREFIX: &str = "tx-";
 /// Key segment prefix for pinned shielded transactions
 pub const PIN_KEY_PREFIX: &str = "pin-";
 /// Key segment prefix for the nullifiers
-pub const MASP_NULLIFIERS_KEY_PREFIX: &str = "nullifiers";
+pub const MASP_NULLIFIERS_KEY: &str = "nullifiers";
 /// Key segment prefix for the note commitment merkle tree
 pub const MASP_NOTE_COMMITMENT_TREE_KEY: &str = "commitment_tree";
 /// Key segment prefix for the note commitment anchor
@@ -1134,14 +1134,24 @@ pub fn is_masp_key(key: &Key) -> bool {
 
 /// Check if the given storage key is allowed to be touched by a masp transfer
 pub fn is_masp_allowed_key(key: &Key) -> bool {
-    matches!(&key.segments[..],
+    match &key.segments[..] {
         [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(key)]
             if *addr == MASP
                 && (key == HEAD_TX_KEY
                     || key.starts_with(TX_KEY_PREFIX)
                     || key.starts_with(PIN_KEY_PREFIX)
-                    || key.starts_with(MASP_NULLIFIERS_KEY_PREFIX)
-                    || key == MASP_NOTE_COMMITMENT_TREE_KEY))
+                    || key == MASP_NOTE_COMMITMENT_TREE_KEY) =>
+        {
+            true
+        }
+
+        [
+            DbKeySeg::AddressSeg(addr),
+            DbKeySeg::StringSeg(key),
+            DbKeySeg::StringSeg(_nullifier),
+        ] if *addr == MASP && key == MASP_NULLIFIERS_KEY => true,
+        _ => false,
+    }
 }
 
 /// Check if the given storage key is a masp tx prefix key
@@ -1149,7 +1159,6 @@ pub fn is_masp_tx_prefix_key(key: &Key) -> bool {
     matches!(&key.segments[..],
         [DbKeySeg::AddressSeg(addr),
              DbKeySeg::StringSeg(prefix),
-             ..
         ] if *addr == MASP && prefix.starts_with(TX_KEY_PREFIX))
 }
 
@@ -1158,7 +1167,6 @@ pub fn is_masp_tx_pin_key(key: &Key) -> bool {
     matches!(&key.segments[..],
         [DbKeySeg::AddressSeg(addr),
              DbKeySeg::StringSeg(prefix),
-             ..
         ] if *addr == MASP && prefix.starts_with(PIN_KEY_PREFIX))
 }
 
@@ -1167,8 +1175,8 @@ pub fn is_masp_nullifier_key(key: &Key) -> bool {
     matches!(&key.segments[..],
         [DbKeySeg::AddressSeg(addr),
              DbKeySeg::StringSeg(prefix),
-             ..
-        ] if *addr == MASP && prefix == MASP_NULLIFIERS_KEY_PREFIX)
+             DbKeySeg::StringSeg(_nullifier)
+        ] if *addr == MASP && prefix == MASP_NULLIFIERS_KEY)
 }
 
 /// Obtain the storage key for the last locked ratio of a token

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -178,8 +178,7 @@ impl TxCustom {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_custom(context, self).await
     }
 }
@@ -398,8 +397,7 @@ impl TxIbcTransfer {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_ibc_transfer(context, self).await
     }
 }
@@ -487,8 +485,7 @@ impl InitProposal {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         let current_epoch = rpc::query_epoch(context.client()).await?;
         let governance_parameters =
             rpc::query_governance_parameters(context.client()).await;
@@ -644,8 +641,7 @@ impl VoteProposal {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         let current_epoch = rpc::query_epoch(context.client()).await?;
         tx::build_vote_proposal(context, self, current_epoch).await
     }
@@ -717,8 +713,7 @@ impl TxInitAccount {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_init_account(context, self).await
     }
 }
@@ -835,8 +830,7 @@ impl TxUpdateAccount {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_update_account(context, self).await
     }
 }
@@ -913,8 +907,7 @@ impl Bond {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_bond(context, self).await
     }
 }
@@ -943,7 +936,6 @@ impl Unbond {
     ) -> crate::error::Result<(
         crate::proto::Tx,
         SigningTxData,
-        Option<Epoch>,
         Option<(Epoch, token::Amount)>,
     )> {
         tx::build_unbond(context, self).await
@@ -1094,8 +1086,7 @@ impl RevealPk {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_reveal_pk(context, &self.tx, &self.public_key).await
     }
 }
@@ -1178,8 +1169,7 @@ impl Withdraw {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_withdraw(context, self).await
     }
 }
@@ -1215,8 +1205,7 @@ impl ClaimRewards {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_claim_rewards(context, self).await
     }
 }
@@ -1348,8 +1337,7 @@ impl CommissionRateChange {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_validator_commission_change(context, self).await
     }
 }
@@ -1466,8 +1454,7 @@ impl MetaDataChange {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_validator_metadata_change(context, self).await
     }
 }
@@ -1522,8 +1509,7 @@ impl UpdateStewardCommission {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_update_steward_commission(context, self).await
     }
 }
@@ -1571,8 +1557,7 @@ impl ResignSteward {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_resign_steward(context, self).await
     }
 }
@@ -1620,8 +1605,7 @@ impl TxUnjailValidator {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_unjail_validator(context, self).await
     }
 }
@@ -1669,8 +1653,7 @@ impl TxDeactivateValidator {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_deactivate_validator(context, self).await
     }
 }
@@ -1718,8 +1701,7 @@ impl TxReactivateValidator {
     pub async fn build<'a>(
         &self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         tx::build_reactivate_validator(context, self).await
     }
 }
@@ -2291,8 +2273,7 @@ impl EthereumBridgePool {
     pub async fn build<'a>(
         self,
         context: &impl Namada<'a>,
-    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData, Option<Epoch>)>
-    {
+    ) -> crate::error::Result<(crate::proto::Tx, SigningTxData)> {
         bridge_pool::build_bridge_pool_tx(context, self).await
     }
 }

--- a/sdk/src/eth_bridge/bridge_pool.rs
+++ b/sdk/src/eth_bridge/bridge_pool.rs
@@ -18,7 +18,6 @@ use namada_core::types::eth_bridge_pool::{
 };
 use namada_core::types::ethereum_events::EthAddress;
 use namada_core::types::keccak::KeccakHash;
-use namada_core::types::storage::Epoch;
 use namada_core::types::token::{balance_key, Amount, DenominatedAmount};
 use namada_core::types::voting_power::FractionalVotingPower;
 use owo_colors::OwoColorize;
@@ -60,7 +59,7 @@ pub async fn build_bridge_pool_tx(
         fee_token,
         code_path,
     }: args::EthereumBridgePool,
-) -> Result<(Tx, SigningTxData, Option<Epoch>), Error> {
+) -> Result<(Tx, SigningTxData), Error> {
     let sender_ = sender.clone();
     let (transfer, tx_code_hash, signing_data) = futures::try_join!(
         validate_bridge_pool_tx(
@@ -98,7 +97,7 @@ pub async fn build_bridge_pool_tx(
     )
     .add_data(transfer);
 
-    let epoch = prepare_tx(
+    prepare_tx(
         context,
         &tx_args,
         &mut tx,
@@ -107,7 +106,7 @@ pub async fn build_bridge_pool_tx(
     )
     .await?;
 
-    Ok((tx, signing_data, epoch))
+    Ok((tx, signing_data))
 }
 
 /// Perform client validation checks on a Bridge pool transfer.

--- a/sdk/src/tx.rs
+++ b/sdk/src/tx.rs
@@ -179,14 +179,14 @@ pub async fn prepare_tx<'a>(
     tx: &mut Tx,
     fee_payer: common::PublicKey,
     tx_source_balance: Option<TxSourcePostBalance>,
-) -> Result<Option<Epoch>> {
+) -> Result<()> {
     if !args.dry_run {
         let epoch = rpc::query_epoch(context.client()).await?;
 
         signing::wrap_tx(context, tx, args, tx_source_balance, epoch, fee_payer)
             .await
     } else {
-        Ok(None)
+        Ok(())
     }
 }
 
@@ -270,7 +270,7 @@ pub async fn build_reveal_pk<'a>(
     context: &impl Namada<'a>,
     args: &args::Tx,
     public_key: &common::PublicKey,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let signing_data =
         signing::aux_signing_data(context, args, None, Some(public_key.into()))
             .await?;
@@ -285,7 +285,7 @@ pub async fn build_reveal_pk<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Broadcast a transaction to be included in the blockchain and checks that
@@ -514,7 +514,7 @@ pub async fn build_validator_commission_change<'a>(
         rate,
         tx_code_path,
     }: &args::CommissionRateChange,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(validator.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -614,7 +614,7 @@ pub async fn build_validator_commission_change<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit validator metadata change
@@ -630,7 +630,7 @@ pub async fn build_validator_metadata_change<'a>(
         commission_rate,
         tx_code_path,
     }: &args::MetaDataChange,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(validator.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -743,7 +743,7 @@ pub async fn build_validator_metadata_change<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Craft transaction to update a steward commission
@@ -755,7 +755,7 @@ pub async fn build_update_steward_commission<'a>(
         commission,
         tx_code_path,
     }: &args::UpdateStewardCommission,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(steward.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -802,7 +802,7 @@ pub async fn build_update_steward_commission<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Craft transaction to resign as a steward
@@ -813,7 +813,7 @@ pub async fn build_resign_steward<'a>(
         steward,
         tx_code_path,
     }: &args::ResignSteward,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(steward.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -842,7 +842,7 @@ pub async fn build_resign_steward<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit transaction to unjail a jailed validator
@@ -853,7 +853,7 @@ pub async fn build_unjail_validator<'a>(
         validator,
         tx_code_path,
     }: &args::TxUnjailValidator,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(validator.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -949,7 +949,7 @@ pub async fn build_unjail_validator<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit transaction to deactivate a validator
@@ -960,7 +960,7 @@ pub async fn build_deactivate_validator<'a>(
         validator,
         tx_code_path,
     }: &args::TxDeactivateValidator,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(validator.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -1020,7 +1020,7 @@ pub async fn build_deactivate_validator<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit transaction to deactivate a validator
@@ -1031,7 +1031,7 @@ pub async fn build_reactivate_validator<'a>(
         validator,
         tx_code_path,
     }: &args::TxReactivateValidator,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(validator.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -1090,7 +1090,7 @@ pub async fn build_reactivate_validator<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Redelegate bonded tokens from one validator to another
@@ -1270,7 +1270,7 @@ pub async fn build_redelegation<'a>(
         None,
     )
     .await
-    .map(|(tx, _epoch)| (tx, signing_data))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit transaction to withdraw an unbond
@@ -1282,7 +1282,7 @@ pub async fn build_withdraw<'a>(
         source,
         tx_code_path,
     }: &args::Withdraw,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_address = source.clone().unwrap_or(validator.clone());
     let default_signer = Some(default_address.clone());
     let signing_data = signing::aux_signing_data(
@@ -1353,7 +1353,7 @@ pub async fn build_withdraw<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit transaction to withdraw an unbond
@@ -1365,7 +1365,7 @@ pub async fn build_claim_rewards<'a>(
         source,
         tx_code_path,
     }: &args::ClaimRewards,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_address = source.clone().unwrap_or(validator.clone());
     let default_signer = Some(default_address.clone());
     let signing_data = signing::aux_signing_data(
@@ -1401,7 +1401,7 @@ pub async fn build_claim_rewards<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit a transaction to unbond
@@ -1414,12 +1414,7 @@ pub async fn build_unbond<'a>(
         source,
         tx_code_path,
     }: &args::Unbond,
-) -> Result<(
-    Tx,
-    SigningTxData,
-    Option<Epoch>,
-    Option<(Epoch, token::Amount)>,
-)> {
+) -> Result<(Tx, SigningTxData, Option<(Epoch, token::Amount)>)> {
     // Require a positive amount of tokens to be bonded
     if amount.is_zero() {
         edisplay_line!(
@@ -1498,7 +1493,7 @@ pub async fn build_unbond<'a>(
         source: source.clone(),
     };
 
-    let (tx, epoch) = build(
+    let tx = build(
         context,
         tx_args,
         tx_code_path.clone(),
@@ -1508,7 +1503,7 @@ pub async fn build_unbond<'a>(
         None,
     )
     .await?;
-    Ok((tx, signing_data, epoch, latest_withdrawal_pre))
+    Ok((tx, signing_data, latest_withdrawal_pre))
 }
 
 /// Query the unbonds post-tx
@@ -1593,7 +1588,7 @@ pub async fn build_bond<'a>(
         native_token,
         tx_code_path,
     }: &args::Bond,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     // Require a positive amount of tokens to be bonded
     if amount.is_zero() {
         edisplay_line!(
@@ -1693,7 +1688,7 @@ pub async fn build_bond<'a>(
         tx_source_balance,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Build a default proposal governance
@@ -1709,7 +1704,7 @@ pub async fn build_default_proposal<'a>(
         tx_code_path,
     }: &args::InitProposal,
     proposal: DefaultProposal,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(proposal.proposal.author.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -1746,7 +1741,7 @@ pub async fn build_default_proposal<'a>(
         None, // TODO: need to pay the fee to submit a proposal
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Build a proposal vote
@@ -1762,7 +1757,7 @@ pub async fn build_vote_proposal<'a>(
         tx_code_path,
     }: &args::VoteProposal,
     epoch: Epoch,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(voter.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -1833,7 +1828,7 @@ pub async fn build_vote_proposal<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Build a pgf funding proposal governance
@@ -1849,7 +1844,7 @@ pub async fn build_pgf_funding_proposal<'a>(
         tx_code_path,
     }: &args::InitProposal,
     proposal: PgfFundingProposal,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(proposal.proposal.author.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -1878,7 +1873,7 @@ pub async fn build_pgf_funding_proposal<'a>(
         None, // TODO: need to pay the fee to submit a proposal
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Build a pgf funding proposal governance
@@ -1894,7 +1889,7 @@ pub async fn build_pgf_stewards_proposal<'a>(
         tx_code_path,
     }: &args::InitProposal,
     proposal: PgfStewardProposal,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(proposal.proposal.author.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -1924,14 +1919,14 @@ pub async fn build_pgf_stewards_proposal<'a>(
         None, // TODO: need to pay the fee to submit a proposal
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit an IBC transfer
 pub async fn build_ibc_transfer<'a>(
     context: &impl Namada<'a>,
     args: &args::TxIbcTransfer,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(args.source.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -2043,7 +2038,7 @@ pub async fn build_ibc_transfer<'a>(
     )
     .add_serialized_data(data);
 
-    let epoch = prepare_tx(
+    prepare_tx(
         context,
         &args.tx,
         &mut tx,
@@ -2052,7 +2047,7 @@ pub async fn build_ibc_transfer<'a>(
     )
     .await?;
 
-    Ok((tx, signing_data, epoch))
+    Ok((tx, signing_data))
 }
 
 /// Abstraction for helping build transactions
@@ -2065,7 +2060,7 @@ pub async fn build<'a, F, D>(
     on_tx: F,
     gas_payer: &common::PublicKey,
     tx_source_balance: Option<TxSourcePostBalance>,
-) -> Result<(Tx, Option<Epoch>)>
+) -> Result<Tx>
 where
     F: FnOnce(&mut Tx, &mut D) -> Result<()>,
     D: BorshSerialize,
@@ -2091,7 +2086,7 @@ async fn build_pow_flag<'a, F, D>(
     on_tx: F,
     gas_payer: &common::PublicKey,
     tx_source_balance: Option<TxSourcePostBalance>,
-) -> Result<(Tx, Option<Epoch>)>
+) -> Result<Tx>
 where
     F: FnOnce(&mut Tx, &mut D) -> Result<()>,
     D: BorshSerialize,
@@ -2113,7 +2108,7 @@ where
         )
         .add_data(data);
 
-    let epoch = prepare_tx(
+    prepare_tx(
         context,
         tx_args,
         &mut tx_builder,
@@ -2121,7 +2116,7 @@ where
         tx_source_balance,
     )
     .await?;
-    Ok((tx_builder, epoch))
+    Ok(tx_builder)
 }
 
 /// Try to decode the given asset type and add its decoding to the supplied set.
@@ -2318,7 +2313,7 @@ pub async fn build_transfer<'a, N: Namada<'a>>(
         };
         Ok(())
     };
-    let (tx, unshielding_epoch) = build_pow_flag(
+    let tx = build_pow_flag(
         context,
         &args.tx,
         args.tx_code_path.clone(),
@@ -2328,26 +2323,7 @@ pub async fn build_transfer<'a, N: Namada<'a>>(
         tx_source_balance,
     )
     .await?;
-    // Manage the two masp epochs
-    let masp_epoch = match (unshielding_epoch, shielded_tx_epoch) {
-        (Some(fee_unshield_epoch), Some(transfer_unshield_epoch)) => {
-            // If the two masp epochs are different, either the wrapper or the
-            // inner tx will fail, so abort tx creation
-            if fee_unshield_epoch != transfer_unshield_epoch && !args.tx.force {
-                return Err(Error::Other(
-                    "Fee unshielding masp tx and inner tx masp transaction \
-                     were crafted on an epoch boundary"
-                        .to_string(),
-                ));
-            }
-            // Take the smaller of the two epochs
-            Some(fee_unshield_epoch.min(transfer_unshield_epoch))
-        }
-        (Some(_fee_unshielding_epoch), None) => unshielding_epoch,
-        (None, Some(_transfer_unshield_epoch)) => shielded_tx_epoch,
-        (None, None) => None,
-    };
-    Ok((tx, signing_data, masp_epoch))
+    Ok((tx, signing_data, shielded_tx_epoch))
 }
 
 /// Submit a transaction to initialize an account
@@ -2360,7 +2336,7 @@ pub async fn build_init_account<'a>(
         public_keys,
         threshold,
     }: &args::TxInitAccount,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let signing_data =
         signing::aux_signing_data(context, tx_args, None, None).await?;
 
@@ -2402,7 +2378,7 @@ pub async fn build_init_account<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit a transaction to update a VP
@@ -2416,7 +2392,7 @@ pub async fn build_update_account<'a>(
         public_keys,
         threshold,
     }: &args::TxUpdateAccount,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(addr.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -2484,7 +2460,7 @@ pub async fn build_update_account<'a>(
         None,
     )
     .await
-    .map(|(tx, epoch)| (tx, signing_data, epoch))
+    .map(|tx| (tx, signing_data))
 }
 
 /// Submit a custom transaction
@@ -2497,7 +2473,7 @@ pub async fn build_custom<'a>(
         serialized_tx,
         owner,
     }: &args::TxCustom,
-) -> Result<(Tx, SigningTxData, Option<Epoch>)> {
+) -> Result<(Tx, SigningTxData)> {
     let default_signer = Some(owner.clone());
     let signing_data = signing::aux_signing_data(
         context,
@@ -2526,7 +2502,7 @@ pub async fn build_custom<'a>(
         tx
     };
 
-    let epoch = prepare_tx(
+    prepare_tx(
         context,
         tx_args,
         &mut tx,
@@ -2535,7 +2511,7 @@ pub async fn build_custom<'a>(
     )
     .await?;
 
-    Ok((tx, signing_data, epoch))
+    Ok((tx, signing_data))
 }
 
 /// Generate IBC shielded transfer

--- a/shared/src/ledger/native_vp/ibc/context.rs
+++ b/shared/src/ledger/native_vp/ibc/context.rs
@@ -5,8 +5,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use borsh_ext::BorshSerializeExt;
 use masp_primitives::transaction::Transaction;
 use namada_core::ledger::ibc::{IbcCommonContext, IbcStorageContext};
-use namada_core::types::hash::Hash;
-use namada_core::types::token::MASP_NULLIFIERS_KEY_PREFIX;
+use namada_core::ledger::masp_utils;
 
 use crate::ledger::ibc::storage::is_ibc_key;
 use crate::ledger::native_vp::CtxPreStorageRead;
@@ -239,19 +238,7 @@ where
         );
         self.write(&current_tx_key, record.serialize_to_vec())?;
         self.write(&head_tx_key, (current_tx_idx + 1).serialize_to_vec())?;
-        for description in shielded
-            .masp_tx
-            .sapling_bundle()
-            .map_or(&vec![], |description| &description.shielded_spends)
-        {
-            // Reveal the nullifier to prevent double spending
-            let nullifier_key = Key::from(masp_addr.to_db_key())
-                .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
-                .expect("Cannot obtain a storage key")
-                .push(&Hash(description.nullifier.0))
-                .expect("Cannot obtain a storage key");
-            self.write(&nullifier_key, ())?;
-        }
+        masp_utils::reveal_nullifiers(self, &shielded.masp_tx)?;
         // If storage key has been supplied, then pin this transaction to it
         if let Some(key) = &shielded.transfer.key {
             let pin_key = Key::from(masp_addr.to_db_key())

--- a/shared/src/ledger/native_vp/ibc/context.rs
+++ b/shared/src/ledger/native_vp/ibc/context.rs
@@ -213,7 +213,12 @@ where
     }
 
     fn handle_masp_tx(&mut self, shielded: &IbcShieldedTransfer) -> Result<()> {
-        masp_utils::handle_masp_tx(self, &shielded.transfer, &shielded.masp_tx)
+        masp_utils::handle_masp_tx(
+            self,
+            &shielded.transfer,
+            &shielded.masp_tx,
+        )?;
+        masp_utils::update_note_commitment_tree(self, &shielded.masp_tx)
     }
 
     fn mint_token(

--- a/shared/src/ledger/native_vp/ibc/context.rs
+++ b/shared/src/ledger/native_vp/ibc/context.rs
@@ -3,7 +3,6 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use borsh_ext::BorshSerializeExt;
-use masp_primitives::transaction::Transaction;
 use namada_core::ledger::ibc::{IbcCommonContext, IbcStorageContext};
 use namada_core::ledger::masp_utils;
 
@@ -12,15 +11,12 @@ use crate::ledger::native_vp::CtxPreStorageRead;
 use crate::ledger::storage::write_log::StorageModification;
 use crate::ledger::storage::{self as ledger_storage, StorageHasher};
 use crate::ledger::storage_api::{self, StorageRead, StorageWrite};
-use crate::types::address::{Address, InternalAddress, MASP};
+use crate::types::address::{Address, InternalAddress};
 use crate::types::ibc::{IbcEvent, IbcShieldedTransfer};
 use crate::types::storage::{
-    BlockHash, BlockHeight, Epoch, Header, Key, KeySeg, TxIndex,
+    BlockHash, BlockHeight, Epoch, Header, Key, TxIndex,
 };
-use crate::types::token::{
-    self, Amount, DenominatedAmount, Transfer, HEAD_TX_KEY, PIN_KEY_PREFIX,
-    TX_KEY_PREFIX,
-};
+use crate::types::token::{self, Amount, DenominatedAmount};
 use crate::vm::WasmCacheAccess;
 
 /// Result of a storage API call.
@@ -217,36 +213,7 @@ where
     }
 
     fn handle_masp_tx(&mut self, shielded: &IbcShieldedTransfer) -> Result<()> {
-        let masp_addr = MASP;
-        let head_tx_key = Key::from(masp_addr.to_db_key())
-            .push(&HEAD_TX_KEY.to_owned())
-            .expect("Cannot obtain a storage key");
-        let current_tx_idx: u64 =
-            self.ctx.read(&head_tx_key).unwrap_or(None).unwrap_or(0);
-        let current_tx_key = Key::from(masp_addr.to_db_key())
-            .push(&(TX_KEY_PREFIX.to_owned() + &current_tx_idx.to_string()))
-            .expect("Cannot obtain a storage key");
-        // Save the Transfer object and its location within the blockchain
-        // so that clients do not have to separately look these
-        // up
-        let record: (Epoch, BlockHeight, TxIndex, Transfer, Transaction) = (
-            self.ctx.get_block_epoch()?,
-            self.ctx.get_block_height()?,
-            self.ctx.get_tx_index()?,
-            shielded.transfer.clone(),
-            shielded.masp_tx.clone(),
-        );
-        self.write(&current_tx_key, record.serialize_to_vec())?;
-        self.write(&head_tx_key, (current_tx_idx + 1).serialize_to_vec())?;
-        masp_utils::reveal_nullifiers(self, &shielded.masp_tx)?;
-        // If storage key has been supplied, then pin this transaction to it
-        if let Some(key) = &shielded.transfer.key {
-            let pin_key = Key::from(masp_addr.to_db_key())
-                .push(&(PIN_KEY_PREFIX.to_owned() + key))
-                .expect("Cannot obtain a storage key");
-            self.write(&pin_key, current_tx_idx.serialize_to_vec())?;
-        }
-        Ok(())
+        masp_utils::handle_masp_tx(self, &shielded.transfer, &shielded.masp_tx)
     }
 
     fn mint_token(

--- a/shared/src/ledger/native_vp/masp.rs
+++ b/shared/src/ledger/native_vp/masp.rs
@@ -189,6 +189,16 @@ where
                     );
                     return Ok(false);
                 }
+
+                // Check that the nullifier is indeed committed (no temp write
+                // and no delete) and carries no associated data (the latter not
+                // strictly necessary for validation, but we don't expect any
+                // value for this key anyway)
+                match self.ctx.read_bytes_post(&nullifier_key)? {
+                    Some(value) if value.is_empty() => (),
+                    _ => return Ok(false),
+                }
+
                 revealed_nullifiers.insert(nullifier_key);
             }
 

--- a/shared/src/ledger/native_vp/masp.rs
+++ b/shared/src/ledger/native_vp/masp.rs
@@ -21,7 +21,7 @@ use namada_core::types::token::{
     self, is_masp_allowed_key, is_masp_key, is_masp_nullifier_key,
     is_masp_tx_pin_key, is_masp_tx_prefix_key, Transfer, HEAD_TX_KEY,
     MASP_CONVERT_ANCHOR_KEY, MASP_NOTE_COMMITMENT_ANCHOR_PREFIX,
-    MASP_NOTE_COMMITMENT_TREE_KEY, MASP_NULLIFIERS_KEY_PREFIX, PIN_KEY_PREFIX,
+    MASP_NOTE_COMMITMENT_TREE_KEY, MASP_NULLIFIERS_KEY, PIN_KEY_PREFIX,
     TX_KEY_PREFIX,
 };
 use namada_sdk::masp::verify_shielded_tx;
@@ -135,7 +135,7 @@ where
             .map_or(&vec![], |description| &description.shielded_spends)
         {
             let nullifier_key = Key::from(MASP.to_db_key())
-                .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
+                .push(&MASP_NULLIFIERS_KEY.to_owned())
                 .expect("Cannot obtain a storage key")
                 .push(&namada_core::types::hash::Hash(description.nullifier.0))
                 .expect("Cannot obtain a storage key");

--- a/shared/src/ledger/native_vp/masp.rs
+++ b/shared/src/ledger/native_vp/masp.rs
@@ -331,7 +331,7 @@ where
         }
 
         // The transaction must correctly update the note commitment tree
-        // and the anchor in storage with the new output descriptions
+        // in storage with the new output descriptions
         if !self.valid_note_commitment_update(keys_changed, &shielded_tx)? {
             return Ok(false);
         }

--- a/shared/src/ledger/protocol/mod.rs
+++ b/shared/src/ledger/protocol/mod.rs
@@ -450,11 +450,7 @@ where
                  This shouldn't happen."
             );
 
-            Err(Error::FeeError(format!(
-                "{}. All the available transparent funds have been moved to \
-                 the block proposer",
-                e
-            )))
+            Err(Error::FeeError(format!("{}", e)))
         }
     }
 }

--- a/shared/src/vm/host_env.rs
+++ b/shared/src/vm/host_env.rs
@@ -13,6 +13,7 @@ use namada_core::ledger::gas::{
 use namada_core::types::address::{ESTABLISHED_ADDRESS_BYTES_LEN, MASP};
 use namada_core::types::internal::KeyVal;
 use namada_core::types::storage::TX_INDEX_LENGTH;
+use namada_core::types::token::MASP_NULLIFIERS_KEY_PREFIX;
 use namada_core::types::transaction::TxSentinel;
 use namada_core::types::validity_predicate::VpSentinel;
 use thiserror::Error;
@@ -2541,6 +2542,19 @@ where
         );
         self.write(&current_tx_key, record)?;
         self.write(&head_tx_key, current_tx_idx + 1)?;
+        for description in shielded
+            .masp_tx
+            .sapling_bundle()
+            .map_or(&vec![], |description| &description.shielded_spends)
+        {
+            // Reveal the nullifier to prevent double spending
+            let nullifier_key = Key::from(masp_addr.to_db_key())
+                .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
+                .expect("Cannot obtain a storage key")
+                .push(&Hash(description.nullifier.0))
+                .expect("Cannot obtain a storage key");
+            self.write(&nullifier_key, ())?;
+        }
         // If storage key has been supplied, then pin this transaction to it
         if let Some(key) = &shielded.transfer.key {
             let pin_key = Key::from(masp_addr.to_db_key())

--- a/shared/src/vm/wasm/host_env.rs
+++ b/shared/src/vm/wasm/host_env.rs
@@ -88,6 +88,7 @@ where
             "namada_tx_ibc_execute" => Function::new_native_with_env(wasm_store, env.clone(), host_env::tx_ibc_execute),
             "namada_tx_set_commitment_sentinel" => Function::new_native_with_env(wasm_store, env.clone(), host_env::tx_set_commitment_sentinel),
             "namada_tx_verify_tx_section_signature" => Function::new_native_with_env(wasm_store, env.clone(), host_env::tx_verify_tx_section_signature),
+            "namada_tx_update_masp_note_commitment_tree" => Function::new_native_with_env(wasm_store, env.clone(), host_env::tx_update_masp_note_commitment_tree)
         },
     }
 }

--- a/tests/src/e2e/ledger_tests.rs
+++ b/tests/src/e2e/ledger_tests.rs
@@ -773,6 +773,9 @@ fn wrapper_disposable_signer() -> Result<()> {
         "--disposable-gas-payer",
         "--ledger-address",
         &validator_one_rpc,
+        // NOTE: Forcing the transaction will make the client produce a
+        // transfer without a masp object attached to it, so don't expect a
+        // failure from the masp vp here but from the check_fees function
         "--force",
     ];
     let mut client = run!(test, Bin::Client, tx_args, Some(720))?;

--- a/tests/src/integration/masp.rs
+++ b/tests/src/integration/masp.rs
@@ -1219,32 +1219,35 @@ fn wrapper_fee_unshielding() -> Result<()> {
     node.assert_success();
 
     // 3. Invalid unshielding
-    // TODO: this test shall panic because of the panic in the sdk. Once the
-    // panics are removed from there, this test can be updated
-    let tx_run = run(
-        &node,
-        Bin::Client,
-        vec![
-            "transfer",
-            "--source",
-            ALBERT,
-            "--target",
-            BERTHA,
-            "--token",
-            NAM,
-            "--amount",
-            "1",
-            "--gas-price",
-            "1000",
-            "--gas-spending-key",
-            B_SPENDING_KEY,
-            "--ledger-address",
-            validator_one_rpc,
-            "--force",
-        ],
-    )
-    .is_err();
+    let tx_args = vec![
+        "transfer",
+        "--source",
+        ALBERT,
+        "--target",
+        BERTHA,
+        "--token",
+        NAM,
+        "--amount",
+        "1",
+        "--gas-price",
+        "1000",
+        "--gas-spending-key",
+        B_SPENDING_KEY,
+        "--ledger-address",
+        validator_one_rpc,
+        // NOTE: Forcing the transaction will make the client produce a
+        // transfer without a masp object attached to it, so don't expect a
+        // failure from the masp vp here but from the check_fees function
+        "--force",
+    ];
 
-    assert!(tx_run);
+    let captured =
+        CapturedOutput::of(|| run(&node, Bin::Client, tx_args.clone()));
+    assert!(
+        captured.result.is_err(),
+        "{:?} unexpectedly succeeded",
+        tx_args
+    );
+
     Ok(())
 }

--- a/tx_prelude/src/ibc.rs
+++ b/tx_prelude/src/ibc.rs
@@ -53,7 +53,12 @@ impl IbcStorageContext for Ctx {
         &mut self,
         shielded: &IbcShieldedTransfer,
     ) -> Result<(), Error> {
-        masp_utils::handle_masp_tx(self, &shielded.transfer, &shielded.masp_tx)
+        masp_utils::handle_masp_tx(
+            self,
+            &shielded.transfer,
+            &shielded.masp_tx,
+        )?;
+        masp_utils::update_note_commitment_tree(self, &shielded.masp_tx)
     }
 
     fn mint_token(

--- a/tx_prelude/src/ibc.rs
+++ b/tx_prelude/src/ibc.rs
@@ -6,12 +6,13 @@ use std::rc::Rc;
 pub use namada_core::ledger::ibc::{
     IbcActions, IbcCommonContext, IbcStorageContext, ProofSpec, TransferModule,
 };
+use namada_core::ledger::masp_utils;
 use namada_core::ledger::tx_env::TxEnv;
 use namada_core::types::address::{Address, InternalAddress};
 pub use namada_core::types::ibc::{IbcEvent, IbcShieldedTransfer};
 use namada_core::types::token::DenominatedAmount;
 
-use crate::token::{burn, handle_masp_tx, mint, transfer};
+use crate::token::{burn, mint, transfer};
 use crate::{Ctx, Error};
 
 /// IBC actions to handle an IBC message
@@ -52,7 +53,7 @@ impl IbcStorageContext for Ctx {
         &mut self,
         shielded: &IbcShieldedTransfer,
     ) -> Result<(), Error> {
-        handle_masp_tx(self, &shielded.transfer, &shielded.masp_tx)
+        masp_utils::handle_masp_tx(self, &shielded.transfer, &shielded.masp_tx)
     }
 
     fn mint_token(

--- a/tx_prelude/src/lib.rs
+++ b/tx_prelude/src/lib.rs
@@ -19,6 +19,7 @@ use std::marker::PhantomData;
 pub use borsh::{BorshDeserialize, BorshSerialize};
 pub use borsh_ext;
 use borsh_ext::BorshSerializeExt;
+use masp_primitives::transaction::Transaction;
 pub use namada_core::ledger::governance::storage as gov_storage;
 pub use namada_core::ledger::parameters::storage as parameters_storage;
 pub use namada_core::ledger::storage::types::encode;
@@ -399,6 +400,23 @@ pub fn verify_signatures_of_pks(
             threshold,
             max_signatures.as_ptr() as _,
             max_signatures.len() as _,
+        )
+    };
+
+    Ok(HostEnvResult::is_success(valid))
+}
+
+/// Update the masp note commitment tree in storage with the new notes
+pub fn update_masp_note_commitment_tree(
+    transaction: &Transaction,
+) -> EnvResult<bool> {
+    // Serialize transaction
+    let transaction = transaction.serialize_to_vec();
+
+    let valid = unsafe {
+        namada_tx_update_masp_note_commitment_tree(
+            transaction.as_ptr() as _,
+            transaction.len() as _,
         )
     };
 

--- a/tx_prelude/src/token.rs
+++ b/tx_prelude/src/token.rs
@@ -1,5 +1,6 @@
 use masp_primitives::transaction::Transaction;
 use namada_core::types::address::{Address, MASP};
+use namada_core::types::hash::Hash;
 use namada_core::types::storage::KeySeg;
 use namada_core::types::token;
 pub use namada_core::types::token::*;
@@ -60,6 +61,18 @@ pub fn handle_masp_tx(
     );
     ctx.write(&current_tx_key, record)?;
     ctx.write(&head_tx_key, current_tx_idx + 1)?;
+    for description in shielded
+        .sapling_bundle()
+        .map_or(&vec![], |description| &description.shielded_spends)
+    {
+        // Reveal the nullifier to prevent double spending
+        let nullifier_key = storage::Key::from(masp_addr.to_db_key())
+            .push(&MASP_NULLIFIERS_KEY_PREFIX.to_owned())
+            .expect("Cannot obtain a storage key")
+            .push(&Hash(description.nullifier.0))
+            .expect("Cannot obtain a storage key");
+        ctx.write(&nullifier_key, ())?;
+    }
     // If storage key has been supplied, then pin this transaction to it
     if let Some(key) = &transfer.key {
         let pin_key = storage::Key::from(masp_addr.to_db_key())

--- a/tx_prelude/src/token.rs
+++ b/tx_prelude/src/token.rs
@@ -1,7 +1,5 @@
-use masp_primitives::transaction::Transaction;
-use namada_core::ledger::masp_utils;
-use namada_core::types::address::{Address, MASP};
-use namada_core::types::storage::KeySeg;
+pub use namada_core::ledger::masp_utils;
+use namada_core::types::address::Address;
 use namada_core::types::token;
 pub use namada_core::types::token::*;
 
@@ -29,45 +27,6 @@ pub fn transfer(
         dest_bal.receive(&amount.amount);
         ctx.write(&src_key, src_bal)?;
         ctx.write(&dest_key, dest_bal)?;
-    }
-    Ok(())
-}
-
-/// Handle a MASP transaction.
-pub fn handle_masp_tx(
-    ctx: &mut Ctx,
-    transfer: &Transfer,
-    shielded: &Transaction,
-) -> TxResult {
-    let masp_addr = MASP;
-    ctx.insert_verifier(&masp_addr)?;
-    let head_tx_key = storage::Key::from(masp_addr.to_db_key())
-        .push(&HEAD_TX_KEY.to_owned())
-        .expect("Cannot obtain a storage key");
-    let current_tx_idx: u64 =
-        ctx.read(&head_tx_key).unwrap_or(None).unwrap_or(0);
-    let current_tx_key = storage::Key::from(masp_addr.to_db_key())
-        .push(&(TX_KEY_PREFIX.to_owned() + &current_tx_idx.to_string()))
-        .expect("Cannot obtain a storage key");
-    // Save the Transfer object and its location within the blockchain
-    // so that clients do not have to separately look these
-    // up
-    let record: (Epoch, BlockHeight, TxIndex, Transfer, Transaction) = (
-        ctx.get_block_epoch()?,
-        ctx.get_block_height()?,
-        ctx.get_tx_index()?,
-        transfer.clone(),
-        shielded.clone(),
-    );
-    ctx.write(&current_tx_key, record)?;
-    ctx.write(&head_tx_key, current_tx_idx + 1)?;
-    masp_utils::reveal_nullifiers(ctx, shielded)?;
-    // If storage key has been supplied, then pin this transaction to it
-    if let Some(key) = &transfer.key {
-        let pin_key = storage::Key::from(masp_addr.to_db_key())
-            .push(&(PIN_KEY_PREFIX.to_owned() + key))
-            .expect("Cannot obtain a storage key");
-        ctx.write(&pin_key, current_tx_idx)?;
     }
     Ok(())
 }

--- a/vm_env/src/lib.rs
+++ b/vm_env/src/lib.rs
@@ -133,6 +133,11 @@ pub mod tx {
             max_signatures_len: u64,
         ) -> i64;
 
+        /// Update the masp note commitment tree with the new notes
+        pub fn namada_tx_update_masp_note_commitment_tree(
+            transaction_ptr: u64,
+            transaction_len: u64,
+        ) -> i64;
     }
 }
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3020,7 +3020,6 @@ dependencies = [
  "itertools 0.10.5",
  "k256",
  "masp_primitives",
- "masp_proofs",
  "namada_macros",
  "num-integer",
  "num-rational 0.4.1",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3020,6 +3020,7 @@ dependencies = [
  "itertools 0.10.5",
  "k256",
  "masp_primitives",
+ "masp_proofs",
  "namada_macros",
  "num-integer",
  "num-rational 0.4.1",

--- a/wasm/wasm_source/src/tx_transfer.rs
+++ b/wasm/wasm_source/src/tx_transfer.rs
@@ -38,7 +38,7 @@ fn apply_tx(ctx: &mut Ctx, tx_data: Tx) -> TxResult {
         })
         .transpose()?;
     if let Some(shielded) = shielded {
-        token::handle_masp_tx(ctx, &transfer, &shielded)?;
+        token::masp_utils::handle_masp_tx(ctx, &transfer, &shielded)?;
     }
     Ok(())
 }

--- a/wasm/wasm_source/src/tx_transfer.rs
+++ b/wasm/wasm_source/src/tx_transfer.rs
@@ -39,6 +39,7 @@ fn apply_tx(ctx: &mut Ctx, tx_data: Tx) -> TxResult {
         .transpose()?;
     if let Some(shielded) = shielded {
         token::masp_utils::handle_masp_tx(ctx, &transfer, &shielded)?;
+        update_masp_note_commitment_tree(&shielded)?;
     }
     Ok(())
 }

--- a/wasm/wasm_source/src/vp_user.rs
+++ b/wasm/wasm_source/src/vp_user.rs
@@ -16,7 +16,6 @@ enum KeyType<'a> {
     Token { owner: &'a Address },
     PoS,
     Vp(&'a Address),
-    Masp,
     PgfStward(&'a Address),
     GovernanceVote(&'a Address),
     Unknown,
@@ -39,8 +38,6 @@ impl<'a> From<&'a storage::Key> for KeyType<'a> {
             Self::PgfStward(address)
         } else if let Some(address) = key.is_validity_predicate() {
             Self::Vp(address)
-        } else if token::is_masp_key(key) {
-            Self::Masp
         } else {
             Self::Unknown
         }
@@ -158,7 +155,6 @@ fn validate_tx(
                     is_vp_whitelisted(ctx, &vp_hash)?
                 }
             }
-            KeyType::Masp => true,
             KeyType::Unknown => {
                 if key.segments.get(0) == Some(&addr.to_db_key()) {
                     // Unknown changes to this address space require a valid

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -3020,7 +3020,6 @@ dependencies = [
  "itertools 0.10.5",
  "k256",
  "masp_primitives",
- "masp_proofs",
  "namada_macros",
  "num-integer",
  "num-rational 0.4.1",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -3020,6 +3020,7 @@ dependencies = [
  "itertools 0.10.5",
  "k256",
  "masp_primitives",
+ "masp_proofs",
  "namada_macros",
  "num-integer",
  "num-rational 0.4.1",


### PR DESCRIPTION
## Describe your changes

Removes epoch for fee unshielding from the sdk that became useless with #2222.
Removes `MASP` key from `vp_user` which is not needed.
Refactors fee unshielding tests.

## Indicate on which release or other PRs this topic is based on

#2248 

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
