### PR TITLE
Fix handling of the optional BIP39 passphrase flag

### DIFF
--- a/.changelog/unreleased/bug-fixes/2489-bip39-optional-derive.md
+++ b/.changelog/unreleased/bug-fixes/2489-bip39-optional-derive.md
@@ -1,0 +1,2 @@
+- Wallet: respect the optional bip39-flag for key derivation.
+  ([\#2489](https://github.com/anoma/namada/pull/2489))

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -188,6 +188,7 @@ fn shielded_key_derive(
         unsafe_dont_encrypt,
         derivation_path,
         allow_non_compliant,
+        prompt_bip39_passphrase,
         use_device,
         ..
     }: args::KeyDerive,
@@ -214,6 +215,7 @@ fn shielded_key_derive(
                 alias_force,
                 derivation_path,
                 None,
+                prompt_bip39_passphrase,
                 encryption_password,
             )
             .unwrap_or_else(|| {
@@ -440,6 +442,7 @@ async fn transparent_key_and_address_derive(
         unsafe_dont_encrypt,
         derivation_path,
         allow_non_compliant,
+        prompt_bip39_passphrase,
         use_device,
         ..
     }: args::KeyDerive,
@@ -470,6 +473,7 @@ async fn transparent_key_and_address_derive(
                 alias_force,
                 derivation_path,
                 None,
+                prompt_bip39_passphrase,
                 encryption_password,
             )
             .unwrap_or_else(|| {

--- a/crates/sdk/src/wallet/mod.rs
+++ b/crates/sdk/src/wallet/mod.rs
@@ -552,6 +552,7 @@ impl<U: WalletIo> Wallet<U> {
     /// provided, will prompt for password from stdin.
     /// Stores the key in decrypted key cache and returns the alias of the key
     /// and a reference-counting pointer to the key.
+    #[allow(clippy::too_many_arguments)]
     pub fn derive_store_key_from_mnemonic_code(
         &mut self,
         scheme: SchemeType,

--- a/crates/sdk/src/wallet/mod.rs
+++ b/crates/sdk/src/wallet/mod.rs
@@ -514,13 +514,20 @@ impl<U: WalletIo> Wallet<U> {
         alias_force: bool,
         derivation_path: DerivationPath,
         mnemonic_passphrase: Option<(Mnemonic, Zeroizing<String>)>,
+        prompt_bip39_passphrase: bool,
         password: Option<Zeroizing<String>>,
     ) -> Option<(String, ExtendedSpendingKey)> {
         let (mnemonic, passphrase) =
             if let Some(mnemonic_passphrase) = mnemonic_passphrase {
                 mnemonic_passphrase
             } else {
-                (U::read_mnemonic_code()?, U::read_mnemonic_passphrase(false))
+                let mnemonic = U::read_mnemonic_code()?;
+                let passphrase = if prompt_bip39_passphrase {
+                    U::read_mnemonic_passphrase(false)
+                } else {
+                    Zeroizing::default()
+                };
+                (mnemonic, passphrase)
             };
         let seed = Seed::new(&mnemonic, &passphrase);
         let spend_key =
@@ -552,13 +559,20 @@ impl<U: WalletIo> Wallet<U> {
         alias_force: bool,
         derivation_path: DerivationPath,
         mnemonic_passphrase: Option<(Mnemonic, Zeroizing<String>)>,
+        prompt_bip39_passphrase: bool,
         password: Option<Zeroizing<String>>,
     ) -> Option<(String, common::SecretKey)> {
         let (mnemonic, passphrase) =
             if let Some(mnemonic_passphrase) = mnemonic_passphrase {
                 mnemonic_passphrase
             } else {
-                (U::read_mnemonic_code()?, U::read_mnemonic_passphrase(false))
+                let mnemonic = U::read_mnemonic_code()?;
+                let passphrase = if prompt_bip39_passphrase {
+                    U::read_mnemonic_passphrase(false)
+                } else {
+                    Zeroizing::default()
+                };
+                (mnemonic, passphrase)
             };
         let seed = Seed::new(&mnemonic, &passphrase);
         let sk = derive_hd_secret_key(

--- a/crates/sdk/src/wallet/store.rs
+++ b/crates/sdk/src/wallet/store.rs
@@ -310,7 +310,8 @@ impl Store {
             .unwrap_or_else(|| Address::Implicit(ImplicitAddress(pkh.clone())));
         if !force {
             if self.pkhs.contains_key(&pkh) {
-                println!("The key already exists.");
+                let alias = self.pkhs.get(&pkh).unwrap();
+                println!("The key already exists with alias {}", alias);
                 return None;
             } else if let Some(alias) = self.addresses.get_by_right(&address) {
                 println!(
@@ -449,7 +450,8 @@ impl Store {
             .unwrap_or_else(|| Address::Implicit(ImplicitAddress(pkh.clone())));
         if !force {
             if self.pkhs.contains_key(&pkh) {
-                println!("The key already exists.");
+                let alias = self.pkhs.get(&pkh).unwrap();
+                println!("The key already exists with alias {}", alias);
                 return None;
             } else if let Some(alias) = self.addresses.get_by_right(&address) {
                 println!(

--- a/crates/sdk/src/wallet/store.rs
+++ b/crates/sdk/src/wallet/store.rs
@@ -325,7 +325,7 @@ impl Store {
 
         // abort if the alias is reserved
         if Alias::is_reserved(&alias).is_some() {
-            println!("The alias {} is reserved", alias);
+            println!("The alias {} is reserved.", alias);
             return None;
         }
 
@@ -372,7 +372,7 @@ impl Store {
     ) -> Option<Alias> {
         // abort if the alias is reserved
         if Alias::is_reserved(&alias).is_some() {
-            println!("The alias {} is reserved", alias);
+            println!("The alias {} is reserved.", alias);
             return None;
         }
         // abort if the alias is empty
@@ -413,7 +413,7 @@ impl Store {
     ) -> Option<Alias> {
         // abort if the alias is reserved
         if Alias::is_reserved(&alias).is_some() {
-            println!("The alias {} is reserved", alias);
+            println!("The alias {} is reserved.", alias);
             return None;
         }
 
@@ -498,7 +498,7 @@ impl Store {
     ) -> Option<Alias> {
         // abort if the alias is reserved
         if Alias::is_reserved(&alias).is_some() {
-            println!("The alias {} is reserved", alias);
+            println!("The alias {} is reserved.", alias);
             return None;
         }
 
@@ -536,7 +536,7 @@ impl Store {
     ) -> Option<Alias> {
         // abort if the alias is reserved
         if Alias::is_reserved(&alias).is_some() {
-            println!("The alias {} is reserved", alias);
+            println!("The alias {} is reserved.", alias);
             return None;
         }
         // abort if the address already exists in the wallet


### PR DESCRIPTION
- Fix: respect the optional bip39-flag for key derivation.
- Improvement: print the alias if the derived key already exists.

Based on v0.30.2

- [x] I have added a changelog
- [x] Git history is in acceptable state
