### PR TITLE
Refactor loading of gov proposals for execution

### DIFF
--- a/crates/apps/src/lib/node/ledger/mod.rs
+++ b/crates/apps/src/lib/node/ledger/mod.rs
@@ -9,14 +9,11 @@ pub mod tendermint_node;
 use std::convert::TryInto;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::thread;
 
 use byte_unit::Byte;
 use futures::future::TryFutureExt;
 use namada::eth_bridge::ethers::providers::{Http, Provider};
-use namada::governance::storage::keys as governance_storage;
-use namada::types::storage::Key;
 use namada::types::time::DateTimeUtc;
 use namada_sdk::tendermint::abci::request::CheckTxKind;
 use once_cell::unsync::Lazy;
@@ -64,35 +61,6 @@ const ENV_VAR_RAYON_THREADS: &str = "NAMADA_RAYON_THREADS";
 //     }
 //```
 impl Shell {
-    fn load_proposals(&mut self) {
-        let proposals_key = governance_storage::get_commiting_proposals_prefix(
-            self.wl_storage.storage.last_epoch.0,
-        );
-
-        let (proposal_iter, _) =
-            self.wl_storage.storage.iter_prefix(&proposals_key);
-        for (key, _, _) in proposal_iter {
-            let key =
-                Key::from_str(key.as_str()).expect("Key should be parsable");
-            if governance_storage::get_commit_proposal_epoch(&key).unwrap()
-                != self.wl_storage.storage.last_epoch.0
-            {
-                // NOTE: `iter_prefix` iterate over the matching prefix. In this
-                // case  a proposal with grace_epoch 110 will be
-                // matched by prefixes  1, 11 and 110. Thus we
-                // have to skip to the next iteration of
-                //  the cycle for all the prefixes that don't actually match
-                //  the desired epoch.
-                continue;
-            }
-
-            let proposal_id = governance_storage::get_commit_proposal_id(&key);
-            if let Some(id) = proposal_id {
-                self.proposal_data.insert(id);
-            }
-        }
-    }
-
     fn call(&mut self, req: Request) -> Result<Response, Error> {
         match req {
             Request::InitChain(init) => {
@@ -128,7 +96,6 @@ impl Shell {
             }
             Request::FinalizeBlock(finalize) => {
                 tracing::debug!("Request FinalizeBlock");
-                self.load_proposals();
                 self.finalize_block(finalize).map(Response::FinalizeBlock)
             }
             Request::Commit => {

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -21,7 +21,7 @@ pub mod testing;
 pub mod utils;
 mod vote_extensions;
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 use std::convert::{TryFrom, TryInto};
 use std::mem;
 use std::path::{Path, PathBuf};
@@ -357,8 +357,6 @@ where
     /// limit the how many block heights in the past can the storage be
     /// queried for reading values.
     storage_read_past_height_limit: Option<u64>,
-    /// Proposal execution tracking
-    pub proposal_data: HashSet<u64>,
     /// Log of events emitted by `FinalizeBlock` ABCI calls.
     event_log: EventLog,
 }
@@ -534,7 +532,6 @@ where
                 tx_wasm_compilation_cache as usize,
             ),
             storage_read_past_height_limit,
-            proposal_data: HashSet::new(),
             // TODO: config event log params
             event_log: EventLog::default(),
         };

--- a/crates/governance/src/storage/mod.rs
+++ b/crates/governance/src/storage/mod.rs
@@ -7,7 +7,7 @@ pub mod proposal;
 /// Vote structures
 pub mod vote;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use namada_core::borsh::BorshDeserialize;
 use namada_core::types::address::Address;
@@ -316,4 +316,29 @@ where
     let key = governance_keys::get_proposal_result_key(proposal_id);
     let proposal_result: Option<ProposalResult> = storage.read(&key)?;
     Ok(proposal_result)
+}
+
+/// Load proposals for execution in the current epoch.
+pub fn load_proposals<S>(
+    storage: &S,
+    current_epoch: Epoch,
+) -> StorageResult<BTreeSet<u64>>
+where
+    S: StorageRead,
+{
+    let mut ids = BTreeSet::<u64>::new();
+    let proposals_key =
+        governance_keys::get_commiting_proposals_prefix(current_epoch.0);
+    for key_val in namada_state::iter_prefix_bytes(storage, &proposals_key)? {
+        let (key, _) = key_val?;
+        let grace_epoch = governance_keys::get_commit_proposal_epoch(&key)
+            .expect("this key segment should correspond to an epoch number");
+        if current_epoch.0 == grace_epoch {
+            let proposal_id = governance_keys::get_commit_proposal_id(&key)
+                .expect("ths key segment should correspond to a proposal id");
+            ids.insert(proposal_id);
+        }
+    }
+
+    Ok(ids)
 }


### PR DESCRIPTION
## Describe your changes
Governance proposals were previously loaded every single block, which was a pointless operation. This logic is now coupled more tightly with the execution of the proposals, occurring only once per epoch within a function that loads and then executes.

This logic is removed from the `Shell` and reimplemented in the governance crate.

## Indicate on which release or other PRs this topic is based on
v0.31.4

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
