### PR TITLE
Fix nullifiers check

### DIFF
--- a/.changelog/unreleased/bug-fixes/2621-fix-nullifier-check.md
+++ b/.changelog/unreleased/bug-fixes/2621-fix-nullifier-check.md
@@ -1,0 +1,2 @@
+- Fixed a bug in the masp vp that allowed a shielding transaction to reveal
+  nullifiers. ([\#2621](https://github.com/anoma/namada/pull/2621))

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -610,11 +610,10 @@ where
                 .transparent_bundle()
                 .is_some_and(|bundle| !bundle.vin.is_empty())
             {
-                let error = native_vp::Error::new_alloc(format!(
+                let error = native_vp::Error::new_const(
                     "Transparent input to a transaction from the masp must be \
-                     0 but is {}",
-                    transp_bundle.vin.len()
-                ))
+                     0",
+                )
                 .into();
                 tracing::debug!("{error}");
                 return Err(error);
@@ -765,11 +764,10 @@ where
                 .transparent_bundle()
                 .is_some_and(|bundle| !bundle.vout.is_empty())
             {
-                let error = native_vp::Error::new_alloc(format!(
+                let error = native_vp::Error::new_const(
                     "Transparent output to a transaction from the masp must \
-                     be 0 but is {}",
-                    transp_bundle.vout.len()
-                ))
+                     be 0",
+                )
                 .into();
                 tracing::debug!("{error}");
                 return Err(error);


### PR DESCRIPTION
## Describe your changes

Closes #2594.

Call `valid_nullifiers_reveal` regardless of the transaction source to make sure that a shielding tx doesn't reveal any nullifier. Enforces that at least one shielded input is present if the source of the tx is the MASP.

Refactors the checks on the bundles and fixes the check on the shielded outputs when the target is MASP which was previously wrong (was not taking into account the case in which `shielded_outputs` was `None`.

## Indicate on which release or other PRs this topic is based on

v0.33.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
