### PR TITLE
Correction to reactivate-validator command metadata

### DIFF
--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -5593,7 +5593,7 @@ pub mod args {
             app.add_args::<Tx<CliTypes>>().arg(
                 VALIDATOR
                     .def()
-                    .help("The address of the jailed validator to deactivate."),
+                    .help("The address of the jailed validator to reactivate."),
             )
         }
     }


### PR DESCRIPTION
## Describe your changes

The current ``reactivate-validator`` command metadata wrongly describes the ``--validator validator_addresss`` as the validator address to deactivate. Instead this is the validator address we are looking to reactivate.

Hence changing the command metadata for the ``--validator `` flag to the correct description to avoid confusion as this is a risky command.

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
