### PR TITLE
enable rocksdb jemalloc only for `make build-release`

### DIFF
--- a/.changelog/unreleased/improvements/2404-opt-jemalloc.md
+++ b/.changelog/unreleased/improvements/2404-opt-jemalloc.md
@@ -1,0 +1,2 @@
+- Disabled RocksDB jemalloc feature by default.
+  ([\#2404](https://github.com/anoma/namada/pull/2404))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,7 +3830,6 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
- "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
@@ -7129,16 +7128,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ build-test:
 	$(cargo) +$(nightly) build --tests $(jobs)
 
 build-release:
-	$(cargo) build $(jobs) --release --timings --package namada_apps --manifest-path Cargo.toml
+	$(cargo) build $(jobs) --release --timings --package namada_apps \
+		--manifest-path Cargo.toml \
+		--features jemalloc
 
 build-debug:
 	$(cargo) build --package namada_apps --manifest-path Cargo.toml

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -60,6 +60,12 @@ testing = ["namada_test_utils"]
 benches = ["testing", "namada_test_utils"]
 integration = []
 
+# RocksDB's "jemalloc" disabled by default as it takes a long time to build.
+# Enabled in `make build-release`.
+[target.'cfg(not(windows))'.features]
+jemalloc = ["rocksdb/jemalloc"]
+[target.'cfg(windows)'.features]
+jemalloc = [] # jemalloc is not supported on windows
 
 [dependencies]
 namada = {path = "../shared", features = ["multicore", "http-client", "tendermint-rpc"]}
@@ -116,6 +122,7 @@ regex.workspace = true
 reqwest.workspace = true
 ripemd.workspace = true
 rlimit.workspace = true
+rocksdb = { workspace = true }
 rpassword.workspace = true
 serde_bytes.workspace = true
 serde_json = {workspace = true, features = ["raw_value"]}
@@ -140,12 +147,6 @@ winapi.workspace = true
 zeroize.workspace = true
 warp = "0.3.2"
 bytes = "1.1.0"
-
-[target.'cfg(not(windows))'.dependencies]
-rocksdb = { workspace = true, features = ['jemalloc'] } # jemalloc is not supported on windows
-
-[target.'cfg(windows)'.dependencies]
-rocksdb = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
## Describe your changes

RocksDB `tikv-jemalloc-sys` takes a long time to build in rust-analyzer. This change disable RocksDB `jemalloc` feature by default and only uses it for `make build-release`

## Indicate on which release or other PRs this topic is based on

0.30.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
