### PR TITLE
MASP VP refactor

### DIFF
--- a/.changelog/unreleased/SDK/2452-masp-vp-refactor.md
+++ b/.changelog/unreleased/SDK/2452-masp-vp-refactor.md
@@ -1,0 +1,3 @@
+- Modified `scan_tx` to require the set of changed keys instead of `Transfer`.
+  `fetch_shielded_transfer` now returns the set of changed keys instead of
+  `Transfer`. ([\#2452](https://github.com/anoma/namada/pull/2452))

--- a/.changelog/unreleased/improvements/2452-masp-vp-refactor.md
+++ b/.changelog/unreleased/improvements/2452-masp-vp-refactor.md
@@ -1,0 +1,2 @@
+- Modified the MASP VP to validate the changed storage keys instead of the
+  `Transfer` object. ([\#2452](https://github.com/anoma/namada/pull/2452))

--- a/crates/apps/src/lib/bench_utils.rs
+++ b/crates/apps/src/lib/bench_utils.rs
@@ -1,6 +1,7 @@
 //! Library code for benchmarks provides a wrapper of the ledger's shell
 //! `BenchShell` and helper functions to generate transactions.
 
+use std::collections::BTreeSet;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::ops::{Deref, DerefMut};
@@ -59,6 +60,7 @@ use namada::ledger::queries::{
 use namada::state::StorageRead;
 use namada::tendermint_rpc::{self};
 use namada::tx::data::pos::Bond;
+use namada::tx::data::{TxResult, VpsResult};
 use namada::tx::{Code, Data, Section, Signature, Tx};
 use namada::types::address::{self, Address, InternalAddress};
 use namada::types::chain::ChainId;
@@ -122,9 +124,9 @@ static SHELL_INIT: Once = Once::new();
 
 pub struct BenchShell {
     pub inner: Shell,
-    // Cache of the masp transactions in the last block committed, the tx index
-    // coincides with the index in this collection
-    pub last_block_masp_txs: Vec<Tx>,
+    // Cache of the masp transactions and their changed keys in the last block
+    // committed, the tx index coincides with the index in this collection
+    pub last_block_masp_txs: Vec<(Tx, BTreeSet<Key>)>,
     // NOTE: Temporary directory should be dropped last since Shell need to
     // flush data on drop
     tempdir: TempDir,
@@ -554,9 +556,9 @@ impl BenchShell {
             .unwrap();
     }
 
+    // Update the block height in state to guarantee a valid response to the
+    // client queries
     pub fn commit_block(&mut self) {
-        // Update the block height in state to guarantee a valid response to the
-        // client queries
         self.inner
             .wl_storage
             .storage
@@ -567,6 +569,14 @@ impl BenchShell {
             .unwrap();
 
         self.inner.commit();
+    }
+
+    // Commit a masp transaction and cache the tx and the changed keys for
+    // client queries
+    pub fn commit_masp_tx(&mut self, masp_tx: Tx) {
+        self.last_block_masp_txs
+            .push((masp_tx, self.wl_storage.write_log.get_keys()));
+        self.wl_storage.commit_tx();
     }
 }
 
@@ -796,7 +806,10 @@ impl Client for BenchShell {
                     evidence_hash: None,
                     proposer_address: tendermint::account::Id::new([0u8; 20]),
                 },
-                last_block_txs.into_iter().map(|tx| tx.to_bytes()).collect(),
+                last_block_txs
+                    .into_iter()
+                    .map(|(tx, _)| tx.to_bytes())
+                    .collect(),
                 tendermint::evidence::List::default(),
                 None,
             )
@@ -827,14 +840,27 @@ impl Client for BenchShell {
                 self.last_block_masp_txs
                     .iter()
                     .enumerate()
-                    .map(|(idx, _tx)| {
+                    .map(|(idx, (_tx, changed_keys))| {
+                        let tx_result = TxResult {
+                            gas_used: 0.into(),
+                            changed_keys: changed_keys.to_owned(),
+                            vps_result: VpsResult::default(),
+                            initialized_accounts: vec![],
+                            ibc_events: BTreeSet::default(),
+                            eth_bridge_events: BTreeSet::default(),
+                        };
                         namada::tendermint::abci::Event {
                             kind: "applied".to_string(),
-                            // Mock only the masp attribute
+                            // Mock the masp and tx attributes
                             attributes: vec![
                                 namada::tendermint::abci::EventAttribute {
                                     key: "is_valid_masp_tx".to_string(),
                                     value: format!("{}", idx),
+                                    index: true,
+                                },
+                                namada::tendermint::abci::EventAttribute {
+                                    key: "inner_tx".to_string(),
+                                    value: tx_result.to_string(),
                                     index: true,
                                 },
                             ],

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -499,7 +499,7 @@ fn setup_storage_for_masp_verification(
         TransferTarget::PaymentAddress(albert_payment_addr),
     );
     shielded_ctx.shell.execute_tx(&shield_tx);
-    shielded_ctx.shell.wl_storage.commit_tx();
+    shielded_ctx.shell.commit_masp_tx(shield_tx);
 
     // Update the anchor in storage
     let tree_key = namada::token::storage_key::masp_commitment_tree_key();
@@ -518,8 +518,6 @@ fn setup_storage_for_masp_verification(
         .write(&anchor_key, ())
         .unwrap();
     shielded_ctx.shell.commit_block();
-    // Cache the masp tx so that it can be returned when queried
-    shielded_ctx.shell.last_block_masp_txs.push(shield_tx);
 
     let (mut shielded_ctx, signed_tx) = match bench_name {
         "shielding" => shielded_ctx.generate_masp_tx(

--- a/crates/benches/txs.rs
+++ b/crates/benches/txs.rs
@@ -86,10 +86,8 @@ fn transfer(c: &mut Criterion) {
                             TransferTarget::PaymentAddress(albert_payment_addr),
                         );
                     shielded_ctx.shell.execute_tx(&shield_tx);
-                    shielded_ctx.shell.wl_storage.commit_tx();
+                    shielded_ctx.shell.commit_masp_tx(shield_tx);
                     shielded_ctx.shell.commit_block();
-                    // Cache the masp tx so that it can be returned when queried
-                    shielded_ctx.shell.last_block_masp_txs.push(shield_tx);
 
                     let (shielded_ctx, signed_tx) = match bench_name {
                         "transparent" => shielded_ctx.generate_masp_tx(

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -551,12 +551,9 @@ where
             // Handle shielded input
             // The following boundary conditions must be satisfied
             // 1. Zero transparent input
-            // 2. the transparent transaction value pool's amount must equal
-            // the containing wrapper transaction's fee
-            // amount Satisfies 1.
-            // 3. The spend descriptions' anchors are valid
-            // 4. The convert descriptions's anchors are valid
-            // 5. The nullifiers provided by the transaction have not been
+            // 2. The spend descriptions' anchors are valid
+            // 3. The convert descriptions's anchors are valid
+            // 4. The nullifiers provided by the transaction have not been
             // revealed previously (even in the same tx) and no unneeded
             // nullifier is being revealed by the tx
             if let Some(transp_bundle) = shielded_tx.transparent_bundle() {

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -23,9 +23,10 @@ use ripemd::Digest as RipemdDigest;
 use sha2::Digest as Sha2Digest;
 use thiserror::Error;
 use token::storage_key::{
-    balance_key, is_any_token_balance_key, is_masp_allowed_key, is_masp_key,
-    is_masp_nullifier_key, is_masp_tx_pin_key, masp_commitment_anchor_key,
-    masp_commitment_tree_key, masp_convert_anchor_key, masp_nullifier_key,
+    balance_key, is_any_shielded_action_balance_key, is_masp_allowed_key,
+    is_masp_key, is_masp_nullifier_key, is_masp_tx_pin_key,
+    masp_commitment_anchor_key, masp_commitment_tree_key,
+    masp_convert_anchor_key, masp_nullifier_key,
 };
 use token::Amount;
 
@@ -287,7 +288,7 @@ where
         // transfer data Get the token from the balance key of the MASP
         let balance_addresses: Vec<[&Address; 2]> = keys_changed
             .iter()
-            .filter_map(is_any_token_balance_key)
+            .filter_map(is_any_shielded_action_balance_key)
             .collect();
 
         let masp_balances: Vec<&[&Address; 2]> = balance_addresses

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -263,10 +263,7 @@ where
                 {
                     Some(IndexedTx { height, index })
                         if height == self.ctx.get_block_height()?
-                            && index == self.ctx.get_tx_index()? =>
-                    {
-                        ()
-                    }
+                            && index == self.ctx.get_tx_index()? => {}
                     Some(_) => {
                         return Err(Error::NativeVpError(
                             native_vp::Error::SimpleMessage(
@@ -300,7 +297,7 @@ where
         let token = match masp_balances.len() {
             0 => {
                 // No masp balance modification found, assume shielded
-                // transaction and return mock transparent data
+                // transaction and return dummy transparent data
                 return Ok(TransparentTransferData {
                     source: Address::Internal(Masp),
                     target: Address::Internal(Masp),
@@ -328,22 +325,12 @@ where
         // there's no need to check the token address in the balance key nor the
         // change to the actual balance, the multitoken VP will verify these
         let counterpart = match counterparts.len() {
-            0 => {
-                return Err(Error::NativeVpError(
-                    native_vp::Error::SimpleMessage(
-                        "No transparent transfer counterpart was found, this \
-                         should not happen",
-                    ),
-                ));
-            }
             1 => counterparts[0][1].to_owned(),
             _ => {
-                // We don't support a masp transfer and one ore more transparent
-                // transfers in the same transaction
                 return Err(Error::NativeVpError(
                     native_vp::Error::SimpleMessage(
-                        "More than one non-MASP transparent balance was \
-                         modified",
+                        "An invalid number of non-MASP transparent balances \
+                         was modified",
                     ),
                 ));
             }

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -67,7 +67,7 @@ use rand_core::{CryptoRng, OsRng, RngCore};
 use ripemd::Digest as RipemdDigest;
 use sha2::Digest;
 use thiserror::Error;
-use token::storage_key::is_any_token_balance_key;
+use token::storage_key::is_any_shielded_action_balance_key;
 use token::Amount;
 
 #[cfg(feature = "testing")]
@@ -1051,7 +1051,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
 
         let balance_keys: Vec<_> = tx_changed_keys
             .iter()
-            .filter_map(is_any_token_balance_key)
+            .filter_map(is_any_shielded_action_balance_key)
             .collect();
         let (source, token, amount) = match balance_keys.len() {
             0 => {

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -2184,27 +2184,28 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
 
         // To speed up integration tests, we can save and load proofs
         #[cfg(feature = "testing")]
-        let load_or_save =
-            if let Ok(masp_proofs) = env::var(ENV_VAR_MASP_TEST_PROOFS) {
-                let parsed = match masp_proofs.to_ascii_lowercase().as_str() {
-                    "load" => LoadOrSaveProofs::Load,
-                    "save" => LoadOrSaveProofs::Save,
-                    env_var => Err(Error::Other(format!(
+        let load_or_save = if let Ok(masp_proofs) =
+            env::var(ENV_VAR_MASP_TEST_PROOFS)
+        {
+            let parsed = match masp_proofs.to_ascii_lowercase().as_str() {
+                "load" => LoadOrSaveProofs::Load,
+                "save" => LoadOrSaveProofs::Save,
+                env_var => Err(Error::Other(format!(
                     "Unexpected value for {ENV_VAR_MASP_TEST_PROOFS} env var. \
                      Expecting \"save\" or \"load\", but got \"{env_var}\"."
                 )))?,
-                };
-                if env::var(ENV_VAR_MASP_TEST_SEED).is_err() {
-                    Err(Error::Other(format!(
+            };
+            if env::var(ENV_VAR_MASP_TEST_SEED).is_err() {
+                Err(Error::Other(format!(
                     "Ensure to set a seed with {ENV_VAR_MASP_TEST_SEED} env \
                      var when using {ENV_VAR_MASP_TEST_PROOFS} for \
                      deterministic proofs."
                 )))?;
-                }
-                parsed
-            } else {
-                LoadOrSaveProofs::Neither
-            };
+            }
+            parsed
+        } else {
+            LoadOrSaveProofs::Neither
+        };
 
         let builder_clone = builder.clone().map_builder(WalletMap);
         #[cfg(feature = "testing")]

--- a/crates/trans_token/src/storage_key.rs
+++ b/crates/trans_token/src/storage_key.rs
@@ -184,3 +184,23 @@ pub fn is_any_minted_balance_key(key: &storage::Key) -> Option<&Address> {
         _ => None,
     }
 }
+
+/// Check if the given storage key is a balance key for a shielded action. If it
+/// is, returns the token and the owner addresses.
+pub fn is_any_shielded_action_balance_key(
+    key: &storage::Key,
+) -> Option<[&Address; 2]> {
+    is_any_token_balance_key(key).map_or_else(
+        || {
+            is_any_minted_balance_key(key).map(|token| {
+                [
+                    token,
+                    &Address::Internal(
+                        namada_core::types::address::InternalAddress::Ibc,
+                    ),
+                ]
+            })
+        },
+        Some,
+    )
+}


### PR DESCRIPTION
## Describe your changes

This PR modifies the masp VP to validate the changed keys in storage instead of validating the `Transfer` object. It also updates the client to retrieve the data from the changed keys instead of the tx data since this doesn't get validated from the vp. Unfortunately it wasn't possible to completely remove the dependency on `Transfer` since we still need it for one thing, retrieve the masp `Transaction` object whose commitment is included in the tx data. Because of this, the masp VP only allows for a single value transfer when a transparent address is involved (whereas the other VPs technically support multiple transfers).

In addition, this PR also makes the operations in the masp VP checked. It has to be noted that operations on `I128Sum` underneath use check operations even though, in case of an over/under-flow, the application crashes. This solution is more desirable than the default behavior (wrapping around) but in our case it would be better to not crash and just discard the transaction. This type comes from the masp library so either we open an issue there to ask for a better support of checked operations or we rewrite the logic ourselves.

## Indicate on which release or other PRs this topic is based on

v0.30.2

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
