### PR TITLE
Feature : add a new cli 'wallet convert' command for coverting tendermnint key json file

### DIFF
--- a/.changelog/unreleased/features/2516-consensus-key-to-tm-key.md
+++ b/.changelog/unreleased/features/2516-consensus-key-to-tm-key.md
@@ -1,0 +1,3 @@
+- Added wallet command to "convert" a consensus key
+  into Tendermint private validator key JSON format.
+  ([\#2516](https://github.com/anoma/namada/pull/2516))

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -724,7 +724,10 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about("Convert to tendermint priv_validator_key.json with your consensus key alias")
+                .about(
+                    "Convert to tendermint priv_validator_key.json with your \
+                     consensus key alias",
+                )
                 .add_args::<args::KeyConvert>()
         }
     }

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -501,6 +501,8 @@ pub mod cmds {
         KeyAddrFind(WalletFindKeysAddresses),
         /// Key export
         KeyExport(WalletExportKey),
+        /// Key convert
+        KeyConvert(WalletConvertKey),
         /// Key import
         KeyImport(WalletImportKey),
         /// Key / address add
@@ -517,6 +519,7 @@ pub mod cmds {
                 .subcommand(WalletListKeysAddresses::def())
                 .subcommand(WalletFindKeysAddresses::def())
                 .subcommand(WalletExportKey::def())
+                .subcommand(WalletConvertKey::def())
                 .subcommand(WalletImportKey::def())
                 .subcommand(WalletAddKeyAddress::def())
                 .subcommand(WalletRemoveKeyAddress::def())
@@ -529,6 +532,7 @@ pub mod cmds {
             let key_addr_list = SubCmd::parse(matches).map(Self::KeyAddrList);
             let key_addr_find = SubCmd::parse(matches).map(Self::KeyAddrFind);
             let export = SubCmd::parse(matches).map(Self::KeyExport);
+            let convert = SubCmd::parse(matches).map(Self::KeyConvert);
             let import = SubCmd::parse(matches).map(Self::KeyImport);
             let key_addr_add = SubCmd::parse(matches).map(Self::KeyAddrAdd);
             let key_addr_remove =
@@ -538,6 +542,7 @@ pub mod cmds {
                 .or(key_addr_list)
                 .or(key_addr_find)
                 .or(export)
+                .or(convert)
                 .or(import)
                 .or(key_addr_add)
                 .or(key_addr_remove)
@@ -701,6 +706,26 @@ pub mod cmds {
                      a file.",
                 )
                 .add_args::<args::KeyExport>()
+        }
+    }
+
+    /// Export key to a file
+    #[derive(Clone, Debug)]
+    pub struct WalletConvertKey(pub args::KeyConvert);
+
+    impl SubCmd for WalletConvertKey {
+        const CMD: &'static str = "convert";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches
+                .subcommand_matches(Self::CMD)
+                .map(|matches| (Self(args::KeyConvert::parse(matches))))
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about("Convert to tendermint priv_validator_key.json with your consensus key alias")
+                .add_args::<args::KeyConvert>()
         }
     }
 
@@ -6570,6 +6595,19 @@ pub mod args {
     }
 
     impl Args for KeyExport {
+        fn parse(matches: &ArgMatches) -> Self {
+            let alias = ALIAS.parse(matches);
+            Self { alias }
+        }
+
+        fn def(app: App) -> App {
+            app.arg(
+                ALIAS.def().help("The alias of the key you wish to export."),
+            )
+        }
+    }
+
+    impl Args for KeyConvert {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
             Self { alias }

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -1257,7 +1257,7 @@ fn key_convert(
     let mut wallet = load_wallet(ctx);
     let sk = wallet.find_secret_key(&alias, None);
     let key: serde_json::Value = validator_key_to_json(&sk.unwrap()).unwrap();
-    let file_name = format!("priv_validator_key.json_{}", alias);
+    let file_name = format!("priv_validator_key_{}.json", alias);
     let file = File::create(&file_name).unwrap();
     serde_json::to_writer_pretty(file, &key).unwrap_or_else(|err| {
         edisplay_line!(io, "{}", err);

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -28,6 +28,7 @@ use crate::cli::api::CliApi;
 use crate::cli::args::CliToSdk;
 use crate::cli::{args, cmds, Context};
 use crate::client::utils::PRE_GENESIS_DIR;
+use crate::node::ledger::tendermint_node::validator_key_to_json;
 use crate::wallet::{
     self, read_and_confirm_encryption_password, CliWalletUtils,
 };
@@ -53,6 +54,9 @@ impl CliApi {
             )) => key_address_find(ctx, io, args),
             cmds::NamadaWallet::KeyExport(cmds::WalletExportKey(args)) => {
                 key_export(ctx, io, args)
+            }
+            cmds::NamadaWallet::KeyConvert(cmds::WalletConvertKey(args)) => {
+                key_convert(ctx, io, args)
             }
             cmds::NamadaWallet::KeyImport(cmds::WalletImportKey(args)) => {
                 key_import(ctx, io, args)
@@ -1241,6 +1245,25 @@ fn key_export(
             edisplay_line!(io, "{}", err);
             cli::safe_exit(1)
         })
+}
+
+/// Convert a consensus key to tendermint validator key in json format
+fn key_convert(
+    ctx: Context,
+    io: &impl Io,
+    args::KeyConvert { alias }: args::KeyConvert,
+) {
+    let alias = alias.to_lowercase();
+    let mut wallet = load_wallet(ctx);
+    let sk = wallet.find_secret_key(&alias, None);
+    let key: serde_json::Value = validator_key_to_json(&sk.unwrap()).unwrap();
+    let file_name = format!("priv_validator_key.json_{}", alias);
+    let file = File::create(&file_name).unwrap();
+    serde_json::to_writer_pretty(file, &key).unwrap_or_else(|err| {
+        edisplay_line!(io, "{}", err);
+        cli::safe_exit(1)
+    });
+    display_line!(io, "Converted to file {}", file_name);
 }
 
 /// Import a transparent keypair / MASP spending key from a file.

--- a/crates/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/crates/apps/src/lib/node/ledger/tendermint_node.rs
@@ -261,7 +261,7 @@ pub fn rollback(tendermint_dir: impl AsRef<Path>) -> Result<BlockHeight> {
 
 /// Convert a common signing scheme validator key into JSON for
 /// Tendermint
-fn validator_key_to_json(
+pub fn validator_key_to_json(
     sk: &common::SecretKey,
 ) -> std::result::Result<serde_json::Value, ParseSecretKeyError> {
     let raw_hash = tm_consensus_key_raw_hash(&sk.ref_to());
@@ -316,7 +316,7 @@ pub fn write_validator_state(home_dir: impl AsRef<Path>) -> Result<()> {
 }
 
 /// Abstract over the initialization of validator data for Tendermint
-fn write_validator(
+pub fn write_validator(
     path: PathBuf,
     err_dir: &'static str,
     err_file: &'static str,

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -2173,6 +2173,13 @@ pub struct KeyExport {
     pub alias: String,
 }
 
+/// Wallet key export arguments
+#[derive(Clone, Debug)]
+pub struct KeyConvert {
+    /// Key alias
+    pub alias: String,
+}
+
 /// Wallet key import arguments
 #[derive(Clone, Debug)]
 pub struct KeyImport {


### PR DESCRIPTION
## Describe your changes

I made a new cli command for namadw  caused by #2515 

```
Usage: namadaw [OPTIONS] <COMMAND>

### Sample
Commands:
  gen               Generates a new transparent / shielded secret key.
  derive            Derive transparent / shielded key from the mnemonic code or a seed stored on the hardware wallet device.
  gen-payment-addr  Generates a payment address from the given spending key.
  list              List known keys and addresses in the wallet.
  find              Find known keys and addresses in the wallet.
  export            Exports a transparent keypair / shielded spending key to a file.
  convert           Convert to tendermint priv_validator_key.json with your consensus key alias
  import            Imports a transparent keypair / shielded spending key from a file.
  add               Adds the given key or address to the wallet.
  remove            Remove the given alias and all associated keys / addresses from the wallet.
  help              Print this message or the help of the given subcommand(s)
```
### How to use

1. submit change consensus key transaction by using namadac
```
namada client change-consensus-key  \
	--validator <your validator address> \
	--signing-keys <your validator account key name> 
        # Add options whatever you want
```

2. you can check created a new consensus key in wallet.toml
```
  Alias "validator-0-consensus-key-1" (encrypted):
    Public key hash: F1E5244875BAB4D5BDBFCDE1EC9862DF3DEC2478
    Public key: tpknam1qqv7xw0wad4v4vk6lyv0ft8hmandffwzeru3khrdvgesye7tjsy3vd2c636
 ```

3. By protocol parameter, the consensus key which connected at your validator will be changed to by this new key after a few epochs(pipeline length)

4. convert a key for generating `priv_validator_key.json` 

```
namadaw convert --alias "validator-0-consensus-key-1"
```

you can see priv_validator_key.json_<alias> file

5.  replace `cometbft/config/priv_validator_key.json` with it


6. you can check tendermint address with both a new `priv_validator_key.json` address and `find-validator` command

### Improvement plan

I'm not sure. Other validators would want to use this feature. Please any comments for improvement validators UX 

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state

### Connected Issue
