### PR TITLE
Masp conversions doesn't require all tokens be in genesis

### DIFF
--- a/.changelog/unreleased/improvments/2285-remove-hardcoded-masp-tokens.md
+++ b/.changelog/unreleased/improvments/2285-remove-hardcoded-masp-tokens.md
@@ -1,0 +1,5 @@
+- Previously, a hardcoded set of tokens were expected to be used in Masp conversions.
+  If these tokens did not have configs in genesis, this would lead to a panic after the first
+  epoch change. This PR fixes this to use the tokens found in genesis belonging to the MASP
+  rewards whitelist instead of hardcoding the tokens.
+  ([\#2285](https://github.com/anoma/namada/pull/2285))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -246,6 +246,7 @@ pub mod cmds {
                 .subcommand(QueryAccount::def().display_order(5))
                 .subcommand(QueryTransfers::def().display_order(5))
                 .subcommand(QueryConversions::def().display_order(5))
+                .subcommand(QueryMaspRewardTokens::def().display_order(5))
                 .subcommand(QueryBlock::def().display_order(5))
                 .subcommand(QueryBalance::def().display_order(5))
                 .subcommand(QueryBonds::def().display_order(5))
@@ -313,6 +314,8 @@ pub mod cmds {
             let query_transfers = Self::parse_with_ctx(matches, QueryTransfers);
             let query_conversions =
                 Self::parse_with_ctx(matches, QueryConversions);
+            let query_masp_reward_tokens =
+                Self::parse_with_ctx(matches, QueryMaspRewardTokens);
             let query_block = Self::parse_with_ctx(matches, QueryBlock);
             let query_balance = Self::parse_with_ctx(matches, QueryBalance);
             let query_bonds = Self::parse_with_ctx(matches, QueryBonds);
@@ -370,6 +373,7 @@ pub mod cmds {
                 .or(query_epoch)
                 .or(query_transfers)
                 .or(query_conversions)
+                .or(query_masp_reward_tokens)
                 .or(query_block)
                 .or(query_balance)
                 .or(query_bonds)
@@ -456,6 +460,7 @@ pub mod cmds {
         QueryAccount(QueryAccount),
         QueryTransfers(QueryTransfers),
         QueryConversions(QueryConversions),
+        QueryMaspRewardTokens(QueryMaspRewardTokens),
         QueryBlock(QueryBlock),
         QueryBalance(QueryBalance),
         QueryBonds(QueryBonds),
@@ -1667,6 +1672,28 @@ pub mod cmds {
             App::new(Self::CMD)
                 .about("Query currently applicable conversions.")
                 .add_args::<args::QueryConversions<args::CliTypes>>()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct QueryMaspRewardTokens(pub args::Query<args::CliTypes>);
+
+    impl SubCmd for QueryMaspRewardTokens {
+        const CMD: &'static str = "masp-reward-tokens";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches.subcommand_matches(Self::CMD).map(|matches| {
+                QueryMaspRewardTokens(args::Query::parse(matches))
+            })
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about(
+                    "Query the tokens which can earn MASP rewards while \
+                     shielded.",
+                )
+                .add_args::<args::Query<args::CliTypes>>()
         }
     }
 

--- a/apps/src/lib/cli/client.rs
+++ b/apps/src/lib/cli/client.rs
@@ -416,6 +416,16 @@ impl CliApi {
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_conversions(&namada, args).await;
                     }
+                    Sub::QueryMaspRewardTokens(QueryMaspRewardTokens(
+                        mut args,
+                    )) => {
+                        let client = client.unwrap_or_else(|| {
+                            C::from_tendermint_address(&mut args.ledger_address)
+                        });
+                        client.wait_until_node_is_synced(&io).await?;
+                        let namada = ctx.to_sdk(client, io);
+                        rpc::query_masp_reward_tokens(&namada).await;
+                    }
                     Sub::QueryBlock(QueryBlock(mut args)) => {
                         let client = client.unwrap_or_else(|| {
                             C::from_tendermint_address(&mut args.ledger_address)

--- a/apps/src/lib/client/rpc.rs
+++ b/apps/src/lib/client/rpc.rs
@@ -2428,6 +2428,17 @@ pub async fn query_conversion<C: namada::ledger::queries::Client + Sync>(
     namada_sdk::rpc::query_conversion(client, asset_type).await
 }
 
+/// Query to read the tokens that earn masp rewards.
+pub async fn query_masp_reward_tokens(context: &impl Namada) {
+    let tokens = namada_sdk::rpc::query_masp_reward_tokens(context.client())
+        .await
+        .expect("The tokens that may earn MASP rewards should be defined");
+    display_line!(context.io(), "The following tokens may ear MASP rewards:");
+    for (alias, address) in tokens {
+        display_line!(context.io(), "{}: {}", alias, address);
+    }
+}
+
 /// Query a wasm code hash
 pub async fn query_wasm_code_hash(
     context: &impl Namada,

--- a/core/src/ledger/masp_conversions.rs
+++ b/core/src/ledger/masp_conversions.rs
@@ -214,29 +214,15 @@ where
     };
     use rayon::prelude::ParallelSlice;
 
-    use crate::types::address;
-
     // The derived conversions will be placed in MASP address space
     let masp_addr = MASP;
 
-    let tokens = address::tokens();
-    let mut masp_reward_keys: Vec<_> = tokens
-        .into_keys()
-        .map(|k| {
-            wl_storage
-                .storage
-                .conversion_state
-                .tokens
-                .get(k)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Could not find token alias {} in MASP conversion \
-                         state.",
-                        k
-                    )
-                })
-                .clone()
-        })
+    let mut masp_reward_keys: Vec<_> = wl_storage
+        .storage
+        .conversion_state
+        .tokens
+        .values()
+        .cloned()
         .collect();
     // Put the native rewards first because other inflation computations depend
     // on it

--- a/sdk/src/queries/shell.rs
+++ b/sdk/src/queries/shell.rs
@@ -84,6 +84,10 @@ router! {SHELL,
     // Conversion state access - read conversion
     ( "conversions" ) -> BTreeMap<AssetType, ConversionWithoutPath> = read_conversions,
 
+
+    // Conversion state access - read conversion
+    ( "masp_reward_tokens" ) -> BTreeMap<String, Address> = masp_reward_tokens,
+
     // Block results access - read bit-vec
     ( "results" ) -> Vec<BlockResults> = read_results,
 
@@ -208,6 +212,17 @@ where
             format!("No conversion found for asset type: {}", asset_type),
         )))
     }
+}
+
+/// Query to read the tokens that earn masp rewards.
+fn masp_reward_tokens<D, H, V, T>(
+    ctx: RequestCtx<'_, D, H, V, T>,
+) -> storage_api::Result<BTreeMap<String, Address>>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    Ok(ctx.wl_storage.storage.conversion_state.tokens.clone())
 }
 
 fn epoch<D, H, V, T>(

--- a/sdk/src/rpc.rs
+++ b/sdk/src/rpc.rs
@@ -283,6 +283,13 @@ pub async fn query_conversions<C: crate::queries::Client + Sync>(
     convert_response::<C, _>(RPC.shell().read_conversions(client).await)
 }
 
+/// Query to read the tokens that earn masp rewards.
+pub async fn query_masp_reward_tokens<C: crate::queries::Client + Sync>(
+    client: &C,
+) -> Result<BTreeMap<String, Address>, Error> {
+    convert_response::<C, _>(RPC.shell().masp_reward_tokens(client).await)
+}
+
 /// Query a wasm code hash
 pub async fn query_wasm_code_hash(
     context: &impl Namada,


### PR DESCRIPTION
Fixes #2283 

## Describe your changes

Previously, a hardcoded set of tokens were expected to be used in Masp conversions.
If these tokens did not have configs in genesis, this would lead to a panic after the first 
epoch change. This PR fixes this to use the tokens found in genesis belonging to the MASP
rewards whitelist instead of hardcoding the tokens.



## Indicate on which release or other PRs this topic is based on
v0.28
## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
