### PR TITLE
No float `epoch_length` in localnet script

### DIFF
--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -90,7 +90,7 @@ if args.params:
 if args.max_validator_slots:
     params['pos_params'] = {'max_validator_slots': args.max_validator_slots}
 if args.epoch_length:
-    epochs_per_year = 365 * 24 * 60 * 60 / args.epoch_length
+    epochs_per_year = round(365 * 24 * 60 * 60 / args.epoch_length)
     params['parameters'] = {'epochs_per_year': epochs_per_year }
 if len(params.keys())>0:
     edit_parameters(localnet_dir + '/parameters.toml', **params)


### PR DESCRIPTION
## Describe your changes

Rounds the epoch length to the closest integer to prevent writing a float value to the config file.

## Indicate on which release or other PRs this topic is based on

v0.33.0

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
