### PR TITLE
Fix ibc-gen-shielded to receive a non-Namada token

### DIFF
--- a/.changelog/unreleased/SDK/2308-fix-ibc-gen-shielded.md
+++ b/.changelog/unreleased/SDK/2308-fix-ibc-gen-shielded.md
@@ -1,0 +1,2 @@
+- ibc-gen-shielded can set non-Namada token
+  ([\#2308](https://github.com/anoma/namada/issues/2308))

--- a/.changelog/unreleased/bug-fixes/2308-fix-ibc-gen-shielded.md
+++ b/.changelog/unreleased/bug-fixes/2308-fix-ibc-gen-shielded.md
@@ -1,0 +1,2 @@
+- Non-Namada token can be given to ibc-gen-shielded
+  ([\#2308](https://github.com/anoma/namada/issues/2308))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -3164,6 +3164,7 @@ pub mod args {
     pub const TM_ADDRESS: Arg<String> = arg("tm-address");
     pub const TOKEN_OPT: ArgOpt<WalletAddress> = TOKEN.opt();
     pub const TOKEN: Arg<WalletAddress> = arg("token");
+    pub const TOKEN_STR: Arg<String> = arg("token");
     pub const TRANSFER_SOURCE: Arg<WalletTransferSource> = arg("source");
     pub const TRANSFER_TARGET: Arg<WalletTransferTarget> = arg("target");
     pub const TX_HASH: Arg<String> = arg("tx-hash");
@@ -5654,7 +5655,7 @@ pub mod args {
                 query,
                 output_folder: self.output_folder,
                 target: chain_ctx.get(&self.target),
-                token: chain_ctx.get(&self.token),
+                token: self.token,
                 amount: self.amount,
                 port_id: self.port_id,
                 channel_id: self.channel_id,
@@ -5667,7 +5668,7 @@ pub mod args {
             let query = Query::parse(matches);
             let output_folder = OUTPUT_FOLDER_PATH.parse(matches);
             let target = TRANSFER_TARGET.parse(matches);
-            let token = TOKEN.parse(matches);
+            let token = TOKEN_STR.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let port_id = PORT_ID.parse(matches);
             let channel_id = CHANNEL_ID.parse(matches);

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -2418,8 +2418,8 @@ pub struct GenIbcShieldedTransafer<C: NamadaTypes = SdkTypes> {
     pub output_folder: Option<PathBuf>,
     /// The target address
     pub target: C::TransferTarget,
-    /// The token address
-    pub token: C::Address,
+    /// The token address which could be a non-namada address
+    pub token: String,
     /// Transferred token amount
     pub amount: InputAmount,
     /// Port ID via which the token is received

--- a/sdk/src/rpc.rs
+++ b/sdk/src/rpc.rs
@@ -1163,12 +1163,33 @@ pub async fn format_denominated_amount(
 /// Look up the IBC denomination from a IbcToken.
 pub async fn query_ibc_denom<N: Namada>(
     context: &N,
-    token: &Address,
+    token: impl AsRef<str>,
     owner: Option<&Address>,
 ) -> String {
-    let hash = match token {
-        Address::Internal(InternalAddress::IbcToken(hash)) => hash.to_string(),
-        _ => return token.to_string(),
+    let hash = match Address::decode(token.as_ref()) {
+        Ok(Address::Internal(InternalAddress::IbcToken(hash))) => {
+            hash.to_string()
+        }
+        Ok(_) => return token.as_ref().to_string(),
+        Err(_) => match namada_core::types::ibc::is_ibc_denom(token.as_ref()) {
+            Some((trace_path, base_denom)) => {
+                let base_token = context
+                    .wallet()
+                    .await
+                    .find_address(&base_denom)
+                    .map(|addr| addr.to_string())
+                    .unwrap_or(base_denom);
+                return format!("{trace_path}/{base_token}");
+            }
+            None => {
+                return context
+                    .wallet()
+                    .await
+                    .find_address(token.as_ref())
+                    .map(|addr| addr.to_string())
+                    .unwrap_or(token.as_ref().to_string());
+            }
+        },
     };
 
     if let Some(owner) = owner {
@@ -1195,5 +1216,5 @@ pub async fn query_ibc_denom<N: Namada>(
         }
     }
 
-    token.to_string()
+    token.as_ref().to_string()
 }

--- a/sdk/src/rpc.rs
+++ b/sdk/src/rpc.rs
@@ -1170,26 +1170,7 @@ pub async fn query_ibc_denom<N: Namada>(
         Ok(Address::Internal(InternalAddress::IbcToken(hash))) => {
             hash.to_string()
         }
-        Ok(_) => return token.as_ref().to_string(),
-        Err(_) => match namada_core::types::ibc::is_ibc_denom(token.as_ref()) {
-            Some((trace_path, base_denom)) => {
-                let base_token = context
-                    .wallet()
-                    .await
-                    .find_address(&base_denom)
-                    .map(|addr| addr.to_string())
-                    .unwrap_or(base_denom);
-                return format!("{trace_path}/{base_token}");
-            }
-            None => {
-                return context
-                    .wallet()
-                    .await
-                    .find_address(token.as_ref())
-                    .map(|addr| addr.to_string())
-                    .unwrap_or(token.as_ref().to_string());
-            }
-        },
+        _ => return token.as_ref().to_string(),
     };
 
     if let Some(owner) = owner {

--- a/sdk/src/tx.rs
+++ b/sdk/src/tx.rs
@@ -1974,7 +1974,8 @@ pub async fn build_ibc_transfer(
             .map_err(|e| Error::from(QueryError::Wasm(e.to_string())))?;
 
     let ibc_denom =
-        rpc::query_ibc_denom(context, &args.token, Some(&source)).await;
+        rpc::query_ibc_denom(context, &args.token.to_string(), Some(&source))
+            .await;
     let token = PrefixedCoin {
         denom: ibc_denom.parse().expect("Invalid IBC denom"),
         // Set the IBC amount as an integer

--- a/tests/src/e2e/ibc_tests.rs
+++ b/tests/src/e2e/ibc_tests.rs
@@ -203,7 +203,7 @@ fn run_ledger_ibc() -> Result<()> {
         &port_id_b,
         &channel_id_b,
     )?;
-    check_shielded_balances(&port_id_b, &channel_id_b, &test_b)?;
+    check_shielded_balances(&port_id_b, &channel_id_b, &test_a, &test_b)?;
 
     // Skip tests for closing a channel and timeout_on_close since the transfer
     // channel cannot be closed
@@ -1024,6 +1024,8 @@ fn shielded_transfer(
     // It will send 10 BTC from Chain A to PA(B) on Chain B
     let rpc_b = get_actor_rpc(test_b, &Who::Validator(0));
     let output_folder = test_b.test_dir.path().to_string_lossy();
+    // PA(B) on Chain B will receive BTC on chain A
+    let token_addr = find_address(test_a, BTC)?;
     let amount = Amount::native_whole(10).to_string_native();
     let args = [
         "ibc-gen-shielded",
@@ -1032,7 +1034,7 @@ fn shielded_transfer(
         "--target",
         AB_PAYMENT_ADDRESS,
         "--token",
-        BTC,
+        &token_addr.to_string(),
         "--amount",
         &amount,
         "--port-id",
@@ -1526,16 +1528,19 @@ fn check_balances_after_back(
 fn check_shielded_balances(
     dest_port_id: &PortId,
     dest_channel_id: &ChannelId,
+    test_a: &Test,
     test_b: &Test,
 ) -> Result<()> {
     // Check the balance on Chain B
     let rpc_b = get_actor_rpc(test_b, &Who::Validator(0));
+    // PA(B) on Chain B has received BTC on chain A
+    let token_addr = find_address(test_a, BTC)?.to_string();
     let query_args = vec![
         "balance",
         "--owner",
         AB_VIEWING_KEY,
         "--token",
-        BTC,
+        &token_addr,
         "--no-conversions",
         "--node",
         &rpc_b,


### PR DESCRIPTION
## Describe your changes
closes #2308
closes #2309
`ibc-gen-shielded` should get not only a Namada token but also a non-Namada token to transfer it from non-Namada chains

## Indicate on which release or other PRs this topic is based on
`v0.28.1`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
