### PR TITLE
Removes the hardcoded masp sentinel key

### DIFF
--- a/.changelog/unreleased/SDK/2376-remove-masp-key.md
+++ b/.changelog/unreleased/SDK/2376-remove-masp-key.md
@@ -1,0 +1,2 @@
+- `tx_signers` returns no signing key when the source of a transaction is MASP.
+  ([\#2376](https://github.com/anoma/namada/pull/2376))

--- a/.changelog/unreleased/improvements/2376-remove-masp-key.md
+++ b/.changelog/unreleased/improvements/2376-remove-masp-key.md
@@ -1,0 +1,2 @@
+- Removed the hardcoded sentinel key of MASP.
+  ([\#2376](https://github.com/anoma/namada/pull/2376))

--- a/core/src/types/address.rs
+++ b/core/src/types/address.rs
@@ -628,17 +628,6 @@ pub fn kartoffel() -> Address {
         .expect("The token address decoding shouldn't fail")
 }
 
-/// Sentinel secret key to indicate a MASP source
-pub fn masp_tx_key() -> crate::types::key::common::SecretKey {
-    use crate::types::key::common;
-    let bytes = [
-        0, 27, 238, 157, 32, 131, 242, 184, 142, 146, 189, 24, 249, 68, 165,
-        205, 71, 213, 158, 25, 253, 52, 217, 87, 52, 171, 225, 110, 131, 238,
-        58, 94, 56,
-    ];
-    common::SecretKey::try_from_slice(bytes.as_ref()).unwrap()
-}
-
 /// Temporary helper for testing
 pub const fn wnam() -> EthAddress {
     // TODO: Replace this with the real wNam ERC20 address once it exists

--- a/sdk/src/signing.rs
+++ b/sdk/src/signing.rs
@@ -14,7 +14,7 @@ use namada_core::ledger::parameters::storage as parameter_storage;
 use namada_core::proto::SignatureIndex;
 use namada_core::types::account::AccountPublicKeysMap;
 use namada_core::types::address::{
-    masp_tx_key, Address, ImplicitAddress, InternalAddress, MASP,
+    Address, ImplicitAddress, InternalAddress, MASP,
 };
 use namada_core::types::key::*;
 use namada_core::types::masp::{ExtendedViewingKey, PaymentAddress};
@@ -129,21 +129,15 @@ pub fn find_key_by_pk<U: WalletIo>(
     args: &args::Tx,
     public_key: &common::PublicKey,
 ) -> Result<common::SecretKey, Error> {
-    if *public_key == masp_tx_key().ref_to() {
-        // We already know the secret key corresponding to the MASP sentinel key
-        Ok(masp_tx_key())
-    } else {
-        // Otherwise we need to search the wallet for the secret key
-        wallet
-            .find_key_by_pk(public_key, args.password.clone())
-            .map_err(|err| {
-                Error::Other(format!(
-                    "Unable to load the keypair from the wallet for public \
-                     key {}. Failed with: {}",
-                    public_key, err
-                ))
-            })
-    }
+    wallet
+        .find_key_by_pk(public_key, args.password.clone())
+        .map_err(|err| {
+            Error::Other(format!(
+                "Unable to load the keypair from the wallet for public key \
+                 {}. Failed with: {}",
+                public_key, err
+            ))
+        })
 }
 
 /// Given CLI arguments and some defaults, determine the rightful transaction
@@ -164,8 +158,8 @@ pub async fn tx_signers(
 
     // Now actually fetch the signing key and apply it
     match signer {
-        Some(signer) if signer == MASP => Ok(vec![masp_tx_key().ref_to()]),
-
+        // No signature needed if the source is MASP
+        Some(MASP) => Ok(vec![]),
         Some(signer) => Ok(vec![find_pk(context, &signer).await?]),
         None => other_err(
             "All transactions must be signed; please either specify the key \
@@ -361,14 +355,6 @@ pub async fn aux_signing_data(
         }
     };
 
-    if fee_payer == masp_tx_key().to_public() {
-        other_err(
-            "The gas payer cannot be the MASP, please provide a different gas \
-             payer."
-                .to_string(),
-        )?;
-    }
-
     Ok(SigningTxData {
         owner,
         public_keys,
@@ -405,14 +391,6 @@ pub async fn init_validator_signing_data(
             None => public_keys.get(0).ok_or(TxError::InvalidFeePayer)?.clone(),
         }
     };
-
-    if fee_payer == masp_tx_key().to_public() {
-        other_err(
-            "The gas payer cannot be the MASP, please provide a different gas \
-             payer."
-                .to_string(),
-        )?;
-    }
 
     Ok(SigningTxData {
         owner: None,


### PR DESCRIPTION
## Describe your changes

Removes the hardcoded masp key from the codebase. Updates `tx_signers` to return an empty vector of keys if the source of the tx is MASP since there's no need to sign the tx in that case.

## Indicate on which release or other PRs this topic is based on

v0.29.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
