### PR TITLE
fix all features build (forked rocksdb jemalloc on non-windows only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,8 +3765,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.11.0+8.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+source = "git+https://github.com/heliaxdev/rust-rocksdb?rev=20f158ade557eea2d62baece0a5b5b55a34f4915#20f158ade557eea2d62baece0a5b5b55a34f4915"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -6271,8 +6270,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+source = "git+https://github.com/heliaxdev/rust-rocksdb?rev=20f158ade557eea2d62baece0a5b5b55a34f4915#20f158ade557eea2d62baece0a5b5b55a34f4915"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,9 @@ regex = "1.4.5"
 reqwest = "0.11.4"
 ripemd = "0.1"
 rlimit = "0.5.4"
-rocksdb = {version = "0.21.0", features = ['zstd'], default-features = false}
+# rocksdb = {version = "0.21.0", features = ['zstd'], default-features = false}
+# TEMP branch "tomas/no-jemalloc-win", replace once upstreamed
+rocksdb = {git = "https://github.com/heliaxdev/rust-rocksdb", rev = "20f158ade557eea2d62baece0a5b5b55a34f4915", features = ['zstd'], default-features = false}
 rpassword = "5.0.1"
 serde = {version = "1.0.125", features = ["derive"]}
 serde_bytes = "0.11.5"

--- a/crates/apps/Cargo.toml
+++ b/crates/apps/Cargo.toml
@@ -50,7 +50,7 @@ name = "namadar"
 path = "src/bin/namada-relayer/main.rs"
 
 [features]
-default = ["no_jemalloc"]
+default = []
 mainnet = [
   "namada/mainnet",
 ]
@@ -58,12 +58,7 @@ mainnet = [
 testing = ["namada_test_utils"]
 benches = ["testing", "namada_test_utils"]
 integration = []
-
-# RocksDB's "jemalloc" disabled by default as it takes a long time to build.
-# Note that only exactly one of these features has to be enabled at a time. 
-# Jemalloc is enabled in `make build-release`.
-no_jemalloc = ["dep:rocksdb"]
-jemalloc = ["rocksdb_with_jemalloc"]
+jemalloc = ["rocksdb/jemalloc"]
 
 [dependencies]
 namada = {path = "../namada", features = ["multicore", "http-client", "tendermint-rpc", "std"]}
@@ -121,6 +116,7 @@ regex.workspace = true
 reqwest.workspace = true
 ripemd.workspace = true
 rlimit.workspace = true
+rocksdb.workspace = true
 rpassword.workspace = true
 serde_bytes.workspace = true
 serde_json = {workspace = true, features = ["raw_value"]}
@@ -145,15 +141,6 @@ winapi.workspace = true
 zeroize.workspace = true
 warp = "0.3.2"
 bytes = "1.1.0"
-
-[target.'cfg(not(windows))'.dependencies]
-rocksdb = { workspace = true, optional = true }
-rocksdb_with_jemalloc = { package = "rocksdb", version = "0.21.0", default-features = false, features = ['zstd', 'jemalloc'], optional = true }
-
-[target.'cfg(windows)'.dependencies]
-rocksdb = { workspace = true, optional = true }
- # jemalloc is not supported on windows
-rocksdb_with_jemalloc = { package = "rocksdb", version = "0.21.0", default-features = false, features = ['zstd'], optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/apps/src/lib/mod.rs
+++ b/crates/apps/src/lib/mod.rs
@@ -29,10 +29,3 @@ pub mod facade {
         pub use tower_abci::BoxError;
     }
 }
-
-#[cfg(all(feature = "no_jemalloc", feature = "jemalloc"))]
-compile_error!("`jemalloc` and `no_jemalloc` may not be used at the same time");
-#[cfg(feature = "no_jemalloc")]
-pub use rocksdb;
-#[cfg(feature = "jemalloc")]
-pub use rocksdb_with_jemalloc as rocksdb;

--- a/crates/apps/src/lib/node/ledger/mod.rs
+++ b/crates/apps/src/lib/node/ledger/mod.rs
@@ -469,9 +469,8 @@ fn start_abci_broadcaster_shell(
     };
 
     // Setup DB cache, it must outlive the DB instance that's in the shell
-    let db_cache = crate::rocksdb::Cache::new_lru_cache(
-        db_block_cache_size_bytes as usize,
-    );
+    let db_cache =
+        rocksdb::Cache::new_lru_cache(db_block_cache_size_bytes as usize);
 
     // Construct our ABCI application.
     let tendermint_mode = config.shell.tendermint_mode.clone();

--- a/crates/apps/src/lib/node/ledger/shims/abcipp_shim.rs
+++ b/crates/apps/src/lib/node/ledger/shims/abcipp_shim.rs
@@ -50,7 +50,7 @@ impl AbcippShim {
         wasm_dir: PathBuf,
         broadcast_sender: UnboundedSender<Vec<u8>>,
         eth_oracle: Option<EthereumOracleChannels>,
-        db_cache: &crate::rocksdb::Cache,
+        db_cache: &rocksdb::Cache,
         vp_wasm_compilation_cache: u64,
         tx_wasm_compilation_cache: u64,
     ) -> (Self, AbciService, broadcast::Sender<()>) {

--- a/crates/core/src/types/token.rs
+++ b/crates/core/src/types/token.rs
@@ -153,6 +153,7 @@ impl Amount {
 
     /// Checked addition. Returns `None` on overflow or if
     /// the amount exceed [`uint::MAX_VALUE`]
+    #[must_use]
     pub fn checked_add(&self, amount: Amount) -> Option<Self> {
         self.raw.checked_add(amount.raw).and_then(|result| {
             if result <= uint::MAX_VALUE {
@@ -165,6 +166,7 @@ impl Amount {
 
     /// Checked addition. Returns `None` on overflow or if
     /// the amount exceed [`uint::MAX_SIGNED_VALUE`]
+    #[must_use]
     pub fn checked_signed_add(&self, amount: Amount) -> Option<Self> {
         self.raw.checked_add(amount.raw).and_then(|result| {
             if result <= uint::MAX_SIGNED_VALUE {
@@ -189,6 +191,7 @@ impl Amount {
     }
 
     /// Checked division. Returns `None` on underflow.
+    #[must_use]
     pub fn checked_div(&self, amount: Amount) -> Option<Self> {
         self.raw
             .checked_div(amount.raw)
@@ -196,6 +199,7 @@ impl Amount {
     }
 
     /// Checked multiplication. Returns `None` on overflow.
+    #[must_use]
     pub fn checked_mul(&self, amount: Amount) -> Option<Self> {
         self.raw
             .checked_mul(amount.raw)

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -5,7 +5,7 @@ use std::collections::{btree_map, BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env;
 use std::fmt::Debug;
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 // use async_std::io::prelude::WriteExt;
@@ -2075,7 +2075,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
                 .map_err(|e| Error::Other(e.to_string()))?
                 // Two up from "tests" dir to the root dir
                 .parent()
-                .and_then(Path::parent)
+                .and_then(std::path::Path::parent)
                 .ok_or_else(|| {
                     Error::Other("Can not get root dir".to_string())
                 })?


### PR DESCRIPTION
## Describe your changes

This is needed for `cargo-release` used by `scripts/release.sh` that compiles with all features enabled.

Using a fork from https://github.com/heliaxdev/rust-rocksdb/pull/1 (upstream in https://github.com/rust-rocksdb/rust-rocksdb/pull/857).

## Indicate on which release or other PRs this topic is based on

#2456 - diff https://github.com/anoma/namada/pull/2457/commits/f4c030a3039ce21c4a09862ff0248ae9fd57a39b

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
