### PR TITLE
Sets gas sentinel in `ibc_tx_charge_gas`

### DIFF
--- a/.changelog/unreleased/improvements/2395-gas-sentinel-fix.md
+++ b/.changelog/unreleased/improvements/2395-gas-sentinel-fix.md
@@ -1,0 +1,2 @@
+- Ibc transactions can be rewrapped in case of a gas error.
+  ([\#2395](https://github.com/anoma/namada/pull/2395))

--- a/shared/src/vm/host_env.rs
+++ b/shared/src/vm/host_env.rs
@@ -2634,6 +2634,8 @@ where
     // if we run out of gas, we need to stop the execution
     let result = gas_meter.consume(used_gas).into_storage_result();
     if let Err(err) = &result {
+        let sentinel = unsafe { ctx.sentinel.get() };
+        sentinel.set_out_of_gas();
         tracing::info!(
             "Stopping transaction execution because of gas error: {}",
             err


### PR DESCRIPTION
## Describe your changes

Small update to set the gas sentinel for ibc transactions to allow them to be rewrapped and resubmitted.

## Indicate on which release or other PRs this topic is based on

v0.30.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
