### PR TITLE
Print generated payment address

### DIFF
--- a/.changelog/unreleased/improvements/2490-wallet-display-gen-payment-addr.md
+++ b/.changelog/unreleased/improvements/2490-wallet-display-gen-payment-addr.md
@@ -1,0 +1,2 @@
+- Wallet: print the generated payment address.
+  ([\#2490](https://github.com/anoma/namada/pull/2490))

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -317,15 +317,12 @@ fn payment_address_gen(
     let alias = alias.to_lowercase();
     let viewing_key = ExtendedFullViewingKey::from(viewing_key).fvk.vk;
     let (div, _g_d) = find_valid_diversifier(&mut OsRng);
-    let payment_addr = viewing_key
+    let masp_payment_addr = viewing_key
         .to_payment_address(div)
         .expect("a PaymentAddress");
+    let payment_addr = PaymentAddress::from(masp_payment_addr).pinned(pin);
     let alias = wallet
-        .insert_payment_addr(
-            alias,
-            PaymentAddress::from(payment_addr).pinned(pin),
-            alias_force,
-        )
+        .insert_payment_addr(alias, payment_addr, alias_force)
         .unwrap_or_else(|| {
             edisplay_line!(io, "Payment address not added");
             cli::safe_exit(1);
@@ -333,7 +330,8 @@ fn payment_address_gen(
     wallet.save().unwrap_or_else(|err| eprintln!("{}", err));
     display_line!(
         io,
-        "Successfully generated a payment address with the following alias: {}",
+        "Successfully generated payment address {} with alias {}",
+        payment_addr,
         alias,
     );
 }


### PR DESCRIPTION
Improvement: print the generated payment address.

Based on v0.31.0

- [x] I have added a changelog
- [x] Git history is in acceptable state
