### PR TITLE
fix fst epoch start height in apps tests

### DIFF
--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -4743,7 +4743,7 @@ mod test_finalize_block {
         next_block_for_inflation(
             &mut shell,
             pkh1.to_vec(),
-            default_all_votes,
+            default_all_votes.clone(),
             None,
         );
         assert!(missed_votes.is_empty(&shell.wl_storage)?);
@@ -4777,6 +4777,13 @@ mod test_finalize_block {
             .unwrap();
         assert_eq!(val5_pipeline_state, ValidatorState::BelowThreshold);
 
+        next_block_for_inflation(
+            &mut shell,
+            pkh1.to_vec(),
+            default_all_votes,
+            None,
+        );
+
         // Advance to the next epoch with no votes from validator 2
         // NOTE: assume the minimum blocks for jailing is larger than remaining
         // blocks to next epoch!
@@ -4786,7 +4793,7 @@ mod test_finalize_block {
         );
         votes_no2.retain(|vote| vote.validator.address != pkh2);
 
-        let first_height_without_vote = 2;
+        let first_height_without_vote = 3;
         let mut val2_num_missed_blocks = 0u64;
         while current_epoch == Epoch::default() {
             next_block_for_inflation(
@@ -4840,7 +4847,10 @@ mod test_finalize_block {
             liveness_sum_missed_votes_handle().get(&shell.wl_storage, &val2)?;
         assert_eq!(
             val2_sum_missed_votes,
-            Some(shell.wl_storage.storage.block.height.0 - 2)
+            Some(
+                shell.wl_storage.storage.block.height.0
+                    - first_height_without_vote
+            )
         );
         for val in &initial_consensus_set {
             if val == &val2 {
@@ -4907,7 +4917,10 @@ mod test_finalize_block {
             if val == &val2 {
                 assert_eq!(
                     sum,
-                    Some(shell.wl_storage.storage.block.height.0 - 2)
+                    Some(
+                        shell.wl_storage.storage.block.height.0
+                            - first_height_without_vote
+                    )
                 );
                 for height in first_height_without_vote
                     ..shell.wl_storage.storage.block.height.0

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -1972,7 +1972,7 @@ mod test_utils {
             },
             validators: vec![],
             app_state_bytes: vec![].into(),
-            initial_height: 0_u32.into(),
+            initial_height: 1_u32.into(),
         };
         test.init_chain(req, num_validators);
         test.wl_storage.commit_block().expect("Test failed");

--- a/crates/apps/src/lib/node/ledger/shell/queries.rs
+++ b/crates/apps/src/lib/node/ledger/shell/queries.rs
@@ -170,6 +170,7 @@ mod test_queries {
     test_must_send_valset_upd! {
         epoch_assertions: [
             // (current epoch, current block height, can send valset upd)
+            // NOTE: can send valset upd on every 2nd block of an epoch
             (0, 1, false),
             (0, 2, true),
             (0, 3, false),

--- a/crates/state/src/wl_storage.rs
+++ b/crates/state/src/wl_storage.rs
@@ -270,16 +270,6 @@ where
     pub fn is_deciding_offset_within_epoch(&self, height_offset: u64) -> bool {
         let current_decision_height = self.get_current_decision_height();
 
-        // NOTE: the first stored height in `fst_block_heights_of_each_epoch`
-        // is 0, because of a bug (should be 1), so this code needs to
-        // handle that case
-        //
-        // we can remove this check once that's fixed
-        if self.storage.get_current_epoch().0 == storage::Epoch(0) {
-            let height_offset_within_epoch = BlockHeight(1 + height_offset);
-            return current_decision_height == height_offset_within_epoch;
-        }
-
         let pred_epochs = &self.storage.block.pred_epochs;
         let fst_heights_of_each_epoch = pred_epochs.first_block_heights();
 


### PR DESCRIPTION
## Describe your changes

On a live chain, we typically receive `InitChain` request with `initial_height = 1`, but the apps `TestShell` was using 0.

## Indicate on which release or other PRs this topic is based on

#2312 

diff for review: https://github.com/anoma/namada/pull/2380/files/72c1fff90bf35dfc5e2f54fa7fcd5dfa708a4a86..99ac08e70c883020f30bc2b67a7c9f52917bd297

## Checklist before merging to `draft`
- ~~[ ] I have added a changelog~~ - test changes only
- [x] Git history is in acceptable state
