### PR TITLE
Fix empty password panic; unify `list` and `find` commands output

### DIFF
--- a/.changelog/unreleased/bug-fixes/2473-wallet-fix-empty-password-panic.md
+++ b/.changelog/unreleased/bug-fixes/2473-wallet-fix-empty-password-panic.md
@@ -1,0 +1,2 @@
+- Wallet: handle the case when empty decryption password is provided.
+  ([\#2473](https://github.com/anoma/namada/pull/2473))

--- a/crates/sdk/src/wallet/keys.rs
+++ b/crates/sdk/src/wallet/keys.rs
@@ -144,6 +144,8 @@ pub enum DecryptionError {
     DeserializingError,
     #[error("Asked not to decrypt")]
     NotDecrypting,
+    #[error("Empty password provided")]
+    EmptyPassword,
 }
 
 impl<T: BorshSerialize + BorshDeserialize + Display + FromStr + Clone>
@@ -217,6 +219,10 @@ impl<T: BorshSerialize + BorshDeserialize> EncryptedKeypair<T> {
         &self,
         password: Zeroizing<String>,
     ) -> Result<T, DecryptionError> {
+        if password.is_empty() {
+            return Err(DecryptionError::EmptyPassword);
+        }
+
         let salt_len = encryption_salt().len();
         let (raw_salt, cipher) = self.0.split_at(salt_len);
 


### PR DESCRIPTION
- This PR fixes panic in the case when user provided decryption password is empty.
- Further improvement: output of `list` and `find` commands has been unified for transparent / shielded settings.

Based on 0.30.2

- [x] I have added a changelog
- [x] Git history is in acceptable state
