### PR TITLE
Show additional proposal data in namada client query-proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4442,6 +4442,7 @@ name = "namada_governance"
 version = "0.31.4"
 dependencies = [
  "borsh",
+ "itertools 0.10.5",
  "namada_core",
  "namada_macros",
  "namada_parameters",

--- a/crates/governance/Cargo.toml
+++ b/crates/governance/Cargo.toml
@@ -23,6 +23,7 @@ namada_state = {path = "../state"}
 namada_trans_token = {path = "../trans_token"}
 
 borsh.workspace = true
+itertools.workspace = true
 proptest = { workspace = true, optional = true }
 serde_json.workspace = true
 serde.workspace = true

--- a/crates/governance/src/cli/onchain.rs
+++ b/crates/governance/src/cli/onchain.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fmt::Display;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use namada_core::types::address::Address;
@@ -281,6 +282,24 @@ pub struct PgfFunding {
     pub continuous: Vec<PGFTarget>,
     /// pgf retro fundings
     pub retro: Vec<PGFTarget>,
+}
+
+impl Display for PgfFunding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.continuous.is_empty() {
+            write!(f, "Continuous: ")?;
+            for target in &self.continuous {
+                write!(f, "  {}", &target)?;
+            }
+        }
+        if !self.retro.is_empty() {
+            write!(f, "Retro: ")?;
+            for target in &self.retro {
+                write!(f, "  {}", &target)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Pgf continuous funding

--- a/crates/governance/src/pgf/storage/mod.rs
+++ b/crates/governance/src/pgf/storage/mod.rs
@@ -64,7 +64,7 @@ where
     Ok(())
 }
 
-/// Query the current pgf continous payments
+/// Query the current pgf continuous payments
 pub fn get_payments<S>(storage: &S) -> StorageResult<Vec<StoragePgfFunding>>
 where
     S: StorageRead,

--- a/crates/governance/src/storage/proposal.rs
+++ b/crates/governance/src/storage/proposal.rs
@@ -121,7 +121,7 @@ impl TryFrom<PgfFundingProposal> for InitProposalData {
     type Error = ProposalError;
 
     fn try_from(value: PgfFundingProposal) -> Result<Self, Self::Error> {
-        let mut continous_fundings = value
+        let mut continuous_fundings = value
             .data
             .continuous
             .iter()
@@ -143,13 +143,13 @@ impl TryFrom<PgfFundingProposal> for InitProposalData {
             .map(PGFAction::Retro)
             .collect::<BTreeSet<PGFAction>>();
 
-        continous_fundings.extend(retro_fundings);
+        continuous_fundings.extend(retro_fundings);
 
         Ok(InitProposalData {
             id: value.proposal.id,
             content: Hash::default(),
             author: value.proposal.author,
-            r#type: ProposalType::PGFPayment(continous_fundings), /* here continous_fundings is contains also the retro funding */
+            r#type: ProposalType::PGFPayment(continuous_fundings), /* here continuous_fundings also contains the retro funding */
             voting_start_epoch: value.proposal.voting_start_epoch,
             voting_end_epoch: value.proposal.voting_end_epoch,
             grace_epoch: value.proposal.grace_epoch,

--- a/crates/governance/src/storage/proposal.rs
+++ b/crates/governance/src/storage/proposal.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use itertools::Itertools;
 use namada_core::ibc::core::host::types::identifiers::{ChannelId, PortId};
 use namada_core::types::address::Address;
 use namada_core::types::hash::Hash;
@@ -223,6 +224,18 @@ pub enum AddRemove<T> {
     Remove(T),
 }
 
+impl<T> Display for AddRemove<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddRemove::Add(address) => write!(f, "Add({})", &address),
+            AddRemove::Remove(address) => write!(f, "Remove({})", &address),
+        }
+    }
+}
+
 /// The target of a PGF payment
 #[derive(
     Debug,
@@ -257,6 +270,19 @@ impl PGFTarget {
         match self {
             PGFTarget::Internal(t) => t.amount,
             PGFTarget::Ibc(t) => t.amount,
+        }
+    }
+}
+
+impl Display for PGFTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PGFTarget::Internal(t) => {
+                write!(f, "Internal address={}, amount={}", t.target, t.amount)
+            }
+            PGFTarget::Ibc(t) => {
+                write!(f, "IBC address={}, amount={}", t.target, t.amount)
+            }
         }
     }
 }
@@ -385,14 +411,35 @@ impl ProposalType {
     pub fn is_default(&self) -> bool {
         matches!(self, ProposalType::Default(_))
     }
+
+    fn format_data(&self) -> String {
+        match self {
+            ProposalType::Default(Some(hash)) => format!("Hash: {}", &hash),
+            ProposalType::Default(None) => "".to_string(),
+            ProposalType::PGFSteward(addresses) => format!(
+                "Addresses:{}",
+                addresses
+                    .iter()
+                    .map(|add_remove| format!("\n  {}", &add_remove))
+                    .join("")
+            ),
+            ProposalType::PGFPayment(actions) => format!(
+                "Actions:{}",
+                actions
+                    .iter()
+                    .map(|action| format!("\n  {}", &action))
+                    .join("")
+            ),
+        }
+    }
 }
 
 impl Display for ProposalType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ProposalType::Default(_) => write!(f, "Default"),
-            ProposalType::PGFSteward(_) => write!(f, "Pgf steward"),
-            ProposalType::PGFPayment(_) => write!(f, "Pgf funding"),
+            ProposalType::PGFSteward(_) => write!(f, "PGF steward"),
+            ProposalType::PGFPayment(_) => write!(f, "PGF funding"),
         }
     }
 }
@@ -447,6 +494,17 @@ impl From<PgfContinuous> for PGFAction {
 impl From<PgfRetro> for PGFAction {
     fn from(value: PgfRetro) -> Self {
         PGFAction::Retro(value.target)
+    }
+}
+
+impl Display for PGFAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PGFAction::Continuous(add_remove) => {
+                write!(f, "Continuous: {}", &add_remove)
+            }
+            PGFAction::Retro(target) => write!(f, "Retroactive: {}", &target),
+        }
     }
 }
 
@@ -509,29 +567,23 @@ impl StorageProposal {
     pub fn to_string_with_status(&self, current_epoch: Epoch) -> String {
         format!(
             "Proposal Id: {}
-        {:2}Type: {}
-        {:2}Author: {}
-        {:2}Content: {:?}
-        {:2}Start Epoch: {}
-        {:2}End Epoch: {}
-        {:2}Grace Epoch: {}
-        {:2}Status: {}
-        ",
+Type: {}
+Author: {}
+Content: {:?}
+Start Epoch: {}
+End Epoch: {}
+Grace Epoch: {}
+Status: {}
+Data: {}",
             self.id,
-            "",
             self.r#type,
-            "",
             self.author,
-            "",
             self.content,
-            "",
             self.voting_start_epoch,
-            "",
             self.voting_end_epoch,
-            "",
             self.grace_epoch,
-            "",
-            self.get_status(current_epoch)
+            self.get_status(current_epoch),
+            self.r#type.format_data()
         )
     }
 }

--- a/crates/namada/src/ledger/governance/mod.rs
+++ b/crates/namada/src/ledger/governance/mod.rs
@@ -379,7 +379,7 @@ where
             ProposalType::PGFPayment(fundings) => {
                 // collect all the funding target that we have to add and are
                 // unique
-                let are_continous_add_targets_unique = fundings
+                let are_continuous_add_targets_unique = fundings
                     .iter()
                     .filter_map(|funding| match funding {
                         PGFAction::Continuous(AddRemove::Add(target)) => {
@@ -391,7 +391,7 @@ where
 
                 // collect all the funding target that we have to remove and are
                 // unique
-                let are_continous_remove_targets_unique = fundings
+                let are_continuous_remove_targets_unique = fundings
                     .iter()
                     .filter_map(|funding| match funding {
                         PGFAction::Continuous(AddRemove::Remove(target)) => {
@@ -411,20 +411,20 @@ where
                 // check that they are unique by checking that the set of add
                 // plus the set of remove plus the set of retro is equal to the
                 // total fundings
-                let are_continous_fundings_unique =
-                    are_continous_add_targets_unique.len()
-                        + are_continous_remove_targets_unique.len()
+                let are_continuous_fundings_unique =
+                    are_continuous_add_targets_unique.len()
+                        + are_continuous_remove_targets_unique.len()
                         + total_retro_targerts
                         == fundings.len();
 
                 // can't remove and add the same target in the same proposal
-                let are_targets_unique = are_continous_add_targets_unique
-                    .intersection(&are_continous_remove_targets_unique)
+                let are_targets_unique = are_continuous_add_targets_unique
+                    .intersection(&are_continuous_remove_targets_unique)
                     .count() as u64
                     == 0;
 
                 Ok(is_total_fundings_valid
-                    && are_continous_fundings_unique
+                    && are_continuous_fundings_unique
                     && are_targets_unique)
             }
             _ => Ok(true), // default proposal

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3489,6 +3489,7 @@ name = "namada_governance"
 version = "0.31.4"
 dependencies = [
  "borsh",
+ "itertools 0.10.5",
  "namada_core",
  "namada_macros",
  "namada_parameters",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -3489,6 +3489,7 @@ name = "namada_governance"
 version = "0.31.4"
 dependencies = [
  "borsh",
+ "itertools 0.10.5",
  "namada_core",
  "namada_macros",
  "namada_parameters",


### PR DESCRIPTION
Better formatting of proposals.

This includes the additional data required to fully review a proposal when using `namada client query-proposal`:

- Default (optional hash of WASM code)
- PGF Steward (add/remove addresses)
- PGF Payment (actions)

Fixes #2570.

Based on my "typos" PR #2569 for easier merging.

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state

Right now it uses debug formatting for some of the types.  Let me know if this is the right approach and I can implement formatting for the remaining types too.