### PR TITLE
Make shielded syncing a separate command

### DIFF
--- a/crates/apps/src/lib/bench_utils.rs
+++ b/crates/apps/src/lib/bench_utils.rs
@@ -957,9 +957,11 @@ impl BenchShieldedCtx {
             .wallet
             .find_spending_key(ALBERT_SPENDING_KEY, None)
             .unwrap();
-        async_runtime
-            .block_on(self.shielded.fetch(
+        self.shielded = async_runtime
+            .block_on(self.shielded.syncing(
                 &self.shell,
+                &StdIo,
+                None,
                 &[spending_key.into()],
                 &[],
             ))

--- a/crates/apps/src/lib/bench_utils.rs
+++ b/crates/apps/src/lib/bench_utils.rs
@@ -685,12 +685,9 @@ impl ShieldedUtils for BenchShieldedUtils {
         // Atomicity is required to prevent other client instances from reading
         // corrupt data.
         std::fs::rename(
-            tmp_path.clone(),
+            tmp_path,
             self.context_dir.0.path().to_path_buf().join(FILE_NAME),
         )?;
-        // Finally, remove our temporary file to allow future saving of shielded
-        // contexts.
-        std::fs::remove_file(tmp_path)?;
         Ok(())
     }
 }

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -1349,24 +1349,23 @@ pub mod cmds {
     }
 
     #[derive(Clone, Debug)]
-    pub struct ShieldedSync(
-        pub args::ShieldedSync<args::CliTypes>
-    );
+    pub struct ShieldedSync(pub args::ShieldedSync<args::CliTypes>);
 
     impl SubCmd for ShieldedSync {
         const CMD: &'static str = "shielded-sync";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches.subcommand_matches(Self::CMD).map(|matches| {
-                ShieldedSync(args::ShieldedSync::parse(matches))
-            })
+            matches
+                .subcommand_matches(Self::CMD)
+                .map(|matches| ShieldedSync(args::ShieldedSync::parse(matches)))
         }
 
         fn def() -> App {
             App::new(Self::CMD)
                 .about(
-                    "Sync the local shielded context with MASP notes owned by the provided \
-                    viewing / spending keys up to an optional specified block height."
+                    "Sync the local shielded context with MASP notes owned by \
+                     the provided viewing / spending keys up to an optional \
+                     specified block height.",
                 )
                 .add_args::<args::ShieldedSync<args::CliTypes>>()
         }
@@ -3084,7 +3083,8 @@ pub mod args {
     pub const SIGNATURES: ArgMulti<PathBuf, GlobStar> = arg_multi("signatures");
     pub const SOURCE: Arg<WalletAddress> = arg("source");
     pub const SOURCE_OPT: ArgOpt<WalletAddress> = SOURCE.opt();
-    pub const SPENDING_KEYS: ArgMulti<WalletSpendingKey, GlobStar> = arg_multi("spending-keys");
+    pub const SPENDING_KEYS: ArgMulti<WalletSpendingKey, GlobStar> =
+        arg_multi("spending-keys");
     pub const STEWARD: Arg<WalletAddress> = arg("steward");
     pub const SOURCE_VALIDATOR: Arg<WalletAddress> = arg("source-validator");
     pub const STORAGE_KEY: Arg<storage::Key> = arg("storage-key");
@@ -3121,7 +3121,8 @@ pub mod args {
     pub const VALUE: Arg<String> = arg("value");
     pub const VOTER_OPT: ArgOpt<WalletAddress> = arg_opt("voter");
     pub const VIEWING_KEY: Arg<WalletViewingKey> = arg("key");
-    pub const VIEWING_KEYS: ArgMulti<WalletViewingKey, GlobStar> = arg_multi("viewing-keys");
+    pub const VIEWING_KEYS: ArgMulti<WalletViewingKey, GlobStar> =
+        arg_multi("viewing-keys");
     pub const VP: ArgOpt<String> = arg_opt("vp");
     pub const WALLET_ALIAS_FORCE: ArgFlag = flag("wallet-alias-force");
     pub const WASM_CHECKSUMS_PATH: Arg<PathBuf> = arg("wasm-checksums-path");
@@ -5643,26 +5644,18 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(
-                LEDGER_ADDRESS_DEFAULT.def().help(LEDGER_ADDRESS_ABOUT),
-            )
-            .arg(
-                BLOCK_HEIGHT_OPT.def().help(
-                    "Option block height to sync up to. Default is latest."
-                )
-            )
-            .arg(
-                SPENDING_KEYS.def().help(
-                    "List of new spending keys with which to check note ownership. \
-                    These will be added to the shielded context."
-                )
-            )
-            .arg(
-                VIEWING_KEYS.def().help(
-                    "List of new viewing keys with which to check note ownership. \
-                    These will be added to the shielded context."
-                )
-            )
+            app.arg(LEDGER_ADDRESS_DEFAULT.def().help(LEDGER_ADDRESS_ABOUT))
+                .arg(BLOCK_HEIGHT_OPT.def().help(
+                    "Option block height to sync up to. Default is latest.",
+                ))
+                .arg(SPENDING_KEYS.def().help(
+                    "List of new spending keys with which to check note \
+                     ownership. These will be added to the shielded context.",
+                ))
+                .arg(VIEWING_KEYS.def().help(
+                    "List of new viewing keys with which to check note \
+                     ownership. These will be added to the shielded context.",
+                ))
         }
     }
 
@@ -5672,11 +5665,13 @@ pub mod args {
             ShieldedSync {
                 ledger_address: (),
                 last_query_height: self.last_query_height,
-                spending_keys: self.spending_keys
+                spending_keys: self
+                    .spending_keys
                     .iter()
                     .map(|sk| chain_ctx.get_cached(sk))
                     .collect(),
-                viewing_keys: self.viewing_keys
+                viewing_keys: self
+                    .viewing_keys
                     .iter()
                     .map(|vk| chain_ctx.get_cached(vk))
                     .collect(),
@@ -5967,11 +5962,11 @@ pub mod args {
         type Keypair = WalletKeypair;
         type NativeAddress = ();
         type PublicKey = WalletPublicKey;
+        type SpendingKey = WalletSpendingKey;
         type TendermintAddress = TendermintAddress;
         type TransferSource = WalletTransferSource;
         type TransferTarget = WalletTransferTarget;
         type ViewingKey = WalletViewingKey;
-        type SpendingKey = WalletSpendingKey;
     }
 
     impl CliToSdk<Tx<SdkTypes>> for Tx<CliTypes> {

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -267,6 +267,7 @@ pub mod cmds {
                 .subcommand(QueryMetaData::def().display_order(5))
                 // Actions
                 .subcommand(SignTx::def().display_order(6))
+                .subcommand(ShieldedSync::def().display_order(6))
                 .subcommand(GenIbcShieldedTransafer::def().display_order(6))
                 // Utils
                 .subcommand(Utils::def().display_order(7))
@@ -346,6 +347,7 @@ pub mod cmds {
             let add_to_eth_bridge_pool =
                 Self::parse_with_ctx(matches, AddToEthBridgePool);
             let sign_tx = Self::parse_with_ctx(matches, SignTx);
+            let shielded_sync = Self::parse_with_ctx(matches, ShieldedSync);
             let gen_ibc_shielded =
                 Self::parse_with_ctx(matches, GenIbcShieldedTransafer);
             let utils = SubCmd::parse(matches).map(Self::WithoutContext);
@@ -397,6 +399,7 @@ pub mod cmds {
                 .or(query_metadata)
                 .or(query_account)
                 .or(sign_tx)
+                .or(shielded_sync)
                 .or(gen_ibc_shielded)
                 .or(utils)
         }
@@ -483,6 +486,7 @@ pub mod cmds {
         QueryValidatorState(QueryValidatorState),
         QueryRewards(QueryRewards),
         SignTx(SignTx),
+        ShieldedSync(ShieldedSync),
         GenIbcShieldedTransafer(GenIbcShieldedTransafer),
     }
 
@@ -1341,6 +1345,30 @@ pub mod cmds {
                      validator.",
                 )
                 .add_args::<args::TxReactivateValidator<args::CliTypes>>()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ShieldedSync(
+        pub args::ShieldedSync<args::CliTypes>
+    );
+
+    impl SubCmd for ShieldedSync {
+        const CMD: &'static str = "shielded-sync";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches.subcommand_matches(Self::CMD).map(|matches| {
+                ShieldedSync(args::ShieldedSync::parse(matches))
+            })
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about(
+                    "Sync the local shielded context with MASP notes owned by the provided \
+                    viewing / spending keys up to an optional specified block height."
+                )
+                .add_args::<args::ShieldedSync<args::CliTypes>>()
         }
     }
 
@@ -3056,6 +3084,7 @@ pub mod args {
     pub const SIGNATURES: ArgMulti<PathBuf, GlobStar> = arg_multi("signatures");
     pub const SOURCE: Arg<WalletAddress> = arg("source");
     pub const SOURCE_OPT: ArgOpt<WalletAddress> = SOURCE.opt();
+    pub const SPENDING_KEYS: ArgMulti<WalletSpendingKey, GlobStar> = arg_multi("spending-keys");
     pub const STEWARD: Arg<WalletAddress> = arg("steward");
     pub const SOURCE_VALIDATOR: Arg<WalletAddress> = arg("source-validator");
     pub const STORAGE_KEY: Arg<storage::Key> = arg("storage-key");
@@ -3092,6 +3121,7 @@ pub mod args {
     pub const VALUE: Arg<String> = arg("value");
     pub const VOTER_OPT: ArgOpt<WalletAddress> = arg_opt("voter");
     pub const VIEWING_KEY: Arg<WalletViewingKey> = arg("key");
+    pub const VIEWING_KEYS: ArgMulti<WalletViewingKey, GlobStar> = arg_multi("viewing-keys");
     pub const VP: ArgOpt<String> = arg_opt("vp");
     pub const WALLET_ALIAS_FORCE: ArgFlag = flag("wallet-alias-force");
     pub const WASM_CHECKSUMS_PATH: Arg<PathBuf> = arg("wasm-checksums-path");
@@ -5598,6 +5628,62 @@ pub mod args {
         }
     }
 
+    impl Args for ShieldedSync<CliTypes> {
+        fn parse(matches: &ArgMatches) -> Self {
+            let ledger_address = LEDGER_ADDRESS_DEFAULT.parse(matches);
+            let last_query_height = BLOCK_HEIGHT_OPT.parse(matches);
+            let spending_keys = SPENDING_KEYS.parse(matches);
+            let viewing_keys = VIEWING_KEYS.parse(matches);
+            Self {
+                ledger_address,
+                last_query_height,
+                spending_keys,
+                viewing_keys,
+            }
+        }
+
+        fn def(app: App) -> App {
+            app.arg(
+                LEDGER_ADDRESS_DEFAULT.def().help(LEDGER_ADDRESS_ABOUT),
+            )
+            .arg(
+                BLOCK_HEIGHT_OPT.def().help(
+                    "Option block height to sync up to. Default is latest."
+                )
+            )
+            .arg(
+                SPENDING_KEYS.def().help(
+                    "List of new spending keys with which to check note ownership. \
+                    These will be added to the shielded context."
+                )
+            )
+            .arg(
+                VIEWING_KEYS.def().help(
+                    "List of new viewing keys with which to check note ownership. \
+                    These will be added to the shielded context."
+                )
+            )
+        }
+    }
+
+    impl CliToSdk<ShieldedSync<SdkTypes>> for ShieldedSync<CliTypes> {
+        fn to_sdk(self, ctx: &mut Context) -> ShieldedSync<SdkTypes> {
+            let chain_ctx = ctx.borrow_mut_chain_or_exit();
+            ShieldedSync {
+                ledger_address: (),
+                last_query_height: self.last_query_height,
+                spending_keys: self.spending_keys
+                    .iter()
+                    .map(|sk| chain_ctx.get_cached(sk))
+                    .collect(),
+                viewing_keys: self.viewing_keys
+                    .iter()
+                    .map(|vk| chain_ctx.get_cached(vk))
+                    .collect(),
+            }
+        }
+    }
+
     impl CliToSdk<GenIbcShieldedTransafer<SdkTypes>>
         for GenIbcShieldedTransafer<CliTypes>
     {
@@ -5885,6 +5971,7 @@ pub mod args {
         type TransferSource = WalletTransferSource;
         type TransferTarget = WalletTransferTarget;
         type ViewingKey = WalletViewingKey;
+        type SpendingKey = WalletSpendingKey;
     }
 
     impl CliToSdk<Tx<SdkTypes>> for Tx<CliTypes> {

--- a/crates/apps/src/lib/cli/client.rs
+++ b/crates/apps/src/lib/cli/client.rs
@@ -300,29 +300,32 @@ impl CliApi {
                     }
                     Sub::ShieldedSync(ShieldedSync(mut args)) => {
                         let client = client.unwrap_or_else(|| {
-                            C::from_tendermint_address(
-                                &mut args.ledger_address,
-                            )
+                            C::from_tendermint_address(&mut args.ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
                         let args = args.to_sdk(&mut ctx);
                         let mut chain_ctx = ctx.take_chain_or_exit();
-                        let sks = args.spending_keys
+                        let sks = args
+                            .spending_keys
                             .into_iter()
                             .map(|sk| sk.into())
                             .collect::<Vec<_>>();
-                        let vks = args.viewing_keys
+                        let vks = args
+                            .viewing_keys
                             .into_iter()
                             .map(|vk| vk.into())
                             .collect::<Vec<_>>();
                         _ = chain_ctx.shielded.load().await;
-                        chain_ctx.shielded.syncing(
-                            &client,
-                            &io,
-                            args.last_query_height,
-                            &sks,
-                            &vks,
-                        ).await?;
+                        chain_ctx
+                            .shielded
+                            .syncing(
+                                &client,
+                                &io,
+                                args.last_query_height,
+                                &sks,
+                                &vks,
+                            )
+                            .await?;
                     }
                     // Eth bridge
                     Sub::AddToEthBridgePool(args) => {

--- a/crates/apps/src/lib/client/rpc.rs
+++ b/crates/apps/src/lib/client/rpc.rs
@@ -849,13 +849,6 @@ pub async fn query_shielded_balance(
     {
         let mut shielded = context.shielded_mut().await;
         let _ = shielded.load().await;
-        let fvks: Vec<_> = viewing_keys
-            .iter()
-            .map(|fvk| ExtendedFullViewingKey::from(*fvk).fvk.vk)
-            .collect();
-        shielded.fetch(context.client(), &[], &fvks).await.unwrap();
-        // Save the update state so that future fetches can be short-circuited
-        let _ = shielded.save().await;
     }
     // The epoch is required to identify timestamped tokens
     let epoch = query_and_print_epoch(context).await;

--- a/crates/apps/src/lib/client/rpc.rs
+++ b/crates/apps/src/lib/client/rpc.rs
@@ -137,7 +137,6 @@ pub async fn query_transfers(
             context.client(),
             &query_owner,
             &query_token,
-            &wallet.get_viewing_keys(),
         )
         .await
         .unwrap();

--- a/crates/apps/src/lib/client/rpc.rs
+++ b/crates/apps/src/lib/client/rpc.rs
@@ -133,11 +133,7 @@ pub async fn query_transfers(
     let _ = shielded.load().await;
     // Obtain the effects of all shielded and transparent transactions
     let transfers = shielded
-        .query_tx_deltas(
-            context.client(),
-            &query_owner,
-            &query_token,
-        )
+        .query_tx_deltas(context.client(), &query_owner, &query_token)
         .await
         .unwrap();
     // To facilitate lookups of human-readable token names

--- a/crates/core/src/types/masp.rs
+++ b/crates/core/src/types/masp.rs
@@ -147,6 +147,13 @@ impl From<masp_primitives::zip32::ExtendedFullViewingKey>
     }
 }
 
+impl From<ExtendedViewingKey> for masp_primitives::sapling::ViewingKey {
+    fn from(value: ExtendedViewingKey) -> Self {
+        let fvk = masp_primitives::zip32::ExtendedFullViewingKey::from(value);
+        fvk.fvk.vk
+    }
+}
+
 impl serde::Serialize for ExtendedViewingKey {
     fn serialize<S>(
         &self,

--- a/crates/core/src/types/storage.rs
+++ b/crates/core/src/types/storage.rs
@@ -1,4 +1,5 @@
 //! Storage types
+use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Display;
@@ -1461,14 +1462,28 @@ impl<E> GetEventNonce for InnerEthEventsQueue<E> {
     BorshDeserialize,
     Eq,
     PartialEq,
-    Ord,
-    PartialOrd,
 )]
 pub struct IndexedTx {
     /// The block height of the indexed tx
     pub height: BlockHeight,
     /// The index in the block of the tx
     pub index: TxIndex,
+}
+
+impl PartialOrd for IndexedTx {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for IndexedTx {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.height == other.height {
+            self.index.cmp(&other.index)
+        } else {
+            self.height.cmp(&other.height)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/types/storage.rs
+++ b/crates/core/src/types/storage.rs
@@ -1454,14 +1454,7 @@ impl<E> GetEventNonce for InnerEthEventsQueue<E> {
 /// Represents the pointers of an indexed tx, which are the block height and the
 /// index inside that block
 #[derive(
-    Default,
-    Debug,
-    Copy,
-    Clone,
-    BorshSerialize,
-    BorshDeserialize,
-    Eq,
-    PartialEq,
+    Default, Debug, Copy, Clone, BorshSerialize, BorshDeserialize, Eq, PartialEq,
 )]
 pub struct IndexedTx {
     /// The block height of the indexed tx

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -96,11 +96,11 @@ impl NamadaTypes for SdkTypes {
     type Keypair = namada_core::types::key::common::SecretKey;
     type NativeAddress = Address;
     type PublicKey = namada_core::types::key::common::PublicKey;
+    type SpendingKey = namada_core::types::masp::ExtendedSpendingKey;
     type TendermintAddress = ();
     type TransferSource = namada_core::types::masp::TransferSource;
     type TransferTarget = namada_core::types::masp::TransferTarget;
     type ViewingKey = namada_core::types::masp::ExtendedViewingKey;
-    type SpendingKey = namada_core::types::masp::ExtendedSpendingKey;
 }
 
 /// Common query arguments

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -11,7 +11,7 @@ use namada_core::types::ethereum_events::EthAddress;
 use namada_core::types::keccak::KeccakHash;
 use namada_core::types::key::{common, SchemeType};
 use namada_core::types::masp::PaymentAddress;
-use namada_core::types::storage::Epoch;
+use namada_core::types::storage::{BlockHeight, Epoch};
 use namada_core::types::time::DateTimeUtc;
 use namada_core::types::{storage, token};
 use namada_governance::cli::onchain::{
@@ -56,6 +56,8 @@ pub trait NamadaTypes: Clone + std::fmt::Debug {
     type EthereumAddress: Clone + std::fmt::Debug;
     /// Represents a viewing key
     type ViewingKey: Clone + std::fmt::Debug;
+    /// Represents a spending key
+    type SpendingKey: Clone + std::fmt::Debug;
     /// Represents the owner of a balance
     type BalanceOwner: Clone + std::fmt::Debug;
     /// Represents a public key
@@ -98,6 +100,7 @@ impl NamadaTypes for SdkTypes {
     type TransferSource = namada_core::types::masp::TransferSource;
     type TransferTarget = namada_core::types::masp::TransferTarget;
     type ViewingKey = namada_core::types::masp::ExtendedViewingKey;
+    type SpendingKey = namada_core::types::masp::ExtendedSpendingKey;
 }
 
 /// Common query arguments
@@ -1821,6 +1824,21 @@ pub struct SignTx<C: NamadaTypes = SdkTypes> {
     pub tx_data: C::Data,
     /// The account address
     pub owner: C::Address,
+}
+
+#[derive(Clone, Debug)]
+/// Sync notes from MASP owned by the provided spending /
+/// viewing keys. Syncing can be told to stop at a given
+/// block height.
+pub struct ShieldedSync<C: NamadaTypes = SdkTypes> {
+    /// The ledger address
+    pub ledger_address: C::TendermintAddress,
+    /// Height to sync up to. Defaults to most recent
+    pub last_query_height: Option<BlockHeight>,
+    /// Spending keys used to determine note ownership
+    pub spending_keys: Vec<C::SpendingKey>,
+    /// Viewing keys used to determine note ownership
+    pub viewing_keys: Vec<C::ViewingKey>,
 }
 
 /// Query PoS commission rate

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -1965,6 +1965,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U, NotSyncing> {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub async fn syncing<C: Client + Sync>(
         self,
         client: &C,

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -1130,7 +1130,7 @@ fn transfer_on_chain(
         "--node",
         &rpc,
     ];
-    let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(120))?;
     client.exp_string(TX_ACCEPTED)?;
     client.exp_string(TX_APPLIED_SUCCESS)?;
     client.assert_success();
@@ -1297,6 +1297,16 @@ fn shielded_transfer(
 
     // Send a token to the shielded address on Chain A
     transfer_on_chain(test_a, ALBERT, AA_PAYMENT_ADDRESS, BTC, 10, ALBERT_KEY)?;
+    let rpc = get_actor_rpc(test_a, Who::Validator(0));
+    let tx_args = vec![
+        "shielded-sync",
+        "--viewing-keys",
+        AA_VIEWING_KEY,
+        "--node",
+        &rpc,
+    ];
+    let mut client = run!(test_a, Bin::Client, tx_args, Some(120))?;
+    client.assert_success();
 
     // Send a token from SP(A) on Chain A to PA(B) on Chain B
     let amount = Amount::native_whole(10).to_string_native();
@@ -1895,6 +1905,16 @@ fn check_shielded_balances(
 ) -> Result<()> {
     // Check the balance on Chain B
     std::env::set_var(ENV_VAR_CHAIN_ID, test_a.net.chain_id.to_string());
+    let rpc_b = get_actor_rpc(test_b, Who::Validator(0));
+    let tx_args = vec![
+        "shielded-sync",
+        "--viewing-keys",
+        AB_VIEWING_KEY,
+        "--node",
+        &rpc_b,
+    ];
+    let mut client = run!(test_a, Bin::Client, tx_args, Some(120))?;
+    client.assert_success();
     // PA(B) on Chain B has received BTC on chain A
     let token_addr = find_address(test_a, BTC)?.to_string();
     std::env::set_var(ENV_VAR_CHAIN_ID, test_b.net.chain_id.to_string());

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -187,7 +187,7 @@ fn run_ledger_ibc() -> Result<()> {
 }
 
 #[test]
-fn run_ledger_ibc_with_hermes() -> Result<()> {
+fn drun_ledger_ibc_with_hermes() -> Result<()> {
     let update_genesis =
         |mut genesis: templates::All<templates::Unvalidated>, base_dir: &_| {
             genesis.parameters.parameters.epochs_per_year = 31536;
@@ -1913,7 +1913,7 @@ fn check_shielded_balances(
         "--node",
         &rpc_b,
     ];
-    let mut client = run!(test_a, Bin::Client, tx_args, Some(120))?;
+    let mut client = run!(test_b, Bin::Client, tx_args, Some(120))?;
     client.assert_success();
     // PA(B) on Chain B has received BTC on chain A
     let token_addr = find_address(test_a, BTC)?.to_string();

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -1905,6 +1905,9 @@ fn check_shielded_balances(
 ) -> Result<()> {
     // Check the balance on Chain B
     std::env::set_var(ENV_VAR_CHAIN_ID, test_a.net.chain_id.to_string());
+    // PA(B) on Chain B has received BTC on chain A
+    let token_addr = find_address(test_a, BTC)?.to_string();
+    std::env::set_var(ENV_VAR_CHAIN_ID, test_b.net.chain_id.to_string());
     let rpc_b = get_actor_rpc(test_b, Who::Validator(0));
     let tx_args = vec![
         "shielded-sync",
@@ -1915,10 +1918,6 @@ fn check_shielded_balances(
     ];
     let mut client = run!(test_b, Bin::Client, tx_args, Some(120))?;
     client.assert_success();
-    // PA(B) on Chain B has received BTC on chain A
-    let token_addr = find_address(test_a, BTC)?.to_string();
-    std::env::set_var(ENV_VAR_CHAIN_ID, test_b.net.chain_id.to_string());
-    let rpc_b = get_actor_rpc(test_b, Who::Validator(0));
     let ibc_denom = format!("{dest_port_id}/{dest_channel_id}/btc");
     let query_args = vec![
         "balance",

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -767,6 +767,13 @@ fn wrapper_disposable_signer() -> Result<()> {
     client.exp_string(TX_APPLIED_SUCCESS)?;
     let _ep1 = epoch_sleep(&test, &validator_one_rpc, 720)?;
     let tx_args = vec![
+        "shielded-sync",
+        "--node",
+        &validator_one_rpc,
+    ];
+    let mut client = run!(test, Bin::Client, tx_args, Some(120))?;
+    client.assert_success();
+    let tx_args = vec![
         "transfer",
         "--source",
         ALBERT,

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -725,7 +725,7 @@ fn wrapper_disposable_signer() -> Result<()> {
         "--token",
         NAM,
         "--amount",
-        "50",
+        "50000",
         "--ledger-address",
         &validator_one_rpc,
     ];
@@ -735,6 +735,16 @@ fn wrapper_disposable_signer() -> Result<()> {
     client.exp_string(TX_APPLIED_SUCCESS)?;
 
     let _ep1 = epoch_sleep(&test, &validator_one_rpc, 720)?;
+    let tx_args = vec![
+        "shielded-sync",
+        "--viewing-keys",
+        AA_VIEWING_KEY,
+        "--node",
+        &validator_one_rpc,
+    ];
+    let mut client = run!(test, Bin::Client, tx_args, Some(120))?;
+    client.assert_success();
+
     let tx_args = vec![
         "transfer",
         "--source",

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -766,11 +766,7 @@ fn wrapper_disposable_signer() -> Result<()> {
     client.exp_string(TX_ACCEPTED)?;
     client.exp_string(TX_APPLIED_SUCCESS)?;
     let _ep1 = epoch_sleep(&test, &validator_one_rpc, 720)?;
-    let tx_args = vec![
-        "shielded-sync",
-        "--node",
-        &validator_one_rpc,
-    ];
+    let tx_args = vec!["shielded-sync", "--node", &validator_one_rpc];
     let mut client = run!(test, Bin::Client, tx_args, Some(120))?;
     client.assert_success();
     let tx_args = vec![

--- a/crates/tests/src/e2e/setup.rs
+++ b/crates/tests/src/e2e/setup.rs
@@ -287,7 +287,7 @@ where
         let mut sign_pre_genesis_txs = run_cmd(
             Bin::Client,
             args,
-            Some(5),
+            Some(10),
             &working_dir(),
             base_dir,
             format!("{}:{}", std::file!(), std::line!()),

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -717,6 +717,14 @@ fn masp_incentives() -> Result<()> {
     )?;
     node.assert_success();
 
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec!["shielded-sync", "--node", validator_one_rpc],
+    )?;
+    node.assert_success();
+
     // Assert NAM balance at VK(A) is 0
     let captured = CapturedOutput::of(|| {
         run(

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -50,6 +50,21 @@ fn masp_incentives() -> Result<()> {
     )?;
     node.assert_success();
 
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            AB_VIEWING_KEY,
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
+
     // Assert BTC balance at VK(A) is 1
     let captured = CapturedOutput::of(|| {
         run(
@@ -90,6 +105,18 @@ fn masp_incentives() -> Result<()> {
 
     // Wait till epoch boundary
     node.next_epoch();
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
 
     // Assert BTC balance at VK(A) is still 1
     let captured = CapturedOutput::of(|| {
@@ -152,6 +179,18 @@ fn masp_incentives() -> Result<()> {
 
     // Wait till epoch boundary
     node.next_epoch();
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
 
     // Assert BTC balance at VK(A) is still 1
     let captured = CapturedOutput::of(|| {
@@ -235,6 +274,18 @@ fn masp_incentives() -> Result<()> {
     )?;
     node.assert_success();
 
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
+
     // Assert ETH balance at VK(B) is 0.001
     let captured = CapturedOutput::of(|| {
         run(
@@ -275,6 +326,18 @@ fn masp_incentives() -> Result<()> {
 
     // Wait till epoch boundary
     node.next_epoch();
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
 
     // Assert ETH balance at VK(B) is still 0.001
     let captured = CapturedOutput::of(|| {
@@ -337,7 +400,6 @@ fn masp_incentives() -> Result<()> {
 
     // Wait till epoch boundary
     node.next_epoch();
-
     // Send 0.001 ETH from SK(B) to Christel
     run(
         &node,
@@ -360,6 +422,19 @@ fn masp_incentives() -> Result<()> {
     )?;
     node.assert_success();
 
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
+
+
     // Assert ETH balance at VK(B) is 0
     let captured = CapturedOutput::of(|| {
         run(
@@ -380,6 +455,17 @@ fn masp_incentives() -> Result<()> {
     assert!(captured.contains("No shielded eth balance found"));
 
     node.next_epoch();
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
 
     // Assert VK(B) retains the NAM rewards dispensed in the correct
     // amount.
@@ -402,6 +488,17 @@ fn masp_incentives() -> Result<()> {
     assert!(captured.contains("nam: 0.09112"));
 
     node.next_epoch();
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
 
     // Assert NAM balance at MASP pool is
     // the accumulation of rewards from the shielded assets (BTC and ETH)
@@ -442,6 +539,18 @@ fn masp_incentives() -> Result<()> {
             "1",
             "--signing-keys",
             ALBERT_KEY,
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
             "--node",
             validator_one_rpc,
         ],
@@ -508,6 +617,17 @@ fn masp_incentives() -> Result<()> {
 
     // Wait till epoch boundary
     node.next_epoch();
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
 
     // Assert NAM balance at VK(A) is the rewards dispensed earlier
     // (since VK(A) has no shielded assets, no further rewards should
@@ -574,7 +694,17 @@ fn masp_incentives() -> Result<()> {
     // Wait till epoch boundary to prevent conversion expiry during transaction
     // construction
     node.next_epoch();
-
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
     // Send all NAM rewards from SK(B) to Christel
     run(
         &node,
@@ -599,7 +729,17 @@ fn masp_incentives() -> Result<()> {
 
     // Wait till epoch boundary
     node.next_epoch();
-
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
     // Send all NAM rewards from SK(A) to Bertha
     run(
         &node,
@@ -641,6 +781,18 @@ fn masp_incentives() -> Result<()> {
     assert!(captured.result.is_ok());
     assert!(captured.contains("No shielded nam balance found"));
 
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
     // Assert NAM balance at VK(B) is 0
     let captured = CapturedOutput::of(|| {
         run(
@@ -698,6 +850,20 @@ fn masp_pinned_txs() -> Result<()> {
     let (mut node, _services) = setup::setup()?;
     // Wait till epoch boundary
     let _ep0 = node.next_epoch();
+
+    // sync shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AC_VIEWING_KEY,
+            "--node",
+            validator_one_rpc,
+        ]
+    )?;
+    node.assert_success();
 
     // Assert PPA(C) cannot be recognized by incorrect viewing key
     let captured =
@@ -768,6 +934,18 @@ fn masp_pinned_txs() -> Result<()> {
     // This makes it more consistent for some reason?
     let _ep2 = node.next_epoch();
 
+    // sync shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ]
+    )?;
+    node.assert_success();
+
     // Assert PPA(C) has the 20 BTC transaction pinned to it
     let captured =
         CapturedOutput::with_input(AC_VIEWING_KEY.into()).run(|| {
@@ -810,6 +988,18 @@ fn masp_pinned_txs() -> Result<()> {
 
     // Wait till epoch boundary
     let _ep1 = node.next_epoch();
+
+    // sync shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ]
+    )?;
+    node.assert_success();
 
     // Assert PPA(C) does not NAM pinned to it on epoch boundary
     let captured =
@@ -865,6 +1055,22 @@ fn masp_txs_and_queries() -> Result<()> {
 
     let (mut node, _services) = setup::setup()?;
     _ = node.next_epoch();
+
+    // add necessary viewing keys to shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            AB_VIEWING_KEY,
+            "--node",
+            validator_one_rpc,
+        ]
+    )?;
+    node.assert_success();
+
     let txs_args = vec![
         // 0. Attempt to spend 10 BTC at SK(A) to PA(B)
         (
@@ -1075,11 +1281,26 @@ fn masp_txs_and_queries() -> Result<()> {
     ];
 
     for (tx_args, tx_result) in &txs_args {
-        // We ensure transfers don't cross epoch boundaries.
-        if tx_args[0] == "transfer" {
+        // sync shielded context
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "shielded-sync",
+                "--node",
+                validator_one_rpc,
+            ]
+        )?;
+        node.assert_success();
+        // there is no need to dry run balance queries
+        let dry_run_args = if tx_args[0] == "transfer" {
+            // We ensure transfers don't cross epoch boundaries.
             node.next_epoch();
-        }
-        for &dry_run in &[true, false] {
+            vec![true, false]
+        } else {
+            vec![false]
+        };
+        for &dry_run in &dry_run_args {
             let tx_args = if dry_run && tx_args[0] == "transfer" {
                 vec![tx_args.clone(), vec!["--dry-run"]].concat()
             } else {
@@ -1191,6 +1412,21 @@ fn wrapper_fee_unshielding() -> Result<()> {
     node.assert_success();
 
     _ = node.next_epoch();
+    // sync shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            AB_VIEWING_KEY,
+            "--node",
+            validator_one_rpc,
+        ]
+    )?;
+    node.assert_success();
+
     // 2. Valid unshielding
     run(
         &node,
@@ -1212,6 +1448,18 @@ fn wrapper_fee_unshielding() -> Result<()> {
             "--ledger-address",
             validator_one_rpc,
         ],
+    )?;
+    node.assert_success();
+
+    // sync shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--node",
+            validator_one_rpc,
+        ]
     )?;
     node.assert_success();
 
@@ -1277,6 +1525,20 @@ fn cross_epoch_tx() -> Result<()> {
             "--ledger-address",
             validator_one_rpc,
         ],
+    )?;
+    node.assert_success();
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            "--node",
+            validator_one_rpc,
+        ]
     )?;
     node.assert_success();
 

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -110,11 +110,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -184,11 +180,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -278,11 +270,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -331,11 +319,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -426,14 +410,9 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
-
 
     // Assert ETH balance at VK(B) is 0
     let captured = CapturedOutput::of(|| {
@@ -459,11 +438,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -492,11 +467,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -549,11 +520,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -621,11 +588,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -698,11 +661,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
     // Send all NAM rewards from SK(B) to Christel
@@ -733,11 +692,7 @@ fn masp_incentives() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
     // Send all NAM rewards from SK(A) to Bertha
@@ -781,16 +736,11 @@ fn masp_incentives() -> Result<()> {
     assert!(captured.result.is_ok());
     assert!(captured.contains("No shielded nam balance found"));
 
-
     // sync the shielded context
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ],
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
     // Assert NAM balance at VK(B) is 0
@@ -861,7 +811,7 @@ fn masp_pinned_txs() -> Result<()> {
             AC_VIEWING_KEY,
             "--node",
             validator_one_rpc,
-        ]
+        ],
     )?;
     node.assert_success();
 
@@ -938,11 +888,7 @@ fn masp_pinned_txs() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ]
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -993,11 +939,7 @@ fn masp_pinned_txs() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ]
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -1067,7 +1009,7 @@ fn masp_txs_and_queries() -> Result<()> {
             AB_VIEWING_KEY,
             "--node",
             validator_one_rpc,
-        ]
+        ],
     )?;
     node.assert_success();
 
@@ -1285,11 +1227,7 @@ fn masp_txs_and_queries() -> Result<()> {
         run(
             &node,
             Bin::Client,
-            vec![
-                "shielded-sync",
-                "--node",
-                validator_one_rpc,
-            ]
+            vec!["shielded-sync", "--node", validator_one_rpc],
         )?;
         node.assert_success();
         // there is no need to dry run balance queries
@@ -1423,7 +1361,7 @@ fn wrapper_fee_unshielding() -> Result<()> {
             AB_VIEWING_KEY,
             "--node",
             validator_one_rpc,
-        ]
+        ],
     )?;
     node.assert_success();
 
@@ -1455,11 +1393,7 @@ fn wrapper_fee_unshielding() -> Result<()> {
     run(
         &node,
         Bin::Client,
-        vec![
-            "shielded-sync",
-            "--node",
-            validator_one_rpc,
-        ]
+        vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
     node.assert_success();
 
@@ -1538,7 +1472,7 @@ fn cross_epoch_tx() -> Result<()> {
             AA_VIEWING_KEY,
             "--node",
             validator_one_rpc,
-        ]
+        ],
     )?;
     node.assert_success();
 


### PR DESCRIPTION
## Describe your changes
Previously, the scanning of MASP notes was done as part of various MASP commands. This moves that logic into a separate command so that it can be done out of band.

## Indicate on which release or other PRs this topic is based on
#2363 
## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
