### PR TITLE
 Ensure ABCI commands are handled synchronously

### DIFF
--- a/.changelog/unreleased/bug-fixes/2547-order-txs.md
+++ b/.changelog/unreleased/bug-fixes/2547-order-txs.md
@@ -1,0 +1,2 @@
+- ABCI calls must be executed synchronously.
+  ([\#2547](https://github.com/anoma/namada/pull/2547))

--- a/crates/apps/src/lib/node/ledger/shims/abcipp_shim.rs
+++ b/crates/apps/src/lib/node/ledger/shims/abcipp_shim.rs
@@ -295,7 +295,7 @@ impl AbciService {
     /// forward it normally.
     fn forward_request(&mut self, req: Req) -> <Self as Service<Req>>::Future {
         let (resp_send, recv) = tokio::sync::oneshot::channel();
-        let shell_send = self.shell_send.clone();
+        let result = self.shell_send.send((req.clone(), resp_send));
         async move {
             let genesis_time = if let Req::InitChain(ref init) = req {
                 Some(
@@ -305,7 +305,6 @@ impl AbciService {
             } else {
                 None
             };
-            let result = shell_send.send((req, resp_send));
             if let Err(err) = result {
                 // The shell has shut-down
                 return Err(err.into());


### PR DESCRIPTION
## Describe your changes

In a previous set of changes, the method that enqueued ABCI calls did so asynchronously. These calls must be handled in the order received, so this is a bug. This PR makes sure that the enqueing is done synchronously.

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
