### PR TITLE
Refactor handling of previous PoS inflation data

### DIFF
--- a/crates/apps/src/lib/config/genesis.rs
+++ b/crates/apps/src/lib/config/genesis.rs
@@ -287,10 +287,6 @@ pub struct Parameters {
     pub epochs_per_year: u64,
     /// Maximum amount of signatures per transaction
     pub max_signatures_per_transaction: u8,
-    /// PoS staked ratio (read + write for every epoch)
-    pub staked_ratio: Dec,
-    /// PoS inflation amount from the last epoch (read + write for every epoch)
-    pub pos_inflation_amount: token::Amount,
     /// Fee unshielding gas limit
     pub fee_unshielding_gas_limit: u64,
     /// Fee unshielding descriptions limit

--- a/crates/apps/src/lib/config/genesis/chain.rs
+++ b/crates/apps/src/lib/config/genesis/chain.rs
@@ -9,7 +9,6 @@ use namada::types::address::{
     Address, EstablishedAddress, EstablishedAddressGen,
 };
 use namada::types::chain::{ChainId, ChainIdPrefix};
-use namada::types::dec::Dec;
 use namada::types::hash::Hash;
 use namada::types::key::{common, RefTo};
 use namada::types::time::{DateTimeUtc, DurationNanos, Rfc3339String};
@@ -299,8 +298,6 @@ impl Finalized {
                 .into();
         let vp_allowlist = vp_allowlist.unwrap_or_default();
         let tx_allowlist = tx_allowlist.unwrap_or_default();
-        let staked_ratio = Dec::zero();
-        let pos_inflation_amount = 0;
 
         namada::ledger::parameters::Parameters {
             max_tx_bytes,
@@ -310,8 +307,6 @@ impl Finalized {
             tx_allowlist,
             implicit_vp_code_hash,
             epochs_per_year,
-            staked_ratio,
-            pos_inflation_amount: Amount::native_whole(pos_inflation_amount),
             max_proposal_bytes,
             max_signatures_per_transaction,
             fee_unshielding_gas_limit,

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -2135,8 +2135,6 @@ mod test_utils {
             implicit_vp_code_hash: Default::default(),
             epochs_per_year: 365,
             max_signatures_per_transaction: 10,
-            staked_ratio: Default::default(),
-            pos_inflation_amount: Default::default(),
             fee_unshielding_gas_limit: 0,
             fee_unshielding_descriptions_limit: 0,
             minimum_gas_price: Default::default(),

--- a/crates/apps/src/lib/node/ledger/storage/mod.rs
+++ b/crates/apps/src/lib/node/ledger/storage/mod.rs
@@ -167,8 +167,6 @@ mod tests {
             implicit_vp_code_hash: Default::default(),
             epochs_per_year: 365,
             max_signatures_per_transaction: 10,
-            staked_ratio: Default::default(),
-            pos_inflation_amount: Default::default(),
             fee_unshielding_gas_limit: 0,
             fee_unshielding_descriptions_limit: 0,
             minimum_gas_price: Default::default(),

--- a/crates/core/src/types/parameters.rs
+++ b/crates/core/src/types/parameters.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeMap;
 
 use super::address::Address;
 use super::chain::ProposalBytes;
-use super::dec::Dec;
 use super::hash::Hash;
 use super::time::DurationSecs;
 use super::token;
@@ -44,10 +43,6 @@ pub struct Parameters {
     pub epochs_per_year: u64,
     /// Maximum number of signature per transaction
     pub max_signatures_per_transaction: u8,
-    /// PoS staked ratio (read + write for every epoch)
-    pub staked_ratio: Dec,
-    /// PoS inflation amount from the last epoch (read + write for every epoch)
-    pub pos_inflation_amount: token::Amount,
     /// Fee unshielding gas limit
     pub fee_unshielding_gas_limit: u64,
     /// Fee unshielding descriptions limit

--- a/crates/parameters/src/lib.rs
+++ b/crates/parameters/src/lib.rs
@@ -5,7 +5,6 @@ use std::collections::BTreeMap;
 
 use namada_core::types::address::{Address, InternalAddress};
 use namada_core::types::chain::ProposalBytes;
-use namada_core::types::dec::Dec;
 use namada_core::types::hash::Hash;
 pub use namada_core::types::parameters::*;
 use namada_core::types::storage::Key;
@@ -59,8 +58,6 @@ where
         implicit_vp_code_hash,
         epochs_per_year,
         max_signatures_per_transaction,
-        staked_ratio,
-        pos_inflation_amount,
         minimum_gas_price,
         fee_unshielding_gas_limit,
         fee_unshielding_descriptions_limit,
@@ -137,12 +134,6 @@ where
         &max_signatures_per_transaction_key,
         max_signatures_per_transaction,
     )?;
-
-    let staked_ratio_key = storage::get_staked_ratio_key();
-    storage.write(&staked_ratio_key, staked_ratio)?;
-
-    let pos_inflation_key = storage::get_pos_inflation_amount_key();
-    storage.write(&pos_inflation_key, pos_inflation_amount)?;
 
     let gas_cost_key = storage::get_gas_cost_key();
     storage.write(&gas_cost_key, minimum_gas_price)?;
@@ -235,32 +226,6 @@ where
     S: StorageRead + StorageWrite,
 {
     let key = storage::get_epochs_per_year_key();
-    storage.write(&key, value)
-}
-
-/// Update the PoS staked ratio parameter in storage. Returns the parameters and
-/// gas cost.
-pub fn update_staked_ratio_parameter<S>(
-    storage: &mut S,
-    value: &Dec,
-) -> namada_storage::Result<()>
-where
-    S: StorageRead + StorageWrite,
-{
-    let key = storage::get_staked_ratio_key();
-    storage.write(&key, value)
-}
-
-/// Update the PoS inflation rate parameter in storage. Returns the parameters
-/// and gas cost.
-pub fn update_pos_inflation_amount_parameter<S>(
-    storage: &mut S,
-    value: &u64,
-) -> namada_storage::Result<()>
-where
-    S: StorageRead + StorageWrite,
-{
-    let key = storage::get_pos_inflation_amount_key();
     storage.write(&key, value)
 }
 
@@ -409,20 +374,6 @@ where
         .ok_or(ReadError::ParametersMissing)
         .into_storage_result()?;
 
-    // read staked ratio
-    let staked_ratio_key = storage::get_staked_ratio_key();
-    let value = storage.read(&staked_ratio_key)?;
-    let staked_ratio = value
-        .ok_or(ReadError::ParametersMissing)
-        .into_storage_result()?;
-
-    // read PoS inflation rate
-    let pos_inflation_key = storage::get_pos_inflation_amount_key();
-    let value = storage.read(&pos_inflation_key)?;
-    let pos_inflation_amount = value
-        .ok_or(ReadError::ParametersMissing)
-        .into_storage_result()?;
-
     // read gas cost
     let gas_cost_key = storage::get_gas_cost_key();
     let value = storage.read(&gas_cost_key)?;
@@ -448,8 +399,6 @@ where
         implicit_vp_code_hash: Some(implicit_vp_code_hash),
         epochs_per_year,
         max_signatures_per_transaction,
-        staked_ratio,
-        pos_inflation_amount,
         minimum_gas_price,
         fee_unshielding_gas_limit,
         fee_unshielding_descriptions_limit,

--- a/crates/parameters/src/storage.rs
+++ b/crates/parameters/src/storage.rs
@@ -25,11 +25,6 @@ struct Keys {
     /// Sub-lkey for storing the Ethereum address of the bridge contract.
     bridge_contract_address: &'static str,
     // ========================================
-    // PoS parameters
-    // ========================================
-    pos_inflation_amount: &'static str,
-    staked_ratio: &'static str,
-    // ========================================
     // Core parameters
     // ========================================
     epoch_duration: &'static str,
@@ -95,16 +90,6 @@ pub fn is_epochs_per_year_key(key: &Key) -> bool {
     is_epochs_per_year_key_at_addr(key, &ADDRESS)
 }
 
-/// Returns if the key is the staked ratio key.
-pub fn is_staked_ratio_key(key: &Key) -> bool {
-    is_staked_ratio_key_at_addr(key, &ADDRESS)
-}
-
-/// Returns if the key is the PoS reward rate key.
-pub fn is_pos_inflation_amount_key(key: &Key) -> bool {
-    is_pos_inflation_amount_key_at_addr(key, &ADDRESS)
-}
-
 /// Returns if the key is the max proposal bytes key.
 pub fn is_max_proposal_bytes_key(key: &Key) -> bool {
     is_max_proposal_bytes_key_at_addr(key, &ADDRESS)
@@ -153,16 +138,6 @@ pub fn get_implicit_vp_key() -> Key {
 /// Storage key used for epochs_per_year parameter.
 pub fn get_epochs_per_year_key() -> Key {
     get_epochs_per_year_key_at_addr(ADDRESS)
-}
-
-/// Storage key used for staked ratio parameter.
-pub fn get_staked_ratio_key() -> Key {
-    get_staked_ratio_key_at_addr(ADDRESS)
-}
-
-/// Storage key used for the inflation amount parameter.
-pub fn get_pos_inflation_amount_key() -> Key {
-    get_pos_inflation_amount_key_at_addr(ADDRESS)
 }
 
 /// Storage key used for the max proposal bytes.

--- a/crates/proof_of_stake/src/lib.rs
+++ b/crates/proof_of_stake/src/lib.rs
@@ -64,8 +64,10 @@ use crate::storage::{
     validator_rewards_products_handle, validator_set_positions_handle,
     validator_slashes_handle, validator_state_handle,
     validator_total_redelegated_bonded_handle,
-    validator_total_redelegated_unbonded_handle, write_last_reward_claim_epoch,
-    write_pos_params, write_validator_address_raw_hash, write_validator_avatar,
+    validator_total_redelegated_unbonded_handle,
+    write_last_pos_inflation_amount, write_last_reward_claim_epoch,
+    write_last_staked_ratio, write_pos_params,
+    write_validator_address_raw_hash, write_validator_avatar,
     write_validator_description, write_validator_discord_handle,
     write_validator_email, write_validator_max_commission_rate_change,
     write_validator_metadata, write_validator_website,
@@ -110,6 +112,11 @@ where
     tracing::debug!("Initializing PoS genesis");
     write_pos_params(storage, params)?;
 
+    // Initialize values for PoS inflation
+    write_last_staked_ratio(storage, Dec::zero())?;
+    write_last_pos_inflation_amount(storage, token::Amount::zero())?;
+
+    // Initialize validator set data
     consensus_validator_set_handle().init(storage, current_epoch)?;
     below_capacity_validator_set_handle().init(storage, current_epoch)?;
     validator_set_positions_handle().init(storage, current_epoch)?;

--- a/crates/proof_of_stake/src/storage.rs
+++ b/crates/proof_of_stake/src/storage.rs
@@ -387,6 +387,52 @@ where
     storage.write(&key, address)
 }
 
+/// Read last epoch's staked ratio.
+pub fn read_last_staked_ratio<S>(
+    storage: &S,
+) -> namada_storage::Result<Option<Dec>>
+where
+    S: StorageRead,
+{
+    let key = storage_key::last_staked_ratio_key();
+    storage.read(&key)
+}
+
+/// Write last epoch's staked ratio.
+pub fn write_last_staked_ratio<S>(
+    storage: &mut S,
+    ratio: Dec,
+) -> namada_storage::Result<()>
+where
+    S: StorageRead + StorageWrite,
+{
+    let key = storage_key::last_staked_ratio_key();
+    storage.write(&key, ratio)
+}
+
+/// Read last epoch's PoS inflation amount.
+pub fn read_last_pos_inflation_amount<S>(
+    storage: &S,
+) -> namada_storage::Result<Option<token::Amount>>
+where
+    S: StorageRead,
+{
+    let key = storage_key::last_pos_inflation_amount_key();
+    storage.read(&key)
+}
+
+/// Write last epoch's pos inflation amount.
+pub fn write_last_pos_inflation_amount<S>(
+    storage: &mut S,
+    inflation: token::Amount,
+) -> namada_storage::Result<()>
+where
+    S: StorageRead + StorageWrite,
+{
+    let key = storage_key::last_pos_inflation_amount_key();
+    storage.write(&key, inflation)
+}
+
 /// Read PoS validator's delta value.
 pub fn read_validator_deltas_value<S>(
     storage: &S,

--- a/crates/proof_of_stake/src/storage_key.rs
+++ b/crates/proof_of_stake/src/storage_key.rs
@@ -58,6 +58,8 @@ const VALIDATOR_AVATAR_KEY: &str = "avatar";
 const LIVENESS_PREFIX: &str = "liveness";
 const LIVENESS_MISSED_VOTES: &str = "missed_votes";
 const LIVENESS_MISSED_VOTES_SUM: &str = "sum_missed_votes";
+const LAST_STAKED_RATIO_KEY: &str = "last_staked_ratio";
+const LAST_POS_INFLATION_AMOUNT_KEY: &str = "last_inflation_amount";
 
 /// Is the given key a PoS storage key?
 pub fn is_pos_key(key: &Key) -> bool {
@@ -1042,5 +1044,19 @@ pub fn liveness_missed_votes_key() -> Key {
 pub fn liveness_sum_missed_votes_key() -> Key {
     liveness_data_prefix()
         .push(&LIVENESS_MISSED_VOTES_SUM.to_owned())
+        .expect("Cannot obtain a storage key")
+}
+
+/// Storage key for the last epoch's staked ratio.
+pub fn last_staked_ratio_key() -> Key {
+    Key::from(ADDRESS.to_db_key())
+        .push(&LAST_STAKED_RATIO_KEY.to_owned())
+        .expect("Cannot obtain a storage key")
+}
+
+/// Storage key for the last epoch's PoS inflation amount.
+pub fn last_pos_inflation_amount_key() -> Key {
+    Key::from(ADDRESS.to_db_key())
+        .push(&LAST_POS_INFLATION_AMOUNT_KEY.to_owned())
         .expect("Cannot obtain a storage key")
 }

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -569,8 +569,6 @@ mod tests {
             implicit_vp_code_hash: Default::default(),
             epochs_per_year: 365,
             max_signatures_per_transaction: 10,
-            staked_ratio: Default::default(),
-            pos_inflation_amount: Default::default(),
             fee_unshielding_gas_limit: 0,
             fee_unshielding_descriptions_limit: 0,
             minimum_gas_price: Default::default(),

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -1172,9 +1172,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use chrono::{TimeZone, Utc};
-    use namada_core::types::dec::Dec;
     use namada_core::types::time::{self, Duration};
-    use namada_core::types::token;
     use namada_parameters::Parameters;
     use proptest::prelude::*;
     use proptest::test_runner::Config;
@@ -1261,8 +1259,6 @@ mod tests {
                 implicit_vp_code_hash: Some(Hash::zero()),
                 epochs_per_year: 100,
                 max_signatures_per_transaction: 15,
-                staked_ratio: Dec::new(1,1).expect("Cannot fail"),
-                pos_inflation_amount: token::Amount::zero(),
                 fee_unshielding_gas_limit: 20_000,
                 fee_unshielding_descriptions_limit: 15,
                 minimum_gas_price: BTreeMap::default(),


### PR DESCRIPTION
## Describe your changes
Closes #2556. These values have been removed from `Parameters` and are now initialized in `proof_of_stake::init_genesis`.  Their storage keys have also been moved under the PoS address storage space.

## Indicate on which release or other PRs this topic is based on
v0.31.2

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
