### PR TITLE
genesis: use the configured native token name for validation

### DIFF
--- a/.changelog/unreleased/bug-fixes/2471-genesis-native-token.md
+++ b/.changelog/unreleased/bug-fixes/2471-genesis-native-token.md
@@ -1,0 +1,2 @@
+- Use the configured native token for genesis validation.
+  ([\#2471](https://github.com/anoma/namada/pull/2471))

--- a/crates/core/src/types/token.rs
+++ b/crates/core/src/types/token.rs
@@ -151,6 +151,11 @@ impl Amount {
         self.raw == Uint::from(0)
     }
 
+    /// Check if [`Amount`] is greater than zero.
+    pub fn is_positive(&self) -> bool {
+        !self.is_zero()
+    }
+
     /// Checked addition. Returns `None` on overflow or if
     /// the amount exceed [`uint::MAX_VALUE`]
     #[must_use]

--- a/genesis/starter/balances.toml
+++ b/genesis/starter/balances.toml
@@ -1,2 +1,3 @@
 [token.NAM]
-# assign balance to public keys
+# assign balance to public keys, e.g.:
+tnam1qxfj3sf6a0meahdu9t6znp05g8zx4dkjtgyn9gfu = "1"


### PR DESCRIPTION
## Describe your changes

A commit was accidentally removed from https://github.com/anoma/namada/pull/2467 to validate native token balance based on its configured name. The validation before the changes would still pass with a rename, but the check would be skipped as it wouldn't match the hard-coded value.

## Indicate on which release or other PRs this topic is based on

0.30.3

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
