### PR TITLE
Crash the ledger if committing a block fails

### DIFF
--- a/.changelog/unreleased/bug-fixes/2657-commit-failure.md
+++ b/.changelog/unreleased/bug-fixes/2657-commit-failure.md
@@ -1,0 +1,3 @@
+- Rather than allowing CometBFT to keep processing blocks after a storage write
+  has failed in Namada, crash the ledger to avoid any potential corruption of
+  state. ([\#2657](https://github.com/anoma/namada/pull/2657))

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -774,12 +774,9 @@ where
             ..Default::default()
         };
         // commit block's data from write log and store the in DB
-        self.wl_storage.commit_block().unwrap_or_else(|e| {
-            tracing::error!(
-                "Encountered a storage error while committing a block {:?}",
-                e
-            )
-        });
+        self.wl_storage
+            .commit_block()
+            .expect("Encountered a storage error while committing a block");
 
         let root = self.wl_storage.storage.merkle_root();
         tracing::info!(

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -769,6 +769,8 @@ where
     /// Commit a block. Persist the application state and return the Merkle root
     /// hash.
     pub fn commit(&mut self) -> response::Commit {
+        self.bump_last_processed_eth_block();
+
         self.wl_storage
             .commit_block()
             .expect("Encountered a storage error while committing a block");
@@ -779,7 +781,6 @@ where
             "Committed block hash: {merkle_root}, height: {committed_height}",
         );
 
-        self.bump_last_processed_eth_block();
         self.broadcast_queued_txs();
 
         response::Commit {

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -784,7 +784,10 @@ where
         self.broadcast_queued_txs();
 
         response::Commit {
+            // NB: by passing 0, we forbid CometBFT from deleting
+            // data pertaining to past blocks
             retain_height: tendermint::block::Height::from(0_u32),
+            // NB: current application hash
             data: merkle_root.0.to_vec().into(),
         }
     }


### PR DESCRIPTION
## Describe your changes

Rather than allowing CometBFT to keep processing blocks after a storage write has failed in Namada, we crash the ledger to avoid any potential corruption of state.

This PR is eligible for non-breaking draft.

## Indicate on which release or other PRs this topic is based on

`v0.31.4`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
