### PR TITLE
Fix CometBFT validator set update

### DIFF
--- a/.changelog/unreleased/bug-fixes/2653-fix-validator-set-update-with-ck.md
+++ b/.changelog/unreleased/bug-fixes/2653-fix-validator-set-update-with-ck.md
@@ -1,0 +1,4 @@
+- Fixed a bug in the communication of validator set updates to
+  CometBFT after a change of validator consensus key that occurs
+  at the same epoch as a validator entering the consensus set.
+  ([\#2653](https://github.com/anoma/namada/pull/2653))

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -38,7 +38,6 @@ use namada::ethereum_bridge::protocol::validation::validator_set_update::validat
 use namada::ledger::events::log::EventLog;
 use namada::ledger::events::Event;
 use namada::ledger::gas::{Gas, TxGasMeter};
-use namada::ledger::pos::into_tm_voting_power;
 use namada::ledger::pos::namada_proof_of_stake::types::{
     ConsensusValidator, ValidatorSetUpdate,
 };
@@ -1305,14 +1304,8 @@ where
                 let (consensus_key, power) = match update {
                     ValidatorSetUpdate::Consensus(ConsensusValidator {
                         consensus_key,
-                        bonded_stake,
-                    }) => {
-                        let power: i64 = into_tm_voting_power(
-                            pos_params.tm_votes_per_token,
-                            bonded_stake,
-                        );
-                        (consensus_key, power)
-                    }
+                        bonded_stake: power,
+                    }) => (consensus_key, power),
                     ValidatorSetUpdate::Deactivated(consensus_key) => {
                         // Any validators that have been dropped from the
                         // consensus set must have voting power set to 0 to

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -1294,7 +1294,7 @@ where
         let validator_set_update_fn = if is_genesis {
             namada_proof_of_stake::genesis_validator_set_tendermint
         } else {
-            namada_proof_of_stake::validator_set_update::validator_set_update_tendermint
+            namada_proof_of_stake::validator_set_update::validator_set_update_comet
         };
 
         validator_set_update_fn(

--- a/crates/proof_of_stake/src/lib.rs
+++ b/crates/proof_of_stake/src/lib.rs
@@ -36,6 +36,7 @@ use namada_storage::collections::lazy_map::{self, Collectable, LazyMap};
 use namada_storage::{StorageRead, StorageWrite};
 pub use namada_trans_token as token;
 pub use parameters::{OwnedPosParams, PosParams};
+use types::into_tm_voting_power;
 
 use crate::queries::{find_bonds, has_bonds};
 use crate::rewards::{
@@ -1843,9 +1844,11 @@ where
         let consensus_key = validator_consensus_key_handle(&address)
             .get(storage, current_epoch, params)?
             .unwrap();
+        let new_tm_voting_power =
+            into_tm_voting_power(params.tm_votes_per_token, new_stake);
         let converted = f(ValidatorSetUpdate::Consensus(ConsensusValidator {
             consensus_key,
-            bonded_stake: new_stake,
+            bonded_stake: new_tm_voting_power,
         }));
         Ok(converted)
     })

--- a/crates/proof_of_stake/src/tests/helpers.rs
+++ b/crates/proof_of_stake/src/tests/helpers.rs
@@ -15,7 +15,7 @@ use proptest::strategy::{Just, Strategy};
 use crate::parameters::testing::arb_pos_params;
 use crate::types::{GenesisValidator, ValidatorSetUpdate};
 use crate::validator_set_update::{
-    copy_validator_sets_and_positions, validator_set_update_tendermint,
+    copy_validator_sets_and_positions, validator_set_update_comet,
 };
 use crate::{
     compute_and_store_total_consensus_stake, OwnedPosParams, PosParams,
@@ -57,7 +57,7 @@ pub fn get_tendermint_set_updates(
     // the start of a new one too and so we give it the predecessor of the
     // current epoch here to actually get the update for the current epoch.
     let epoch = Epoch(epoch - 1);
-    validator_set_update_tendermint(s, params, epoch, |update| update).unwrap()
+    validator_set_update_comet(s, params, epoch, |update| update).unwrap()
 }
 
 /// Advance to the next epoch. Returns the new epoch.

--- a/crates/proof_of_stake/src/tests/test_validator.rs
+++ b/crates/proof_of_stake/src/tests/test_validator.rs
@@ -556,7 +556,10 @@ fn test_validator_sets() {
         tm_updates[0],
         ValidatorSetUpdate::Consensus(ConsensusValidator {
             consensus_key: pk3,
-            bonded_stake: stake3,
+            bonded_stake: into_tm_voting_power(
+                params.tm_votes_per_token,
+                stake3
+            ),
         })
     );
 
@@ -611,7 +614,10 @@ fn test_validator_sets() {
         tm_updates[0],
         ValidatorSetUpdate::Consensus(ConsensusValidator {
             consensus_key: pk5,
-            bonded_stake: stake5,
+            bonded_stake: into_tm_voting_power(
+                params.tm_votes_per_token,
+                stake5
+            ),
         })
     );
     assert_eq!(tm_updates[1], ValidatorSetUpdate::Deactivated(pk2));
@@ -812,7 +818,10 @@ fn test_validator_sets() {
         tm_updates[0],
         ValidatorSetUpdate::Consensus(ConsensusValidator {
             consensus_key: pk4.clone(),
-            bonded_stake: stake4,
+            bonded_stake: into_tm_voting_power(
+                params.tm_votes_per_token,
+                stake4
+            ),
         })
     );
     assert_eq!(tm_updates[1], ValidatorSetUpdate::Deactivated(pk1));
@@ -927,7 +936,10 @@ fn test_validator_sets() {
         tm_updates[0],
         ValidatorSetUpdate::Consensus(ConsensusValidator {
             consensus_key: pk6,
-            bonded_stake: stake6,
+            bonded_stake: into_tm_voting_power(
+                params.tm_votes_per_token,
+                stake6
+            ),
         })
     );
     assert_eq!(tm_updates[1], ValidatorSetUpdate::Deactivated(pk4));
@@ -1187,7 +1199,10 @@ fn test_validator_sets_swap() {
         tm_updates[0],
         ValidatorSetUpdate::Consensus(ConsensusValidator {
             consensus_key: pk3.clone(),
-            bonded_stake: stake3,
+            bonded_stake: into_tm_voting_power(
+                params.tm_votes_per_token,
+                stake3
+            ),
         })
     );
 
@@ -1226,14 +1241,17 @@ fn test_validator_sets_swap() {
     assert_eq!(epoch, bonds_epoch_3);
 
     let tm_updates = get_tendermint_set_updates(&s, &params, epoch);
-    dbg!(&tm_updates);
+    // dbg!(&tm_updates);
     assert_eq!(tm_updates.len(), 2);
     assert_eq!(
         tm_updates,
         vec![
             ValidatorSetUpdate::Consensus(ConsensusValidator {
                 consensus_key: new_ck2,
-                bonded_stake: stake2,
+                bonded_stake: into_tm_voting_power(
+                    params.tm_votes_per_token,
+                    stake2
+                ),
             }),
             ValidatorSetUpdate::Deactivated(pk3),
         ]

--- a/crates/proof_of_stake/src/tests/test_validator.rs
+++ b/crates/proof_of_stake/src/tests/test_validator.rs
@@ -42,8 +42,9 @@ use crate::validator_set_update::{
     insert_validator_into_validator_set, update_validator_set,
 };
 use crate::{
-    become_validator, bond_tokens, is_validator, staking_token_address,
-    unbond_tokens, withdraw_tokens, BecomeValidator, OwnedPosParams,
+    become_validator, bond_tokens, change_consensus_key, is_validator,
+    staking_token_address, unbond_tokens, withdraw_tokens, BecomeValidator,
+    OwnedPosParams,
 };
 
 proptest! {
@@ -1185,9 +1186,57 @@ fn test_validator_sets_swap() {
     assert_eq!(
         tm_updates[0],
         ValidatorSetUpdate::Consensus(ConsensusValidator {
-            consensus_key: pk3,
+            consensus_key: pk3.clone(),
             bonded_stake: stake3,
         })
+    );
+
+    // Now give val2 stake such that it bumps val3 out of the consensus set, and
+    // also change val2's consensus key
+    let pipeline_epoch = epoch + params.pipeline_len;
+    let bonds_epoch_3 = pipeline_epoch;
+    let bonds = token::Amount::native_whole(1);
+    let stake2 = stake2 + bonds;
+
+    update_validator_set(&mut s, &params, &val2, bonds.change(), epoch, None)
+        .unwrap();
+    update_validator_deltas(
+        &mut s,
+        &params,
+        &val2,
+        bonds.change(),
+        epoch,
+        None,
+    )
+    .unwrap();
+
+    sk_seed += 1;
+    let new_ck2 = key::testing::common_sk_from_simple_seed(sk_seed).to_public();
+    change_consensus_key(&mut s, &val2, &new_ck2, epoch).unwrap();
+
+    // Advance to EPOCH 5
+    let epoch = advance_epoch(&mut s, &params);
+
+    // Check tendermint validator set updates
+    let tm_updates = get_tendermint_set_updates(&s, &params, epoch);
+    assert!(tm_updates.is_empty());
+
+    // Advance to EPOCH 6
+    let epoch = advance_epoch(&mut s, &params);
+    assert_eq!(epoch, bonds_epoch_3);
+
+    let tm_updates = get_tendermint_set_updates(&s, &params, epoch);
+    dbg!(&tm_updates);
+    assert_eq!(tm_updates.len(), 2);
+    assert_eq!(
+        tm_updates,
+        vec![
+            ValidatorSetUpdate::Consensus(ConsensusValidator {
+                consensus_key: new_ck2,
+                bonded_stake: stake2,
+            }),
+            ValidatorSetUpdate::Deactivated(pk3),
+        ]
     );
 }
 

--- a/crates/proof_of_stake/src/types/mod.rs
+++ b/crates/proof_of_stake/src/types/mod.rs
@@ -388,13 +388,13 @@ pub enum ValidatorSetUpdate {
     Deactivated(common::PublicKey),
 }
 
-/// Consensus validator's consensus key and its bonded stake.
+/// Newly updated consensus validator's consensus key and bonded stake.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConsensusValidator {
     /// A public key used for signing validator's consensus actions
     pub consensus_key: common::PublicKey,
     /// Total bonded stake of the validator
-    pub bonded_stake: token::Amount,
+    pub bonded_stake: i64,
 }
 
 /// ID of a bond and/or an unbond.

--- a/crates/proof_of_stake/src/validator_set_update.rs
+++ b/crates/proof_of_stake/src/validator_set_update.rs
@@ -653,7 +653,7 @@ where
                 return vec![ValidatorSetUpdate::Consensus(
                     ConsensusValidator {
                         consensus_key: new_consensus_key,
-                        bonded_stake: new_stake,
+                        bonded_stake: *new_tm_voting_power,
                     },
                 )];
             }
@@ -667,7 +667,7 @@ where
                 vec![
                     ValidatorSetUpdate::Consensus(ConsensusValidator {
                         consensus_key: new_consensus_key,
-                        bonded_stake: new_stake,
+                        bonded_stake: *new_tm_voting_power,
                     }),
                     ValidatorSetUpdate::Deactivated(
                         prev_consensus_key.unwrap(),
@@ -682,7 +682,7 @@ where
             } else {
                 vec![ValidatorSetUpdate::Consensus(ConsensusValidator {
                     consensus_key: new_consensus_key,
-                    bonded_stake: new_stake,
+                    bonded_stake: *new_tm_voting_power,
                 })]
             }
         });

--- a/crates/proof_of_stake/src/validator_set_update.rs
+++ b/crates/proof_of_stake/src/validator_set_update.rs
@@ -561,7 +561,7 @@ where
 /// Communicate imminent validator set updates to Tendermint. This function is
 /// called two blocks before the start of a new epoch because Tendermint
 /// validator updates become active two blocks after the updates are submitted.
-pub fn validator_set_update_tendermint<S, T>(
+pub fn validator_set_update_comet<S, T>(
     storage: &S,
     params: &PosParams,
     current_epoch: Epoch,
@@ -570,9 +570,11 @@ pub fn validator_set_update_tendermint<S, T>(
 where
     S: StorageRead,
 {
-    tracing::debug!("Communicating validator set updates to Tendermint.");
-    // Because this is called 2 blocks before a start on an epoch, we're gonna
-    // give Tendermint updates for the next epoch
+    tracing::debug!(
+        "Communicating post-genesis validator set updates to CometBFT."
+    );
+    // Because this is called 2 blocks before the start on an epoch, we will
+    // give CometBFT the updates for the next epoch
     let next_epoch = current_epoch.next();
 
     let new_consensus_validator_handle =
@@ -580,6 +582,7 @@ where
     let prev_consensus_validator_handle =
         consensus_validator_set_handle().at(&current_epoch);
 
+    tracing::debug!("Iterating over new consensus validators:");
     let new_consensus_validators = new_consensus_validator_handle
         .iter(storage)?
         .map(|validator| {
@@ -596,12 +599,42 @@ where
                 new_stake.to_string_native()
             );
 
+            let prev_tm_voting_power = Lazy::new(|| {
+                let prev_validator_stake = read_validator_stake(
+                    storage,
+                    params,
+                    &address,
+                    current_epoch,
+                )
+                .unwrap();
+                into_tm_voting_power(
+                    params.tm_votes_per_token,
+                    prev_validator_stake,
+                )
+            });
+            let new_tm_voting_power = Lazy::new(|| {
+                into_tm_voting_power(params.tm_votes_per_token, new_stake)
+            });
+
+            // If both previous and current voting powers are 0, and the
+            // validator_stake_threshold is 0, skip update
+            if params.validator_stake_threshold.is_zero()
+                && *prev_tm_voting_power == 0
+                && *new_tm_voting_power == 0
+            {
+                tracing::debug!(
+                    "Skipping CometBFT validator set update, {address} is in \
+                     consensus set but without voting power"
+                );
+                return vec![];
+            }
+
             let new_consensus_key = validator_consensus_key_handle(&address)
                 .get(storage, next_epoch, params)
                 .unwrap()
                 .unwrap();
 
-            let old_consensus_key = validator_consensus_key_handle(&address)
+            let prev_consensus_key = validator_consensus_key_handle(&address)
                 .get(storage, current_epoch, params)
                 .unwrap();
 
@@ -609,85 +642,43 @@ where
                 .get(storage, current_epoch, params)
                 .unwrap();
 
-            // Check if the validator was consensus in the previous epoch with
-            // the same stake. If so, no updated is needed.
-            // Look up previous state and prev and current voting powers
-            if !prev_consensus_validator_handle.is_empty(storage).unwrap() {
-                let prev_tm_voting_power = Lazy::new(|| {
-                    let prev_validator_stake = read_validator_stake(
-                        storage,
-                        params,
-                        &address,
-                        current_epoch,
-                    )
-                    .unwrap();
-                    into_tm_voting_power(
-                        params.tm_votes_per_token,
-                        prev_validator_stake,
-                    )
-                });
-                let new_tm_voting_power = Lazy::new(|| {
-                    into_tm_voting_power(params.tm_votes_per_token, new_stake)
-                });
-
-                // If it was in `Consensus` before and voting power has not
-                // changed, skip the update
-                if matches!(prev_state, Some(ValidatorState::Consensus))
-                    && *prev_tm_voting_power == *new_tm_voting_power
-                {
-                    if old_consensus_key.as_ref().unwrap() == &new_consensus_key
-                    {
-                        tracing::debug!(
-                            "skipping validator update, {address} is in \
-                             consensus set but voting power hasn't changed"
-                        );
-                        return vec![];
-                    } else {
-                        return vec![
-                            ValidatorSetUpdate::Consensus(ConsensusValidator {
-                                consensus_key: new_consensus_key,
-                                bonded_stake: new_stake,
-                            }),
-                            ValidatorSetUpdate::Deactivated(
-                                old_consensus_key.unwrap(),
-                            ),
-                        ];
-                    }
-                }
-                // If both previous and current voting powers are 0, and the
-                // validator_stake_threshold is 0, skip update
-                if params.validator_stake_threshold.is_zero()
-                    && *prev_tm_voting_power == 0
-                    && *new_tm_voting_power == 0
-                {
-                    tracing::info!(
-                        "skipping validator update, {address} is in consensus \
-                         set but without voting power"
-                    );
-                    return vec![];
-                }
-            }
-
             tracing::debug!(
-                "{address} consensus key {}",
+                "{address} new consensus key {}",
                 new_consensus_key.tm_raw_hash()
             );
 
-            if old_consensus_key.as_ref() == Some(&new_consensus_key)
-                || old_consensus_key.is_none()
-            {
-                vec![ValidatorSetUpdate::Consensus(ConsensusValidator {
-                    consensus_key: new_consensus_key,
-                    bonded_stake: new_stake,
-                })]
-            } else if matches!(prev_state, Some(ValidatorState::Consensus)) {
+            // If the old state was not Consensus, then just a
+            // ConsensusValidator update is required
+            if !matches!(prev_state, Some(ValidatorState::Consensus)) {
+                return vec![ValidatorSetUpdate::Consensus(
+                    ConsensusValidator {
+                        consensus_key: new_consensus_key,
+                        bonded_stake: new_stake,
+                    },
+                )];
+            }
+
+            // Now we've matched validators that were previously Consensus and
+            // remain so, which also implies that an old consensus key exists
+
+            // If the consensus key has changed, then both ConsensusValidator
+            // and DeactivatedValidator updates are required
+            if prev_consensus_key.as_ref() != Some(&new_consensus_key) {
                 vec![
                     ValidatorSetUpdate::Consensus(ConsensusValidator {
                         consensus_key: new_consensus_key,
                         bonded_stake: new_stake,
                     }),
-                    ValidatorSetUpdate::Deactivated(old_consensus_key.unwrap()),
+                    ValidatorSetUpdate::Deactivated(
+                        prev_consensus_key.unwrap(),
+                    ),
                 ]
+            } else if *prev_tm_voting_power == *new_tm_voting_power {
+                tracing::debug!(
+                    "Skipping CometBFT validator set update; {address} \
+                     remains in consensus set but voting power hasn't changed"
+                );
+                vec![]
             } else {
                 vec![ValidatorSetUpdate::Consensus(ConsensusValidator {
                     consensus_key: new_consensus_key,
@@ -696,6 +687,7 @@ where
             }
         });
 
+    tracing::debug!("Iterating over previous consensus validators:");
     let prev_consensus_validators = prev_consensus_validator_handle
         .iter(storage)?
         .map(|validator| {
@@ -725,7 +717,7 @@ where
                 )
             });
 
-            let old_consensus_key = validator_consensus_key_handle(&address)
+            let prev_consensus_key = validator_consensus_key_handle(&address)
                 .get(storage, current_epoch, params)
                 .unwrap()
                 .unwrap();
@@ -740,24 +732,25 @@ where
                 // If the new state is not Consensus but its prev voting power
                 // was 0 and the stake threshold is 0, we can also skip the
                 // update
-                tracing::info!(
-                    "skipping validator update, {address} is in consensus set \
-                     but without voting power"
+                tracing::debug!(
+                    "Skipping CometBFT validator set update, {address} is in \
+                     not in consensus set anymore, but it previously had no \
+                     voting power"
                 );
                 return vec![];
             }
 
             // The remaining validators were previously Consensus but no longer
             // are, so they must be deactivated
-            let consensus_key = validator_consensus_key_handle(&address)
+            let new_consensus_key = validator_consensus_key_handle(&address)
                 .get(storage, next_epoch, params)
                 .unwrap()
                 .unwrap();
             tracing::debug!(
-                "{address} consensus key {}",
-                consensus_key.tm_raw_hash()
+                "{address} new consensus key {}",
+                new_consensus_key.tm_raw_hash()
             );
-            vec![ValidatorSetUpdate::Deactivated(old_consensus_key)]
+            vec![ValidatorSetUpdate::Deactivated(prev_consensus_key)]
         });
 
     Ok(new_consensus_validators


### PR DESCRIPTION
## Describe your changes
A consensus failure occurred on the SE that appears to be due to a bug in the communication of validator set updates to CometBFT for the change to epoch 9.

To summarize, there is a validator in the below-capacity set in epoch 8, to become a consensus validator in epoch 9, and whose consensus key was changed and to become active in epoch 9. In addition to a ConsensusValidator update, we also sent a DeactivateValidator update with the old consensus key, though this should not have been done since the validator was not previously a Consensus validator.

A test case that reproduces the error is added, followed by a fix. Then a more thorough refactor of `validator_set_update_tendermint` is done. Another refactor of the types used to hold voting power is done at the end.

## Indicate on which release or other PRs this topic is based on
v0.31.4

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
