### PR TITLE
MASP vp panics

### DIFF
--- a/.changelog/unreleased/SDK/2345-masp-vp-panics.md
+++ b/.changelog/unreleased/SDK/2345-masp-vp-panics.md
@@ -1,0 +1,2 @@
+- Refactors MASP keys construction.
+  ([\#2345](https://github.com/anoma/namada/pull/2345))

--- a/.changelog/unreleased/improvements/2345-masp-vp-panics.md
+++ b/.changelog/unreleased/improvements/2345-masp-vp-panics.md
@@ -1,0 +1,2 @@
+- Removes panics from masp vp. Refactors masp storage keys generation.
+  ([\#2345](https://github.com/anoma/namada/pull/2345))

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -5,7 +5,6 @@ use masp_primitives::merkle_tree::CommitmentTree;
 use masp_primitives::sapling::Node;
 use namada::core::ledger::masp_conversions::update_allowed_conversions;
 use namada::core::ledger::pgf::inflation as pgf_inflation;
-use namada::core::types::storage::KeySeg;
 use namada::ledger::events::EventType;
 use namada::ledger::gas::{GasMetering, TxGasMeter};
 use namada::ledger::pos::namada_proof_of_stake;
@@ -1864,9 +1863,11 @@ mod test_finalize_block {
         // won't receive votes from TM since we receive votes at a 1-block
         // delay, so votes will be empty here
         next_block_for_inflation(&mut shell, pkh1.to_vec(), vec![], None);
-        assert!(rewards_accumulator_handle()
-            .is_empty(&shell.wl_storage)
-            .unwrap());
+        assert!(
+            rewards_accumulator_handle()
+                .is_empty(&shell.wl_storage)
+                .unwrap()
+        );
 
         // FINALIZE BLOCK 2. Tell Namada that val1 is the block proposer.
         // Include votes that correspond to block 1. Make val2 the next block's
@@ -1881,9 +1882,11 @@ mod test_finalize_block {
         assert!(rewards_prod_2.is_empty(&shell.wl_storage).unwrap());
         assert!(rewards_prod_3.is_empty(&shell.wl_storage).unwrap());
         assert!(rewards_prod_4.is_empty(&shell.wl_storage).unwrap());
-        assert!(!rewards_accumulator_handle()
-            .is_empty(&shell.wl_storage)
-            .unwrap());
+        assert!(
+            !rewards_accumulator_handle()
+                .is_empty(&shell.wl_storage)
+                .unwrap()
+        );
         // Val1 was the proposer, so its reward should be larger than all
         // others, which should themselves all be equal
         let acc_sum = get_rewards_sum(&shell.wl_storage);
@@ -2015,9 +2018,11 @@ mod test_finalize_block {
                 None,
             );
         }
-        assert!(rewards_accumulator_handle()
-            .is_empty(&shell.wl_storage)
-            .unwrap());
+        assert!(
+            rewards_accumulator_handle()
+                .is_empty(&shell.wl_storage)
+                .unwrap()
+        );
         let rp1 = rewards_prod_1
             .get(&shell.wl_storage, &Epoch::default())
             .unwrap()
@@ -2105,9 +2110,11 @@ mod test_finalize_block {
         // won't receive votes from TM since we receive votes at a 1-block
         // delay, so votes will be empty here
         next_block_for_inflation(&mut shell, pkh1.to_vec(), vec![], None);
-        assert!(rewards_accumulator_handle()
-            .is_empty(&shell.wl_storage)
-            .unwrap());
+        assert!(
+            rewards_accumulator_handle()
+                .is_empty(&shell.wl_storage)
+                .unwrap()
+        );
 
         let (current_epoch, inflation) =
             advance_epoch(&mut shell, &pkh1, &votes, None);
@@ -2355,9 +2362,11 @@ mod test_finalize_block {
         // won't receive votes from TM since we receive votes at a 1-block
         // delay, so votes will be empty here
         next_block_for_inflation(&mut shell, pkh1.clone(), vec![], None);
-        assert!(rewards_accumulator_handle()
-            .is_empty(&shell.wl_storage)
-            .unwrap());
+        assert!(
+            rewards_accumulator_handle()
+                .is_empty(&shell.wl_storage)
+                .unwrap()
+        );
 
         // Make an account with balance and delegate some tokens
         let delegator = address::testing::gen_implicit_address();
@@ -2524,9 +2533,11 @@ mod test_finalize_block {
         // won't receive votes from TM since we receive votes at a 1-block
         // delay, so votes will be empty here
         next_block_for_inflation(&mut shell, pkh1.clone(), vec![], None);
-        assert!(rewards_accumulator_handle()
-            .is_empty(&shell.wl_storage)
-            .unwrap());
+        assert!(
+            rewards_accumulator_handle()
+                .is_empty(&shell.wl_storage)
+                .unwrap()
+        );
 
         // Check that there's 3 unique consensus keys
         let consensus_keys =
@@ -2834,21 +2845,25 @@ mod test_finalize_block {
         assert_eq!(root_pre.0, root_post.0);
 
         // Check transaction's hash in storage
-        assert!(shell
-            .shell
-            .wl_storage
-            .write_log
-            .has_replay_protection_entry(&wrapper_tx.header_hash())
-            .unwrap_or_default());
+        assert!(
+            shell
+                .shell
+                .wl_storage
+                .write_log
+                .has_replay_protection_entry(&wrapper_tx.header_hash())
+                .unwrap_or_default()
+        );
         // Check that the hash is present in the merkle tree
-        assert!(!shell
-            .shell
-            .wl_storage
-            .storage
-            .block
-            .tree
-            .has_key(&wrapper_hash_key)
-            .unwrap());
+        assert!(
+            !shell
+                .shell
+                .wl_storage
+                .storage
+                .block
+                .tree
+                .has_key(&wrapper_hash_key)
+                .unwrap()
+        );
     }
 
     /// Test that a decrypted tx that has already been applied in the same block
@@ -2953,16 +2968,20 @@ mod test_finalize_block {
         assert_eq!(code, String::from(ResultCode::WasmRuntimeError).as_str());
 
         for (inner, wrapper) in [(inner, wrapper), (new_inner, new_wrapper)] {
-            assert!(shell
-                .wl_storage
-                .write_log
-                .has_replay_protection_entry(&inner.raw_header_hash())
-                .unwrap_or_default());
-            assert!(!shell
-                .wl_storage
-                .write_log
-                .has_replay_protection_entry(&wrapper.header_hash())
-                .unwrap_or_default());
+            assert!(
+                shell
+                    .wl_storage
+                    .write_log
+                    .has_replay_protection_entry(&inner.raw_header_hash())
+                    .unwrap_or_default()
+            );
+            assert!(
+                !shell
+                    .wl_storage
+                    .write_log
+                    .has_replay_protection_entry(&wrapper.header_hash())
+                    .unwrap_or_default()
+            );
         }
     }
 
@@ -3119,27 +3138,37 @@ mod test_finalize_block {
             (unsigned_inner, unsigned_wrapper),
             (wrong_commitment_inner, wrong_commitment_wrapper),
         ] {
-            assert!(!shell
+            assert!(
+                !shell
+                    .wl_storage
+                    .write_log
+                    .has_replay_protection_entry(
+                        &invalid_inner.raw_header_hash()
+                    )
+                    .unwrap_or_default()
+            );
+            assert!(
+                shell
+                    .wl_storage
+                    .storage
+                    .has_replay_protection_entry(&valid_wrapper.header_hash())
+                    .unwrap_or_default()
+            );
+        }
+        assert!(
+            shell
                 .wl_storage
                 .write_log
-                .has_replay_protection_entry(&invalid_inner.raw_header_hash())
-                .unwrap_or_default());
-            assert!(shell
+                .has_replay_protection_entry(&failing_inner.raw_header_hash())
+                .expect("test failed")
+        );
+        assert!(
+            !shell
                 .wl_storage
-                .storage
-                .has_replay_protection_entry(&valid_wrapper.header_hash())
-                .unwrap_or_default());
-        }
-        assert!(shell
-            .wl_storage
-            .write_log
-            .has_replay_protection_entry(&failing_inner.raw_header_hash())
-            .expect("test failed"));
-        assert!(!shell
-            .wl_storage
-            .write_log
-            .has_replay_protection_entry(&failing_wrapper.header_hash())
-            .unwrap_or_default());
+                .write_log
+                .has_replay_protection_entry(&failing_wrapper.header_hash())
+                .unwrap_or_default()
+        );
     }
 
     #[test]
@@ -3205,16 +3234,20 @@ mod test_finalize_block {
             .as_str();
         assert_eq!(code, String::from(ResultCode::InvalidTx).as_str());
 
-        assert!(shell
-            .wl_storage
-            .write_log
-            .has_replay_protection_entry(&wrapper_hash)
-            .unwrap_or_default());
-        assert!(!shell
-            .wl_storage
-            .write_log
-            .has_replay_protection_entry(&wrapper.raw_header_hash())
-            .unwrap_or_default());
+        assert!(
+            shell
+                .wl_storage
+                .write_log
+                .has_replay_protection_entry(&wrapper_hash)
+                .unwrap_or_default()
+        );
+        assert!(
+            !shell
+                .wl_storage
+                .write_log
+                .has_replay_protection_entry(&wrapper.raw_header_hash())
+                .unwrap_or_default()
+        );
     }
 
     // Test that if the fee payer doesn't have enough funds for fee payment the
@@ -3513,9 +3546,11 @@ mod test_finalize_block {
                 .unwrap(),
             Some(ValidatorState::Consensus)
         );
-        assert!(enqueued_slashes_handle()
-            .at(&Epoch::default())
-            .is_empty(&shell.wl_storage)?);
+        assert!(
+            enqueued_slashes_handle()
+                .at(&Epoch::default())
+                .is_empty(&shell.wl_storage)?
+        );
         assert_eq!(
             get_num_consensus_validators(&shell.wl_storage, Epoch::default())
                 .unwrap(),
@@ -3534,17 +3569,21 @@ mod test_finalize_block {
                     .unwrap(),
                 Some(ValidatorState::Jailed)
             );
-            assert!(enqueued_slashes_handle()
-                .at(&epoch)
-                .is_empty(&shell.wl_storage)?);
+            assert!(
+                enqueued_slashes_handle()
+                    .at(&epoch)
+                    .is_empty(&shell.wl_storage)?
+            );
             assert_eq!(
                 get_num_consensus_validators(&shell.wl_storage, epoch).unwrap(),
                 5_u64
             );
         }
-        assert!(!enqueued_slashes_handle()
-            .at(&processing_epoch)
-            .is_empty(&shell.wl_storage)?);
+        assert!(
+            !enqueued_slashes_handle()
+                .at(&processing_epoch)
+                .is_empty(&shell.wl_storage)?
+        );
 
         // Advance to the processing epoch
         loop {
@@ -3567,9 +3606,11 @@ mod test_finalize_block {
                 // println!("Reached processing epoch");
                 break;
             } else {
-                assert!(enqueued_slashes_handle()
-                    .at(&shell.wl_storage.storage.block.epoch)
-                    .is_empty(&shell.wl_storage)?);
+                assert!(
+                    enqueued_slashes_handle()
+                        .at(&shell.wl_storage.storage.block.epoch)
+                        .is_empty(&shell.wl_storage)?
+                );
                 let stake1 = read_validator_stake(
                     &shell.wl_storage,
                     &params,
@@ -4063,11 +4104,13 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(misbehavior_epoch));
-        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
-            &val1.address
-        )
-        .is_empty(&shell.wl_storage)
-        .unwrap());
+        assert!(
+            namada_proof_of_stake::storage::validator_slashes_handle(
+                &val1.address
+            )
+            .is_empty(&shell.wl_storage)
+            .unwrap()
+        );
 
         tracing::debug!("Advancing to epoch 7");
 
@@ -4131,18 +4174,22 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(Epoch(4)));
-        assert!(namada_proof_of_stake::is_validator_frozen(
-            &shell.wl_storage,
-            &val1.address,
-            current_epoch,
-            &params
-        )
-        .unwrap());
-        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
-            &val1.address
-        )
-        .is_empty(&shell.wl_storage)
-        .unwrap());
+        assert!(
+            namada_proof_of_stake::is_validator_frozen(
+                &shell.wl_storage,
+                &val1.address,
+                current_epoch,
+                &params
+            )
+            .unwrap()
+        );
+        assert!(
+            namada_proof_of_stake::storage::validator_slashes_handle(
+                &val1.address
+            )
+            .is_empty(&shell.wl_storage)
+            .unwrap()
+        );
 
         let pre_stake_10 =
             namada_proof_of_stake::storage::read_validator_stake(

--- a/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -3,7 +3,6 @@
 use data_encoding::HEXUPPER;
 use masp_primitives::merkle_tree::CommitmentTree;
 use masp_primitives::sapling::Node;
-use masp_proofs::bls12_381;
 use namada::core::ledger::masp_conversions::update_allowed_conversions;
 use namada::core::ledger::pgf::inflation as pgf_inflation;
 use namada::core::types::storage::KeySeg;
@@ -571,7 +570,7 @@ where
                 .into_storage_result()?;
             let anchor_key =
                 namada::core::types::token::masp_commitment_anchor_key(
-                    &bls12_381::Scalar::from(updated_tree.root()),
+                    updated_tree.root(),
                 );
             self.wl_storage.write(&anchor_key, ())?;
         }

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -5,7 +5,6 @@ use std::ops::ControlFlow;
 use masp_primitives::merkle_tree::CommitmentTree;
 use masp_primitives::sapling::Node;
 use masp_proofs::bls12_381;
-use namada::core::types::storage::KeySeg;
 use namada::ledger::parameters::Parameters;
 use namada::ledger::storage::traits::StorageHasher;
 use namada::ledger::storage::{DBIter, DB};

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -147,9 +147,7 @@ where
             .write(&note_commitment_tree_key, empty_commitment_tree)
             .unwrap();
         let commitment_tree_anchor_key =
-            namada::core::types::token::masp_commitment_anchor_key(
-                &bls12_381::Scalar::from(anchor),
-            );
+            namada::core::types::token::masp_commitment_anchor_key(anchor);
         self.wl_storage
             .write(&commitment_tree_anchor_key, ())
             .unwrap();

--- a/apps/src/lib/node/ledger/shell/init_chain.rs
+++ b/apps/src/lib/node/ledger/shell/init_chain.rs
@@ -13,14 +13,10 @@ use namada::ledger::storage_api::token::{credit_tokens, write_denom};
 use namada::ledger::storage_api::StorageWrite;
 use namada::ledger::{ibc, pos};
 use namada::proof_of_stake::BecomeValidator;
-use namada::types::address::{Address, MASP};
+use namada::types::address::Address;
 use namada::types::hash::Hash as CodeHash;
 use namada::types::key::*;
 use namada::types::time::{DateTimeUtc, TimeZone, Utc};
-use namada::types::token::{
-    MASP_CONVERT_ANCHOR_KEY, MASP_NOTE_COMMITMENT_ANCHOR_PREFIX,
-    MASP_NOTE_COMMITMENT_TREE_KEY,
-};
 use namada::vm::validate_untrusted_wasm;
 use namada_sdk::eth_bridge::EthBridgeStatus;
 use namada_sdk::proof_of_stake::PosParams;
@@ -145,27 +141,22 @@ where
         let empty_commitment_tree: CommitmentTree<Node> =
             CommitmentTree::empty();
         let anchor = empty_commitment_tree.root();
-        let note_commitment_tree_key = Key::from(MASP.to_db_key())
-            .push(&MASP_NOTE_COMMITMENT_TREE_KEY.to_owned())
-            .expect("Cannot obtain a storage key");
+        let note_commitment_tree_key =
+            namada::core::types::token::masp_commitment_tree_key();
         self.wl_storage
             .write(&note_commitment_tree_key, empty_commitment_tree)
             .unwrap();
-        let commitment_tree_anchor_key = Key::from(MASP.to_db_key())
-            .push(&MASP_NOTE_COMMITMENT_ANCHOR_PREFIX.to_owned())
-            .expect("Cannot obtain a storage key")
-            .push(&namada::core::types::hash::Hash(
-                bls12_381::Scalar::from(anchor).to_bytes(),
-            ))
-            .expect("Cannot obtain a storage key");
+        let commitment_tree_anchor_key =
+            namada::core::types::token::masp_commitment_anchor_key(
+                &bls12_381::Scalar::from(anchor),
+            );
         self.wl_storage
             .write(&commitment_tree_anchor_key, ())
             .unwrap();
 
         // Init masp convert anchor
-        let convert_anchor_key = Key::from(MASP.to_db_key())
-            .push(&MASP_CONVERT_ANCHOR_KEY.to_owned())
-            .expect("Cannot obtain a storage key");
+        let convert_anchor_key =
+            namada::core::types::token::masp_convert_anchor_key();
         self.wl_storage.write(
             &convert_anchor_key,
             namada::core::types::hash::Hash(

--- a/benches/native_vps.rs
+++ b/benches/native_vps.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 use std::str::FromStr;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use masp_primitives::bls12_381;
 use masp_primitives::sapling::Node;
 use namada::core::ledger::governance::storage::proposal::ProposalType;
 use namada::core::ledger::governance::storage::vote::{
@@ -516,7 +515,7 @@ fn setup_storage_for_masp_verification(
         .unwrap()
         .unwrap();
     let anchor_key = namada::core::types::token::masp_commitment_anchor_key(
-        &bls12_381::Scalar::from(updated_tree.root()),
+        updated_tree.root(),
     );
     shielded_ctx
         .shell

--- a/benches/native_vps.rs
+++ b/benches/native_vps.rs
@@ -46,13 +46,10 @@ use namada::namada_sdk::masp_primitives::transaction::Transaction;
 use namada::proof_of_stake;
 use namada::proof_of_stake::KeySeg;
 use namada::proto::{Code, Section, Tx};
-use namada::types::address::{InternalAddress, MASP};
+use namada::types::address::InternalAddress;
 use namada::types::eth_bridge_pool::{GasFee, PendingTransfer};
 use namada::types::masp::{TransferSource, TransferTarget};
 use namada::types::storage::{Epoch, TxIndex};
-use namada::types::token::{
-    MASP_NOTE_COMMITMENT_ANCHOR_PREFIX, MASP_NOTE_COMMITMENT_TREE_KEY,
-};
 use namada::types::transaction::governance::{
     InitProposalData, VoteProposalData,
 };
@@ -511,22 +508,16 @@ fn setup_storage_for_masp_verification(
     shielded_ctx.shell.wl_storage.commit_tx();
 
     // Update the anchor in storage
-    let tree_key = namada::core::types::storage::Key::from(MASP.to_db_key())
-        .push(&MASP_NOTE_COMMITMENT_TREE_KEY.to_owned())
-        .expect("Cannot obtain a storage key");
+    let tree_key = namada::core::types::token::masp_commitment_tree_key();
     let updated_tree: CommitmentTree<Node> = shielded_ctx
         .shell
         .wl_storage
         .read(&tree_key)
         .unwrap()
         .unwrap();
-    let anchor_key = namada::core::types::storage::Key::from(MASP.to_db_key())
-        .push(&MASP_NOTE_COMMITMENT_ANCHOR_PREFIX.to_owned())
-        .expect("Cannot obtain a storage key")
-        .push(&namada::core::types::hash::Hash(
-            bls12_381::Scalar::from(updated_tree.root()).to_bytes(),
-        ))
-        .expect("Cannot obtain a storage key");
+    let anchor_key = namada::core::types::token::masp_commitment_anchor_key(
+        &bls12_381::Scalar::from(updated_tree.root()),
+    );
     shielded_ctx
         .shell
         .wl_storage

--- a/core/src/ledger/masp_conversions.rs
+++ b/core/src/ledger/masp_conversions.rs
@@ -212,9 +212,6 @@ where
     };
     use rayon::prelude::ParallelSlice;
 
-    use crate::types::address;
-    use crate::types::storage::{Key, KeySeg};
-
     // The derived conversions will be placed in MASP address space
     let masp_addr = MASP;
 

--- a/core/src/ledger/masp_conversions.rs
+++ b/core/src/ledger/masp_conversions.rs
@@ -212,8 +212,8 @@ where
     };
     use rayon::prelude::ParallelSlice;
 
+    use crate::types::address;
     use crate::types::storage::{Key, KeySeg};
-    use crate::types::token::MASP_CONVERT_ANCHOR_KEY;
 
     // The derived conversions will be placed in MASP address space
     let masp_addr = MASP;
@@ -447,11 +447,8 @@ where
     wl_storage.storage.conversion_state.tree =
         FrozenCommitmentTree::merge(&tree_parts);
     // Update the anchor in storage
-    let anchor_key = Key::from(MASP.to_db_key())
-        .push(&MASP_CONVERT_ANCHOR_KEY.to_owned())
-        .expect("Cannot obtain a storage key");
     wl_storage.write(
-        &anchor_key,
+        &crate::types::token::masp_convert_anchor_key(),
         crate::types::hash::Hash(
             bls12_381::Scalar::from(
                 wl_storage.storage.conversion_state.tree.root(),

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -1301,11 +1301,11 @@ pub fn masp_commitment_tree_key() -> Key {
 }
 
 /// Get a key for a masp commitment tree anchor
-pub fn masp_commitment_anchor_key(anchor: &Scalar) -> Key {
+pub fn masp_commitment_anchor_key(anchor: impl Into<Scalar>) -> Key {
     Key::from(MASP.to_db_key())
         .push(&MASP_NOTE_COMMITMENT_ANCHOR_PREFIX.to_owned())
         .expect("Cannot obtain a storage key")
-        .push(&Hash(anchor.to_bytes()))
+        .push(&Hash(anchor.into().to_bytes()))
         .expect("Cannot obtain a storage key")
 }
 

--- a/core/src/types/token.rs
+++ b/core/src/types/token.rs
@@ -9,6 +9,8 @@ use std::str::FromStr;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use data_encoding::BASE32HEX_NOPAD;
 use ethabi::ethereum_types::U256;
+use masp_primitives::bls12_381::Scalar;
+use masp_primitives::sapling::Nullifier;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -1280,6 +1282,59 @@ pub fn masp_last_inflation_key(token_address: &Address) -> Key {
         MASP_LAST_INFLATION_KEY,
         "cannot obtain storage key for the last inflation rate",
     )
+}
+
+/// Get a key for a masp nullifier
+pub fn masp_nullifier_key(nullifier: &Nullifier) -> Key {
+    Key::from(MASP.to_db_key())
+        .push(&MASP_NULLIFIERS_KEY.to_owned())
+        .expect("Cannot obtain a storage key")
+        .push(&Hash(nullifier.0))
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get the key for the masp commitment tree
+pub fn masp_commitment_tree_key() -> Key {
+    Key::from(MASP.to_db_key())
+        .push(&MASP_NOTE_COMMITMENT_TREE_KEY.to_owned())
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get a key for a masp commitment tree anchor
+pub fn masp_commitment_anchor_key(anchor: &Scalar) -> Key {
+    Key::from(MASP.to_db_key())
+        .push(&MASP_NOTE_COMMITMENT_ANCHOR_PREFIX.to_owned())
+        .expect("Cannot obtain a storage key")
+        .push(&Hash(anchor.to_bytes()))
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get the key for the masp convert tree anchor
+pub fn masp_convert_anchor_key() -> Key {
+    Key::from(MASP.to_db_key())
+        .push(&MASP_CONVERT_ANCHOR_KEY.to_owned())
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get the masp head-tx key
+pub fn masp_head_tx_key() -> Key {
+    Key::from(MASP.to_db_key())
+        .push(&HEAD_TX_KEY.to_owned())
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get the masp tx key for the provided tx id
+pub fn masp_tx_key(tx_id: u64) -> Key {
+    Key::from(MASP.to_db_key())
+        .push(&(TX_KEY_PREFIX.to_owned() + &tx_id.to_string()))
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get the masp pin tx key for the provided pin key
+pub fn masp_pin_tx_key(pin_key: &str) -> Key {
+    Key::from(MASP.to_db_key())
+        .push(&(PIN_KEY_PREFIX.to_owned() + pin_key))
+        .expect("Cannot obtain a storage key")
 }
 
 /// Check if the given storage key is for a minter of a unspecified token.

--- a/sdk/src/masp.rs
+++ b/sdk/src/masp.rs
@@ -1770,27 +1770,28 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
 
         // To speed up integration tests, we can save and load proofs
         #[cfg(feature = "testing")]
-        let load_or_save =
-            if let Ok(masp_proofs) = env::var(ENV_VAR_MASP_TEST_PROOFS) {
-                let parsed = match masp_proofs.to_ascii_lowercase().as_str() {
-                    "load" => LoadOrSaveProofs::Load,
-                    "save" => LoadOrSaveProofs::Save,
-                    env_var => Err(Error::Other(format!(
+        let load_or_save = if let Ok(masp_proofs) =
+            env::var(ENV_VAR_MASP_TEST_PROOFS)
+        {
+            let parsed = match masp_proofs.to_ascii_lowercase().as_str() {
+                "load" => LoadOrSaveProofs::Load,
+                "save" => LoadOrSaveProofs::Save,
+                env_var => Err(Error::Other(format!(
                     "Unexpected value for {ENV_VAR_MASP_TEST_PROOFS} env var. \
                      Expecting \"save\" or \"load\", but got \"{env_var}\"."
                 )))?,
-                };
-                if env::var(ENV_VAR_MASP_TEST_SEED).is_err() {
-                    Err(Error::Other(format!(
+            };
+            if env::var(ENV_VAR_MASP_TEST_SEED).is_err() {
+                Err(Error::Other(format!(
                     "Ensure to set a seed with {ENV_VAR_MASP_TEST_SEED} env \
                      var when using {ENV_VAR_MASP_TEST_PROOFS} for \
                      deterministic proofs."
                 )))?;
-                }
-                parsed
-            } else {
-                LoadOrSaveProofs::Neither
-            };
+            }
+            parsed
+        } else {
+            LoadOrSaveProofs::Neither
+        };
 
         let builder_clone = builder.clone().map_builder(WalletMap);
         #[cfg(feature = "testing")]

--- a/shared/src/ledger/native_vp/masp.rs
+++ b/shared/src/ledger/native_vp/masp.rs
@@ -236,7 +236,7 @@ where
         for description in shielded_spends {
             let anchor_key =
                 namada_core::types::token::masp_commitment_anchor_key(
-                    &description.anchor,
+                    description.anchor,
                 );
 
             // Check if the provided anchor was published before

--- a/shared/src/ledger/native_vp/masp.rs
+++ b/shared/src/ledger/native_vp/masp.rs
@@ -97,7 +97,7 @@ fn convert_amount(
     // Combine the value and unit into one amount
 
     I128Sum::from_nonnegative(asset_type, denom.denominate(&val) as i128)
-            .map_err(|()| {
+        .map_err(|()| {
             Error::NativeVpError(native_vp::Error::SimpleMessage(
                 "Invalid value for amount",
             ))


### PR DESCRIPTION
## Describe your changes

Removes panics from the native masp vp. Introduces helper functions to construct masp keys.

## Indicate on which release or other PRs this topic is based on

v0.29.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
