### PR TITLE
Move Ethereum bridge components from `apps` to their own crate

### DIFF
--- a/.changelog/v0.29.0/improvements/2289-ethbridge-move-from-apps.md
+++ b/.changelog/v0.29.0/improvements/2289-ethbridge-move-from-apps.md
@@ -1,0 +1,2 @@
+- Move Ethereum bridge transaction code from `apps` to the `ethereum_bridge`
+  crate. ([\#2289](https://github.com/anoma/namada/pull/2289))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,6 +4444,7 @@ dependencies = [
  "tendermint",
  "tendermint-proto",
  "tendermint-rpc",
+ "thiserror",
  "toml 0.5.11",
  "tracing",
 ]

--- a/apps/src/lib/node/ledger/shell/vote_extensions.rs
+++ b/apps/src/lib/node/ledger/shell/vote_extensions.rs
@@ -4,6 +4,7 @@ pub mod bridge_pool_vext;
 pub mod eth_events;
 pub mod val_set_update;
 
+pub use namada::eth_bridge::protocol::validation::VoteExtensionError;
 use namada::proto::{SignableEthMessage, Signed};
 use namada::types::keccak::keccak_hash;
 use namada::types::transaction::protocol::EthereumTxData;
@@ -17,51 +18,6 @@ use crate::node::ledger::shims::abcipp_shim_types::shim::TxBytes;
 
 /// Message to be passed to `.expect()` calls in this module.
 const VALIDATOR_EXPECT_MSG: &str = "Only validators receive this method call.";
-
-/// The error yielded from validating faulty vote extensions in the shell
-#[derive(Error, Debug)]
-pub enum VoteExtensionError {
-    #[error(
-        "A validator set update proof is already available in storage for the \
-         given epoch"
-    )]
-    ValsetUpdProofAvailable,
-    #[error("The length of the transfers and their validity map differ")]
-    TransfersLenMismatch,
-    #[error("The nonce in the Ethereum event is invalid")]
-    InvalidEthEventNonce,
-    #[error("The vote extension was issued for an unexpected block height")]
-    UnexpectedBlockHeight,
-    #[error("The vote extension was issued for an unexpected epoch")]
-    UnexpectedEpoch,
-    #[error(
-        "The vote extension contains duplicate or non-sorted Ethereum events"
-    )]
-    HaveDupesOrNonSorted,
-    #[error(
-        "The public key of the vote extension's associated validator could \
-         not be found in storage"
-    )]
-    PubKeyNotInStorage,
-    #[error("The vote extension's signature is invalid")]
-    VerifySigFailed,
-    #[error(
-        "Validator is missing from an expected field in the vote extension"
-    )]
-    ValidatorMissingFromExtension,
-    #[error(
-        "Found value for a field in the vote extension diverging from the \
-         equivalent field in storage"
-    )]
-    DivergesFromStorage,
-    #[error("The signature of the Bridge pool root is invalid")]
-    InvalidBPRootSig,
-    #[error(
-        "Received a vote extension for the Ethereum bridge which is currently \
-         not active"
-    )]
-    EthereumBridgeInactive,
-}
 
 impl<D, H> Shell<D, H>
 where

--- a/ethereum_bridge/Cargo.toml
+++ b/ethereum_bridge/Cargo.toml
@@ -33,6 +33,7 @@ rand.workspace = true
 tendermint = {workspace = true}
 tendermint-rpc = {workspace = true}
 tendermint-proto = {workspace = true}
+thiserror.workspace = true
 tracing = "0.1.30"
 
 [dev-dependencies]

--- a/ethereum_bridge/src/protocol/mod.rs
+++ b/ethereum_bridge/src/protocol/mod.rs
@@ -1,1 +1,2 @@
 pub mod transactions;
+pub mod validation;

--- a/ethereum_bridge/src/protocol/validation.rs
+++ b/ethereum_bridge/src/protocol/validation.rs
@@ -1,0 +1,50 @@
+//! Validation logic for Ethereum bridge protocol actions.
+
+pub mod bridge_pool_roots;
+pub mod ethereum_events;
+pub mod validator_set_update;
+
+use thiserror::Error;
+
+/// The error yielded from validating faulty vote extensions.
+#[derive(Error, Debug)]
+pub enum VoteExtensionError {
+    #[error(
+        "A validator set update proof is already available in storage for the \
+         given epoch"
+    )]
+    ValsetUpdProofAvailable,
+    #[error("The nonce in the Ethereum event is invalid")]
+    InvalidEthEventNonce,
+    #[error("The vote extension was issued for an unexpected block height")]
+    UnexpectedBlockHeight,
+    #[error("The vote extension was issued for an unexpected epoch")]
+    UnexpectedEpoch,
+    #[error(
+        "The vote extension contains duplicate or non-sorted Ethereum events"
+    )]
+    HaveDupesOrNonSorted,
+    #[error(
+        "The public key of the vote extension's associated validator could \
+         not be found in storage"
+    )]
+    PubKeyNotInStorage,
+    #[error("The vote extension's signature is invalid")]
+    VerifySigFailed,
+    #[error(
+        "Validator is missing from an expected field in the vote extension"
+    )]
+    ValidatorMissingFromExtension,
+    #[error(
+        "Found value for a field in the vote extension diverging from the \
+         equivalent field in storage"
+    )]
+    DivergesFromStorage,
+    #[error("The signature of the Bridge pool root is invalid")]
+    InvalidBPRootSig,
+    #[error(
+        "Received a vote extension for the Ethereum bridge which is currently \
+         not active"
+    )]
+    EthereumBridgeInactive,
+}

--- a/ethereum_bridge/src/protocol/validation/bridge_pool_roots.rs
+++ b/ethereum_bridge/src/protocol/validation/bridge_pool_roots.rs
@@ -1,0 +1,129 @@
+//! Bridge pool roots validation.
+
+use namada_core::ledger::storage;
+use namada_core::ledger::storage::WlStorage;
+use namada_core::proto::{SignableEthMessage, Signed};
+use namada_core::types::keccak::keccak_hash;
+use namada_core::types::storage::BlockHeight;
+use namada_core::types::vote_extensions::bridge_pool_roots;
+use namada_proof_of_stake::pos_queries::PosQueries;
+
+use super::VoteExtensionError;
+use crate::storage::eth_bridge_queries::EthBridgeQueries;
+
+/// Validates a vote extension issued at the provided
+/// block height signing over the latest Ethereum bridge
+/// pool root and nonce.
+///
+/// Checks that at epoch of the provided height:
+///  * The inner Namada address corresponds to a consensus validator.
+///  * Check that the root and nonce are correct.
+///  * The validator correctly signed the extension.
+///  * The validator signed over the correct height inside of the extension.
+///  * Check that the inner signature is valid.
+pub fn validate_bp_roots_vext<D, H>(
+    wl_storage: &WlStorage<D, H>,
+    ext: &Signed<bridge_pool_roots::Vext>,
+    last_height: BlockHeight,
+) -> Result<(), VoteExtensionError>
+where
+    D: 'static + storage::DB + for<'iter> storage::DBIter<'iter>,
+    H: 'static + storage::StorageHasher,
+{
+    // NOTE: for ABCI++, we should pass
+    // `last_height` here, instead of `ext.data.block_height`
+    let ext_height_epoch =
+        match wl_storage.pos_queries().get_epoch(ext.data.block_height) {
+            Some(epoch) => epoch,
+            _ => {
+                tracing::debug!(
+                    block_height = ?ext.data.block_height,
+                    "The epoch of the Bridge pool root's vote extension's \
+                     block height should always be known",
+                );
+                return Err(VoteExtensionError::UnexpectedEpoch);
+            }
+        };
+    if !wl_storage
+        .ethbridge_queries()
+        .is_bridge_active_at(ext_height_epoch)
+    {
+        tracing::debug!(
+            vext_epoch = ?ext_height_epoch,
+            "The Ethereum bridge was not enabled when the pool
+             root's vote extension was cast",
+        );
+        return Err(VoteExtensionError::EthereumBridgeInactive);
+    }
+
+    if ext.data.block_height > last_height {
+        tracing::debug!(
+            ext_height = ?ext.data.block_height,
+            ?last_height,
+            "Bridge pool root's vote extension issued for a block height \
+             higher than the chain's last height."
+        );
+        return Err(VoteExtensionError::UnexpectedBlockHeight);
+    }
+    if ext.data.block_height.0 == 0 {
+        tracing::debug!("Dropping vote extension issued at genesis");
+        return Err(VoteExtensionError::UnexpectedBlockHeight);
+    }
+
+    // get the public key associated with this validator
+    let validator = &ext.data.validator_addr;
+    let (_, pk) = wl_storage
+        .pos_queries()
+        .get_validator_from_address(validator, Some(ext_height_epoch))
+        .map_err(|err| {
+            tracing::debug!(
+                ?err,
+                %validator,
+                "Could not get public key from Storage for some validator, \
+                 while validating Bridge pool root's vote extension"
+            );
+            VoteExtensionError::PubKeyNotInStorage
+        })?;
+    // verify the signature of the vote extension
+    ext.verify(&pk).map_err(|err| {
+        tracing::debug!(
+            ?err,
+            ?ext.sig,
+            ?pk,
+            %validator,
+            "Failed to verify the signature of an Bridge pool root's vote \
+             extension issued by some validator"
+        );
+        VoteExtensionError::VerifySigFailed
+    })?;
+
+    let bp_root = wl_storage
+        .ethbridge_queries()
+        .get_bridge_pool_root_at_height(ext.data.block_height)
+        .expect("We asserted that the queried height is correct")
+        .0;
+    let nonce = wl_storage
+        .ethbridge_queries()
+        .get_bridge_pool_nonce_at_height(ext.data.block_height)
+        .to_bytes();
+    let signed = Signed::<_, SignableEthMessage>::new_from(
+        keccak_hash([bp_root, nonce].concat()),
+        ext.data.sig.clone(),
+    );
+    let pk = wl_storage
+        .pos_queries()
+        .read_validator_eth_hot_key(validator, Some(ext_height_epoch))
+        .expect("A validator should have an Ethereum hot key in storage.");
+    signed.verify(&pk).map_err(|err| {
+        tracing::debug!(
+            ?err,
+            ?signed.sig,
+            ?pk,
+            %validator,
+            "Failed to verify the signature of an Bridge pool root \
+            issued by some validator."
+        );
+        VoteExtensionError::InvalidBPRootSig
+    })?;
+    Ok(())
+}

--- a/ethereum_bridge/src/protocol/validation/ethereum_events.rs
+++ b/ethereum_bridge/src/protocol/validation/ethereum_events.rs
@@ -1,0 +1,141 @@
+//! Ethereum events validation.
+
+use namada_core::ledger::storage;
+use namada_core::ledger::storage::WlStorage;
+use namada_core::proto::Signed;
+use namada_core::types::storage::BlockHeight;
+use namada_core::types::vote_extensions::ethereum_events;
+use namada_proof_of_stake::pos_queries::PosQueries;
+
+use super::VoteExtensionError;
+use crate::storage::eth_bridge_queries::EthBridgeQueries;
+
+/// Validates an Ethereum events vote extension issued at the provided
+/// block height.
+///
+/// Checks that at epoch of the provided height:
+///  * The inner Namada address corresponds to a consensus validator.
+///  * The validator correctly signed the extension.
+///  * The validator signed over the correct height inside of the extension.
+///  * There are no duplicate Ethereum events in this vote extension, and the
+///    events are sorted in ascending order.
+pub fn validate_eth_events_vext<D, H>(
+    wl_storage: &WlStorage<D, H>,
+    ext: &Signed<ethereum_events::Vext>,
+    last_height: BlockHeight,
+) -> Result<(), VoteExtensionError>
+where
+    D: 'static + storage::DB + for<'iter> storage::DBIter<'iter>,
+    H: 'static + storage::StorageHasher,
+{
+    // NOTE: for ABCI++, we should pass
+    // `last_height` here, instead of `ext.data.block_height`
+    let ext_height_epoch =
+        match wl_storage.pos_queries().get_epoch(ext.data.block_height) {
+            Some(epoch) => epoch,
+            _ => {
+                tracing::debug!(
+                    block_height = ?ext.data.block_height,
+                    "The epoch of the Ethereum events vote extension's \
+                     block height should always be known",
+                );
+                return Err(VoteExtensionError::UnexpectedEpoch);
+            }
+        };
+    if !wl_storage
+        .ethbridge_queries()
+        .is_bridge_active_at(ext_height_epoch)
+    {
+        tracing::debug!(
+            vext_epoch = ?ext_height_epoch,
+            "The Ethereum bridge was not enabled when the Ethereum
+             events' vote extension was cast",
+        );
+        return Err(VoteExtensionError::EthereumBridgeInactive);
+    }
+    if ext.data.block_height > last_height {
+        tracing::debug!(
+            ext_height = ?ext.data.block_height,
+            ?last_height,
+            "Ethereum events vote extension issued for a block height \
+             higher than the chain's last height."
+        );
+        return Err(VoteExtensionError::UnexpectedBlockHeight);
+    }
+    if ext.data.block_height.0 == 0 {
+        tracing::debug!("Dropping vote extension issued at genesis");
+        return Err(VoteExtensionError::UnexpectedBlockHeight);
+    }
+    validate_eth_events(wl_storage, &ext.data)?;
+    // get the public key associated with this validator
+    let validator = &ext.data.validator_addr;
+    let (_, pk) = wl_storage
+        .pos_queries()
+        .get_validator_from_address(validator, Some(ext_height_epoch))
+        .map_err(|err| {
+            tracing::debug!(
+                ?err,
+                %validator,
+                "Could not get public key from Storage for some validator, \
+                 while validating Ethereum events vote extension"
+            );
+            VoteExtensionError::PubKeyNotInStorage
+        })?;
+    // verify the signature of the vote extension
+    ext.verify(&pk).map_err(|err| {
+        tracing::debug!(
+            ?err,
+            ?ext.sig,
+            ?pk,
+            %validator,
+            "Failed to verify the signature of an Ethereum events vote \
+             extension issued by some validator"
+        );
+        VoteExtensionError::VerifySigFailed
+    })?;
+    Ok(())
+}
+
+/// Validate a batch of Ethereum events contained in
+/// an [`ethereum_events::Vext`].
+///
+/// The supplied Ethereum events must be ordered in
+/// ascending ordering, must not contain any dupes
+/// and must have valid nonces.
+fn validate_eth_events<D, H>(
+    wl_storage: &WlStorage<D, H>,
+    ext: &ethereum_events::Vext,
+) -> Result<(), VoteExtensionError>
+where
+    D: 'static + storage::DB + for<'iter> storage::DBIter<'iter>,
+    H: 'static + storage::StorageHasher,
+{
+    // verify if we have any duplicate Ethereum events,
+    // and if these are sorted in ascending order
+    let have_dupes_or_non_sorted = {
+        !ext.ethereum_events
+            // TODO: move to `array_windows` when it reaches Rust stable
+            .windows(2)
+            .all(|evs| evs[0] < evs[1])
+    };
+    let validator = &ext.validator_addr;
+    if have_dupes_or_non_sorted {
+        tracing::debug!(
+            %validator,
+            "Found duplicate or non-sorted Ethereum events in a vote extension from \
+             some validator"
+        );
+        return Err(VoteExtensionError::HaveDupesOrNonSorted);
+    }
+    // for the proposal to be valid, at least one of the
+    // event's nonces must be valid
+    if ext.ethereum_events.iter().any(|event| {
+        wl_storage
+            .ethbridge_queries()
+            .validate_eth_event_nonce(event)
+    }) {
+        Ok(())
+    } else {
+        Err(VoteExtensionError::InvalidEthEventNonce)
+    }
+}

--- a/ethereum_bridge/src/protocol/validation/validator_set_update.rs
+++ b/ethereum_bridge/src/protocol/validation/validator_set_update.rs
@@ -1,0 +1,120 @@
+//! Validator set update validation.
+
+use namada_core::ledger::storage;
+use namada_core::ledger::storage::WlStorage;
+use namada_core::types::storage::Epoch;
+use namada_core::types::vote_extensions::validator_set_update;
+use namada_proof_of_stake::pos_queries::PosQueries;
+
+use super::VoteExtensionError;
+use crate::storage::eth_bridge_queries::EthBridgeQueries;
+
+/// Validates a validator set update vote extension issued at the
+/// epoch provided as an argument.
+///
+/// # Validation checks
+///
+/// To validate a [`validator_set_update::SignedVext`], Namada nodes
+/// check if:
+///
+///  * The signing validator is a consensus validator during the epoch
+///    `signing_epoch` inside the extension.
+///  * A validator set update proof is not available yet for `signing_epoch`.
+///  * The validator correctly signed the extension, with its Ethereum hot key.
+///  * The validator signed over the epoch inside of the extension, whose value
+///    should not be greater than `last_epoch`.
+///  * The voting powers in the vote extension correspond to the voting powers
+///    of the validators of `signing_epoch + 1`.
+///  * The voting powers signed over were Ethereum ABI encoded, normalized to
+///    `2^32`, and sorted in descending order.
+pub fn validate_valset_upd_vext<D, H>(
+    wl_storage: &WlStorage<D, H>,
+    ext: &validator_set_update::SignedVext,
+    last_epoch: Epoch,
+) -> Result<(), VoteExtensionError>
+where
+    D: 'static + storage::DB + for<'iter> storage::DBIter<'iter>,
+    H: 'static + storage::StorageHasher,
+{
+    if wl_storage.storage.last_block.is_none() {
+        tracing::debug!(
+            "Dropping validator set update vote extension issued at genesis"
+        );
+        return Err(VoteExtensionError::UnexpectedBlockHeight);
+    }
+    let signing_epoch = ext.data.signing_epoch;
+    if signing_epoch > last_epoch {
+        tracing::debug!(
+            vext_epoch = ?signing_epoch,
+            ?last_epoch,
+            "Validator set update vote extension issued for an epoch \
+             greater than the last one.",
+        );
+        return Err(VoteExtensionError::UnexpectedEpoch);
+    }
+    if wl_storage
+        .ethbridge_queries()
+        .valset_upd_seen(signing_epoch.next())
+    {
+        let err = VoteExtensionError::ValsetUpdProofAvailable;
+        tracing::debug!(
+            proof_epoch = ?signing_epoch.next(),
+            "{err}"
+        );
+        return Err(err);
+    }
+    // verify if the new epoch validators' voting powers in storage match
+    // the voting powers in the vote extension
+    for (eth_addr_book, namada_addr, namada_power) in wl_storage
+        .ethbridge_queries()
+        .get_consensus_eth_addresses(Some(signing_epoch.next()))
+        .iter()
+    {
+        let &ext_power = match ext.data.voting_powers.get(&eth_addr_book) {
+            Some(voting_power) => voting_power,
+            _ => {
+                tracing::debug!(
+                    ?eth_addr_book,
+                    "Could not find expected Ethereum addresses in valset upd \
+                     vote extension",
+                );
+                return Err(VoteExtensionError::ValidatorMissingFromExtension);
+            }
+        };
+        if namada_power != ext_power {
+            tracing::debug!(
+                validator = %namada_addr,
+                expected = ?namada_power,
+                got = ?ext_power,
+                "Found unexpected voting power value in valset upd vote extension",
+            );
+            return Err(VoteExtensionError::DivergesFromStorage);
+        }
+    }
+    // get the public key associated with this validator
+    let validator = &ext.data.validator_addr;
+    let pk = wl_storage
+        .pos_queries()
+        .read_validator_eth_hot_key(validator, Some(signing_epoch))
+        .ok_or_else(|| {
+            tracing::debug!(
+                %validator,
+                "Could not get Ethereum hot key from Storage for some validator, \
+                 while validating valset upd vote extension"
+            );
+            VoteExtensionError::PubKeyNotInStorage
+        })?;
+    // verify the signature of the vote extension
+    ext.verify(&pk).map_err(|err| {
+        tracing::debug!(
+            ?err,
+            ?ext.sig,
+            ?pk,
+            %validator,
+            "Failed to verify the signature of a valset upd vote \
+             extension issued by some validator"
+        );
+        VoteExtensionError::VerifySigFailed
+    })?;
+    Ok(())
+}

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3435,6 +3435,7 @@ dependencies = [
  "tendermint",
  "tendermint-proto",
  "tendermint-rpc",
+ "thiserror",
  "tracing",
 ]
 

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -3435,6 +3435,7 @@ dependencies = [
  "tendermint",
  "tendermint-proto",
  "tendermint-rpc",
+ "thiserror",
  "tracing",
 ]
 


### PR DESCRIPTION
## Describe your changes

Move Ethereum bridge components from `apps` to the `ethereum_bridge` crate. This is part of the modularization effort of Namada.

## Indicate on which release or other PRs this topic is based on

`v0.29.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
