### PR TITLE
Fix the token address when shielded transfer back to Namada

### DIFF
--- a/.changelog/unreleased/bug-fixes/2634-fix-ibc-shielded-transfer-back.md
+++ b/.changelog/unreleased/bug-fixes/2634-fix-ibc-shielded-transfer-back.md
@@ -1,0 +1,2 @@
+- Fix ibc-gen-shielded for shielded transfers back to the origin
+  ([\#2634](https://github.com/anoma/namada/issues/2634))

--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -348,7 +348,12 @@ pub fn received_ibc_token(
             TracePrefix::new(dest_port_id.clone(), dest_channel_id.clone());
         ibc_denom.add_trace_prefix(prefix);
     }
-    Ok(storage::ibc_token(ibc_denom.to_string()))
+    if ibc_denom.trace_path.is_empty() {
+        Address::decode(ibc_denom.to_string())
+            .map_err(|e| Error::Denom(format!("Invalid base denom: {e}")))
+    } else {
+        Ok(storage::ibc_token(ibc_denom.to_string()))
+    }
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -168,6 +168,7 @@ fn run_ledger_ibc() -> Result<()> {
     // The balance should not be changed
     check_balances_after_back(&port_id_b, &channel_id_b, &test_a, &test_b)?;
 
+    // Shielded transfer 10 BTC from Chain A to Chain B
     shielded_transfer(
         &test_a,
         &test_b,
@@ -179,6 +180,25 @@ fn run_ledger_ibc() -> Result<()> {
         &channel_id_b,
     )?;
     check_shielded_balances(&port_id_b, &channel_id_b, &test_a, &test_b)?;
+
+    // Shielded transfer 5 BTC back from Chain B to the origin-specific account
+    // on Chain A
+    shielded_transfer_back(
+        &test_a,
+        &test_b,
+        &client_id_a,
+        &client_id_b,
+        &port_id_a,
+        &channel_id_a,
+        &port_id_b,
+        &channel_id_b,
+    )?;
+    check_shielded_balances_after_back(
+        &port_id_b,
+        &channel_id_b,
+        &test_a,
+        &test_b,
+    )?;
 
     // Skip tests for closing a channel and timeout_on_close since the transfer
     // channel cannot be closed
@@ -1358,6 +1378,102 @@ fn shielded_transfer(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn shielded_transfer_back(
+    test_a: &Test,
+    test_b: &Test,
+    client_id_a: &ClientId,
+    client_id_b: &ClientId,
+    port_id_a: &PortId,
+    channel_id_a: &ChannelId,
+    port_id_b: &PortId,
+    channel_id_b: &ChannelId,
+) -> Result<()> {
+    // Get masp proof for the following IBC transfer from the destination chain
+    let rpc_a = get_actor_rpc(test_a, Who::Validator(0));
+    // It will send 5 BTC from Chain B to PA(A) on Chain A
+    // Chain A will receive Chain A's BTC
+    std::env::set_var(ENV_VAR_CHAIN_ID, test_a.net.chain_id.to_string());
+    let output_folder = test_b.test_dir.path().to_string_lossy();
+    // PA(A) on Chain A will receive BTC on chain A
+    let token_addr = find_address(test_a, BTC)?;
+    let ibc_token = format!("{port_id_b}/{channel_id_b}/{token_addr}");
+    let args = [
+        "ibc-gen-shielded",
+        "--output-folder-path",
+        &output_folder,
+        "--target",
+        AA_PAYMENT_ADDRESS,
+        "--token",
+        &ibc_token,
+        "--amount",
+        "5",
+        "--port-id",
+        port_id_a.as_ref(),
+        "--channel-id",
+        channel_id_a.as_ref(),
+        "--node",
+        &rpc_a,
+    ];
+    let mut client = run!(test_a, Bin::Client, args, Some(120))?;
+    let file_path = get_shielded_transfer_path(&mut client)?;
+    client.assert_success();
+
+    // Send a token from SP(B) on Chain B to PA(A) on Chain A
+    let height = transfer(
+        test_b,
+        B_SPENDING_KEY,
+        AA_PAYMENT_ADDRESS,
+        &ibc_token,
+        "5",
+        ALBERT_KEY,
+        port_id_b,
+        channel_id_b,
+        Some(&file_path.to_string_lossy()),
+        None,
+        None,
+        false,
+    )?;
+    let events = get_events(test_b, height)?;
+    let packet = get_packet_from_events(&events).ok_or(eyre!(TX_FAILED))?;
+
+    let height_b = query_height(test_b)?;
+    let proof_commitment_on_b =
+        get_commitment_proof(test_b, &packet, height_b)?;
+    // the message member names are confusing, "_a" means the source
+    let msg = MsgRecvPacket {
+        packet,
+        proof_commitment_on_a: proof_commitment_on_b,
+        proof_height_on_a: height_b,
+        signer: signer(),
+    };
+    // Update the client state of Chain B on Chain A
+    update_client_with_height(test_b, test_a, client_id_a, height_b)?;
+    // Receive the token on Chain A
+    let height = submit_ibc_tx(test_a, msg, ALBERT, ALBERT_KEY, false)?;
+    let events = get_events(test_a, height)?;
+    let packet = get_packet_from_events(&events).ok_or(eyre!(TX_FAILED))?;
+    let ack = get_ack_from_events(&events).ok_or(eyre!(TX_FAILED))?;
+
+    // get the proof on Chain A
+    let height_a = query_height(test_a)?;
+    let proof_acked_on_a = get_ack_proof(test_a, &packet, height_a)?;
+    // the message member names are confusing, "_b" means the destination
+    let msg = MsgAcknowledgement {
+        packet,
+        acknowledgement: ack.try_into().expect("invalid ack"),
+        proof_acked_on_b: proof_acked_on_a,
+        proof_height_on_b: height_a,
+        signer: signer(),
+    };
+    // Update the client state of Chain A on Chain B
+    update_client_with_height(test_a, test_b, client_id_b, height_a)?;
+    // Acknowledge on Chain B
+    submit_ibc_tx(test_b, msg, ALBERT, ALBERT_KEY, false)?;
+
+    Ok(())
+}
+
 fn get_shielded_transfer_path(client: &mut NamadaCmd) -> Result<PathBuf> {
     let (_unread, matched) =
         client.exp_regex("Output IBC shielded transfer .*")?;
@@ -1914,6 +2030,54 @@ fn check_shielded_balances(
     let mut client = run!(test_b, Bin::Client, query_args, Some(40))?;
     client.exp_string(&expected)?;
     client.assert_success();
+    Ok(())
+}
+
+/// Check balances after IBC shielded transfer after transfer back
+fn check_shielded_balances_after_back(
+    src_port_id: &PortId,
+    src_channel_id: &ChannelId,
+    test_a: &Test,
+    test_b: &Test,
+) -> Result<()> {
+    std::env::set_var(ENV_VAR_CHAIN_ID, test_a.net.chain_id.to_string());
+    let token_addr = find_address(test_a, BTC)?.to_string();
+    // Check the balance on Chain B
+    std::env::set_var(ENV_VAR_CHAIN_ID, test_b.net.chain_id.to_string());
+    let rpc_b = get_actor_rpc(test_b, Who::Validator(0));
+    let ibc_denom = format!("{src_port_id}/{src_channel_id}/btc");
+    let query_args = vec![
+        "balance",
+        "--owner",
+        AB_VIEWING_KEY,
+        "--token",
+        &token_addr,
+        "--no-conversions",
+        "--node",
+        &rpc_b,
+    ];
+    let expected = format!("{ibc_denom}: 5");
+    let mut client = run!(test_b, Bin::Client, query_args, Some(40))?;
+    client.exp_string(&expected)?;
+    client.assert_success();
+
+    // Check the balance on Chain A
+    std::env::set_var(ENV_VAR_CHAIN_ID, test_a.net.chain_id.to_string());
+    let rpc_a = get_actor_rpc(test_a, Who::Validator(0));
+    let query_args = vec![
+        "balance",
+        "--owner",
+        AA_VIEWING_KEY,
+        "--token",
+        &token_addr,
+        "--no-conversions",
+        "--node",
+        &rpc_a,
+    ];
+    let mut client = run!(test_a, Bin::Client, query_args, Some(40))?;
+    client.exp_string("btc: 5")?;
+    client.assert_success();
+
     Ok(())
 }
 


### PR DESCRIPTION
## Describe your changes
When trying to transfer a token back to the source Namada, the token address was always `IbcToken` in `ibc-gen-shielded`. If the destination Namada is the origin of the token, the address should be an established address.
And, added a test to transfer back over IBC shielded transfer.

## Indicate on which release or other PRs this topic is based on
`v0.31.4`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
