### PR TITLE
fix: increase timeout from 30 to 180

### DIFF
--- a/.changelog/unreleased/improvements/2668-time-out.md
+++ b/.changelog/unreleased/improvements/2668-time-out.md
@@ -1,0 +1,2 @@
+- Increase broadcaster timeout and allow users to increase it via environment
+  variable. ([\#2668](https://github.com/anoma/namada/pull/2668))

--- a/crates/apps/src/lib/node/ledger/broadcaster.rs
+++ b/crates/apps/src/lib/node/ledger/broadcaster.rs
@@ -48,7 +48,7 @@ impl Broadcaster {
                 strategy: time::Constant(time::Duration::from_secs(1)),
             }
             .timeout(
-                time::Instant::now() + time::Duration::from_secs(30),
+                time::Instant::now() + time::Duration::from_secs(180),
                 || async {
                     match self.client.status().await {
                         Ok(status) => ControlFlow::Break(status),

--- a/crates/apps/src/lib/node/ledger/broadcaster.rs
+++ b/crates/apps/src/lib/node/ledger/broadcaster.rs
@@ -7,6 +7,9 @@ use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::facade::tendermint_rpc::{Client, HttpClient};
 
+const DEFAULT_BROADCAST_TIMEOUT: u64 = 180;
+const BROADCASTER_TIMEOUT_ENV_VAR: &str = "NAMADA_BROADCASTER_TIMEOUT_SECS";
+
 /// A service for broadcasting txs via an HTTP client.
 /// The receiver is for receiving message payloads for other services
 /// to be broadcast.
@@ -44,11 +47,17 @@ impl Broadcaster {
             },
         }
         .run(|| async {
+            let timeout =
+                if let Ok(value) = std::env::var(BROADCASTER_TIMEOUT_ENV_VAR) {
+                    value.parse::<u64>().unwrap_or(DEFAULT_BROADCAST_TIMEOUT)
+                } else {
+                    DEFAULT_BROADCAST_TIMEOUT
+                };
             let status_result = time::Sleep {
                 strategy: time::Constant(time::Duration::from_secs(1)),
             }
             .timeout(
-                time::Instant::now() + time::Duration::from_secs(180),
+                time::Instant::now() + time::Duration::from_secs(timeout),
                 || async {
                     match self.client.status().await {
                         Ok(status) => ControlFlow::Break(status),


### PR DESCRIPTION
## Describe your changes

Closes #2662

This change increase the timeout of the broadcaster from 30 to 180 seconds. In the last upgrade of the Shielded Expedition some validators couldn't restart their node because of the timeout. Increasing this value solved it and avoid restarting from scratch.

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
