### PR TITLE
Fix bond amount for addresses

### DIFF
--- a/.changelog/unreleased/improvements/2374-fix-bond-amount.md
+++ b/.changelog/unreleased/improvements/2374-fix-bond-amount.md
@@ -1,0 +1,2 @@
+- Fix the function  to more accurately account for slashes.
+  ([\#2374](https://github.com/anoma/namada/pull/2374))


### PR DESCRIPTION
## Describe your changes
The `bond_amount` that is used primarily to compute a delegator's votes in governance is fixed to properly account for slashed redelegated tokens.

## Indicate on which release or other PRs this topic is based on
v0.29.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
