### PR TITLE
Governance: fix tally computation

### DIFF
--- a/.changelog/unreleased/bug-fixes/2579-governance-fix.md
+++ b/.changelog/unreleased/bug-fixes/2579-governance-fix.md
@@ -1,0 +1,2 @@
+- Governance tallying for delegators now works.
+  ([\#2579](https://github.com/anoma/namada/pull/2579))

--- a/crates/governance/src/utils.rs
+++ b/crates/governance/src/utils.rs
@@ -333,19 +333,11 @@ impl ProposalVotes {
         voting_power: VotePower,
         vote: TallyVote,
     ) {
-        match self.delegators_vote.insert(address.clone(), vote) {
-            None => {
-                self.delegator_voting_power
-                    .entry(address.clone())
-                    .or_default()
-                    .insert(validator_address.clone(), voting_power);
-            }
-            // the value was update, this should never happen
-            _ => tracing::error!(
-                "Duplicate vote for delegator {}",
-                address.clone()
-            ),
-        }
+        self.delegator_voting_power
+            .entry(address.clone())
+            .or_default()
+            .insert(validator_address.clone(), voting_power);
+        self.delegators_vote.insert(address.clone(), vote);
     }
 }
 


### PR DESCRIPTION
## Describe your changes

Governance tallying didn't used to work for delegators. Now it does.

## Indicate on which release or other PRs this topic is based on
0.31.2

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state (I think so)
