### PR TITLE
Mandatory CometBFT timestamp

### DIFF
--- a/.changelog/unreleased/improvements/2383-comet-timestamp.md
+++ b/.changelog/unreleased/improvements/2383-comet-timestamp.md
@@ -1,0 +1,2 @@
+- Updated block validation to require a valid timestamp.
+  ([\#2383](https://github.com/anoma/namada/pull/2383))

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -1763,6 +1763,7 @@ mod test_utils {
             &self,
             req: ProcessProposal,
         ) -> std::result::Result<Vec<ProcessedTx>, TestError> {
+            let time = DateTimeUtc::now();
             let (resp, tx_results) =
                 self.shell.process_proposal(RequestProcessProposal {
                     txs: req
@@ -1780,6 +1781,11 @@ mod test_utils {
                         )
                         .unwrap()
                         .into(),
+                    time: Some(Timestamp {
+                        seconds: time.0.timestamp(),
+                        nanos: time.0.timestamp_subsec_nanos() as i32,
+                    }),
+
                     ..Default::default()
                 });
             let results = tx_results

--- a/apps/src/lib/node/ledger/shell/mod.rs
+++ b/apps/src/lib/node/ledger/shell/mod.rs
@@ -79,7 +79,6 @@ use crate::config::{self, genesis, TendermintMode, ValidatorLocalConfig};
 use crate::facade::tendermint::abci::types::{Misbehavior, MisbehaviorKind};
 use crate::facade::tendermint::v0_37::abci::{request, response};
 use crate::facade::tendermint::{self, validator};
-use crate::facade::tendermint_proto::google::protobuf::Timestamp;
 use crate::facade::tendermint_proto::v0_37::crypto::public_key;
 use crate::node::ledger::shims::abcipp_shim_types::shim;
 use crate::node::ledger::shims::abcipp_shim_types::shim::response::TxResult;
@@ -582,25 +581,6 @@ where
         response
     }
 
-    /// Takes the optional tendermint timestamp of the block: if it's Some than
-    /// converts it to a [`DateTimeUtc`], otherwise retrieve from self the
-    /// time of the last block committed
-    pub fn get_block_timestamp(
-        &self,
-        tendermint_block_time: Option<Timestamp>,
-    ) -> DateTimeUtc {
-        if let Some(t) = tendermint_block_time {
-            if let Ok(t) = t.try_into() {
-                return t;
-            }
-        }
-        // Default to last committed block time
-        self.wl_storage
-            .storage
-            .get_last_block_timestamp()
-            .expect("Failed to retrieve last block timestamp")
-    }
-
     /// Read the value for a storage key dropping any error
     pub fn read_storage_key<T>(&self, key: &Key) -> Option<T>
     where
@@ -1095,7 +1075,11 @@ where
 
         // Tx expiration
         if let Some(exp) = tx.header.expiration {
-            let last_block_timestamp = self.get_block_timestamp(None);
+            let last_block_timestamp = self
+                .wl_storage
+                .storage
+                .get_last_block_timestamp()
+                .expect("Failed to retrieve last block timestamp");
 
             if last_block_timestamp > exp {
                 response.code = ResultCode::ExpiredTx.into();

--- a/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -104,7 +104,10 @@ where
 
         let (tx_results, meta) = self.process_txs(
             &req.txs,
-            self.get_block_timestamp(req.time),
+            req.time
+                .expect("Missing timestamp in proposed block")
+                .try_into()
+                .expect("Failed conversion of Comet timestamp"),
             &native_block_proposer_address,
         );
 

--- a/apps/src/lib/node/ledger/shell/testing/node.rs
+++ b/apps/src/lib/node/ledger/shell/testing/node.rs
@@ -36,6 +36,7 @@ use namada::types::key::tm_consensus_key_raw_hash;
 use namada::types::storage::{BlockHash, BlockHeight, Epoch, Header};
 use namada::types::time::DateTimeUtc;
 use namada_sdk::queries::Client;
+use namada_sdk::tendermint_proto::google::protobuf::Timestamp;
 use regex::Regex;
 use tokio::sync::mpsc;
 
@@ -459,9 +460,14 @@ impl MockNode {
         self.advance_to_allowed_block();
         let (proposer_address, votes) = self.prepare_request();
 
+        let time = DateTimeUtc::now();
         let req = RequestProcessProposal {
             txs: txs.clone().into_iter().map(|tx| tx.into()).collect(),
             proposer_address: proposer_address.clone().into(),
+            time: Some(Timestamp {
+                seconds: time.0.timestamp(),
+                nanos: time.0.timestamp_subsec_nanos() as i32,
+            }),
             ..Default::default()
         };
         let mut locked = self.shell.lock().unwrap();


### PR DESCRIPTION
## Describe your changes

Removes `get_block_timestamp` method. In `process_proposal` always require CometBFT to attach a valid timestamp to the block.

## Indicate on which release or other PRs this topic is based on

v0.29.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
