### PR TITLE
Reworks the way the ledger waits for genesis start.

### DIFF
--- a/.changelog/unreleased/improvements/2502-wait-for-genesis-logs.md
+++ b/.changelog/unreleased/improvements/2502-wait-for-genesis-logs.md
@@ -1,0 +1,4 @@
+- Reworks the way the ledger waits for genesis start. It now fully initializes the node and 
+  outputs logs before sleeping until genesis start time. Previously it would not start any 
+  processes until genesis times, giving no feedback to users until genesis time was reached.
+  ([\#2502](https://github.com/anoma/namada/pull/2502))

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ test-e2e:
 	NAMADA_E2E_USE_PREBUILT_BINARIES=$(NAMADA_E2E_USE_PREBUILT_BINARIES) \
 	NAMADA_E2E_DEBUG=$(NAMADA_E2E_DEBUG) \
 	RUST_BACKTRACE=$(RUST_BACKTRACE) \
-	$(cargo) +$(nightly) test e2e::$(TEST_FILTER) \
+	$(cargo) +$(nightly) test $(jobs) e2e::$(TEST_FILTER) \
 	-Z unstable-options \
 	-- \
 	--test-threads=1 \


### PR DESCRIPTION
Resolves #2495

## Describe your changes

 It now fully initializes the node and outputs logs before sleeping until genesis start time. Previously it would not start any processes until genesis times, giving no feedback to users until genesis time was reached.

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
