### PR TITLE
IBC transfer from a spending key

### DIFF
--- a/.changelog/unreleased/SDK/2321-ibc_shielded_transfer.md
+++ b/.changelog/unreleased/SDK/2321-ibc_shielded_transfer.md
@@ -1,0 +1,2 @@
+- ibc-transfer can set a spending key to the source
+  ([\#2321](https://github.com/anoma/namada/issues/2321))

--- a/.changelog/unreleased/features/2321-ibc_shielded_transfer.md
+++ b/.changelog/unreleased/features/2321-ibc_shielded_transfer.md
@@ -1,0 +1,2 @@
+- IBC transfer from a spending key
+  ([\#2321](https://github.com/anoma/namada/issues/2321))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -4025,7 +4025,7 @@ pub mod args {
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
             TxIbcTransfer::<SdkTypes> {
                 tx,
-                source: chain_ctx.get(&self.source),
+                source: chain_ctx.get_cached(&self.source),
                 receiver: self.receiver,
                 token: chain_ctx.get(&self.token),
                 amount: self.amount,
@@ -4042,7 +4042,7 @@ pub mod args {
     impl Args for TxIbcTransfer<CliTypes> {
         fn parse(matches: &ArgMatches) -> Self {
             let tx = Tx::parse(matches);
-            let source = SOURCE.parse(matches);
+            let source = TRANSFER_SOURCE.parse(matches);
             let receiver = RECEIVER.parse(matches);
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));

--- a/apps/src/lib/client/tx.rs
+++ b/apps/src/lib/client/tx.rs
@@ -989,7 +989,12 @@ pub async fn submit_ibc_transfer<N: Namada>(
 where
     <N::Client as namada::ledger::queries::Client>::Error: std::fmt::Display,
 {
-    submit_reveal_aux(namada, args.tx.clone(), &args.source).await?;
+    submit_reveal_aux(
+        namada,
+        args.tx.clone(),
+        &args.source.effective_address(),
+    )
+    .await?;
     let (mut tx, signing_data, _epoch) = args.build(namada).await?;
     signing::generate_test_vector(namada, &tx).await?;
 

--- a/core/src/ledger/ibc/mod.rs
+++ b/core/src/ledger/ibc/mod.rs
@@ -128,7 +128,7 @@ where
                     .map_err(|e| Error::Context(Box::new(e)))?;
                 // the current ibc-rs execution doesn't store the denom for the
                 // token hash when transfer with MsgRecvPacket
-                self.store_denom(&envelope)?;
+                self.store_denom(envelope)?;
                 // For receiving the token to a shielded address
                 self.handle_masp_tx(message)
             }

--- a/core/src/ledger/ibc/mod.rs
+++ b/core/src/ledger/ibc/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::Debug;
 use std::rc::Rc;
 use std::str::FromStr;
 
+use borsh::BorshDeserialize;
 pub use context::common::IbcCommonContext;
 use context::router::IbcRouter;
 pub use context::storage::{IbcStorageContext, ProofSpec};
@@ -37,16 +38,16 @@ use crate::ibc::core::router::types::module::ModuleId;
 use crate::ibc::primitives::proto::Any;
 use crate::types::address::{Address, MASP};
 use crate::types::ibc::{
-    get_shielded_transfer, is_ibc_denom, EVENT_TYPE_DENOM_TRACE,
-    EVENT_TYPE_PACKET,
+    get_shielded_transfer, is_ibc_denom, MsgShieldedTransfer,
+    EVENT_TYPE_DENOM_TRACE, EVENT_TYPE_PACKET,
 };
 use crate::types::masp::PaymentAddress;
 
 #[allow(missing_docs)]
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Decoding IBC data error: {0}")]
-    DecodingData(prost::DecodeError),
+    #[error("Decoding IBC data error")]
+    DecodingData,
     #[error("Decoding message error: {0}")]
     DecodingMessage(RouterError),
     #[error("IBC context error: {0}")]
@@ -99,28 +100,37 @@ where
 
     /// Execute according to the message in an IBC transaction or VP
     pub fn execute(&mut self, tx_data: &[u8]) -> Result<(), Error> {
-        let any_msg = Any::decode(tx_data).map_err(Error::DecodingData)?;
-        match MsgTransfer::try_from(any_msg.clone()) {
-            Ok(msg) => {
+        let message = decode_message(tx_data)?;
+        match &message {
+            IbcMessage::Transfer(msg) => {
                 let mut token_transfer_ctx =
                     TokenTransferContext::new(self.ctx.inner.clone());
                 send_transfer_execute(
                     &mut self.ctx,
                     &mut token_transfer_ctx,
-                    msg,
+                    msg.clone(),
                 )
                 .map_err(Error::TokenTransfer)
             }
-            Err(_) => {
-                let envelope = MsgEnvelope::try_from(any_msg)
-                    .map_err(Error::DecodingMessage)?;
+            IbcMessage::ShieldedTransfer(msg) => {
+                let mut token_transfer_ctx =
+                    TokenTransferContext::new(self.ctx.inner.clone());
+                send_transfer_execute(
+                    &mut self.ctx,
+                    &mut token_transfer_ctx,
+                    msg.message.clone(),
+                )
+                .map_err(Error::TokenTransfer)?;
+                self.handle_masp_tx(message)
+            }
+            IbcMessage::Envelope(envelope) => {
                 execute(&mut self.ctx, &mut self.router, envelope.clone())
                     .map_err(|e| Error::Context(Box::new(e)))?;
-                // For receiving the token to a shielded address
-                self.handle_masp_tx(&envelope)?;
                 // the current ibc-rs execution doesn't store the denom for the
                 // token hash when transfer with MsgRecvPacket
-                self.store_denom(&envelope)
+                self.store_denom(&envelope)?;
+                // For receiving the token to a shielded address
+                self.handle_masp_tx(message)
             }
         }
     }
@@ -218,17 +228,25 @@ where
 
     /// Validate according to the message in IBC VP
     pub fn validate(&self, tx_data: &[u8]) -> Result<(), Error> {
-        let any_msg = Any::decode(tx_data).map_err(Error::DecodingData)?;
-        match MsgTransfer::try_from(any_msg.clone()) {
-            Ok(msg) => {
+        let message = decode_message(tx_data)?;
+        match message {
+            IbcMessage::Transfer(msg) => {
                 let token_transfer_ctx =
                     TokenTransferContext::new(self.ctx.inner.clone());
                 send_transfer_validate(&self.ctx, &token_transfer_ctx, msg)
                     .map_err(Error::TokenTransfer)
             }
-            Err(_) => {
-                let envelope = MsgEnvelope::try_from(any_msg)
-                    .map_err(Error::DecodingMessage)?;
+            IbcMessage::ShieldedTransfer(msg) => {
+                let token_transfer_ctx =
+                    TokenTransferContext::new(self.ctx.inner.clone());
+                send_transfer_validate(
+                    &self.ctx,
+                    &token_transfer_ctx,
+                    msg.message,
+                )
+                .map_err(Error::TokenTransfer)
+            }
+            IbcMessage::Envelope(envelope) => {
                 validate(&self.ctx, &self.router, envelope)
                     .map_err(|e| Error::Context(Box::new(e)))
             }
@@ -236,9 +254,9 @@ where
     }
 
     /// Handle the MASP transaction if needed
-    fn handle_masp_tx(&mut self, envelope: &MsgEnvelope) -> Result<(), Error> {
-        let shielded_transfer = match envelope {
-            MsgEnvelope::Packet(PacketMsg::Recv(_)) => {
+    fn handle_masp_tx(&mut self, message: IbcMessage) -> Result<(), Error> {
+        let shielded_transfer = match message {
+            IbcMessage::Envelope(MsgEnvelope::Packet(PacketMsg::Recv(_))) => {
                 let event = self
                     .ctx
                     .inner
@@ -257,6 +275,7 @@ where
                     None => return Ok(()),
                 }
             }
+            IbcMessage::ShieldedTransfer(msg) => Some(msg.shielded_transfer),
             _ => return Ok(()),
         };
         if let Some(shielded_transfer) = shielded_transfer {
@@ -270,6 +289,31 @@ where
         }
         Ok(())
     }
+}
+
+enum IbcMessage {
+    Envelope(MsgEnvelope),
+    Transfer(MsgTransfer),
+    ShieldedTransfer(MsgShieldedTransfer),
+}
+
+fn decode_message(tx_data: &[u8]) -> Result<IbcMessage, Error> {
+    // ibc-rs message
+    if let Ok(any_msg) = Any::decode(tx_data) {
+        if let Ok(transfer_msg) = MsgTransfer::try_from(any_msg.clone()) {
+            return Ok(IbcMessage::Transfer(transfer_msg));
+        }
+        if let Ok(envelope) = MsgEnvelope::try_from(any_msg) {
+            return Ok(IbcMessage::Envelope(envelope));
+        }
+    }
+
+    // Message with Transfer for the shielded transfer
+    if let Ok(msg) = MsgShieldedTransfer::try_from_slice(tx_data) {
+        return Ok(IbcMessage::ShieldedTransfer(msg));
+    }
+
+    Err(Error::DecodingData)
 }
 
 /// Get the IbcToken from the source/destination ports and channels

--- a/core/src/types/ibc.rs
+++ b/core/src/types/ibc.rs
@@ -106,8 +106,8 @@ impl std::fmt::Display for IbcEvent {
 pub struct MsgShieldedTransfer {
     /// IBC transfer message
     pub message: MsgTransfer,
-    /// Token transfer with the masp section hash
-    pub transfer: Transfer,
+    /// MASP tx with token transfer
+    pub shielded_transfer: IbcShieldedTransfer,
 }
 
 impl BorshSerialize for MsgShieldedTransfer {
@@ -116,7 +116,7 @@ impl BorshSerialize for MsgShieldedTransfer {
         writer: &mut W,
     ) -> std::io::Result<()> {
         let encoded_msg = self.message.clone().encode_vec();
-        let members = (encoded_msg, self.transfer.clone());
+        let members = (encoded_msg, self.shielded_transfer.clone());
         BorshSerialize::serialize(&members, writer)
     }
 }
@@ -126,11 +126,14 @@ impl BorshDeserialize for MsgShieldedTransfer {
         reader: &mut R,
     ) -> std::io::Result<Self> {
         use std::io::{Error, ErrorKind};
-        let (msg, transfer): (Vec<u8>, Transfer) =
+        let (msg, shielded_transfer): (Vec<u8>, IbcShieldedTransfer) =
             BorshDeserialize::deserialize_reader(reader)?;
         let message = MsgTransfer::decode_vec(&msg)
             .map_err(|err| Error::new(ErrorKind::InvalidData, err))?;
-        Ok(Self { message, transfer })
+        Ok(Self {
+            message,
+            shielded_transfer,
+        })
     }
 }
 

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -296,7 +296,7 @@ pub struct TxIbcTransfer<C: NamadaTypes = SdkTypes> {
     /// Common tx arguments
     pub tx: Tx<C>,
     /// Transfer source address
-    pub source: C::Address,
+    pub source: C::TransferSource,
     /// Transfer target address
     pub receiver: String,
     /// Transferred token address
@@ -331,7 +331,7 @@ impl<C: NamadaTypes> TxBuilder<C> for TxIbcTransfer<C> {
 
 impl<C: NamadaTypes> TxIbcTransfer<C> {
     /// Transfer source address
-    pub fn source(self, source: C::Address) -> Self {
+    pub fn source(self, source: C::TransferSource) -> Self {
         Self { source, ..self }
     }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -245,7 +245,7 @@ pub trait Namada: Sized + MaybeSync + MaybeSend {
     /// Make a TxIbcTransfer builder from the given minimum set of arguments
     fn new_ibc_transfer(
         &self,
-        source: Address,
+        source: TransferSource,
         receiver: String,
         token: Address,
         amount: InputAmount,

--- a/sdk/src/tx.rs
+++ b/sdk/src/tx.rs
@@ -2041,7 +2041,7 @@ pub async fn build_ibc_transfer(
     let data = match shielded_parts {
         Some((shielded_transfer, asset_types)) => {
             let masp_tx_hash =
-                tx.add_masp_tx_section(shielded_transfer.masp_tx).1;
+                tx.add_masp_tx_section(shielded_transfer.masp_tx.clone()).1;
             let transfer = token::Transfer {
                 source: source.clone(),
                 target: MASP,
@@ -2059,7 +2059,15 @@ pub async fn build_ibc_transfer(
                 builder: shielded_transfer.builder,
                 target: masp_tx_hash,
             });
-            MsgShieldedTransfer { message, transfer }.serialize_to_vec()
+            let shielded_transfer = IbcShieldedTransfer {
+                transfer,
+                masp_tx: shielded_transfer.masp_tx,
+            };
+            MsgShieldedTransfer {
+                message,
+                shielded_transfer,
+            }
+            .serialize_to_vec()
         }
         None => {
             let any_msg = message.to_any();

--- a/sdk/src/tx.rs
+++ b/sdk/src/tx.rs
@@ -1974,7 +1974,7 @@ pub async fn build_ibc_transfer(
             .map_err(|e| Error::from(QueryError::Wasm(e.to_string())))?;
 
     // For transfer from a spending key
-    let shielded_parts = construct_shielded_part(
+    let shielded_parts = construct_shielded_parts(
         context,
         &args.source,
         // The token will be escrowed to IBC address
@@ -2282,7 +2282,7 @@ pub async fn build_transfer<N: Namada>(
         _ => None,
     };
 
-    let shielded_parts = construct_shielded_part(
+    let shielded_parts = construct_shielded_parts(
         context,
         &args.source,
         &args.target,
@@ -2367,7 +2367,7 @@ pub async fn build_transfer<N: Namada>(
 }
 
 // Construct the shielded part of the transaction, if any
-async fn construct_shielded_part<N: Namada>(
+async fn construct_shielded_parts<N: Namada>(
     context: &N,
     source: &TransferSource,
     target: &TransferTarget,

--- a/tests/src/e2e/ibc_tests.rs
+++ b/tests/src/e2e/ibc_tests.rs
@@ -167,7 +167,8 @@ fn run_ledger_ibc() -> Result<()> {
     try_invalid_transfers(&test_a, &test_b, &port_id_a, &channel_id_a)?;
 
     // Transfer 50000 received over IBC on Chain B
-    transfer_received_token(&port_id_b, &channel_id_b, &test_b)?;
+    let token = format!("{port_id_b}/{channel_id_b}/nam");
+    transfer_on_chain(&test_b, BERTHA, ALBERT, token, 50000, BERTHA_KEY)?;
     check_balances_after_non_ibc(&port_id_b, &channel_id_b, &test_b)?;
 
     // Transfer 50000 back from the origin-specific account on Chain B to Chain
@@ -862,26 +863,27 @@ fn try_invalid_transfers(
     Ok(())
 }
 
-fn transfer_received_token(
-    port_id: &PortId,
-    channel_id: &ChannelId,
+fn transfer_on_chain(
     test: &Test,
+    sender: impl AsRef<str>,
+    receiver: impl AsRef<str>,
+    token: impl AsRef<str>,
+    amount: u64,
+    signer: impl AsRef<str>,
 ) -> Result<()> {
     let rpc = get_actor_rpc(test, &Who::Validator(0));
-    let ibc_denom = format!("{port_id}/{channel_id}/nam");
-    let amount = Amount::native_whole(50000).to_string_native();
     let tx_args = [
         "transfer",
         "--source",
-        BERTHA,
+        sender.as_ref(),
         "--target",
-        ALBERT,
+        receiver.as_ref(),
         "--token",
-        &ibc_denom,
+        token.as_ref(),
         "--amount",
-        &amount,
-        "--gas-token",
-        NAM,
+        &amount.to_string(),
+        "--signing-keys",
+        signer.as_ref(),
         "--node",
         &rpc,
     ];
@@ -1046,11 +1048,14 @@ fn shielded_transfer(
     let file_path = get_shielded_transfer_path(&mut client)?;
     client.assert_success();
 
-    // Send a token from Chain A to PA(B) on Chain B
+    // Send a token to the shielded address on Chain A
+    transfer_on_chain(test_a, ALBERT, AA_PAYMENT_ADDRESS, BTC, 10, ALBERT_KEY)?;
+
+    // Send a token from SP(A) on Chain A to PA(B) on Chain B
     let amount = Amount::native_whole(10).to_string_native();
     let height = transfer(
         test_a,
-        ALBERT,
+        A_SPENDING_KEY,
         AB_PAYMENT_ADDRESS,
         BTC,
         amount,


### PR DESCRIPTION
## Describe your changes
closes #2314 
- Change the `source` type in `ibc-transfer` to `TransferSource` to set a spending key
- Add `MsgShieldedTransfer` to pass `token::Transfer` and MASP tx with `MsgTransfer`
- Call `handle_masp_tx` after `send_transfer_execute` in `IbcActions` if it's a shielded transfer
- Modify an E2E test to send a token from a spending key to a payment key on another Namada

## Indicate on which release or other PRs this topic is based on
`v0.28.1`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
