### PR TITLE
Fix the balance query for IBC tokens

### DIFF
--- a/.changelog/unreleased/bug-fixes/2625-fix-shielded-balance-query.md
+++ b/.changelog/unreleased/bug-fixes/2625-fix-shielded-balance-query.md
@@ -1,0 +1,2 @@
+- Fix shielded balance query for IBC tokens
+  ([\#2625](https://github.com/anoma/namada/issues/2625))

--- a/crates/apps/src/lib/client/rpc.rs
+++ b/crates/apps/src/lib/client/rpc.rs
@@ -153,7 +153,9 @@ pub async fn query_transfers(
     // Precompute asset types to increase chances of success in decoding
     let token_map = query_tokens(context, None, None).await;
     let tokens = token_map.values().collect();
-    let _ = shielded.precompute_asset_types(context, tokens).await;
+    let _ = shielded
+        .precompute_asset_types(context.client(), tokens)
+        .await;
     // Obtain the effects of all shielded and transparent transactions
     let transfers = shielded
         .query_tx_deltas(
@@ -457,7 +459,7 @@ pub async fn query_pinned_balance(
     let _ = context
         .shielded_mut()
         .await
-        .precompute_asset_types(context, tokens)
+        .precompute_asset_types(context.client(), tokens)
         .await;
     // Print the token balances by payment address
     for owner in owners {
@@ -909,7 +911,9 @@ pub async fn query_shielded_balance(
         // Precompute asset types to increase chances of success in decoding
         let token_map = query_tokens(context, None, None).await;
         let tokens = token_map.values().collect();
-        let _ = shielded.precompute_asset_types(context, tokens).await;
+        let _ = shielded
+            .precompute_asset_types(context.client(), tokens)
+            .await;
         // Save the update state so that future fetches can be short-circuited
         let _ = shielded.save().await;
     }

--- a/crates/apps/src/lib/client/rpc.rs
+++ b/crates/apps/src/lib/client/rpc.rs
@@ -151,7 +151,9 @@ pub async fn query_transfers(
     let mut shielded = context.shielded_mut().await;
     let _ = shielded.load().await;
     // Precompute asset types to increase chances of success in decoding
-    let _ = shielded.precompute_asset_types(context).await;
+    let token_map = query_tokens(context, None, None).await;
+    let tokens = token_map.values().collect();
+    let _ = shielded.precompute_asset_types(context, tokens).await;
     // Obtain the effects of all shielded and transparent transactions
     let transfers = shielded
         .query_tx_deltas(
@@ -450,10 +452,12 @@ pub async fn query_pinned_balance(
         .collect();
     let _ = context.shielded_mut().await.load().await;
     // Precompute asset types to increase chances of success in decoding
+    let token_map = query_tokens(context, None, None).await;
+    let tokens = token_map.values().collect();
     let _ = context
         .shielded_mut()
         .await
-        .precompute_asset_types(context)
+        .precompute_asset_types(context, tokens)
         .await;
     // Print the token balances by payment address
     for owner in owners {
@@ -903,7 +907,9 @@ pub async fn query_shielded_balance(
             .collect();
         shielded.fetch(context.client(), &[], &fvks).await.unwrap();
         // Precompute asset types to increase chances of success in decoding
-        let _ = shielded.precompute_asset_types(context).await;
+        let token_map = query_tokens(context, None, None).await;
+        let tokens = token_map.values().collect();
+        let _ = shielded.precompute_asset_types(context, tokens).await;
         // Save the update state so that future fetches can be short-circuited
         let _ = shielded.save().await;
     }

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -1228,14 +1228,14 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
 
     /// Use the addresses already stored in the wallet to precompute as many
     /// asset types as possible.
-    pub async fn precompute_asset_types<N: Namada>(
+    pub async fn precompute_asset_types<C: Client + Sync>(
         &mut self,
-        context: &N,
+        client: &C,
         tokens: Vec<&Address>,
     ) -> Result<(), Error> {
         // To facilitate lookups of human-readable token names
         for token in tokens {
-            let Some(denom) = query_denom(context.client(), token).await else {
+            let Some(denom) = query_denom(client, token).await else {
                 return Err(Error::Query(QueryError::General(format!(
                     "denomination for token {token}"
                 ))))

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -1231,9 +1231,10 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
     pub async fn precompute_asset_types<N: Namada>(
         &mut self,
         context: &N,
+        tokens: Vec<&Address>,
     ) -> Result<(), Error> {
         // To facilitate lookups of human-readable token names
-        for token in context.wallet().await.get_addresses().values() {
+        for token in tokens {
             let Some(denom) = query_denom(context.client(), token).await else {
                 return Err(Error::Query(QueryError::General(format!(
                     "denomination for token {token}"

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2428,7 +2428,7 @@ async fn construct_shielded_parts<N: Namada>(
     let _ = context
         .shielded_mut()
         .await
-        .precompute_asset_types(context, tokens)
+        .precompute_asset_types(context.client(), tokens)
         .await;
     let stx_result =
         ShieldedContext::<N::ShieldedUtils>::gen_shielded_transfer(
@@ -2697,7 +2697,7 @@ pub async fn gen_ibc_shielded_transfer<N: Namada>(
     let _ = context
         .shielded_mut()
         .await
-        .precompute_asset_types(context, tokens)
+        .precompute_asset_types(context.client(), tokens)
         .await;
 
     let shielded_transfer =

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2423,10 +2423,12 @@ async fn construct_shielded_parts<N: Namada>(
     amount: token::DenominatedAmount,
 ) -> Result<Option<(ShieldedTransfer, HashSet<AssetData>)>> {
     // Precompute asset types to increase chances of success in decoding
+    let token_map = context.wallet().await.get_addresses();
+    let tokens = token_map.values().collect();
     let _ = context
         .shielded_mut()
         .await
-        .precompute_asset_types(context)
+        .precompute_asset_types(context, tokens)
         .await;
     let stx_result =
         ShieldedContext::<N::ShieldedUtils>::gen_shielded_transfer(
@@ -2690,10 +2692,12 @@ pub async fn gen_ibc_shielded_transfer<N: Namada>(
         validate_amount(context, args.amount, &token, false).await?;
 
     // Precompute asset types to increase chances of success in decoding
+    let token_map = context.wallet().await.get_addresses();
+    let tokens = token_map.values().collect();
     let _ = context
         .shielded_mut()
         .await
-        .precompute_asset_types(context)
+        .precompute_asset_types(context, tokens)
         .await;
 
     let shielded_transfer =


### PR DESCRIPTION
## Describe your changes
The shielded balance query sometimes doesn't know the received IBC tokens.
By modifing `precompute_asset_types` to get all tokens received over IBC, the query can get the balances of these tokens.

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
