### PR TITLE
Show help for query-proposal-votes when no arg provided

### DIFF
--- a/.changelog/unreleased/improvements/2611-show-help-for-query-proposal-votes.md
+++ b/.changelog/unreleased/improvements/2611-show-help-for-query-proposal-votes.md
@@ -1,0 +1,2 @@
+- Show help message for query-proposal subcommand instead of crashing when no
+  arg provided. ([\#2611](https://github.com/anoma/namada/pull/2611))

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -1038,6 +1038,7 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about("Query votes for the proposal.")
+                .arg_required_else_help(true)
                 .add_args::<args::QueryProposalVotes<args::CliTypes>>()
         }
     }


### PR DESCRIPTION
## Describe your changes

Show help message for query-proposal-votes subcommand instead of crashing when no arg provided.


#### Before (crashed with panick)
```
$ ./namadac query-proposal-votes
The application panicked (crashed).
Message:  called `Option::unwrap()` on a `None` value
Location: crates/apps/src/lib/cli/utils.rs:204

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

#### After
```
$ ./namadac query-proposal-votes
Query votes for the proposal.

Usage: namadac query-proposal-votes [OPTIONS]

Options:
      --node <node>                Address of a ledger node as "{scheme}://{host}:{port}". If the scheme is not supplied, it is assumed to be TCP.
      --proposal-id <proposal-id>  The proposal identifier.
      --voter <voter>              The address of the proposal voter.
  -h, --help                       Print help
```


## Indicate on which release or other PRs this topic is based on

[v0.31.4](https://github.com/anoma/namada/releases/tag/v0.31.4)

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
