### PR TITLE
Murisi/test vectors 0.30.2 rev 1

### DIFF
--- a/.changelog/unreleased/improvements/2588-test-vectors-0.30.2-rev-1.md
+++ b/.changelog/unreleased/improvements/2588-test-vectors-0.30.2-rev-1.md
@@ -1,0 +1,3 @@
+- Expanded the variety of test vectors generated for hardware
+  wallets and simplified their format in some places.
+  ([\#2588](https://github.com/anoma/namada/pull/2588))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4418,6 +4418,7 @@ dependencies = [
 name = "namada_examples"
 version = "0.30.2"
 dependencies = [
+ "data-encoding",
  "masp_proofs",
  "namada_sdk",
  "proptest",

--- a/crates/governance/src/storage/proposal.rs
+++ b/crates/governance/src/storage/proposal.rs
@@ -589,16 +589,55 @@ pub mod testing {
     }
 
     prop_compose! {
-        /// Generate an arbitrary PGF target
-        pub fn arb_pgf_target()(
+        /// Generate an arbitrary PGF internal target
+        pub fn arb_pgf_internal_target()(
             target in arb_non_internal_address(),
             amount in arb_amount(),
-        ) -> PGFTarget {
-            PGFTarget::Internal(PGFInternalTarget {
+        ) -> PGFInternalTarget {
+            PGFInternalTarget {
                 target,
                 amount,
-            })
+            }
         }
+    }
+
+    prop_compose! {
+        /// Generate an arbitrary port ID
+        pub fn arb_ibc_port_id()(id in "[a-zA-Z0-9_+.\\-\\[\\]#<>]{2,128}") -> PortId {
+            PortId::new(id).expect("generated invalid port ID")
+        }
+    }
+
+    prop_compose! {
+        /// Generate an arbitrary channel ID
+        pub fn arb_ibc_channel_id()(id: u64) -> ChannelId {
+            ChannelId::new(id)
+        }
+    }
+
+    prop_compose! {
+        /// Generate an arbitrary PGF IBC target
+        pub fn arb_pgf_ibc_target()(
+            target in "[a-zA-Z0-9_]*",
+            amount in arb_amount(),
+            port_id in arb_ibc_port_id(),
+            channel_id in arb_ibc_channel_id(),
+        ) -> PGFIbcTarget {
+            PGFIbcTarget {
+                target,
+                amount,
+                port_id,
+                channel_id,
+            }
+        }
+    }
+
+    /// Generate an arbitrary PGF target
+    pub fn arb_pgf_target() -> impl Strategy<Value = PGFTarget> {
+        prop_oneof![
+            arb_pgf_internal_target().prop_map(PGFTarget::Internal),
+            arb_pgf_ibc_target().prop_map(PGFTarget::Ibc),
+        ]
     }
 
     /// Generate an arbitrary PGF action

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1002,20 +1002,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             transfer in arb_transfer(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(transfer.clone());
             tx.add_code_from_hash(code_hash, Some(TX_TRANSFER_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::Transfer(transfer))
         }
     }
@@ -1054,7 +1045,6 @@ pub mod testing {
                 (Just(MaspTxType::Deshielding), arb_deshielding_transfer(encode_address(&transfer.target), 1)),
             ],
             mut transfer in Just(transfer),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
@@ -1098,14 +1088,6 @@ pub mod testing {
                 // Link the Builder to the Transaction by hash code
                 target: masp_tx_hash,
             });
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::Transfer(transfer))
         }
     }
@@ -1117,20 +1099,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             bond in arb_bond(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(bond.clone());
             tx.add_code_from_hash(code_hash, Some(TX_BOND_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::Bond(bond))
         }
     }
@@ -1142,20 +1115,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             unbond in arb_bond(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(unbond.clone());
             tx.add_code_from_hash(code_hash, Some(TX_UNBOND_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::Unbond(unbond))
         }
     }
@@ -1168,7 +1132,6 @@ pub mod testing {
             mut init_account in arb_init_account(),
             extra_data in arb_code(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
@@ -1176,14 +1139,6 @@ pub mod testing {
             init_account.vp_code_hash = vp_code_hash;
             tx.add_data(init_account.clone());
             tx.add_code_from_hash(code_hash, Some(TX_INIT_ACCOUNT_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::InitAccount(init_account))
         }
     }
@@ -1195,20 +1150,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             become_validator in arb_become_validator(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(become_validator.clone());
             tx.add_code_from_hash(code_hash, Some(TX_BECOME_VALIDATOR_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::InitValidator(become_validator))
         }
     }
@@ -1222,7 +1168,6 @@ pub mod testing {
             content_extra_data in arb_code(),
             type_extra_data in arb_code(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
@@ -1234,6 +1179,16 @@ pub mod testing {
             }
             tx.add_data(init_proposal.clone());
             tx.add_code_from_hash(code_hash, Some(TX_INIT_PROPOSAL.to_owned()));
+            (tx, TxData::InitProposal(init_proposal))
+        }
+    }
+
+    prop_compose! {
+        // Generate an arbitrary transaction with maybe a memo
+        pub fn arb_memoed_tx()(
+            (mut tx, tx_data) in arb_tx(),
+            memo in option::of(arb_utf8_code()),
+        ) -> (Tx, TxData) {
             if let Some(memo) = memo {
                 let sechash = tx
                     .add_section(Section::ExtraData(memo))
@@ -1242,7 +1197,7 @@ pub mod testing {
             } else {
                 tx.set_memo_sechash(Default::default());
             }
-            (tx, TxData::InitProposal(init_proposal))
+            (tx, tx_data)
         }
     }
 
@@ -1253,20 +1208,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             vote_proposal in arb_vote_proposal(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(vote_proposal.clone());
             tx.add_code_from_hash(code_hash, Some(TX_VOTE_PROPOSAL.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::VoteProposal(vote_proposal))
         }
     }
@@ -1278,20 +1224,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             pk in arb_common_pk(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(pk.clone());
             tx.add_code_from_hash(code_hash, Some(TX_REVEAL_PK.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::RevealPk(pk))
         }
     }
@@ -1304,7 +1241,6 @@ pub mod testing {
             mut update_account in arb_update_account(),
             extra_data in arb_code(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
@@ -1314,14 +1250,6 @@ pub mod testing {
             }
             tx.add_data(update_account.clone());
             tx.add_code_from_hash(code_hash, Some(TX_UPDATE_ACCOUNT_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::UpdateAccount(update_account))
         }
     }
@@ -1333,20 +1261,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             withdraw in arb_withdraw(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(withdraw.clone());
             tx.add_code_from_hash(code_hash, Some(TX_WITHDRAW_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::Withdraw(withdraw))
         }
     }
@@ -1358,20 +1277,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             claim_rewards in arb_withdraw(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(claim_rewards.clone());
             tx.add_code_from_hash(code_hash, Some(TX_CLAIM_REWARDS_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::ClaimRewards(claim_rewards))
         }
     }
@@ -1383,20 +1293,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             commission_change in arb_commission_change(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(commission_change.clone());
             tx.add_code_from_hash(code_hash, Some(TX_CHANGE_COMMISSION_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::CommissionChange(commission_change))
         }
     }
@@ -1408,20 +1309,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             metadata_change in arb_metadata_change(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(metadata_change.clone());
             tx.add_code_from_hash(code_hash, Some(TX_CHANGE_METADATA_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::MetaDataChange(metadata_change))
         }
     }
@@ -1433,20 +1325,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             address in arb_non_internal_address(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(address.clone());
             tx.add_code_from_hash(code_hash, Some(TX_UNJAIL_VALIDATOR_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::UnjailValidator(address))
         }
     }
@@ -1458,20 +1341,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             address in arb_non_internal_address(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(address.clone());
             tx.add_code_from_hash(code_hash, Some(TX_DEACTIVATE_VALIDATOR_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::DeactivateValidator(address))
         }
     }
@@ -1483,20 +1357,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             address in arb_non_internal_address(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(address.clone());
             tx.add_code_from_hash(code_hash, Some(TX_REACTIVATE_VALIDATOR_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::ReactivateValidator(address))
         }
     }
@@ -1508,20 +1373,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             consensus_key_change in arb_consensus_key_change(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(consensus_key_change.clone());
             tx.add_code_from_hash(code_hash, Some(TX_CHANGE_CONSENSUS_KEY_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::ConsensusKeyChange(consensus_key_change))
         }
     }
@@ -1533,20 +1389,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             redelegation in arb_redelegation(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(redelegation.clone());
             tx.add_code_from_hash(code_hash, Some(TX_REDELEGATE_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::Redelegation(redelegation))
         }
     }
@@ -1558,20 +1405,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             update_steward_commission in arb_update_steward_commission(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(update_steward_commission.clone());
             tx.add_code_from_hash(code_hash, Some(TX_UPDATE_STEWARD_COMMISSION.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::UpdateStewardCommission(update_steward_commission))
         }
     }
@@ -1583,20 +1421,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             steward in arb_non_internal_address(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(steward.clone());
             tx.add_code_from_hash(code_hash, Some(TX_RESIGN_STEWARD.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::ResignSteward(steward))
         }
     }
@@ -1608,20 +1437,11 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             pending_transfer in arb_pending_transfer(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
             tx.add_data(pending_transfer.clone());
             tx.add_code_from_hash(code_hash, Some(TX_BRIDGE_POOL_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::PendingTransfer(pending_transfer))
         }
     }
@@ -1633,7 +1453,6 @@ pub mod testing {
             wrapper in arb_wrapper_tx(),
             ibc_any in arb_ibc_any(),
             code_hash in arb_hash(),
-            memo in option::of(arb_utf8_code()),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
@@ -1641,14 +1460,6 @@ pub mod testing {
             ibc_any.encode(&mut tx_data).expect("unable to encode IBC data");
             tx.add_serialized_data(tx_data);
             tx.add_code_from_hash(code_hash, Some(TX_IBC_WASM.to_owned()));
-            if let Some(memo) = memo {
-                let sechash = tx
-                    .add_section(Section::ExtraData(memo))
-                    .get_hash();
-                tx.set_memo_sechash(sechash);
-            } else {
-                tx.set_memo_sechash(Default::default());
-            }
             (tx, TxData::IbcAny(ibc_any))
         }
     }
@@ -1708,7 +1519,7 @@ pub mod testing {
 
     prop_compose! {
         // Generate an arbitrary signed tx
-        pub fn arb_signed_tx()(tx in arb_tx())(
+        pub fn arb_signed_tx()(tx in arb_memoed_tx())(
             sigs in collection::vec(arb_signature(tx.0.sechashes()), 0..3),
             mut tx in Just(tx),
         ) -> (Tx, TxData) {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -846,7 +846,7 @@ pub mod testing {
         pub fn arb_commitment()(
             commitment in prop_oneof![
                 arb_hash().prop_map(Commitment::Hash),
-                arbitrary::any::<Vec<u8>>().prop_map(Commitment::Id),
+                collection::vec(arbitrary::any::<u8>(), 0..=1024).prop_map(Commitment::Id),
             ],
         ) -> Commitment {
             commitment
@@ -873,7 +873,7 @@ pub mod testing {
         pub fn arb_utf8_commitment()(
             commitment in prop_oneof![
                 arb_hash().prop_map(Commitment::Hash),
-                "[a-zA-Z0-9_]*".prop_map(|x| Commitment::Id(x.into_bytes())),
+                "[a-zA-Z0-9_]{0,1024}".prop_map(|x| Commitment::Id(x.into_bytes())),
             ],
         ) -> Commitment {
             commitment
@@ -885,7 +885,7 @@ pub mod testing {
         pub fn arb_utf8_code()(
             salt: [u8; 8],
             code in arb_utf8_commitment(),
-            tag in option::of("[a-zA-Z0-9_]*"),
+            tag in option::of("[a-zA-Z0-9_]{0,1024}"),
         ) -> Code {
             Code {
                 salt,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -987,7 +987,7 @@ pub mod testing {
     }
 
     // Maximum number of notes to include in a transaction
-    const MAX_ASSETS: usize = 10;
+    const MAX_ASSETS: usize = 2;
 
     // Type of MASP transaction
     #[derive(Debug, Clone)]

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -2955,7 +2955,7 @@ pub mod testing {
     // Maximum value for a note partition
     const MAX_MONEY: u64 = 100;
     // Maximum number of partitions for a note
-    const MAX_SPLITS: usize = 10;
+    const MAX_SPLITS: usize = 3;
 
     prop_compose! {
         // Arbitrarily partition the given vector of integers into sets and sum

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -1219,7 +1219,7 @@ pub async fn to_ledger_vector(
         tv.output.push(format!("ID : {}", init_proposal_data.id));
         proposal_type_to_ledger_vector(
             &init_proposal_data.r#type,
-            &tx,
+            tx,
             &mut tv.output,
         );
         tv.output.extend(vec![
@@ -1240,7 +1240,7 @@ pub async fn to_ledger_vector(
             .push(format!("ID : {}", init_proposal_data.id));
         proposal_type_to_ledger_vector(
             &init_proposal_data.r#type,
-            &tx,
+            tx,
             &mut tv.output_expert,
         );
         tv.output_expert.extend(vec![

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -948,6 +948,9 @@ fn proposal_type_to_ledger_vector(
         }
         ProposalType::PGFSteward(actions) => {
             output.push("Proposal type : PGF Steward".to_string());
+            let mut actions = actions.iter().collect::<Vec<_>>();
+            // Print the test vectors in the same order as the serializations
+            actions.sort();
             for action in actions {
                 match action {
                     AddRemove::Add(addr) => {
@@ -971,7 +974,7 @@ fn proposal_type_to_ledger_vector(
                         );
                         output.push(format!("Target: {}", target.target));
                         output.push(format!(
-                            "Amount: {}",
+                            "Amount: NAM {}",
                             to_ledger_decimal(
                                 &target.amount.to_string_native()
                             )
@@ -985,7 +988,7 @@ fn proposal_type_to_ledger_vector(
                         );
                         output.push(format!("Target: {}", target.target));
                         output.push(format!(
-                            "Amount: {}",
+                            "Amount: NAM {}",
                             to_ledger_decimal(
                                 &target.amount.to_string_native()
                             )
@@ -1003,7 +1006,7 @@ fn proposal_type_to_ledger_vector(
                         );
                         output.push(format!("Target: {}", target.target));
                         output.push(format!(
-                            "Amount: {}",
+                            "Amount: NAM {}",
                             to_ledger_decimal(
                                 &target.amount.to_string_native()
                             )
@@ -1018,7 +1021,7 @@ fn proposal_type_to_ledger_vector(
                         );
                         output.push(format!("Target: {}", target.target));
                         output.push(format!(
-                            "Amount: {}",
+                            "Amount: NAM {}",
                             to_ledger_decimal(
                                 &target.amount.to_string_native()
                             )
@@ -1031,7 +1034,7 @@ fn proposal_type_to_ledger_vector(
                         output.push("PGF Action : Retro Payment".to_string());
                         output.push(format!("Target: {}", target.target));
                         output.push(format!(
-                            "Amount: {}",
+                            "Amount: NAM {}",
                             to_ledger_decimal(
                                 &target.amount.to_string_native()
                             )
@@ -1041,7 +1044,7 @@ fn proposal_type_to_ledger_vector(
                         output.push("PGF Action : Retro Payment".to_string());
                         output.push(format!("Target: {}", target.target));
                         output.push(format!(
-                            "Amount: {}",
+                            "Amount: NAM {}",
                             to_ledger_decimal(
                                 &target.amount.to_string_native()
                             )

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -770,9 +770,6 @@ fn format_outputs(output: &mut Vec<String>) {
         let key = key.trim().chars().take(MAX_KEY_LEN - 1).collect::<String>();
         // Trim value because we will insert spaces later
         value = value.trim();
-        if value.is_empty() {
-            value = "(none)"
-        }
         if value.chars().count() < MAX_VALUE_LEN {
             // No need to split the line in this case
             output[pos] = format!("{} | {} : {}", i, key, value);

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -1495,30 +1495,24 @@ pub async fn to_ledger_vector(
         tv.output.extend(vec!["Type : Change metadata".to_string()]);
 
         let mut other_items = vec![];
+        other_items.push(format!("Validator : {}", metadata_change.validator));
         if let Some(email) = metadata_change.email {
-            other_items.push(format!("New email : {}", email));
+            other_items.push(format!("Email : {}", email));
         }
         if let Some(description) = metadata_change.description {
-            if description.is_empty() {
-                other_items.push("Description removed".to_string());
-            } else {
-                other_items.push(format!("New description : {}", description));
-            }
+            other_items.push(format!("Description : {}", description));
         }
         if let Some(website) = metadata_change.website {
-            if website.is_empty() {
-                other_items.push("Website removed".to_string());
-            } else {
-                other_items.push(format!("New website : {}", website));
-            }
+            other_items.push(format!("Website : {}", website));
         }
         if let Some(discord_handle) = metadata_change.discord_handle {
-            if discord_handle.is_empty() {
-                other_items.push("Discord handle removed".to_string());
-            } else {
-                other_items
-                    .push(format!("New discord handle : {}", discord_handle));
-            }
+            other_items.push(format!("Discord handle : {}", discord_handle));
+        }
+        if let Some(avatar) = metadata_change.avatar {
+            other_items.push(format!("Avatar : {}", avatar));
+        }
+        if let Some(commission_rate) = metadata_change.commission_rate {
+            other_items.push(format!("Commission rate : {}", commission_rate));
         }
 
         tv.output.extend(other_items.clone());
@@ -1646,15 +1640,19 @@ pub async fn to_ledger_vector(
             format!("Type : Update Steward Commission"),
             format!("Steward : {}", update.steward),
         ]);
-        for (address, dec) in &update.commission {
-            tv.output.push(format!("Commission : {} {}", address, dec));
+        let mut commission = update.commission.iter().collect::<Vec<_>>();
+        // Print the test vectors in the same order as the serializations
+        commission.sort_by(|(a, _), (b, _)| a.cmp(b));
+        for (address, dec) in &commission {
+            tv.output.push(format!("Validator : {}", address));
+            tv.output.push(format!("Commission Rate : {}", dec));
         }
 
         tv.output_expert
             .push(format!("Steward : {}", update.steward));
-        for (address, dec) in &update.commission {
-            tv.output_expert
-                .push(format!("Commission : {} {}", address, dec));
+        for (address, dec) in &commission {
+            tv.output_expert.push(format!("Validator : {}", address));
+            tv.output_expert.push(format!("Commission Rate : {}", dec));
         }
     } else if code_sec.tag == Some(TX_RESIGN_STEWARD.to_string()) {
         let address = Address::try_from_slice(

--- a/crates/tx/src/data/pos.rs
+++ b/crates/tx/src/data/pos.rs
@@ -267,11 +267,11 @@ pub mod tests {
         /// Generate an arbitrary metadata change
         pub fn arb_metadata_change()(
             validator in arb_non_internal_address(),
-            email in option::of("[a-zA-Z0-9_]*"),
-            description in option::of("[a-zA-Z0-9_]*"),
-            website in option::of("[a-zA-Z0-9_]*"),
-            discord_handle in option::of("[a-zA-Z0-9_]*"),
-            avatar in option::of("[a-zA-Z0-9_]*"),
+            email in option::of("[a-zA-Z0-9_]+"),
+            description in option::of("[a-zA-Z0-9_]+"),
+            website in option::of("[a-zA-Z0-9_]+"),
+            discord_handle in option::of("[a-zA-Z0-9_]+"),
+            avatar in option::of("[a-zA-Z0-9_]+"),
             commission_rate in option::of(arb_dec()),
         ) -> MetaDataChange {
             MetaDataChange {
@@ -309,11 +309,11 @@ pub mod tests {
             protocol_key in arb_common_pk(),
             commission_rate in arb_dec(),
             max_commission_rate_change in arb_dec(),
-            email in "[a-zA-Z0-9_]*",
-            description in option::of("[a-zA-Z0-9_]*"),
-            website in option::of("[a-zA-Z0-9_]*"),
-            discord_handle in option::of("[a-zA-Z0-9_]*"),
-            avatar in option::of("[a-zA-Z0-9_]*"),
+            email in "[a-zA-Z0-9_]+",
+            description in option::of("[a-zA-Z0-9_]+"),
+            website in option::of("[a-zA-Z0-9_]+"),
+            discord_handle in option::of("[a-zA-Z0-9_]+"),
+            avatar in option::of("[a-zA-Z0-9_]+"),
         ) -> BecomeValidator {
             BecomeValidator {
                 address,

--- a/crates/tx/src/data/pos.rs
+++ b/crates/tx/src/data/pos.rs
@@ -267,11 +267,11 @@ pub mod tests {
         /// Generate an arbitrary metadata change
         pub fn arb_metadata_change()(
             validator in arb_non_internal_address(),
-            email in option::of("[a-zA-Z0-9_]+"),
-            description in option::of("[a-zA-Z0-9_]+"),
-            website in option::of("[a-zA-Z0-9_]+"),
-            discord_handle in option::of("[a-zA-Z0-9_]+"),
-            avatar in option::of("[a-zA-Z0-9_]+"),
+            email in option::of("[a-zA-Z0-9_]*"),
+            description in option::of("[a-zA-Z0-9_]*"),
+            website in option::of("[a-zA-Z0-9_]*"),
+            discord_handle in option::of("[a-zA-Z0-9_]*"),
+            avatar in option::of("[a-zA-Z0-9_]*"),
             commission_rate in option::of(arb_dec()),
         ) -> MetaDataChange {
             MetaDataChange {
@@ -309,11 +309,11 @@ pub mod tests {
             protocol_key in arb_common_pk(),
             commission_rate in arb_dec(),
             max_commission_rate_change in arb_dec(),
-            email in "[a-zA-Z0-9_]+",
-            description in option::of("[a-zA-Z0-9_]+"),
-            website in option::of("[a-zA-Z0-9_]+"),
-            discord_handle in option::of("[a-zA-Z0-9_]+"),
-            avatar in option::of("[a-zA-Z0-9_]+"),
+            email in "[a-zA-Z0-9_]*",
+            description in option::of("[a-zA-Z0-9_]*"),
+            website in option::of("[a-zA-Z0-9_]*"),
+            discord_handle in option::of("[a-zA-Z0-9_]*"),
+            avatar in option::of("[a-zA-Z0-9_]*"),
         ) -> BecomeValidator {
             BecomeValidator {
                 address,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,7 @@ path = "generate_txs.rs"
 [dev-dependencies]
 masp_proofs = { workspace = true, default-features = false, features = ["local-prover", "download-params"] }
 namada_sdk = { path = "../crates/sdk", default-features = false, features = ["namada-sdk", "std", "testing"] }
+data-encoding.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
 tokio = {workspace = true, default-features = false}

--- a/examples/generate_txs.rs
+++ b/examples/generate_txs.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use data_encoding::HEXLOWER;
 use namada_sdk::signing::to_ledger_vector;
-use namada_sdk::testing::arb_tx;
+use namada_sdk::testing::arb_signed_tx;
 use namada_sdk::wallet::fs::FsWalletUtils;
 use proptest::strategy::{Strategy, ValueTree};
 use proptest::test_runner::{Reason, TestRunner};
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Reason> {
     let mut debug_vectors = vec![];
     let mut test_vectors = vec![];
     for i in 0..1000 {
-        let (tx, tx_data) = arb_tx().new_tree(&mut runner)?.current();
+        let (tx, tx_data) = arb_signed_tx().new_tree(&mut runner)?.current();
         let mut ledger_vector = to_ledger_vector(&wallet, &tx)
             .await
             .expect("unable to construct test vector");


### PR DESCRIPTION
## Describe your changes
Various changes in order to increase the detail presented in test vectors, increase the variety of test vectors, and ease the implementation of hardware wallet apps. Specifically the changes are as follows:
* Test vector generator now sometimes generates signed transactions
* Greatly increased the level of detail presented in Init Proposal transactions
* Increased the coverage PGF steward transactions to include the IBC variants
* Started including memos in generated transactions sometimes, both in hashed and full form
* Now print out the section hashes in debug vectors to facilitate constructing signing test vectors
* Improved the formatting of Update Steward Commission transactions for the hardware wallet

## Indicate on which release or other PRs this topic is based on
Namada v0.30.2

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
