### PR TITLE
Fee validation refactor

### DIFF
--- a/.changelog/unreleased/improvements/2382-fee-refactor.md
+++ b/.changelog/unreleased/improvements/2382-fee-refactor.md
@@ -1,0 +1,2 @@
+- Refactored the fee validation process.
+  ([\#2382](https://github.com/anoma/namada/pull/2382))

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -901,44 +901,6 @@ where
         }
     }
 
-    /// Checks that neither the wrapper nor the inner transaction have already
-    /// been applied. Requires a [`TempWlStorage`] to perform the check during
-    /// block construction and validation
-    pub fn replay_protection_checks(
-        &self,
-        wrapper: &Tx,
-        temp_wl_storage: &mut TempWlStorage<D, H>,
-    ) -> Result<()> {
-        let inner_tx_hash = wrapper.raw_header_hash();
-        // Check the inner tx hash only against the storage, skip the write
-        // log
-        if temp_wl_storage
-            .has_committed_replay_protection_entry(&inner_tx_hash)
-            .expect("Error while checking inner tx hash key in storage")
-        {
-            return Err(Error::ReplayAttempt(format!(
-                "Inner transaction hash {} already in storage",
-                &inner_tx_hash,
-            )));
-        }
-
-        let wrapper_hash = wrapper.header_hash();
-        if temp_wl_storage
-            .has_replay_protection_entry(&wrapper_hash)
-            .expect("Error while checking wrapper tx hash key in storage")
-        {
-            return Err(Error::ReplayAttempt(format!(
-                "Wrapper transaction hash {} already in storage",
-                wrapper_hash
-            )));
-        }
-
-        // Write wrapper hash to WAL
-        temp_wl_storage
-            .write_tx_hash(wrapper_hash)
-            .map_err(|e| Error::ReplayAttempt(e.to_string()))
-    }
-
     /// If a handle to an Ethereum oracle was provided to the [`Shell`], attempt
     /// to send it an updated configuration, using a configuration
     /// based on Ethereum bridge parameters in blockchain storage.
@@ -1287,7 +1249,7 @@ where
                 }
 
                 // Validate wrapper fees
-                if let Err(e) = self.mempool_fee_check(
+                if let Err(e) = mempool_fee_check(
                     &wrapper,
                     get_fee_unshielding_transaction(&tx, &wrapper),
                     &mut TempWlStorage::new(&self.wl_storage.storage),
@@ -1318,177 +1280,6 @@ where
             response.log = VALID_MSG.into();
         }
         response
-    }
-
-    // Perfomr the fee check in mempool
-    fn mempool_fee_check<CA>(
-        &self,
-        wrapper: &WrapperTx,
-        masp_transaction: Option<Transaction>,
-        temp_wl_storage: &mut TempWlStorage<D, H>,
-        vp_wasm_cache: &mut VpCache<CA>,
-        tx_wasm_cache: &mut TxCache<CA>,
-    ) -> Result<()>
-    where
-        CA: 'static + WasmCacheAccess + Sync,
-    {
-        let minimum_gas_price = namada::ledger::parameters::read_gas_cost(
-            &self.wl_storage,
-            &wrapper.fee.token,
-        )
-        .expect("Must be able to read gas cost parameter")
-        .ok_or(Error::TxApply(protocol::Error::FeeError(format!(
-            "The provided {} token is not allowed for fee payment",
-            wrapper.fee.token
-        ))))?;
-
-        self.wrapper_fee_check(
-            wrapper,
-            masp_transaction,
-            minimum_gas_price,
-            temp_wl_storage,
-            vp_wasm_cache,
-            tx_wasm_cache,
-        )?;
-        protocol::check_fees(temp_wl_storage, wrapper).map_err(Error::TxApply)
-    }
-
-    /// Check the validity of the fee payment, including the minimum amounts
-    /// required and the optional unshield
-    pub fn wrapper_fee_check<CA>(
-        &self,
-        wrapper: &WrapperTx,
-        masp_transaction: Option<Transaction>,
-        minimum_gas_price: token::Amount,
-        temp_wl_storage: &mut TempWlStorage<D, H>,
-        vp_wasm_cache: &mut VpCache<CA>,
-        tx_wasm_cache: &mut TxCache<CA>,
-    ) -> Result<()>
-    where
-        CA: 'static + WasmCacheAccess + Sync,
-    {
-        match wrapper
-            .fee
-            .amount_per_gas_unit
-            .to_amount(&wrapper.fee.token, &self.wl_storage)
-        {
-            Ok(amount_per_gas_unit)
-                if amount_per_gas_unit < minimum_gas_price =>
-            {
-                // The fees do not match the minimum required
-                return Err(Error::TxApply(protocol::Error::FeeError(
-                    format!(
-                        "Fee amount {:?} do not match the minimum required \
-                         amount {:?} for token {}",
-                        wrapper.fee.amount_per_gas_unit,
-                        minimum_gas_price,
-                        wrapper.fee.token
-                    ),
-                )));
-            }
-            Ok(_) => {}
-            Err(err) => {
-                return Err(Error::TxApply(protocol::Error::FeeError(
-                    format!(
-                        "The precision of the fee amount {:?} is higher than \
-                         the denomination for token {}: {}",
-                        wrapper.fee.amount_per_gas_unit, wrapper.fee.token, err,
-                    ),
-                )));
-            }
-        }
-
-        if let Some(transaction) = masp_transaction {
-            self.fee_unshielding_validation(
-                wrapper,
-                transaction,
-                temp_wl_storage,
-                vp_wasm_cache,
-                tx_wasm_cache,
-            )?;
-        }
-
-        Ok(())
-    }
-
-    // Verifies the correctness of the masp transaction for fee payment
-    fn fee_unshielding_validation<CA>(
-        &self,
-        wrapper: &WrapperTx,
-        masp_transaction: Transaction,
-        temp_wl_storage: &mut TempWlStorage<D, H>,
-        vp_wasm_cache: &mut VpCache<CA>,
-        tx_wasm_cache: &mut TxCache<CA>,
-    ) -> Result<()>
-    where
-        CA: 'static + WasmCacheAccess + Sync,
-    {
-        // Validation of the commitment to this section is done when
-        // checking the aggregated signature of the wrapper, no need for
-        // further validation
-
-        // Validate data and generate unshielding tx
-        let transfer_code_hash =
-            get_transfer_hash_from_storage(temp_wl_storage);
-
-        let descriptions_limit = self.wl_storage.read(&parameters::storage::get_fee_unshielding_descriptions_limit_key()).expect("Error reading the storage").expect("Missing fee unshielding descriptions limit param in storage");
-
-        let unshield = wrapper
-            .check_and_generate_fee_unshielding(
-                transfer_code_hash,
-                Some(namada_sdk::tx::TX_TRANSFER_WASM.to_string()),
-                descriptions_limit,
-                masp_transaction,
-            )
-            .map_err(|e| {
-                Error::TxApply(protocol::Error::FeeUnshieldingError(e))
-            })?;
-
-        let fee_unshielding_gas_limit = temp_wl_storage
-            .read(&parameters::storage::get_fee_unshielding_gas_limit_key())
-            .expect("Error reading from storage")
-            .expect("Missing fee unshielding gas limit in storage");
-
-        // Runtime check
-        // NOTE: A clean tx write log must be provided to this call for a
-        // correct vp validation. Block write log, instead, should contain
-        // any prior changes (if any). This is to simulate the
-        // unshielding tx (to prevent the already written keys
-        // from being passed/triggering VPs) but we cannot
-        // commit the tx write log yet cause the tx could still
-        // be invalid.
-        temp_wl_storage.write_log.precommit_tx();
-
-        let result = apply_wasm_tx(
-            unshield,
-            &TxIndex::default(),
-            ShellParams::new(
-                &mut TxGasMeter::new(fee_unshielding_gas_limit),
-                temp_wl_storage,
-                vp_wasm_cache,
-                tx_wasm_cache,
-            ),
-        )
-        .map_err(|e| {
-            Error::TxApply(protocol::Error::FeeUnshieldingError(
-                namada::types::transaction::WrapperTxErr::InvalidUnshield(
-                    format!("Wasm run failed: {}", e),
-                ),
-            ))
-        })?;
-
-        if result.is_accepted() {
-            Ok(())
-        } else {
-            Err(Error::TxApply(protocol::Error::FeeUnshieldingError(
-                namada::types::transaction::WrapperTxErr::InvalidUnshield(
-                    format!(
-                        "Some VPs rejected fee unshielding: {:#?}",
-                        result.vps_result.rejected_vps
-                    ),
-                ),
-            )))
-        }
     }
 
     fn get_abci_validator_updates<F, V>(
@@ -1542,6 +1333,216 @@ where
                 validator_conv(consensus_key, power)
             },
         )
+    }
+}
+
+/// Checks that neither the wrapper nor the inner transaction have already
+/// been applied. Requires a [`TempWlStorage`] to perform the check during
+/// block construction and validation
+pub fn replay_protection_checks<D, H>(
+    wrapper: &Tx,
+    temp_wl_storage: &mut TempWlStorage<D, H>,
+) -> Result<()>
+where
+    D: DB + for<'iter> DBIter<'iter> + Sync + 'static,
+    H: StorageHasher + Sync + 'static,
+{
+    let inner_tx_hash = wrapper.raw_header_hash();
+    // Check the inner tx hash only against the storage, skip the write
+    // log
+    if temp_wl_storage
+        .has_committed_replay_protection_entry(&inner_tx_hash)
+        .expect("Error while checking inner tx hash key in storage")
+    {
+        return Err(Error::ReplayAttempt(format!(
+            "Inner transaction hash {} already in storage",
+            &inner_tx_hash,
+        )));
+    }
+
+    let wrapper_hash = wrapper.header_hash();
+    if temp_wl_storage
+        .has_replay_protection_entry(&wrapper_hash)
+        .expect("Error while checking wrapper tx hash key in storage")
+    {
+        return Err(Error::ReplayAttempt(format!(
+            "Wrapper transaction hash {} already in storage",
+            wrapper_hash
+        )));
+    }
+
+    // Write wrapper hash to WAL
+    temp_wl_storage
+        .write_tx_hash(wrapper_hash)
+        .map_err(|e| Error::ReplayAttempt(e.to_string()))
+}
+
+// Perform the fee check in mempool
+fn mempool_fee_check<D, H, CA>(
+    wrapper: &WrapperTx,
+    masp_transaction: Option<Transaction>,
+    temp_wl_storage: &mut TempWlStorage<D, H>,
+    vp_wasm_cache: &mut VpCache<CA>,
+    tx_wasm_cache: &mut TxCache<CA>,
+) -> Result<()>
+where
+    D: DB + for<'iter> DBIter<'iter> + Sync + 'static,
+    H: StorageHasher + Sync + 'static,
+    CA: 'static + WasmCacheAccess + Sync,
+{
+    let minimum_gas_price = namada::ledger::parameters::read_gas_cost(
+        temp_wl_storage,
+        &wrapper.fee.token,
+    )
+    .expect("Must be able to read gas cost parameter")
+    .ok_or(Error::TxApply(protocol::Error::FeeError(format!(
+        "The provided {} token is not allowed for fee payment",
+        wrapper.fee.token
+    ))))?;
+
+    wrapper_fee_check(
+        wrapper,
+        masp_transaction,
+        minimum_gas_price,
+        temp_wl_storage,
+        vp_wasm_cache,
+        tx_wasm_cache,
+    )?;
+    protocol::check_fees(temp_wl_storage, wrapper).map_err(Error::TxApply)
+}
+
+/// Check the validity of the fee payment, including the minimum amounts
+/// required and the optional unshield
+pub fn wrapper_fee_check<D, H, CA>(
+    wrapper: &WrapperTx,
+    masp_transaction: Option<Transaction>,
+    minimum_gas_price: token::Amount,
+    temp_wl_storage: &mut TempWlStorage<D, H>,
+    vp_wasm_cache: &mut VpCache<CA>,
+    tx_wasm_cache: &mut TxCache<CA>,
+) -> Result<()>
+where
+    D: DB + for<'iter> DBIter<'iter> + Sync + 'static,
+    H: StorageHasher + Sync + 'static,
+    CA: 'static + WasmCacheAccess + Sync,
+{
+    match wrapper
+        .fee
+        .amount_per_gas_unit
+        .to_amount(&wrapper.fee.token, temp_wl_storage)
+    {
+        Ok(amount_per_gas_unit) if amount_per_gas_unit < minimum_gas_price => {
+            // The fees do not match the minimum required
+            return Err(Error::TxApply(protocol::Error::FeeError(format!(
+                "Fee amount {:?} do not match the minimum required amount \
+                 {:?} for token {}",
+                wrapper.fee.amount_per_gas_unit,
+                minimum_gas_price,
+                wrapper.fee.token
+            ))));
+        }
+        Ok(_) => {}
+        Err(err) => {
+            return Err(Error::TxApply(protocol::Error::FeeError(format!(
+                "The precision of the fee amount {:?} is higher than the \
+                 denomination for token {}: {}",
+                wrapper.fee.amount_per_gas_unit, wrapper.fee.token, err,
+            ))));
+        }
+    }
+
+    if let Some(transaction) = masp_transaction {
+        fee_unshielding_validation(
+            wrapper,
+            transaction,
+            temp_wl_storage,
+            vp_wasm_cache,
+            tx_wasm_cache,
+        )?;
+    }
+
+    Ok(())
+}
+
+// Verifies the correctness of the masp transaction for fee payment
+fn fee_unshielding_validation<D, H, CA>(
+    wrapper: &WrapperTx,
+    masp_transaction: Transaction,
+    temp_wl_storage: &mut TempWlStorage<D, H>,
+    vp_wasm_cache: &mut VpCache<CA>,
+    tx_wasm_cache: &mut TxCache<CA>,
+) -> Result<()>
+where
+    D: DB + for<'iter> DBIter<'iter> + Sync + 'static,
+    H: StorageHasher + Sync + 'static,
+    CA: 'static + WasmCacheAccess + Sync,
+{
+    // Validation of the commitment to this section is done when
+    // checking the aggregated signature of the wrapper, no need for
+    // further validation
+
+    // Validate data and generate unshielding tx
+    let transfer_code_hash = get_transfer_hash_from_storage(temp_wl_storage);
+
+    let descriptions_limit = temp_wl_storage
+        .read(
+            &parameters::storage::get_fee_unshielding_descriptions_limit_key(),
+        )
+        .expect("Error reading the storage")
+        .expect("Missing fee unshielding descriptions limit param in storage");
+
+    let unshield = wrapper
+        .check_and_generate_fee_unshielding(
+            transfer_code_hash,
+            Some(namada_sdk::tx::TX_TRANSFER_WASM.to_string()),
+            descriptions_limit,
+            masp_transaction,
+        )
+        .map_err(|e| Error::TxApply(protocol::Error::FeeUnshieldingError(e)))?;
+
+    let fee_unshielding_gas_limit = temp_wl_storage
+        .read(&parameters::storage::get_fee_unshielding_gas_limit_key())
+        .expect("Error reading from storage")
+        .expect("Missing fee unshielding gas limit in storage");
+
+    // Runtime check
+    // NOTE: A clean tx write log must be provided to this call for a
+    // correct vp validation. Block write log, instead, should contain
+    // any prior changes (if any). This is to simulate the
+    // unshielding tx (to prevent the already written keys
+    // from being passed/triggering VPs) but we cannot
+    // commit the tx write log yet cause the tx could still
+    // be invalid.
+    temp_wl_storage.write_log.precommit_tx();
+
+    let result = apply_wasm_tx(
+        unshield,
+        &TxIndex::default(),
+        ShellParams::new(
+            &mut TxGasMeter::new(fee_unshielding_gas_limit),
+            temp_wl_storage,
+            vp_wasm_cache,
+            tx_wasm_cache,
+        ),
+    )
+    .map_err(|e| {
+        Error::TxApply(protocol::Error::FeeUnshieldingError(
+            namada::types::transaction::WrapperTxErr::InvalidUnshield(format!(
+                "Wasm run failed: {}",
+                e
+            )),
+        ))
+    })?;
+
+    if result.is_accepted() {
+        Ok(())
+    } else {
+        Err(Error::TxApply(protocol::Error::FeeUnshieldingError(
+            namada::types::transaction::WrapperTxErr::InvalidUnshield(format!(
+                "Some VPs rejected fee unshielding: {:#?}",
+                result.vps_result.rejected_vps
+            )),
+        )))
     }
 }
 

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -661,14 +661,13 @@ where
                 }
 
                 // Check that the fee payer has sufficient balance.
-                match self.wrapper_fee_check(
+                match self.process_proposal_fee_check(
                     &wrapper,
                     get_fee_unshielding_transaction(&tx, &wrapper),
+                    block_proposer,
                     temp_wl_storage,
                     vp_wasm_cache,
                     tx_wasm_cache,
-                    Some(block_proposer),
-                    false,
                 ) {
                     Ok(()) => TxResult {
                         code: ResultCode::Ok.into(),
@@ -698,6 +697,41 @@ where
         let is_2nd_height_off = pos_queries.is_deciding_offset_within_epoch(1);
         let is_3rd_height_off = pos_queries.is_deciding_offset_within_epoch(2);
         is_2nd_height_off || is_3rd_height_off
+    }
+
+    fn process_proposal_fee_check<CA>(
+        &self,
+        wrapper: &WrapperTx,
+        masp_transaction: Option<Transaction>,
+        proposer: &Address,
+        temp_wl_storage: &mut TempWlStorage<D, H>,
+        vp_wasm_cache: &mut VpCache<CA>,
+        tx_wasm_cache: &mut TxCache<CA>,
+    ) -> Result<()>
+    where
+        CA: 'static + WasmCacheAccess + Sync,
+    {
+        let minimum_gas_price = namada::ledger::parameters::read_gas_cost(
+            &self.wl_storage,
+            &wrapper.fee.token,
+        )
+        .expect("Must be able to read gas cost parameter")
+        .ok_or(Error::TxApply(protocol::Error::FeeError(format!(
+            "The provided {} token is not allowed for fee payment",
+            wrapper.fee.token
+        ))))?;
+
+        self.wrapper_fee_check(
+            wrapper,
+            masp_transaction,
+            minimum_gas_price,
+            temp_wl_storage,
+            vp_wasm_cache,
+            tx_wasm_cache,
+        )?;
+
+        protocol::transfer_fee(temp_wl_storage, proposer, wrapper)
+            .map_err(Error::TxApply)
     }
 }
 


### PR DESCRIPTION
## Describe your changes

Refactors `wrapper_fee_check` into three different functions, one for each consensus state (`CheckTx`, `PrepareProposal` and `ProcessProposal`). Extract the fee unshield processing to a separate function. Also changes some methods of `Shell` to just be functions since we don't really need a reference to the shell.

## Indicate on which release or other PRs this topic is based on

v0.29.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
