### PR TITLE
Make BIP39 passphrase optional

### DIFF
--- a/.changelog/unreleased/features/2417-wallet-zip32-0.30.1.md
+++ b/.changelog/unreleased/features/2417-wallet-zip32-0.30.1.md
@@ -1,0 +1,2 @@
+- Implemented ZIP32 functionality for shielded pool keys.
+  ([\#2417](https://github.com/anoma/namada/pull/2417))

--- a/.changelog/unreleased/improvements/2442-bip39-optional-0.30.1.md
+++ b/.changelog/unreleased/improvements/2442-bip39-optional-0.30.1.md
@@ -1,0 +1,2 @@
+- BIP39 passphrase made optional.
+  ([\#2442](https://github.com/anoma/namada/pull/2442))

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -2975,8 +2975,10 @@ pub mod args {
         arg("validator");
     pub const HALT_ACTION: ArgFlag = flag("halt");
     pub const HASH_LIST: Arg<String> = arg("hash-list");
-    pub const HD_WALLET_DERIVATION_PATH: ArgDefault<String> =
+    pub const HD_DERIVATION_PATH: ArgDefault<String> =
         arg_default("hd-path", DefaultFn(|| "default".to_string()));
+    pub const HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH: ArgFlag =
+        flag("allow-non-compliant");
     pub const HISTORIC: ArgFlag = flag("historic");
     pub const IBC_TRANSFER_MEMO_PATH: ArgOpt<PathBuf> = arg_opt("memo-path");
     pub const INPUT_OPT: ArgOpt<PathBuf> = arg_opt("input");
@@ -6196,7 +6198,9 @@ pub mod args {
             let alias_force = ALIAS_FORCE.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             let use_device = USE_DEVICE.parse(matches);
-            let derivation_path = HD_WALLET_DERIVATION_PATH.parse(matches);
+            let derivation_path = HD_DERIVATION_PATH.parse(matches);
+            let allow_non_compliant =
+                HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.parse(matches);
             Self {
                 scheme,
                 shielded,
@@ -6205,6 +6209,7 @@ pub mod args {
                 unsafe_dont_encrypt,
                 use_device,
                 derivation_path,
+                allow_non_compliant,
             }
         }
 
@@ -6234,14 +6239,29 @@ pub mod args {
                 "Derive an address and public key from the seed stored on the \
                  connected hardware wallet.",
             ))
-            .arg(HD_WALLET_DERIVATION_PATH.def().help(
+            .arg(HD_DERIVATION_PATH.def().help(
                 "HD key derivation path. Use keyword `default` to refer to a \
-                 scheme default path:\n- m/44'/60'/0'/0/0 for secp256k1 \
-                 scheme\n- m/44'/877'/0'/0'/0' for ed25519 scheme.\nFor \
-                 ed25519, all path indices will be promoted to hardened \
-                 indexes. If none is specified, the scheme default path is \
-                 used.",
+                 scheme default path:\n- m/44'/60'/0'/0/0 for the transparent \
+                 secp256k1 scheme\n- m/44'/877'/0'/0'/0' for the transparent \
+                 ed25519 scheme\n- m/32'/877'/0' for the shielded \
+                 setting\nFor ed25519 scheme, all path indices will be \
+                 promoted to hardened indexes. If none is specified, the \
+                 scheme default path is used.",
             ))
+            .arg(HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.def().help(
+                "Allow non-compliant HD derivation path. The compliant \
+                 derivation path schemes include:\n- \
+                 m/44'/60'/account'/change/address_index for the transparent \
+                 secp256k1 scheme\n- \
+                 m/44'/877'/account'/change'/address_index' for the \
+                 transparent ed25519 scheme\n- m/32'/877'/account' and\n- \
+                 m/32'/877'/account'/address_index for the shielded setting",
+            ))
+            .group(
+                ArgGroup::new("requires_group")
+                    .args([HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.name])
+                    .requires(HD_DERIVATION_PATH.name),
+            )
         }
     }
 
@@ -6253,7 +6273,9 @@ pub mod args {
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
-            let derivation_path = HD_WALLET_DERIVATION_PATH.parse(matches);
+            let derivation_path = HD_DERIVATION_PATH.parse(matches);
+            let allow_non_compliant =
+                HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.parse(matches);
             Self {
                 scheme,
                 shielded,
@@ -6262,6 +6284,7 @@ pub mod args {
                 alias_force,
                 unsafe_dont_encrypt,
                 derivation_path,
+                allow_non_compliant,
             }
         }
 
@@ -6280,7 +6303,7 @@ pub mod args {
             .arg(
                 RAW_KEY_GEN
                     .def()
-                    .conflicts_with(HD_WALLET_DERIVATION_PATH.name)
+                    .conflicts_with(HD_DERIVATION_PATH.name)
                     .help(
                         "Generate a random non-HD secret / spending key. No \
                          mnemonic code is generated.",
@@ -6294,14 +6317,29 @@ pub mod args {
                 "UNSAFE: Do not encrypt the keypair. Do not use this for keys \
                  used in a live network.",
             ))
-            .arg(HD_WALLET_DERIVATION_PATH.def().help(
+            .arg(HD_DERIVATION_PATH.def().help(
                 "HD key derivation path. Use keyword `default` to refer to a \
-                 scheme default path:\n- m/44'/60'/0'/0/0 for secp256k1 \
-                 scheme\n- m/44'/877'/0'/0'/0' for ed25519 scheme.\nFor \
-                 ed25519, all path indices will be promoted to hardened \
-                 indexes. If none is specified, the scheme default path is \
-                 used.",
+                 scheme default path:\n- m/44'/60'/0'/0/0 for the transparent \
+                 secp256k1 scheme\n- m/44'/877'/0'/0'/0' for the transparent \
+                 ed25519 scheme\n- m/32'/877'/0' for the shielded \
+                 setting\nFor ed25519 scheme, all path indices will be \
+                 promoted to hardened indexes. If none is specified, the \
+                 scheme default path is used.",
             ))
+            .arg(HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.def().help(
+                "Allow non-compliant HD derivation path. The compliant \
+                 derivation path schemes include:\n- \
+                 m/44'/60'/account'/change/address_index for the transparent \
+                 secp256k1 scheme\n- \
+                 m/44'/877'/account'/change'/address_index' for the \
+                 transparent ed25519 scheme\n- m/32'/877'/account' and\n- \
+                 m/32'/877'/account'/address_index for the shielded setting",
+            ))
+            .group(
+                ArgGroup::new("requires_group")
+                    .args([HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.name])
+                    .requires(HD_DERIVATION_PATH.name),
+            )
         }
     }
 

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -2979,6 +2979,7 @@ pub mod args {
         arg_default("hd-path", DefaultFn(|| "default".to_string()));
     pub const HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH: ArgFlag =
         flag("allow-non-compliant");
+    pub const HD_PROMPT_BIP39_PASSPHRASE: ArgFlag = flag("bip39-passphrase");
     pub const HISTORIC: ArgFlag = flag("historic");
     pub const IBC_TRANSFER_MEMO_PATH: ArgOpt<PathBuf> = arg_opt("memo-path");
     pub const INPUT_OPT: ArgOpt<PathBuf> = arg_opt("input");
@@ -6201,6 +6202,8 @@ pub mod args {
             let derivation_path = HD_DERIVATION_PATH.parse(matches);
             let allow_non_compliant =
                 HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.parse(matches);
+            let prompt_bip39_passphrase =
+                HD_PROMPT_BIP39_PASSPHRASE.parse(matches);
             Self {
                 scheme,
                 shielded,
@@ -6210,6 +6213,7 @@ pub mod args {
                 use_device,
                 derivation_path,
                 allow_non_compliant,
+                prompt_bip39_passphrase,
             }
         }
 
@@ -6262,6 +6266,11 @@ pub mod args {
                     .args([HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.name])
                     .requires(HD_DERIVATION_PATH.name),
             )
+            .arg(
+                HD_PROMPT_BIP39_PASSPHRASE.def().help(
+                    "Use an additional passphrase for HD-key generation.",
+                ),
+            )
         }
     }
 
@@ -6276,6 +6285,8 @@ pub mod args {
             let derivation_path = HD_DERIVATION_PATH.parse(matches);
             let allow_non_compliant =
                 HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.parse(matches);
+            let prompt_bip39_passphrase =
+                HD_PROMPT_BIP39_PASSPHRASE.parse(matches);
             Self {
                 scheme,
                 shielded,
@@ -6285,6 +6296,7 @@ pub mod args {
                 unsafe_dont_encrypt,
                 derivation_path,
                 allow_non_compliant,
+                prompt_bip39_passphrase,
             }
         }
 
@@ -6339,6 +6351,11 @@ pub mod args {
                 ArgGroup::new("requires_group")
                     .args([HD_ALLOW_NON_COMPLIANT_DERIVATION_PATH.name])
                     .requires(HD_DERIVATION_PATH.name),
+            )
+            .arg(
+                HD_PROMPT_BIP39_PASSPHRASE.def().help(
+                    "Use an additional passphrase for HD-key generation.",
+                ),
             )
         }
     }

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -284,16 +284,17 @@ fn shielded_key_address_add(
 }
 
 /// Decode the derivation path from the given string unless it is "default",
-/// in which case use the default derivation path for the given scheme.
-pub fn decode_derivation_path(
+/// in which case use the default derivation path for the given transparent
+/// scheme.
+pub fn decode_transparent_derivation_path(
     scheme: SchemeType,
     derivation_path: String,
 ) -> Result<DerivationPath, DerivationPathError> {
     let is_default = derivation_path.eq_ignore_ascii_case("DEFAULT");
     let parsed_derivation_path = if is_default {
-        DerivationPath::default_for_scheme(scheme)
+        DerivationPath::default_for_transparent_scheme(scheme)
     } else {
-        DerivationPath::from_path_str(scheme, &derivation_path)?
+        DerivationPath::from_path_string_for_scheme(scheme, &derivation_path)?
     };
     if !parsed_derivation_path.is_compatible(scheme) {
         println!(
@@ -321,11 +322,12 @@ async fn transparent_key_and_address_derive(
     }: args::KeyDerive,
 ) {
     let mut wallet = load_wallet(ctx);
-    let derivation_path = decode_derivation_path(scheme, derivation_path)
-        .unwrap_or_else(|err| {
-            edisplay_line!(io, "{}", err);
-            cli::safe_exit(1)
-        });
+    let derivation_path =
+        decode_transparent_derivation_path(scheme, derivation_path)
+            .unwrap_or_else(|err| {
+                edisplay_line!(io, "{}", err);
+                cli::safe_exit(1)
+            });
     let alias = alias.to_lowercase();
     let alias = if !use_device {
         let encryption_password =
@@ -430,11 +432,12 @@ fn transparent_key_and_address_gen(
             &mut OsRng,
         )
     } else {
-        let derivation_path = decode_derivation_path(scheme, derivation_path)
-            .unwrap_or_else(|err| {
-                edisplay_line!(io, "{}", err);
-                cli::safe_exit(1)
-            });
+        let derivation_path =
+            decode_transparent_derivation_path(scheme, derivation_path)
+                .unwrap_or_else(|err| {
+                    edisplay_line!(io, "{}", err);
+                    cli::safe_exit(1)
+                });
         let (_mnemonic, seed) =
             Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng)
                 .unwrap_or_else(|err| {

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -246,11 +246,7 @@ fn shielded_key_gen(
                 cli::safe_exit(1)
             });
         let (_mnemonic, seed) =
-            Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng)
-                .unwrap_or_else(|err| {
-                    edisplay_line!(io, "{}", err);
-                    cli::safe_exit(1)
-                });
+            Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng);
         wallet.derive_store_hd_spendind_key(
             alias,
             alias_force,
@@ -443,8 +439,8 @@ async fn transparent_key_and_address_derive(
                 None,
                 encryption_password,
             )
-            .unwrap_or_else(|err| {
-                edisplay_line!(io, "{}", err);
+            .unwrap_or_else(|| {
+                edisplay_line!(io, "Failed to derive a keypair.");
                 display_line!(io, "No changes are persisted. Exiting.");
                 cli::safe_exit(1)
             })
@@ -541,11 +537,7 @@ fn transparent_key_and_address_gen(
                     cli::safe_exit(1)
                 });
         let (_mnemonic, seed) =
-            Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng)
-                .unwrap_or_else(|err| {
-                    edisplay_line!(io, "{}", err);
-                    cli::safe_exit(1)
-                });
+            Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng);
         wallet.derive_store_hd_secret_key(
             scheme,
             Some(alias),
@@ -556,8 +548,8 @@ fn transparent_key_and_address_gen(
         )
     }
     .map(|x| x.0)
-    .unwrap_or_else(|err| {
-        eprintln!("{}", err);
+    .unwrap_or_else(|| {
+        edisplay_line!(io, "Failed to generate a keypair.");
         println!("No changes are persisted. Exiting.");
         cli::safe_exit(0);
     });
@@ -1266,8 +1258,8 @@ fn transparent_secret_key_add(
         read_and_confirm_encryption_password(unsafe_dont_encrypt);
     let alias = wallet
         .insert_keypair(alias, alias_force, sk, encryption_password, None, None)
-        .unwrap_or_else(|err| {
-            edisplay_line!(io, "{}", err);
+        .unwrap_or_else(|| {
+            edisplay_line!(io, "Failed to add a keypair.");
             display_line!(io, "No changes are persisted. Exiting.");
             cli::safe_exit(1);
         });

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -263,7 +263,7 @@ fn shielded_key_gen(
     .unwrap_or_else(|| {
         eprintln!("Failed to generate a key.");
         println!("No changes are persisted. Exiting.");
-        cli::safe_exit(0);
+        cli::safe_exit(1);
     });
 
     wallet

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -239,6 +239,7 @@ fn shielded_key_gen(
         unsafe_dont_encrypt,
         derivation_path,
         allow_non_compliant,
+        prompt_bip39_passphrase,
         ..
     }: args::KeyGen,
 ) {
@@ -261,8 +262,11 @@ fn shielded_key_gen(
             display_line!(io, "No changes are persisted. Exiting.");
             cli::safe_exit(1)
         }
-        let (_mnemonic, seed) =
-            Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng);
+        let (_mnemonic, seed) = Wallet::<CliWalletUtils>::gen_hd_seed(
+            None,
+            &mut OsRng,
+            prompt_bip39_passphrase,
+        );
         wallet.derive_store_hd_spendind_key(
             alias,
             alias_force,
@@ -535,6 +539,7 @@ fn transparent_key_and_address_gen(
         unsafe_dont_encrypt,
         derivation_path,
         allow_non_compliant,
+        prompt_bip39_passphrase,
         ..
     }: args::KeyGen,
 ) {
@@ -565,8 +570,11 @@ fn transparent_key_and_address_gen(
             display_line!(io, "No changes are persisted. Exiting.");
             cli::safe_exit(1)
         }
-        let (_mnemonic, seed) =
-            Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng);
+        let (_mnemonic, seed) = Wallet::<CliWalletUtils>::gen_hd_seed(
+            None,
+            &mut OsRng,
+            prompt_bip39_passphrase,
+        );
         wallet.derive_store_hd_secret_key(
             scheme,
             Some(alias),

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -435,15 +435,12 @@ fn transparent_key_and_address_gen(
                 edisplay_line!(io, "{}", err);
                 cli::safe_exit(1)
             });
-        let (_mnemonic, seed) = Wallet::<CliWalletUtils>::gen_hd_seed(
-            None,
-            &mut OsRng,
-            unsafe_dont_encrypt,
-        )
-        .unwrap_or_else(|err| {
-            edisplay_line!(io, "{}", err);
-            cli::safe_exit(1)
-        });
+        let (_mnemonic, seed) =
+            Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng)
+                .unwrap_or_else(|err| {
+                    edisplay_line!(io, "{}", err);
+                    cli::safe_exit(1)
+                });
         wallet.derive_store_hd_secret_key(
             scheme,
             Some(alias),

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -377,7 +377,7 @@ async fn transparent_key_and_address_derive(
         let encryption_password =
             read_and_confirm_encryption_password(unsafe_dont_encrypt);
         wallet
-            .derive_key_from_mnemonic_code(
+            .derive_store_key_from_mnemonic_code(
                 scheme,
                 Some(alias),
                 alias_force,

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -338,7 +338,13 @@ fn shielded_key_address_add(
             let password =
                 read_and_confirm_encryption_password(unsafe_dont_encrypt);
             let alias = wallet
-                .insert_spending_key(alias, spending_key, password, alias_force)
+                .insert_spending_key(
+                    alias,
+                    alias_force,
+                    spending_key,
+                    password,
+                    None,
+                )
                 .unwrap_or_else(|| {
                     edisplay_line!(io, "Spending key not added");
                     cli::safe_exit(1);

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -188,6 +188,12 @@ fn shielded_key_derive(
             edisplay_line!(io, "{}", err);
             cli::safe_exit(1)
         });
+    println!("Using HD derivation path {}", derivation_path);
+    if !derivation_path.is_namada_shielded_compliant() {
+        display_line!(io, "Path {} is not compliant.", derivation_path);
+        display_line!(io, "No changes are persisted. Exiting.");
+        cli::safe_exit(1)
+    }
     let alias = alias.to_lowercase();
     let alias = if !use_device {
         let encryption_password =
@@ -245,6 +251,12 @@ fn shielded_key_gen(
                 edisplay_line!(io, "{}", err);
                 cli::safe_exit(1)
             });
+        println!("Using HD derivation path {}", derivation_path);
+        if !derivation_path.is_namada_shielded_compliant() {
+            display_line!(io, "Path {} is not compliant.", derivation_path);
+            display_line!(io, "No changes are persisted. Exiting.");
+            cli::safe_exit(1)
+        }
         let (_mnemonic, seed) =
             Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng);
         wallet.derive_store_hd_spendind_key(
@@ -377,15 +389,11 @@ pub fn decode_transparent_derivation_path(
     let parsed_derivation_path = if is_default {
         DerivationPath::default_for_transparent_scheme(scheme)
     } else {
-        DerivationPath::from_path_string_for_scheme(scheme, &derivation_path)?
+        DerivationPath::from_path_string_for_transparent_scheme(
+            scheme,
+            &derivation_path,
+        )?
     };
-    if !parsed_derivation_path.is_compatible(scheme) {
-        println!(
-            "WARNING: the specified derivation path may be incompatible with \
-             the chosen cryptography scheme."
-        )
-    }
-    println!("Using HD derivation path {}", parsed_derivation_path);
     Ok(parsed_derivation_path)
 }
 
@@ -400,7 +408,6 @@ pub fn decode_shielded_derivation_path(
     } else {
         DerivationPath::from_path_string(&derivation_path)?
     };
-    println!("Using HD derivation path {}", parsed_derivation_path);
     Ok(parsed_derivation_path)
 }
 
@@ -426,6 +433,12 @@ async fn transparent_key_and_address_derive(
                 edisplay_line!(io, "{}", err);
                 cli::safe_exit(1)
             });
+    println!("Using HD derivation path {}", derivation_path);
+    if !derivation_path.is_namada_transparent_compliant(scheme) {
+        display_line!(io, "Path {} is not compliant.", derivation_path);
+        display_line!(io, "No changes are persisted. Exiting.");
+        cli::safe_exit(1)
+    }
     let alias = alias.to_lowercase();
     let alias = if !use_device {
         let encryption_password =
@@ -536,6 +549,12 @@ fn transparent_key_and_address_gen(
                     edisplay_line!(io, "{}", err);
                     cli::safe_exit(1)
                 });
+        println!("Using HD derivation path {}", derivation_path);
+        if !derivation_path.is_namada_transparent_compliant(scheme) {
+            display_line!(io, "Path {} is not compliant.", derivation_path);
+            display_line!(io, "No changes are persisted. Exiting.");
+            cli::safe_exit(1)
+        }
         let (_mnemonic, seed) =
             Wallet::<CliWalletUtils>::gen_hd_seed(None, &mut OsRng);
         wallet.derive_store_hd_secret_key(

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -178,6 +178,7 @@ fn shielded_key_derive(
         alias_force,
         unsafe_dont_encrypt,
         derivation_path,
+        allow_non_compliant,
         use_device,
         ..
     }: args::KeyDerive,
@@ -189,7 +190,7 @@ fn shielded_key_derive(
             cli::safe_exit(1)
         });
     println!("Using HD derivation path {}", derivation_path);
-    if !derivation_path.is_namada_shielded_compliant() {
+    if !allow_non_compliant && !derivation_path.is_namada_shielded_compliant() {
         display_line!(io, "Path {} is not compliant.", derivation_path);
         display_line!(io, "No changes are persisted. Exiting.");
         cli::safe_exit(1)
@@ -237,6 +238,7 @@ fn shielded_key_gen(
         alias_force,
         unsafe_dont_encrypt,
         derivation_path,
+        allow_non_compliant,
         ..
     }: args::KeyGen,
 ) {
@@ -252,7 +254,9 @@ fn shielded_key_gen(
                 cli::safe_exit(1)
             });
         println!("Using HD derivation path {}", derivation_path);
-        if !derivation_path.is_namada_shielded_compliant() {
+        if !allow_non_compliant
+            && !derivation_path.is_namada_shielded_compliant()
+        {
             display_line!(io, "Path {} is not compliant.", derivation_path);
             display_line!(io, "No changes are persisted. Exiting.");
             cli::safe_exit(1)
@@ -422,6 +426,7 @@ async fn transparent_key_and_address_derive(
         alias_force,
         unsafe_dont_encrypt,
         derivation_path,
+        allow_non_compliant,
         use_device,
         ..
     }: args::KeyDerive,
@@ -434,7 +439,9 @@ async fn transparent_key_and_address_derive(
                 cli::safe_exit(1)
             });
     println!("Using HD derivation path {}", derivation_path);
-    if !derivation_path.is_namada_transparent_compliant(scheme) {
+    if !allow_non_compliant
+        && !derivation_path.is_namada_transparent_compliant(scheme)
+    {
         display_line!(io, "Path {} is not compliant.", derivation_path);
         display_line!(io, "No changes are persisted. Exiting.");
         cli::safe_exit(1)
@@ -527,6 +534,7 @@ fn transparent_key_and_address_gen(
         alias_force,
         unsafe_dont_encrypt,
         derivation_path,
+        allow_non_compliant,
         ..
     }: args::KeyGen,
 ) {
@@ -550,7 +558,9 @@ fn transparent_key_and_address_gen(
                     cli::safe_exit(1)
                 });
         println!("Using HD derivation path {}", derivation_path);
-        if !derivation_path.is_namada_transparent_compliant(scheme) {
+        if !allow_non_compliant
+            && !derivation_path.is_namada_transparent_compliant(scheme)
+        {
             display_line!(io, "Path {} is not compliant.", derivation_path);
             display_line!(io, "No changes are persisted. Exiting.");
             cli::safe_exit(1)

--- a/crates/apps/src/lib/client/tx.rs
+++ b/crates/apps/src/lib/client/tx.rs
@@ -689,7 +689,9 @@ pub async fn submit_become_validator(
             None,
             None,
         )
-        .map_err(|err| error::Error::Other(err.to_string()))?;
+        .ok_or(error::Error::Other(String::from(
+            "Failed to store the keypair.",
+        )))?;
 
     let tx_code_hash =
         query_wasm_code_hash(namada, tx_code_path.to_string_lossy())

--- a/crates/apps/src/lib/wallet/mod.rs
+++ b/crates/apps/src/lib/wallet/mod.rs
@@ -12,7 +12,7 @@ pub use namada_sdk::wallet::alias::Alias;
 use namada_sdk::wallet::fs::FsWalletStorage;
 use namada_sdk::wallet::store::Store;
 use namada_sdk::wallet::{
-    ConfirmationResponse, FindKeyError, GenDeriveKeyError, Wallet, WalletIo,
+    ConfirmationResponse, FindKeyError, Wallet, WalletIo,
 };
 pub use namada_sdk::wallet::{ValidatorData, ValidatorKeys};
 use rand_core::OsRng;
@@ -85,11 +85,14 @@ impl WalletIo for CliWalletUtils {
         alias.trim().to_owned()
     }
 
-    fn read_mnemonic_code() -> Result<Mnemonic, GenDeriveKeyError> {
+    fn read_mnemonic_code() -> Option<Mnemonic> {
         let phrase = get_secure_user_input("Input mnemonic code: ")
-            .map_err(|_| GenDeriveKeyError::MnemonicInputError)?;
-        Mnemonic::from_phrase(phrase.as_ref(), Language::English)
-            .map_err(|_| GenDeriveKeyError::MnemonicInputError)
+            .unwrap_or_else(|e| {
+                eprintln!("{}", e);
+                eprintln!("Action cancelled, no changes persisted.");
+                cli::safe_exit(1)
+            });
+        Mnemonic::from_phrase(phrase.as_ref(), Language::English).ok()
     }
 
     fn read_mnemonic_passphrase(confirm: bool) -> Zeroizing<String> {
@@ -295,11 +298,9 @@ mod tests {
 
         let mut rng = rand_core::OsRng;
         let mnemonic1 =
-            CliWalletUtils::generate_mnemonic_code(MNEMONIC_TYPE, &mut rng)
-                .unwrap();
+            CliWalletUtils::generate_mnemonic_code(MNEMONIC_TYPE, &mut rng);
         let mnemonic2 =
-            CliWalletUtils::generate_mnemonic_code(MNEMONIC_TYPE, &mut rng)
-                .unwrap();
+            CliWalletUtils::generate_mnemonic_code(MNEMONIC_TYPE, &mut rng);
         assert_ne!(mnemonic1.into_phrase(), mnemonic2.into_phrase());
     }
 }

--- a/crates/apps/src/lib/wallet/mod.rs
+++ b/crates/apps/src/lib/wallet/mod.rs
@@ -12,7 +12,7 @@ pub use namada_sdk::wallet::alias::Alias;
 use namada_sdk::wallet::fs::FsWalletStorage;
 use namada_sdk::wallet::store::Store;
 use namada_sdk::wallet::{
-    ConfirmationResponse, FindKeyError, GenRestoreKeyError, Wallet, WalletIo,
+    ConfirmationResponse, FindKeyError, GenDeriveKeyError, Wallet, WalletIo,
 };
 pub use namada_sdk::wallet::{ValidatorData, ValidatorKeys};
 use rand_core::OsRng;
@@ -85,11 +85,11 @@ impl WalletIo for CliWalletUtils {
         alias.trim().to_owned()
     }
 
-    fn read_mnemonic_code() -> Result<Mnemonic, GenRestoreKeyError> {
+    fn read_mnemonic_code() -> Result<Mnemonic, GenDeriveKeyError> {
         let phrase = get_secure_user_input("Input mnemonic code: ")
-            .map_err(|_| GenRestoreKeyError::MnemonicInputError)?;
+            .map_err(|_| GenDeriveKeyError::MnemonicInputError)?;
         Mnemonic::from_phrase(phrase.as_ref(), Language::English)
-            .map_err(|_| GenRestoreKeyError::MnemonicInputError)
+            .map_err(|_| GenDeriveKeyError::MnemonicInputError)
     }
 
     fn read_mnemonic_passphrase(confirm: bool) -> Zeroizing<String> {

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -2112,6 +2112,8 @@ pub struct KeyGen {
     pub unsafe_dont_encrypt: bool,
     /// BIP44 / ZIP32 derivation path
     pub derivation_path: String,
+    /// Allow non-compliant derivation path
+    pub allow_non_compliant: bool,
 }
 
 /// Wallet restore key and implicit address arguments
@@ -2129,6 +2131,8 @@ pub struct KeyDerive {
     pub unsafe_dont_encrypt: bool,
     /// BIP44 / ZIP32 derivation path
     pub derivation_path: String,
+    /// Allow non-compliant derivation path
+    pub allow_non_compliant: bool,
     /// Use device to generate key and address
     pub use_device: bool,
 }

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -2127,7 +2127,7 @@ pub struct KeyDerive {
     pub alias_force: bool,
     /// Don't encrypt the keypair
     pub unsafe_dont_encrypt: bool,
-    /// BIP44 derivation path
+    /// BIP44 / ZIP32 derivation path
     pub derivation_path: String,
     /// Use device to generate key and address
     pub use_device: bool,

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -2112,6 +2112,8 @@ pub struct KeyGen {
     pub unsafe_dont_encrypt: bool,
     /// BIP44 / ZIP32 derivation path
     pub derivation_path: String,
+    /// Prompt for BIP39 passphrase
+    pub prompt_bip39_passphrase: bool,
     /// Allow non-compliant derivation path
     pub allow_non_compliant: bool,
 }
@@ -2133,6 +2135,8 @@ pub struct KeyDerive {
     pub derivation_path: String,
     /// Allow non-compliant derivation path
     pub allow_non_compliant: bool,
+    /// Prompt for BIP39 passphrase
+    pub prompt_bip39_passphrase: bool,
     /// Use device to generate key and address
     pub use_device: bool,
 }

--- a/crates/sdk/src/wallet/derivation_path.rs
+++ b/crates/sdk/src/wallet/derivation_path.rs
@@ -45,8 +45,9 @@ impl DerivationPath {
     }
 
     fn bip44_base_indexes_for_scheme(scheme: SchemeType) -> Vec<ChildIndex> {
+        const BIP44_PURPOSE: u32 = 44;
         vec![
-            ChildIndex::Hardened(44),
+            ChildIndex::Hardened(BIP44_PURPOSE),
             match scheme {
                 SchemeType::Secp256k1 => ChildIndex::Hardened(ETH_COIN_TYPE),
                 SchemeType::Ed25519 => ChildIndex::Hardened(NAMADA_COIN_TYPE),

--- a/crates/sdk/src/wallet/derivation_path.rs
+++ b/crates/sdk/src/wallet/derivation_path.rs
@@ -97,6 +97,7 @@ impl DerivationPath {
                 // all indices must be hardened
                 self.0.as_ref().iter().all(|idx| idx.is_hardened())
             }
+            // no restriction for secp256k1 scheme
             _ => true,
         }
     }

--- a/crates/sdk/src/wallet/mod.rs
+++ b/crates/sdk/src/wallet/mod.rs
@@ -614,7 +614,6 @@ impl<U: WalletIo> Wallet<U> {
     pub fn gen_hd_seed(
         passphrase: Option<Zeroizing<String>>,
         rng: &mut U::Rng,
-        unsafe_dont_encrypt: bool,
     ) -> Result<(Mnemonic, Seed), GenRestoreKeyError> {
         const MNEMONIC_TYPE: MnemonicType = MnemonicType::Words24;
         let mnemonic = U::generate_mnemonic_code(MNEMONIC_TYPE, rng)?;
@@ -624,11 +623,8 @@ impl<U: WalletIo> Wallet<U> {
         );
         println!("{}", mnemonic.clone().into_phrase());
 
-        let passphrase = if unsafe_dont_encrypt {
-            Zeroizing::new(String::new())
-        } else {
-            passphrase.unwrap_or_else(|| U::read_mnemonic_passphrase(true))
-        };
+        let passphrase =
+            passphrase.unwrap_or_else(|| U::read_mnemonic_passphrase(true));
         let seed = Seed::new(&mnemonic, &passphrase);
         Ok((mnemonic, seed))
     }

--- a/crates/sdk/src/wallet/mod.rs
+++ b/crates/sdk/src/wallet/mod.rs
@@ -886,6 +886,11 @@ impl<U: WalletIo> Wallet<U> {
             .map(Into::into)
     }
 
+    /// Add a new keypair with the given alias. If the alias is already used,
+    /// will ask whether the existing alias should be replaced, a different
+    /// alias is desired, or the alias creation should be cancelled. Return
+    /// the chosen alias if the keypair has been added, otherwise return
+    /// nothing.
     pub fn insert_keypair(
         &mut self,
         alias: String,

--- a/crates/sdk/src/wallet/mod.rs
+++ b/crates/sdk/src/wallet/mod.rs
@@ -621,10 +621,12 @@ impl<U: WalletIo> Wallet<U> {
     }
 
     /// Generate a BIP39 mnemonic code, and derive HD wallet seed from it using
-    /// the given passphrase.
+    /// the given passphrase. If no passphrase is provided, optionally prompt
+    /// for a passphrase.
     pub fn gen_hd_seed(
         passphrase: Option<Zeroizing<String>>,
         rng: &mut U::Rng,
+        prompt_bip39_passphrase: bool,
     ) -> (Mnemonic, Seed) {
         const MNEMONIC_TYPE: MnemonicType = MnemonicType::Words24;
         let mnemonic = U::generate_mnemonic_code(MNEMONIC_TYPE, rng);
@@ -634,8 +636,13 @@ impl<U: WalletIo> Wallet<U> {
         );
         println!("{}", mnemonic.clone().into_phrase());
 
-        let passphrase =
-            passphrase.unwrap_or_else(|| U::read_mnemonic_passphrase(true));
+        let passphrase = passphrase.unwrap_or_else(|| {
+            if prompt_bip39_passphrase {
+                U::read_mnemonic_passphrase(true)
+            } else {
+                Zeroizing::default()
+            }
+        });
         let seed = Seed::new(&mnemonic, &passphrase);
         (mnemonic, seed)
     }

--- a/crates/sdk/src/wallet/mod.rs
+++ b/crates/sdk/src/wallet/mod.rs
@@ -529,7 +529,7 @@ impl<U: WalletIo> Wallet<U> {
     /// provided, will prompt for password from stdin.
     /// Stores the key in decrypted key cache and returns the alias of the key
     /// and a reference-counting pointer to the key.
-    pub fn derive_key_from_mnemonic_code(
+    pub fn derive_store_key_from_mnemonic_code(
         &mut self,
         scheme: SchemeType,
         alias: Option<String>,

--- a/crates/sdk/src/wallet/store.rs
+++ b/crates/sdk/src/wallet/store.rs
@@ -799,9 +799,11 @@ mod test_wallet {
         let seed = Seed::new(&mnemonic, PASSPHRASE);
         assert_eq!(format!("{:x}", seed), SEED_EXPECTED);
 
-        let derivation_path =
-            DerivationPath::from_path_str(SCHEME, DERIVATION_PATH)
-                .expect("Derivation path construction cannot fail");
+        let derivation_path = DerivationPath::from_path_string_for_scheme(
+            SCHEME,
+            DERIVATION_PATH,
+        )
+        .expect("Derivation path construction cannot fail");
 
         let sk = derive_hd_secret_key(SCHEME, seed.as_bytes(), derivation_path);
 
@@ -825,13 +827,18 @@ mod test_wallet {
         let seed = Seed::new(&mnemonic, PASSPHRASE);
         assert_eq!(format!("{:x}", seed), SEED_EXPECTED);
 
-        let derivation_path =
-            DerivationPath::from_path_str(SCHEME, DERIVATION_PATH)
-                .expect("Derivation path construction cannot fail");
+        let derivation_path = DerivationPath::from_path_string_for_scheme(
+            SCHEME,
+            DERIVATION_PATH,
+        )
+        .expect("Derivation path construction cannot fail");
 
         let derivation_path_hardened =
-            DerivationPath::from_path_str(SCHEME, DERIVATION_PATH_HARDENED)
-                .expect("Derivation path construction cannot fail");
+            DerivationPath::from_path_string_for_scheme(
+                SCHEME,
+                DERIVATION_PATH_HARDENED,
+            )
+            .expect("Derivation path construction cannot fail");
 
         let sk = derive_hd_secret_key(SCHEME, seed.as_bytes(), derivation_path);
 
@@ -857,8 +864,11 @@ mod test_wallet {
                 .decode(seed.as_bytes())
                 .expect("Seed parsing cannot fail.")
                 .as_slice(),
-            DerivationPath::from_path_str(scheme, derivation_path)
-                .expect("Derivation path construction cannot fail"),
+            DerivationPath::from_path_string_for_scheme(
+                scheme,
+                derivation_path,
+            )
+            .expect("Derivation path construction cannot fail"),
         );
         let sk_expected = if priv_key.starts_with("xprv") {
             // this is an extended private key encoded in base58

--- a/crates/sdk/src/wallet/store.rs
+++ b/crates/sdk/src/wallet/store.rs
@@ -817,11 +817,12 @@ mod test_wallet {
         let seed = Seed::new(&mnemonic, PASSPHRASE);
         assert_eq!(format!("{:x}", seed), SEED_EXPECTED);
 
-        let derivation_path = DerivationPath::from_path_string_for_scheme(
-            SCHEME,
-            DERIVATION_PATH,
-        )
-        .expect("Derivation path construction cannot fail");
+        let derivation_path =
+            DerivationPath::from_path_string_for_transparent_scheme(
+                SCHEME,
+                DERIVATION_PATH,
+            )
+            .expect("Derivation path construction cannot fail");
 
         let sk = derive_hd_secret_key(SCHEME, seed.as_bytes(), derivation_path);
 
@@ -845,14 +846,15 @@ mod test_wallet {
         let seed = Seed::new(&mnemonic, PASSPHRASE);
         assert_eq!(format!("{:x}", seed), SEED_EXPECTED);
 
-        let derivation_path = DerivationPath::from_path_string_for_scheme(
-            SCHEME,
-            DERIVATION_PATH,
-        )
-        .expect("Derivation path construction cannot fail");
+        let derivation_path =
+            DerivationPath::from_path_string_for_transparent_scheme(
+                SCHEME,
+                DERIVATION_PATH,
+            )
+            .expect("Derivation path construction cannot fail");
 
         let derivation_path_hardened =
-            DerivationPath::from_path_string_for_scheme(
+            DerivationPath::from_path_string_for_transparent_scheme(
                 SCHEME,
                 DERIVATION_PATH_HARDENED,
             )
@@ -882,7 +884,7 @@ mod test_wallet {
                 .decode(seed.as_bytes())
                 .expect("Seed parsing cannot fail.")
                 .as_slice(),
-            DerivationPath::from_path_string_for_scheme(
+            DerivationPath::from_path_string_for_transparent_scheme(
                 scheme,
                 derivation_path,
             )

--- a/crates/sdk/src/wallet/store.rs
+++ b/crates/sdk/src/wallet/store.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use bimap::BiBTreeMap;
 use itertools::Itertools;
-use masp_primitives::zip32::ExtendedFullViewingKey;
+use masp_primitives::zip32;
 use namada_core::types::address::{Address, ImplicitAddress};
 use namada_core::types::key::*;
 use namada_core::types::masp::{
@@ -394,7 +394,8 @@ impl Store {
             StoredKeypair::new(spendkey, password);
         self.spend_keys.insert(alias.clone(), spendkey_to_store);
         // Simultaneously add the derived viewing key to ease balance viewing
-        let viewkey = ExtendedFullViewingKey::from(&spendkey.into()).into();
+        let viewkey =
+            zip32::ExtendedFullViewingKey::from(&spendkey.into()).into();
         self.view_keys.insert(alias.clone(), viewkey);
         Some(alias)
     }

--- a/crates/sdk/src/wallet/store.rs
+++ b/crates/sdk/src/wallet/store.rs
@@ -733,6 +733,20 @@ pub fn derive_hd_secret_key(
     }
 }
 
+/// Generate a new spending key from the seed.
+pub fn derive_hd_spending_key(
+    seed: &[u8],
+    derivation_path: DerivationPath,
+) -> ExtendedSpendingKey {
+    let master_spend_key = zip32::sapling::ExtendedSpendingKey::master(seed);
+    let zip32_path: Vec<zip32::ChildIndex> = derivation_path.into();
+    zip32::sapling::ExtendedSpendingKey::from_path(
+        &master_spend_key,
+        &zip32_path,
+    )
+    .into()
+}
+
 impl Display for AddressVpType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -2957,7 +2957,13 @@ fn implicit_account_reveal_pk() -> Result<()> {
         let mut cmd = run!(
             test,
             Bin::Wallet,
-            &["gen", "--alias", &key_alias, "--unsafe-dont-encrypt"],
+            &[
+                "gen",
+                "--alias",
+                &key_alias,
+                "--unsafe-dont-encrypt",
+                "--raw"
+            ],
             Some(20),
         )?;
         cmd.assert_success();

--- a/crates/tests/src/e2e/setup.rs
+++ b/crates/tests/src/e2e/setup.rs
@@ -171,7 +171,7 @@ where
                 None,
                 &mut OsRng,
             )
-            .unwrap_or_else(|_| {
+            .unwrap_or_else(|| {
                 panic!("Could not generate new key for validator-{}", val)
             });
         println!("alias: {}, pk: {}", alias, sk.ref_to());

--- a/crates/tests/src/e2e/wallet_tests.rs
+++ b/crates/tests/src/e2e/wallet_tests.rs
@@ -16,6 +16,9 @@ use color_eyre::eyre::Result;
 use super::setup;
 use crate::e2e::setup::Bin;
 use crate::run;
+use crate::strings::{
+    WALLET_FOUND_TRANSPARENT_KEYS, WALLET_HD_PASSPHRASE_PROMPT,
+};
 
 /// Test wallet key commands with an encrypted key:
 /// 1. key gen
@@ -35,7 +38,7 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
     cmd.send_line(password)?;
     cmd.exp_string("Enter same passphrase again: ")?;
     cmd.send_line(password)?;
-    cmd.exp_string("Enter BIP39 passphrase (empty for none): ")?;
+    cmd.exp_string(WALLET_HD_PASSPHRASE_PROMPT)?;
     cmd.send_line("")?;
     cmd.exp_string(&format!(
         "Successfully added a key and an address with alias: \"{}\"",
@@ -50,7 +53,7 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
         Some(20),
     )?;
 
-    cmd.exp_string("Found transparent keys:")?;
+    cmd.exp_string(WALLET_FOUND_TRANSPARENT_KEYS)?;
     cmd.exp_string(&format!(
         "  Alias \"{}\" (encrypted):",
         key_alias.to_lowercase()
@@ -86,7 +89,7 @@ fn wallet_encrypted_key_cmds_env_var() -> Result<()> {
     let mut cmd =
         run!(test, Bin::Wallet, &["gen", "--alias", key_alias], Some(20),)?;
 
-    cmd.exp_string("Enter BIP39 passphrase (empty for none): ")?;
+    cmd.exp_string(WALLET_HD_PASSPHRASE_PROMPT)?;
     cmd.send_line("")?;
 
     cmd.exp_string(&format!(
@@ -102,7 +105,7 @@ fn wallet_encrypted_key_cmds_env_var() -> Result<()> {
         Some(20),
     )?;
 
-    cmd.exp_string("Found transparent keys:")?;
+    cmd.exp_string(WALLET_FOUND_TRANSPARENT_KEYS)?;
     cmd.exp_string(&format!(
         "  Alias \"{}\" (encrypted):",
         key_alias.to_lowercase()
@@ -137,7 +140,7 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
         Some(20),
     )?;
 
-    cmd.exp_string("Enter BIP39 passphrase (empty for none): ")?;
+    cmd.exp_string(WALLET_HD_PASSPHRASE_PROMPT)?;
     cmd.send_line("")?;
 
     cmd.exp_string(&format!(
@@ -153,7 +156,7 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
         Some(20),
     )?;
 
-    cmd.exp_string("Found transparent keys:")?;
+    cmd.exp_string(WALLET_FOUND_TRANSPARENT_KEYS)?;
     cmd.exp_string(&format!(
         "  Alias \"{}\" (not encrypted):",
         key_alias.to_lowercase()

--- a/crates/tests/src/e2e/wallet_tests.rs
+++ b/crates/tests/src/e2e/wallet_tests.rs
@@ -136,6 +136,10 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
         &["gen", "--alias", key_alias, "--unsafe-dont-encrypt"],
         Some(20),
     )?;
+
+    cmd.exp_string("Enter BIP39 passphrase (empty for none): ")?;
+    cmd.send_line("")?;
+
     cmd.exp_string(&format!(
         "Successfully added a key and an address with alias: \"{}\"",
         key_alias.to_lowercase()
@@ -183,7 +187,13 @@ fn wallet_address_cmds() -> Result<()> {
     let mut cmd = run!(
         test,
         Bin::Wallet,
-        &["gen", "--alias", gen_address_alias, "--unsafe-dont-encrypt"],
+        &[
+            "gen",
+            "--alias",
+            gen_address_alias,
+            "--unsafe-dont-encrypt",
+            "--raw"
+        ],
         Some(20),
     )?;
     cmd.exp_string(&format!(

--- a/crates/tests/src/e2e/wallet_tests.rs
+++ b/crates/tests/src/e2e/wallet_tests.rs
@@ -17,7 +17,8 @@ use super::setup;
 use crate::e2e::setup::Bin;
 use crate::run;
 use crate::strings::{
-    WALLET_FOUND_TRANSPARENT_KEYS, WALLET_HD_PASSPHRASE_PROMPT,
+    WALLET_FOUND_TRANSPARENT_KEYS, WALLET_HD_PASSPHRASE_CONFIRMATION_PROMPT,
+    WALLET_HD_PASSPHRASE_PROMPT,
 };
 
 /// Test wallet key commands with an encrypted key:
@@ -31,15 +32,21 @@ fn wallet_encrypted_key_cmds() -> Result<()> {
     let password = "VeRySeCuR3";
 
     // 1. key gen
-    let mut cmd =
-        run!(test, Bin::Wallet, &["gen", "--alias", key_alias], Some(20),)?;
+    let mut cmd = run!(
+        test,
+        Bin::Wallet,
+        &["gen", "--alias", key_alias, "--bip39-passphrase"],
+        Some(20),
+    )?;
 
     cmd.exp_string("Enter your encryption password:")?;
     cmd.send_line(password)?;
     cmd.exp_string("Enter same passphrase again: ")?;
     cmd.send_line(password)?;
     cmd.exp_string(WALLET_HD_PASSPHRASE_PROMPT)?;
-    cmd.send_line("")?;
+    cmd.send_line("test")?;
+    cmd.exp_string(WALLET_HD_PASSPHRASE_CONFIRMATION_PROMPT)?;
+    cmd.send_line("test")?;
     cmd.exp_string(&format!(
         "Successfully added a key and an address with alias: \"{}\"",
         key_alias.to_lowercase()
@@ -89,9 +96,6 @@ fn wallet_encrypted_key_cmds_env_var() -> Result<()> {
     let mut cmd =
         run!(test, Bin::Wallet, &["gen", "--alias", key_alias], Some(20),)?;
 
-    cmd.exp_string(WALLET_HD_PASSPHRASE_PROMPT)?;
-    cmd.send_line("")?;
-
     cmd.exp_string(&format!(
         "Successfully added a key and an address with alias: \"{}\"",
         key_alias.to_lowercase()
@@ -139,9 +143,6 @@ fn wallet_unencrypted_key_cmds() -> Result<()> {
         &["gen", "--alias", key_alias, "--unsafe-dont-encrypt"],
         Some(20),
     )?;
-
-    cmd.exp_string(WALLET_HD_PASSPHRASE_PROMPT)?;
-    cmd.send_line("")?;
 
     cmd.exp_string(&format!(
         "Successfully added a key and an address with alias: \"{}\"",

--- a/crates/tests/src/strings.rs
+++ b/crates/tests/src/strings.rs
@@ -23,3 +23,8 @@ pub const TX_FAILED: &str = "Transaction failed";
 
 /// Wrapper transaction accepted.
 pub const TX_ACCEPTED: &str = "Wrapper transaction accepted";
+
+pub const WALLET_HD_PASSPHRASE_PROMPT: &str =
+    "Enter BIP39 passphrase (empty for none): ";
+
+pub const WALLET_FOUND_TRANSPARENT_KEYS: &str = "Found transparent keys:";

--- a/crates/tests/src/strings.rs
+++ b/crates/tests/src/strings.rs
@@ -27,4 +27,7 @@ pub const TX_ACCEPTED: &str = "Wrapper transaction accepted";
 pub const WALLET_HD_PASSPHRASE_PROMPT: &str =
     "Enter BIP39 passphrase (empty for none): ";
 
+pub const WALLET_HD_PASSPHRASE_CONFIRMATION_PROMPT: &str =
+    "Enter same passphrase again: ";
+
 pub const WALLET_FOUND_TRANSPARENT_KEYS: &str = "Found transparent keys:";


### PR DESCRIPTION
- Added a CLI option for BIP39 passphrase prompt.

Based on #2417 - diff https://github.com/anoma/namada/pull/2442/files/b6bc0e976d50a5df55e56165068c41ffaa49e07a..92e2b0dd58e6ff941971eab967a5c319552597a4

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
