### PR TITLE
look-up validator by native address and query consensus key

### DIFF
--- a/.changelog/unreleased/improvements/2368-lookup-validator-consensus-key.md
+++ b/.changelog/unreleased/improvements/2368-lookup-validator-consensus-key.md
@@ -1,0 +1,3 @@
+- Added validator's consensus key look-up to `client find-validator`
+  command, which now also accepts a native validator address.
+  ([\#2368](https://github.com/anoma/namada/pull/2368))

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -3031,7 +3031,7 @@ pub mod args {
     pub const TEMPLATES_PATH: Arg<PathBuf> = arg("templates-path");
     pub const TIMEOUT_HEIGHT: ArgOpt<u64> = arg_opt("timeout-height");
     pub const TIMEOUT_SEC_OFFSET: ArgOpt<u64> = arg_opt("timeout-sec-offset");
-    pub const TM_ADDRESS: Arg<String> = arg("tm-address");
+    pub const TM_ADDRESS: ArgOpt<String> = arg_opt("tm-address");
     pub const TOKEN_OPT: ArgOpt<WalletAddress> = TOKEN.opt();
     pub const TOKEN: Arg<WalletAddress> = arg("token");
     pub const TOKEN_STR: Arg<String> = arg("token");
@@ -5733,15 +5733,26 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let query = Query::parse(matches);
             let tm_addr = TM_ADDRESS.parse(matches);
-            Self { query, tm_addr }
+            let validator_addr = VALIDATOR_OPT.parse(matches);
+            Self {
+                query,
+                tm_addr,
+                validator_addr,
+            }
         }
 
         fn def(app: App) -> App {
-            app.add_args::<Query<CliTypes>>().arg(
-                TM_ADDRESS
-                    .def()
-                    .help("The address of the validator in Tendermint."),
-            )
+            app.add_args::<Query<CliTypes>>()
+                .arg(
+                    TM_ADDRESS
+                        .def()
+                        .help("The address of the validator in Tendermint."),
+                )
+                .arg(
+                    VALIDATOR_OPT
+                        .def()
+                        .help("The native address of the validator."),
+                )
         }
     }
 
@@ -5750,6 +5761,9 @@ pub mod args {
             QueryFindValidator::<SdkTypes> {
                 query: self.query.to_sdk(ctx),
                 tm_addr: self.tm_addr,
+                validator_addr: self
+                    .validator_addr
+                    .map(|x| ctx.borrow_chain_or_exit().get(&x)),
             }
         }
     }

--- a/apps/src/lib/cli.rs
+++ b/apps/src/lib/cli.rs
@@ -1757,7 +1757,10 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Find a PoS validator by its Tendermint address.")
+                .about(
+                    "Find a PoS validator and its consensus key by its native \
+                     address or Tendermint address.",
+                )
                 .add_args::<args::QueryFindValidator<args::CliTypes>>()
         }
     }

--- a/proof_of_stake/src/storage.rs
+++ b/proof_of_stake/src/storage.rs
@@ -846,3 +846,16 @@ where
     let handle = LazySet::open(key);
     handle.contains(storage, consensus_key)
 }
+
+/// Find a consensus key of a validator account.
+pub fn get_consensus_key<S>(
+    storage: &S,
+    addr: &Address,
+    epoch: Epoch,
+) -> storage_api::Result<Option<common::PublicKey>>
+where
+    S: StorageRead,
+{
+    let params = read_pos_params(storage)?;
+    validator_consensus_key_handle(addr).get(storage, epoch, &params)
+}

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -1812,7 +1812,9 @@ pub struct QueryFindValidator<C: NamadaTypes = SdkTypes> {
     /// Common query args
     pub query: Query<C>,
     /// Tendermint address
-    pub tm_addr: String,
+    pub tm_addr: Option<String>,
+    /// Native validator address
+    pub validator_addr: Option<C::Address>,
 }
 
 /// Query the raw bytes of given storage key

--- a/sdk/src/queries/vp/pos.rs
+++ b/sdk/src/queries/vp/pos.rs
@@ -42,6 +42,8 @@ router! {POS,
     ( "validator" ) = {
         ( "is_validator" / [addr: Address] ) -> bool = is_validator,
 
+        ( "consensus_key" / [addr: Address] ) -> Option<common::PublicKey> = consensus_key,
+
         ( "addresses" / [epoch: opt Epoch] )
             -> HashSet<Address> = validator_addresses,
 
@@ -192,6 +194,23 @@ where
     H: 'static + StorageHasher + Sync,
 {
     namada_proof_of_stake::is_validator(ctx.wl_storage, &addr)
+}
+
+/// Find a consensus key of a validator account.
+fn consensus_key<D, H, V, T>(
+    ctx: RequestCtx<'_, D, H, V, T>,
+    addr: Address,
+) -> storage_api::Result<Option<common::PublicKey>>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    let current_epoch = ctx.wl_storage.storage.last_epoch;
+    namada_proof_of_stake::storage::get_consensus_key(
+        ctx.wl_storage,
+        &addr,
+        current_epoch,
+    )
 }
 
 /// Find if the given address is a delegator

--- a/sdk/src/rpc.rs
+++ b/sdk/src/rpc.rs
@@ -15,6 +15,7 @@ use namada_core::ledger::governance::utils::Vote;
 use namada_core::ledger::ibc::storage::{
     ibc_denom_key, ibc_denom_key_prefix, is_ibc_denom_key,
 };
+use namada_core::ledger::pgf::storage::steward::StewardDetail;
 use namada_core::ledger::storage::LastBlock;
 use namada_core::types::account::Account;
 use namada_core::types::address::{Address, InternalAddress};
@@ -221,6 +222,27 @@ pub async fn has_bonds<C: crate::queries::Client + Sync>(
     source: &Address,
 ) -> Result<bool, error::Error> {
     convert_response::<C, bool>(RPC.vp().pos().has_bonds(client, source).await)
+}
+
+/// Get the set of pgf stewards
+pub async fn query_pgf_stewards<C: crate::queries::Client + Sync>(
+    client: &C,
+) -> Result<Vec<StewardDetail>, error::Error> {
+    convert_response::<C, Vec<StewardDetail>>(
+        RPC.vp().pgf().stewards(client).await,
+    )
+}
+
+/// Query the consensus key by validator address
+pub async fn query_validator_consensus_keys<
+    C: crate::queries::Client + Sync,
+>(
+    client: &C,
+    address: &Address,
+) -> Result<Option<common::PublicKey>, error::Error> {
+    convert_response::<C, Option<common::PublicKey>>(
+        RPC.vp().pos().consensus_key(client, address).await,
+    )
 }
 
 /// Get the set of consensus keys registered in the network


### PR DESCRIPTION
## Describe your changes

closes #2367

CLI example:
```shell
> namadac find-validator --validator validator-0
Consensus key: tpknam1qqq8nts0j99jylpx74ks48hsasvclu2syhfh0gfy2853dr8v4ehq654ck6n
Tendermint key: 3AD4F16E9BE4364D4B5660772939E7587A79E9CE
Consensus key hash: 3EA0322AB6800890B79B8494E40E8427EC6D7065
```

## Indicate on which release or other PRs this topic is based on

v0.29.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
