### PR TITLE
Light sdk dependencies cleanup

### DIFF
--- a/.changelog/unreleased/SDK/2372-light-sdk-deps.md
+++ b/.changelog/unreleased/SDK/2372-light-sdk-deps.md
@@ -1,0 +1,2 @@
+- Cleaned up the unused ibc dependency of the light sdk crate.
+  ([\#2372](https://github.com/anoma/namada/pull/2372))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,34 +2901,6 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184eb22140cb4143bbcf7ddc8fdfeb9cc058ef73a6066f8ea78162e69d3565d1"
-dependencies = [
- "bytes",
- "derive_more",
- "displaydoc",
- "ibc-derive 0.3.0",
- "ibc-proto 0.37.1",
- "ics23",
- "num-traits 0.2.17",
- "primitive-types",
- "prost 0.12.3",
- "serde 1.0.193",
- "serde-json-wasm",
- "serde_derive",
- "sha2 0.10.8",
- "subtle-encoding",
- "tendermint",
- "tendermint-light-client-verifier",
- "tendermint-proto",
- "time",
- "tracing",
- "uint",
-]
-
-[[package]]
-name = "ibc"
 version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "429b6aca6624a9364878e28c90311438c2621a8270942d80732b2651ac38ac74"
@@ -2937,7 +2909,7 @@ dependencies = [
  "ibc-clients",
  "ibc-core",
  "ibc-core-host-cosmos",
- "ibc-derive 0.4.0",
+ "ibc-derive",
  "ibc-primitives",
 ]
 
@@ -2961,7 +2933,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-core",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "primitive-types",
  "serde 1.0.193",
  "uint",
@@ -3006,7 +2978,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost 0.12.3",
  "serde 1.0.193",
  "tendermint",
@@ -3069,7 +3041,7 @@ dependencies = [
  "ibc-core-connection-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost 0.12.3",
  "serde 1.0.193",
  "sha2 0.10.8",
@@ -3104,7 +3076,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-handler-types",
  "ibc-core-host-types",
- "ibc-derive 0.4.0",
+ "ibc-derive",
  "ibc-primitives",
  "prost 0.12.3",
  "subtle-encoding",
@@ -3122,7 +3094,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost 0.12.3",
  "serde 1.0.193",
  "subtle-encoding",
@@ -3138,7 +3110,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "ics23",
  "prost 0.12.3",
  "serde 1.0.193",
@@ -3171,7 +3143,7 @@ dependencies = [
  "ibc-core-commitment-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost 0.12.3",
  "serde 1.0.193",
  "subtle-encoding",
@@ -3209,7 +3181,7 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost 0.12.3",
  "serde 1.0.193",
  "subtle-encoding",
@@ -3253,7 +3225,7 @@ dependencies = [
  "ibc-core-handler-types",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost 0.12.3",
  "serde 1.0.193",
  "sha2 0.10.8",
@@ -3299,24 +3271,12 @@ dependencies = [
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "ics23",
  "prost 0.12.3",
  "serde 1.0.193",
  "subtle-encoding",
  "tendermint",
-]
-
-[[package]]
-name = "ibc-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f1528535e9ca495badb76c143bdd4763c1c9d987f59d1f8b47963ba0c11674"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.39",
 ]
 
 [[package]]
@@ -3339,27 +3299,11 @@ checksum = "d5edea4685267fd68514c87e7aa3a62712340c4cff6903f088a9ab571428a08a"
 dependencies = [
  "derive_more",
  "displaydoc",
- "ibc-proto 0.38.0",
+ "ibc-proto",
  "prost 0.12.3",
  "serde 1.0.193",
  "tendermint",
  "time",
-]
-
-[[package]]
-name = "ibc-proto"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63042806bb2f662ca1c68026231900cfe13361136ddfd0dd09bcb315056a22b8"
-dependencies = [
- "base64 0.21.5",
- "bytes",
- "flex-error",
- "ics23",
- "prost 0.12.3",
- "serde 1.0.193",
- "subtle-encoding",
- "tendermint-proto",
 ]
 
 [[package]]
@@ -3387,8 +3331,8 @@ dependencies = [
  "bytes",
  "derive_more",
  "displaydoc",
- "ibc 0.48.1",
- "ibc-proto 0.38.0",
+ "ibc",
+ "ibc-proto",
  "parking_lot",
  "primitive-types",
  "prost 0.12.3",
@@ -4371,8 +4315,8 @@ dependencies = [
  "ethabi",
  "ethbridge-structs",
  "eyre",
- "ibc 0.48.1",
- "ibc-derive 0.4.0",
+ "ibc",
+ "ibc-derive",
  "ibc-testkit",
  "ics23",
  "impl-num-traits",
@@ -4465,7 +4409,6 @@ version = "0.29.0"
 dependencies = [
  "borsh",
  "borsh-ext",
- "ibc 0.47.0",
  "namada_core",
  "namada_sdk",
  "prost 0.12.3",

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ crates += namada_apps
 crates += namada_benchmarks
 crates += namada_encoding_spec
 crates += namada_ethereum_bridge
+crates += namada_light_sdk
 crates += namada_macros
 crates += namada_proof_of_stake
 crates += namada_sdk

--- a/light_sdk/Cargo.toml
+++ b/light_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "namada_light_sdk"
-description = "A more simple version of the Namada SDK"
+description = "A higher level, user friendly version of the Namada SDK"
 resolver = "2"
 authors.workspace = true
 edition.workspace = true
@@ -17,10 +17,9 @@ version.workspace = true
 [dependencies]
 borsh.workspace = true
 borsh-ext.workspace = true
-ibc = "0.47.0"
 namada_core = {path = "../core"}
 namada_sdk = {path = "../sdk"}
 prost.workspace = true
 tendermint-config.workspace = true
-tendermint-rpc = { worskpace = true, features = ["http-client"] }
+tendermint-rpc = {worskpace = true, features = ["http-client"]}
 tokio = {workspace = true, features = ["rt"]}


### PR DESCRIPTION
## Describe your changes

Removes the unused `ibc` dependency of the light sdk. Also adds the light sdk crate to the Makefile.

## Indicate on which release or other PRs this topic is based on

v0.29.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
