### PR TITLE
MASP vp multiple txs

### DIFF
--- a/.changelog/unreleased/bug-fixes/2621-fix-nullifier-check.md
+++ b/.changelog/unreleased/bug-fixes/2621-fix-nullifier-check.md
@@ -1,0 +1,2 @@
+- Fixed a bug in the masp vp that allowed a shielding transaction to reveal
+  nullifiers. ([\#2621](https://github.com/anoma/namada/pull/2621))

--- a/.changelog/unreleased/improvements/2690-multi-tx-masp-vp.md
+++ b/.changelog/unreleased/improvements/2690-multi-tx-masp-vp.md
@@ -1,0 +1,2 @@
+- Updated the masp vp to accept multiple transfers in a single transaction.
+  ([\#2690](https://github.com/anoma/namada/pull/2690))

--- a/crates/namada/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
+++ b/crates/namada/src/ledger/native_vp/ethereum_bridge/bridge_pool_vp.rs
@@ -32,7 +32,7 @@ use namada_tx::Tx;
 use crate::address::{Address, InternalAddress};
 use crate::eth_bridge_pool::{PendingTransfer, TransferToEthereumKind};
 use crate::ethereum_events::EthAddress;
-use crate::ledger::native_vp::{Ctx, NativeVp, StorageReader};
+use crate::ledger::native_vp::{Ctx, NativeVp, SignedAmount, StorageReader};
 use crate::storage::Key;
 use crate::token::storage_key::balance_key;
 use crate::token::Amount;
@@ -42,13 +42,6 @@ use crate::vm::WasmCacheAccess;
 #[error(transparent)]
 /// Generic error that may be returned by the validity predicate
 pub struct Error(#[from] eyre::Error);
-
-/// A positive or negative amount
-#[derive(Copy, Clone)]
-enum SignedAmount {
-    Positive(Amount),
-    Negative(Amount),
-}
 
 /// An [`Amount`] that has been updated with some delta value.
 #[derive(Copy, Clone)]

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -79,7 +79,6 @@ where
         // than once in the same tx
         let mut revealed_nullifiers = HashSet::new();
 
-        // FIXME: test this check in some way if possible
         for description in transaction
             .sapling_bundle()
             .map_or(&vec![], |bundle| &bundle.shielded_spends)
@@ -557,16 +556,14 @@ where
             // 2. At least one shielded input
             // 3. The spend descriptions' anchors are valid
             // 4. The convert descriptions's anchors are valid
-            // FIXME: can improve this?
-            if let Some(transp_bundle) = shielded_tx.transparent_bundle() {
-                if !transp_bundle.vin.is_empty() {
-                    tracing::debug!(
-                        "Transparent input to a transaction from the masp \
-                         must be 0 but is {}",
-                        transp_bundle.vin.len()
-                    );
-                    return Ok(false);
-                }
+            if shielded_tx
+                .transparent_bundle()
+                .is_some_and(|bundle| !bundle.vin.is_empty())
+            {
+                tracing::debug!(
+                    "No transparent inputs are allowed when the source is masp",
+                );
+                return Ok(false);
             }
 
             if !shielded_tx
@@ -695,24 +692,21 @@ where
             // 2. At least one shielded output
 
             // Satisfies 1.
-            // FIXME: can this be improved?
-            if let Some(transp_bundle) = shielded_tx.transparent_bundle() {
-                if !transp_bundle.vout.is_empty() {
-                    tracing::debug!(
-                        "Transparent output to a transaction from the masp \
-                         must be 0 but is {}",
-                        transp_bundle.vout.len()
-                    );
-                    return Ok(false);
-                }
+            if shielded_tx
+                .transparent_bundle()
+                .is_some_and(|bundle| !bundle.vout.is_empty())
+            {
+                tracing::debug!(
+                    "No transparent outputs are allowed when the target is \
+                     the masp",
+                );
+                return Ok(false);
             }
 
             // Staisfies 2.
-            // FIXME: I think this is wrong! What if it's None?
-            // FIXME: is this even  needed?
-            if shielded_tx
+            if !shielded_tx
                 .sapling_bundle()
-                .is_some_and(|bundle| bundle.shielded_outputs.is_empty())
+                .is_some_and(|bundle| !bundle.shielded_outputs.is_empty())
             {
                 return Ok(false);
             }

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -57,14 +57,48 @@ where
     pub ctx: Ctx<'a, S, CA>,
 }
 
+#[derive(PartialEq)]
+enum DeltaBalance {
+    Positive(Amount),
+    Negative(Amount),
+}
+
+impl DeltaBalance {
+    fn checked_add(&self, rhs: Self) -> Option<Self> {
+        match (self, rhs) {
+            (Self::Positive(lhs), Self::Positive(rhs)) => {
+                let tmp = lhs.checked_add(rhs)?;
+                Some(Self::Positive(tmp))
+            }
+            (Self::Positive(lhs), Self::Negative(rhs)) => {
+                match lhs.checked_sub(rhs) {
+                    Some(diff) => Some(Self::Positive(diff)),
+                    None => Some(Self::Negative(rhs - *lhs)),
+                }
+            }
+            (Self::Negative(lhs), Self::Positive(rhs)) => {
+                match rhs.checked_sub(*lhs) {
+                    Some(diff) => Some(Self::Positive(diff)),
+                    None => Some(Self::Negative(*lhs - rhs)),
+                }
+            }
+            (Self::Negative(lhs), Self::Negative(rhs)) => {
+                let tmp = lhs.checked_add(rhs)?;
+                Some(Self::Negative(tmp))
+            }
+        }
+    }
+}
+
 // The balances changed by the transaction, split between masp and non-masp
 // balances. The masp collection carries the token addresses. The collection of
 // the other balances maps the token address to the addresses of the
-// senders/receivers and their pre and post amounts
+// senders/receivers, their balance diff and whether this is positive or
+// negative diff
 #[derive(Default)]
 struct ChangedBalances<'vp> {
     masp: BTreeSet<&'vp Address>,
-    other: BTreeMap<&'vp Address, Vec<(&'vp Address, Amount, Amount)>>,
+    other: BTreeMap<&'vp Address, BTreeMap<[u8; 20], DeltaBalance>>,
 }
 
 impl<'a, S, CA> MaspVp<'a, S, CA>
@@ -293,7 +327,9 @@ where
         // Get the changed balance keys
         // FIXME: can partiotion here?
         // FIXME: does this also contain temp modification? Yes, is this
-        // correct?
+        // correct? I don't think so, I might end up validating keys that are
+        // not committed, so wrong validation FIXME: probably I need to
+        // read post from storage to circumvent this
         let balance_addresses: Vec<[&Address; 2]> = keys_changed
             .iter()
             .filter_map(is_any_shielded_action_balance_key)
@@ -316,20 +352,36 @@ where
             .collect();
 
         for &[token, counterpart] in counterparts {
+            // FIXME: incorrect use read_bytes like in the other places
+            // otherwise I read temp modifications FIXME: also
+            // mention this in red teaming. Also the fact that temporary keys
+            // changed are passed to the vps
             let pre_balance: Amount = self
                 .ctx
                 .read_pre(&balance_key(token, counterpart))?
                 .unwrap_or_default();
+            // FIXME: incorrect use read_bytes like in the other places
+            // otherwise I read temp modifications FIXME: actually,
+            // not sure, maybe this method is correct, depend on the
+            // implementation on Ctx
             let post_balance: Amount = self
                 .ctx
                 .read_post(&balance_key(token, counterpart))?
                 .unwrap_or_default();
-
-            result.other.entry(token).or_insert(vec![]).push((
-                counterpart,
-                pre_balance,
-                post_balance,
+            // Public keys must be the hash of the sources/targets
+            let address_hash = <[u8; 20]>::from(ripemd::Ripemd160::digest(
+                sha2::Sha256::digest(&counterpart.serialize_to_vec()),
             ));
+            let diff = match post_balance.checked_sub(pre_balance) {
+                Some(diff) => DeltaBalance::Positive(diff),
+                None => DeltaBalance::Negative(pre_balance - post_balance),
+            };
+
+            result
+                .other
+                .entry(token)
+                .or_insert(BTreeMap::default())
+                .insert(address_hash, diff);
         }
 
         Ok(result)
@@ -405,87 +457,132 @@ where
 
         // FIXME: extract to function
         // Checks on the transparent bundle, if present
-        let (mut vin_bundle_balances, mut vout_bundle_balances) =
-            if let Some(transp_bundle) = shielded_tx.transparent_bundle() {
-                let mut total_vin_bundle_balances: BTreeMap<
-                    &Address,
-                    BTreeMap<[u8; 20], Amount>,
-                > = BTreeMap::default();
-                let mut total_vout_bundle_balances: BTreeMap<
-                    &Address,
-                    BTreeMap<[u8; 20], Amount>,
-                > = BTreeMap::default();
+        let bundle_balances = if let Some(transp_bundle) =
+            shielded_tx.transparent_bundle()
+        {
+            let mut total_bundle_balances: BTreeMap<
+                &Address,
+                BTreeMap<[u8; 20], DeltaBalance>,
+            > = BTreeMap::default();
 
-                let mut processed_vins = vec![false; transp_bundle.vin.len()];
-                let mut processed_vouts = vec![false; transp_bundle.vout.len()];
+            let mut processed_vins = vec![false; transp_bundle.vin.len()];
+            let mut processed_vouts = vec![false; transp_bundle.vout.len()];
 
-                // Run the checks fore every token involved in the transaction
-                for token in changed_balances.masp {
-                    let denom = read_denom(&self.ctx.pre(), token)?
-                        .ok_or_err_msg(
-                            "No denomination found in storage for the given \
-                             token",
-                        )?;
+            // Run the checks fore every token involved in the transaction
+            for token in changed_balances.masp {
+                let denom = read_denom(&self.ctx.pre(), token)?.ok_or_err_msg(
+                    "No denomination found in storage for the given token",
+                )?;
 
-                    let mut vin_bundle_balances = BTreeMap::default();
-                    let mut vout_bundle_balances = BTreeMap::default();
+                let mut token_bundle_balances = BTreeMap::default();
 
-                    // To help recognize asset types not in the conversion tree
-                    let unepoched_tokens = unepoched_tokens(token, denom)?;
+                // To help recognize asset types not in the conversion tree
+                let unepoched_tokens = unepoched_tokens(token, denom)?;
 
-                    // FIXME: can we support a fully transparent transfer
-                    // triggering the masp vp? Probably not if it carries the
-                    // Transaction object. Actually maybe yes, in protcol
-                    // instead of just checking that the masp vp was triggered
-                    // and was succesful I should ALSO check that at least one
-                    // masp key was changed
+                // FIXME: can we support a fully transparent transfer
+                // triggering the masp vp? Probably not if it carries the
+                // Transaction object. Actually maybe yes, in protcol
+                // instead of just checking that the masp vp was triggered
+                // and was succesful I should ALSO check that at least one
+                // masp key was changed
 
-                    // Handle transparent input
-                    // The following boundary condition must be satisfied: asset
-                    // type must be properly derived
-                    for (idx, vin) in transp_bundle.vin.iter().enumerate() {
-                        if processed_vins[idx] {
-                            continue;
-                        }
-                        // Non-masp sources add to the transparent tx pool
-                        transparent_tx_pool = transparent_tx_pool
-                            .checked_add(
-                                &I128Sum::from_nonnegative(
-                                    vin.asset_type,
-                                    vin.value as i128,
-                                )
-                                .ok()
-                                .ok_or_err_msg(
-                                    "invalid value or asset type for amount",
-                                )?,
+                // Handle transparent input
+                // The following boundary condition must be satisfied: asset
+                // type must be properly derived
+                for (idx, vin) in transp_bundle.vin.iter().enumerate() {
+                    if processed_vins[idx] {
+                        continue;
+                    }
+                    // Non-masp sources add to the transparent tx pool
+                    transparent_tx_pool = transparent_tx_pool
+                        .checked_add(
+                            &I128Sum::from_nonnegative(
+                                vin.asset_type,
+                                vin.value as i128,
                             )
-                            .ok_or_err_msg("Overflow in input sum")?;
+                            .ok()
+                            .ok_or_err_msg(
+                                "invalid value or asset type for amount",
+                            )?,
+                        )
+                        .ok_or_err_msg("Overflow in input sum")?;
 
-                        match conversion_state.assets.get(&vin.asset_type) {
-                            // Note how the asset's epoch must be equal to
-                            // the present: users must never be allowed to
-                            // backdate transparent
-                            // inputs to a transaction for they would then
-                            // be able to claim rewards while locking their
-                            // assets for negligible
-                            // time periods.
-                            Some((
-                                (address, asset_denom, digit),
-                                asset_epoch,
-                                _,
-                                _,
-                            )) if address == token
-                                && *asset_denom == denom
-                                && *asset_epoch == epoch =>
+                    match conversion_state.assets.get(&vin.asset_type) {
+                        // Note how the asset's epoch must be equal to
+                        // the present: users must never be allowed to
+                        // backdate transparent
+                        // inputs to a transaction for they would then
+                        // be able to claim rewards while locking their
+                        // assets for negligible
+                        // time periods.
+                        Some((
+                            (address, asset_denom, digit),
+                            asset_epoch,
+                            _,
+                            _,
+                        )) if address == token
+                            && *asset_denom == denom
+                            && *asset_epoch == epoch =>
+                        {
+                            let amount = token::Amount::from_masp_denominated(
+                                vin.value, *digit,
+                            );
+                            let bref = token_bundle_balances
+                                .entry(vin.address.0)
+                                .or_insert(DeltaBalance::Negative(
+                                    Amount::default(),
+                                ));
+                            *bref = bref
+                                .checked_add(DeltaBalance::Negative(amount))
+                                .ok_or_else(|| {
+                                    Error::NativeVpError(
+                                        native_vp::Error::SimpleMessage(
+                                            "Overflow in bundle balance",
+                                        ),
+                                    )
+                                })?;
+                        }
+                        // Maybe the asset type has no attached epoch
+                        None if unepoched_tokens
+                            .contains_key(&vin.asset_type) =>
+                        {
+                            let (token, denom, digit) =
+                                &unepoched_tokens[&vin.asset_type];
+                            // Determine what the asset type would be if it
+                            // were epoched
+                            let epoched_asset_type = encode_asset_type(
+                                token.clone(),
+                                *denom,
+                                *digit,
+                                Some(epoch),
+                            )
+                            .wrap_err("unable to create asset type")?;
+                            if conversion_state
+                                .assets
+                                .contains_key(&epoched_asset_type)
                             {
+                                // If such an epoched asset type is
+                                // available in the
+                                // conversion tree, then we must reject the
+                                // unepoched variant
+                                tracing::debug!(
+                                    "epoch is missing from asset type"
+                                );
+                                return Ok(false);
+                            } else {
+                                // Otherwise note the contribution to this
+                                // transparent input
                                 let amount =
                                     token::Amount::from_masp_denominated(
                                         vin.value, *digit,
                                     );
-                                vin_bundle_balances
+                                let bref = token_bundle_balances
                                     .entry(vin.address.0)
-                                    .or_insert(Amount::default())
-                                    .checked_add(amount)
+                                    .or_insert(DeltaBalance::Negative(
+                                        Amount::default(),
+                                    ));
+                                *bref = bref
+                                    .checked_add(DeltaBalance::Negative(amount))
                                     .ok_or_else(|| {
                                         Error::NativeVpError(
                                             native_vp::Error::SimpleMessage(
@@ -494,230 +591,119 @@ where
                                         )
                                     })?;
                             }
-                            // Maybe the asset type has no attached epoch
-                            None if unepoched_tokens
-                                .contains_key(&vin.asset_type) =>
-                            {
-                                let (token, denom, digit) =
-                                    &unepoched_tokens[&vin.asset_type];
-                                // Determine what the asset type would be if it
-                                // were epoched
-                                let epoched_asset_type = encode_asset_type(
-                                    token.clone(),
-                                    *denom,
-                                    *digit,
-                                    Some(epoch),
-                                )
-                                .wrap_err("unable to create asset type")?;
-                                if conversion_state
-                                    .assets
-                                    .contains_key(&epoched_asset_type)
-                                {
-                                    // If such an epoched asset type is
-                                    // available in the
-                                    // conversion tree, then we must reject the
-                                    // unepoched variant
-                                    tracing::debug!(
-                                        "epoch is missing from asset type"
-                                    );
-                                    return Ok(false);
-                                } else {
-                                    // Otherwise note the contribution to this
-                                    // transparent input
-                                    let amount =
-                                        token::Amount::from_masp_denominated(
-                                            vin.value, *digit,
-                                        );
-                                    vin_bundle_balances
-                                        .entry(vin.address.0)
-                                        .or_insert(Amount::default())
-                                        .checked_add(amount)
-                                        .ok_or_else(|| {
-                                            Error::NativeVpError(
-                                                native_vp::Error::SimpleMessage(
-                                                    "Overflow in bundle \
-                                                     balance",
-                                                ),
-                                            )
-                                        })?;
-                                }
-                            }
-                            // FIXME: this is wrong, I could fin it in another
-                            // token unrecognized
-                            // asset
-                            _ => return Ok(false),
-                        };
-
-                        processed_vins[idx] = true;
-                    }
-
-                    // Handle transparent output
-                    // The following boundary condition must be satisfied: asset
-                    // type must be properly derived
-                    for (idx, out) in transp_bundle.vout.iter().enumerate() {
-                        if processed_vouts[idx] {
-                            continue;
                         }
-                        // Non-masp destinations subtract from transparent tx
-                        // pool
-                        transparent_tx_pool = transparent_tx_pool
-                            .checked_sub(
-                                &I128Sum::from_nonnegative(
-                                    out.asset_type,
-                                    out.value as i128,
-                                )
-                                .ok()
-                                .ok_or_err_msg(
-                                    "invalid value or asset type for amount",
-                                )?,
-                            )
-                            .ok_or_err_msg("Underflow in output subtraction")?;
+                        // FIXME: this is wrong, I could fin it in another
+                        // token unrecognized
+                        // asset
+                        _ => return Ok(false),
+                    };
 
-                        match conversion_state.assets.get(&out.asset_type) {
-                            Some((
-                                (address, asset_denom, digit),
-                                asset_epoch,
-                                _,
-                                _,
-                            )) if address == token
-                                && *asset_denom == denom
-                                && *asset_epoch <= epoch =>
-                            {
-                                let amount =
-                                    token::Amount::from_masp_denominated(
-                                        out.value, *digit,
-                                    );
-                                vout_bundle_balances
-                                    .entry(out.address.0)
-                                    .or_insert(Amount::default())
-                                    .checked_add(amount)
-                                    .ok_or_else(|| {
-                                        Error::NativeVpError(
-                                            native_vp::Error::SimpleMessage(
-                                                "Overflow in bundle balance",
-                                            ),
-                                        )
-                                    })?;
-                            }
-                            // Maybe the asset type has no attached epoch
-                            None if unepoched_tokens
-                                .contains_key(&out.asset_type) =>
-                            {
-                                // Otherwise note the contribution to this
-                                // transparent output
-                                let (_token, _denom, digit) =
-                                    &unepoched_tokens[&out.asset_type];
-                                let amount =
-                                    token::Amount::from_masp_denominated(
-                                        out.value, *digit,
-                                    );
-                                vout_bundle_balances
-                                    .entry(out.address.0)
-                                    .or_insert(Amount::default())
-                                    .checked_add(amount)
-                                    .ok_or_else(|| {
-                                        Error::NativeVpError(
-                                            native_vp::Error::SimpleMessage(
-                                                "Overflow in bundle balance",
-                                            ),
-                                        )
-                                    })?;
-                            }
-                            // FIXME: this is wrong, I could fin it in another
-                            // token unrecognized
-                            // asset
-                            _ => return Ok(false),
-                        };
-
-                        processed_vouts[idx] = true;
-                    }
-
-                    total_vin_bundle_balances
-                        .insert(token, vin_bundle_balances);
-                    total_vout_bundle_balances
-                        .insert(token, vout_bundle_balances);
+                    processed_vins[idx] = true;
                 }
-                (total_vin_bundle_balances, total_vout_bundle_balances)
-            } else {
-                (BTreeMap::default(), BTreeMap::default())
-            };
+
+                // Handle transparent output
+                // The following boundary condition must be satisfied: asset
+                // type must be properly derived
+                for (idx, out) in transp_bundle.vout.iter().enumerate() {
+                    if processed_vouts[idx] {
+                        continue;
+                    }
+                    // Non-masp destinations subtract from transparent tx
+                    // pool
+                    transparent_tx_pool = transparent_tx_pool
+                        .checked_sub(
+                            &I128Sum::from_nonnegative(
+                                out.asset_type,
+                                out.value as i128,
+                            )
+                            .ok()
+                            .ok_or_err_msg(
+                                "invalid value or asset type for amount",
+                            )?,
+                        )
+                        .ok_or_err_msg("Underflow in output subtraction")?;
+
+                    match conversion_state.assets.get(&out.asset_type) {
+                        Some((
+                            (address, asset_denom, digit),
+                            asset_epoch,
+                            _,
+                            _,
+                        )) if address == token
+                            && *asset_denom == denom
+                            && *asset_epoch <= epoch =>
+                        {
+                            let amount = token::Amount::from_masp_denominated(
+                                out.value, *digit,
+                            );
+                            let bref = token_bundle_balances
+                                .entry(out.address.0)
+                                .or_insert(DeltaBalance::Positive(
+                                    Amount::default(),
+                                ));
+                            *bref = bref
+                                .checked_add(DeltaBalance::Positive(amount))
+                                .ok_or_else(|| {
+                                    Error::NativeVpError(
+                                        native_vp::Error::SimpleMessage(
+                                            "Overflow in bundle balance",
+                                        ),
+                                    )
+                                })?;
+                        }
+                        // Maybe the asset type has no attached epoch
+                        None if unepoched_tokens
+                            .contains_key(&out.asset_type) =>
+                        {
+                            // Otherwise note the contribution to this
+                            // transparent output
+                            let (_token, _denom, digit) =
+                                &unepoched_tokens[&out.asset_type];
+                            let amount = token::Amount::from_masp_denominated(
+                                out.value, *digit,
+                            );
+                            let bref = token_bundle_balances
+                                .entry(out.address.0)
+                                .or_insert(DeltaBalance::Positive(
+                                    Amount::default(),
+                                ));
+                            *bref = bref
+                                .checked_add(DeltaBalance::Positive(amount))
+                                .ok_or_else(|| {
+                                    Error::NativeVpError(
+                                        native_vp::Error::SimpleMessage(
+                                            "Overflow in bundle balance",
+                                        ),
+                                    )
+                                })?;
+                        }
+                        // FIXME: this is wrong, I could fin it in another
+                        // token unrecognized
+                        // asset
+                        _ => return Ok(false),
+                    };
+
+                    processed_vouts[idx] = true;
+                }
+
+                total_bundle_balances.insert(token, token_bundle_balances);
+            }
+            total_bundle_balances
+        } else {
+            BTreeMap::default()
+        };
 
         // Check that the changed balance keys in storage match the
         // modifications carried by the transparent bundle
-        // FIXME: improve if possible
-        for (token, balances) in changed_balances.other {
-            let mut token_vins = vin_bundle_balances.get_mut(token);
-            let mut token_vouts = vout_bundle_balances.get_mut(token);
-
-            // FIXME: better, transform the two collections to be the same,
-            // collections of tokens, address, delta and than just compare them
-            // for equality
-            for (address, pre_balance, post_balance) in balances {
-                // Public keys must be the hash of the sources/targets
-                let address_hash = <[u8; 20]>::from(ripemd::Ripemd160::digest(
-                    sha2::Sha256::digest(&address.serialize_to_vec()),
-                ));
-
-                // FIXME: actually should I check that the sign of the change is
-                // the same? (i.e. credit or debit?) If I don't I jsut need the
-                // absolute value of the difference
-                let storage_balance_diff =
-                    match post_balance.checked_sub(pre_balance) {
-                        Some(diff) => diff,
-                        None => pre_balance - post_balance, /* FIXME: is this ok?
-                                                             * Should use checked
-                                                             * op? Maybe not */
-                    };
-
-                // FIXME: improve
-                let bundle_vin = match &mut token_vins {
-                    Some(vins) => {
-                        vins.remove(&address_hash).unwrap_or_default()
-                    }
-                    None => Amount::zero(),
-                };
-                let bundle_vout = match &mut token_vouts {
-                    Some(vouts) => {
-                        vouts.remove(&address_hash).unwrap_or_default()
-                    }
-                    None => Amount::zero(),
-                };
-                let transparent_bundle_diff =
-                    match bundle_vout.checked_sub(bundle_vin) {
-                        Some(diff) => diff,
-                        None => bundle_vin - bundle_vout, /* FIXME: better
-                                                           * checked op? */
-                    };
-
-                // NOTE: this effectively prevent this address from being
-                // involved in other transparent transfers in the same tx since
-                // that would lead to a different change in the balance
-                if transparent_bundle_diff != storage_balance_diff {
-                    tracing::debug!(
-                        "The transparent bundle modifications for token {} \
-                         and address {} don't match the actual changes in \
-                         storage.\nBundle balance delta: {}, storage balance \
-                         delta: {}",
-                        token,
-                        address,
-                        transparent_bundle_diff,
-                        storage_balance_diff
-                    );
-                    return Ok(false);
-                }
-            }
-            // Check that no transparent bundle data is left for this token,
-            // which means that no matching balance keys in storage were found
-            for bundle in [token_vins, token_vouts] {
-                if bundle.as_ref().is_some_and(|map| !map.is_empty()) {
-                    tracing::debug!(
-                        "Data in the transparent bundle does not match the \
-                         storage modification: {:#?}",
-                        bundle
-                    );
-                    return Ok(false);
-                }
-            }
+        if bundle_balances != changed_balances.other {
+            // NOTE: this effectively prevent addresses from being
+            // involved in other transparent transfers in the same tx since
+            // that would lead to a different change in their balances
+            tracing::debug!(
+                "The transparent bundle modifications don't match the actual \
+                 changes in storage."
+            );
+            return Ok(false);
         }
 
         match transparent_tx_pool.partial_cmp(&I128Sum::zero()) {

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -69,27 +69,21 @@ where
     S: StateRead,
     CA: 'static + WasmCacheAccess,
 {
-    // Check that the transaction correctly revealed the nullifiers
+    // Check that the transaction correctly revealed the nullifiers, if needed
     fn valid_nullifiers_reveal(
         &self,
         keys_changed: &BTreeSet<Key>,
         transaction: &Transaction,
     ) -> Result<bool> {
+        // Support set to check that a nullifier was not revealed more
+        // than once in the same tx
         let mut revealed_nullifiers = HashSet::new();
-        let shielded_spends = match transaction.sapling_bundle() {
-            Some(bundle) if !bundle.shielded_spends.is_empty() => {
-                &bundle.shielded_spends
-            }
-            _ => {
-                tracing::debug!(
-                    "Missing expected spend descriptions in shielded \
-                     transaction"
-                );
-                return Ok(false);
-            }
-        };
 
-        for description in shielded_spends {
+        // FIXME: test this check in some way if possible
+        for description in transaction
+            .sapling_bundle()
+            .map_or(&vec![], |bundle| &bundle.shielded_spends)
+        {
             let nullifier_key = masp_nullifier_key(&description.nullifier);
             if self.ctx.has_key_pre(&nullifier_key)?
                 || revealed_nullifiers.contains(&nullifier_key)
@@ -114,6 +108,7 @@ where
             revealed_nullifiers.insert(nullifier_key);
         }
 
+        // Check that no unneeded nullifier has been revealed
         for nullifier_key in
             keys_changed.iter().filter(|key| is_masp_nullifier_key(key))
         {
@@ -559,11 +554,10 @@ where
             // Handle shielded input
             // The following boundary conditions must be satisfied
             // 1. Zero transparent input
-            // 2. The spend descriptions' anchors are valid
-            // 3. The convert descriptions's anchors are valid
-            // 4. The nullifiers provided by the transaction have not been
-            // revealed previously (even in the same tx) and no unneeded
-            // nullifier is being revealed by the tx
+            // 2. At least one shielded input
+            // 3. The spend descriptions' anchors are valid
+            // 4. The convert descriptions's anchors are valid
+            // FIXME: can improve this?
             if let Some(transp_bundle) = shielded_tx.transparent_bundle() {
                 if !transp_bundle.vin.is_empty() {
                     tracing::debug!(
@@ -574,17 +568,31 @@ where
                     return Ok(false);
                 }
             }
+
+            if !shielded_tx
+                .sapling_bundle()
+                .is_some_and(|bundle| !bundle.shielded_spends.is_empty())
+            {
+                return Ok(false);
+            }
+
             if !(self.valid_spend_descriptions_anchor(&shielded_tx)?
-                && self.valid_convert_descriptions_anchor(&shielded_tx)?
-                && self.valid_nullifiers_reveal(keys_changed, &shielded_tx)?)
+                && self.valid_convert_descriptions_anchor(&shielded_tx)?)
             {
                 return Ok(false);
             }
         }
 
         // The transaction must correctly update the note commitment tree
-        // in storage with the new output descriptions
-        if !self.valid_note_commitment_update(&shielded_tx)? {
+        // in storage with the new output descriptions and also reveal the
+        // nullifiers correctly (only if needed) NOTE: these two checks
+        // validate the keys that the transaction write in storage and therefore
+        // must be done regardless of the type of transaction (shielding,
+        // shielded, unshielding) since a malicious tx could try to write keys
+        // in an invalid way
+        if !(self.valid_note_commitment_update(&shielded_tx)?
+            || self.valid_nullifiers_reveal(keys_changed, &shielded_tx)?)
+        {
             return Ok(false);
         }
 
@@ -687,6 +695,7 @@ where
             // 2. At least one shielded output
 
             // Satisfies 1.
+            // FIXME: can this be improved?
             if let Some(transp_bundle) = shielded_tx.transparent_bundle() {
                 if !transp_bundle.vout.is_empty() {
                     tracing::debug!(
@@ -699,6 +708,8 @@ where
             }
 
             // Staisfies 2.
+            // FIXME: I think this is wrong! What if it's None?
+            // FIXME: is this even  needed?
             if shielded_tx
                 .sapling_bundle()
                 .is_some_and(|bundle| bundle.shielded_outputs.is_empty())

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -14,8 +14,9 @@ use namada_core::address::InternalAddress::Masp;
 use namada_core::masp::encode_asset_type;
 use namada_core::storage::{IndexedTx, Key};
 use namada_gas::MASP_VERIFY_SHIELDED_TX_GAS;
+use namada_proof_of_stake::Epoch;
 use namada_sdk::masp::verify_shielded_tx;
-use namada_state::{OptionExt, ResultExt, StateRead};
+use namada_state::{ConversionState, OptionExt, ResultExt, StateRead};
 use namada_token::read_denom;
 use namada_tx::Tx;
 use namada_vp_env::VpEnv;
@@ -310,9 +311,6 @@ where
             }
         }
 
-        // FIXME: I also need to update note fetching in the client? Yes more
-        // than one transfer
-
         let mut result = ChangedBalances::default();
         // Get the changed balance keys
         let (masp_balances, counterparts_balances): (Vec<_>, Vec<_>) =
@@ -357,72 +355,15 @@ where
 
         Ok(result)
     }
-}
 
-// Make a map to help recognize asset types lacking an epoch
-fn unepoched_tokens(
-    token: &Address,
-    denom: token::Denomination,
-) -> Result<HashMap<AssetType, (Address, token::Denomination, MaspDigitPos)>> {
-    let mut unepoched_tokens = HashMap::new();
-    for digit in MaspDigitPos::iter() {
-        let asset_type = encode_asset_type(token.clone(), denom, digit, None)
-            .wrap_err("unable to create asset type")?;
-        unepoched_tokens.insert(asset_type, (token.clone(), denom, digit));
-    }
-    Ok(unepoched_tokens)
-}
-
-impl<'a, S, CA> NativeVp for MaspVp<'a, S, CA>
-where
-    S: StateRead,
-    CA: 'static + WasmCacheAccess,
-{
-    type Error = Error;
-
-    fn validate_tx(
+    fn validate_transparent_bundle(
         &self,
-        tx_data: &Tx,
-        keys_changed: &BTreeSet<Key>,
-        _verifiers: &BTreeSet<Address>,
+        shielded_tx: &Transaction,
+        changed_balances: ChangedBalances,
+        transparent_tx_pool: &mut I128Sum,
+        epoch: Epoch,
+        conversion_state: &ConversionState,
     ) -> Result<bool> {
-        let epoch = self.ctx.get_block_epoch()?;
-        let conversion_state = self.ctx.state.in_mem().get_conversion_state();
-        let shielded_tx = self.ctx.get_shielded_action(tx_data)?;
-
-        if u64::from(self.ctx.get_block_height()?)
-            > u64::from(shielded_tx.expiry_height())
-        {
-            tracing::debug!("MASP transaction is expired");
-            return Ok(false);
-        }
-
-        let mut transparent_tx_pool = I128Sum::zero();
-        // The Sapling value balance adds to the transparent tx pool
-        transparent_tx_pool += shielded_tx.sapling_value_balance();
-
-        // Check the validity of the keys and get the transfer data
-        let changed_balances =
-            self.validate_state_and_get_transfer_data(keys_changed)?;
-
-        // Checks on the sapling bundle
-        // 1. The spend descriptions' anchors are valid
-        // 2. The convert descriptions's anchors are valid
-        // 3. The nullifiers provided by the transaction have not been
-        // revealed previously (even in the same tx) and no unneeded
-        // nullifier is being revealed by the tx
-        // 4. The transaction must correctly update the note commitment tree
-        // in storage with the new output descriptions
-        if !(self.valid_spend_descriptions_anchor(&shielded_tx)?
-            && self.valid_convert_descriptions_anchor(&shielded_tx)?
-            && self.valid_nullifiers_reveal(keys_changed, &shielded_tx)?
-            && self.valid_note_commitment_update(&shielded_tx)?)
-        {
-            return Ok(false);
-        }
-
-        // FIXME: extract to function
-        // Checks on the transparent bundle, if present
         let bundle_balances = if let Some(transp_bundle) =
             shielded_tx.transparent_bundle()
         {
@@ -455,7 +396,7 @@ where
                         continue;
                     }
                     // Non-masp sources add to the transparent tx pool
-                    transparent_tx_pool = transparent_tx_pool
+                    *transparent_tx_pool = transparent_tx_pool
                         .checked_add(
                             &I128Sum::from_nonnegative(
                                 vin.asset_type,
@@ -569,7 +510,7 @@ where
                     }
                     // Non-masp destinations subtract from transparent tx
                     // pool
-                    transparent_tx_pool = transparent_tx_pool
+                    *transparent_tx_pool = transparent_tx_pool
                         .checked_sub(
                             &I128Sum::from_nonnegative(
                                 out.asset_type,
@@ -667,6 +608,82 @@ where
                 "The transparent bundle modifications don't match the actual \
                  changes in storage."
             );
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+}
+
+// Make a map to help recognize asset types lacking an epoch
+fn unepoched_tokens(
+    token: &Address,
+    denom: token::Denomination,
+) -> Result<HashMap<AssetType, (Address, token::Denomination, MaspDigitPos)>> {
+    let mut unepoched_tokens = HashMap::new();
+    for digit in MaspDigitPos::iter() {
+        let asset_type = encode_asset_type(token.clone(), denom, digit, None)
+            .wrap_err("unable to create asset type")?;
+        unepoched_tokens.insert(asset_type, (token.clone(), denom, digit));
+    }
+    Ok(unepoched_tokens)
+}
+
+impl<'a, S, CA> NativeVp for MaspVp<'a, S, CA>
+where
+    S: StateRead,
+    CA: 'static + WasmCacheAccess,
+{
+    type Error = Error;
+
+    fn validate_tx(
+        &self,
+        tx_data: &Tx,
+        keys_changed: &BTreeSet<Key>,
+        _verifiers: &BTreeSet<Address>,
+    ) -> Result<bool> {
+        let epoch = self.ctx.get_block_epoch()?;
+        let conversion_state = self.ctx.state.in_mem().get_conversion_state();
+        let shielded_tx = self.ctx.get_shielded_action(tx_data)?;
+
+        if u64::from(self.ctx.get_block_height()?)
+            > u64::from(shielded_tx.expiry_height())
+        {
+            tracing::debug!("MASP transaction is expired");
+            return Ok(false);
+        }
+
+        // The Sapling value balance adds to the transparent tx pool
+        let mut transparent_tx_pool = shielded_tx.sapling_value_balance();
+
+        // Check the validity of the keys and get the transfer data
+        let changed_balances =
+            self.validate_state_and_get_transfer_data(keys_changed)?;
+
+        // Checks on the sapling bundle
+        // 1. The spend descriptions' anchors are valid
+        // 2. The convert descriptions's anchors are valid
+        // 3. The nullifiers provided by the transaction have not been
+        // revealed previously (even in the same tx) and no unneeded
+        // nullifier is being revealed by the tx
+        // 4. The transaction must correctly update the note commitment tree
+        // in storage with the new output descriptions
+        if !(self.valid_spend_descriptions_anchor(&shielded_tx)?
+            && self.valid_convert_descriptions_anchor(&shielded_tx)?
+            && self.valid_nullifiers_reveal(keys_changed, &shielded_tx)?
+            && self.valid_note_commitment_update(&shielded_tx)?)
+        {
+            return Ok(false);
+        }
+
+        // Checks on the transparent bundle, if present
+        if !self.validate_transparent_bundle(
+            &shielded_tx,
+            changed_balances,
+            &mut transparent_tx_pool,
+            epoch,
+            conversion_state,
+        )? {
             return Ok(false);
         }
 

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -59,10 +59,25 @@ where
     pub ctx: Ctx<'a, S, CA>,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Debug)]
 enum DeltaBalance {
     Positive(Amount),
     Negative(Amount),
+}
+
+impl PartialEq for DeltaBalance {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Positive(lhs), Self::Positive(rhs)) => lhs == rhs,
+            (Self::Negative(lhs), Self::Negative(rhs)) => lhs == rhs,
+            (Self::Positive(lhs), Self::Negative(rhs)) => {
+                lhs == &Amount::default() && rhs == &Amount::default()
+            }
+            (Self::Negative(lhs), Self::Positive(rhs)) => {
+                lhs == &Amount::default() && rhs == &Amount::default()
+            }
+        }
+    }
 }
 
 impl DeltaBalance {
@@ -324,8 +339,9 @@ where
 
         for (token, _) in masp_balances {
             // NOTE: no need to extract the changes of the masp balances too,
-            // we'll examine those of the other transparent addresses and the
-            // multitoken vp ensures a correct match between the two sets
+            // we'll examine those of the other transparent addresses and we'll
+            // check the match with the transparent bundle. The rest of the
+            // validation is up to the multitoken vp
             result.masp.insert(token);
         }
 
@@ -381,12 +397,16 @@ where
         conversion_state: &ConversionState,
     ) -> Result<bool> {
         if let Some(transp_bundle) = shielded_tx.transparent_bundle() {
+            // Support structs to allow a valid check on the asset derivation.
+            // These also allow to check if some transparent inputs or outputs
+            // were not utilized for a given token which would lead to an
+            // inconsistent transparent balance of masp
             let mut unprocessed_vins =
                 BTreeSet::from_iter(0..transp_bundle.vin.len());
             let mut unprocessed_vouts =
                 BTreeSet::from_iter(0..transp_bundle.vout.len());
 
-            // Run the checks fore every token involved in the transaction
+            // Run the checks fore every token that involved the masp balances
             for token in changed_balances.masp {
                 let denom = read_denom(&self.ctx.pre(), token)?.ok_or_err_msg(
                     "No denomination found in storage for the given token",
@@ -593,7 +613,7 @@ where
                     unprocessed_vouts.remove(idx);
                 }
 
-                // Iterate ofver the delta balances described by the transparent
+                // Iterate over the delta balances described by the transparent
                 // bundle and verify that these match the actual modifications
                 // in storage NOTE: this effectively prevent the
                 // same addresses/tokens couples from being
@@ -626,10 +646,20 @@ where
             }
             if !(unprocessed_vins.is_empty() && unprocessed_vouts.is_empty()) {
                 tracing::debug!(
-                    "Some transparent assets could not be recognized"
+                    "Some transparent assets could not be recognized or were \
+                     not utilized"
                 );
                 return Ok(false);
             }
+        } else if !changed_balances.masp.is_empty() {
+            // If no transparent bundle is present than no change to the
+            // transparent balances of masp is allowed
+            tracing::debug!(
+                "No transparent bundle was provided with the transaction but \
+                 the following masp balances were changed: {:#?}",
+                changed_balances.masp
+            );
+            return Ok(false);
         }
 
         Ok(true)

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -588,7 +588,7 @@ where
         // shielded, unshielding) since a malicious tx could try to write keys
         // in an invalid way
         if !(self.valid_note_commitment_update(&shielded_tx)?
-            || self.valid_nullifiers_reveal(keys_changed, &shielded_tx)?)
+            && self.valid_nullifiers_reveal(keys_changed, &shielded_tx)?)
         {
             return Ok(false);
         }

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -59,7 +59,7 @@ where
     pub ctx: Ctx<'a, S, CA>,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 enum DeltaBalance {
     Positive(Amount),
     Negative(Amount),
@@ -380,14 +380,7 @@ where
         epoch: Epoch,
         conversion_state: &ConversionState,
     ) -> Result<bool> {
-        let bundle_balances = if let Some(transp_bundle) =
-            shielded_tx.transparent_bundle()
-        {
-            let mut total_bundle_balances: BTreeMap<
-                &Address,
-                BTreeMap<[u8; 20], DeltaBalance>,
-            > = BTreeMap::default();
-
+        if let Some(transp_bundle) = shielded_tx.transparent_bundle() {
             let mut unprocessed_vins =
                 BTreeSet::from_iter(0..transp_bundle.vin.len());
             let mut unprocessed_vouts =
@@ -600,7 +593,36 @@ where
                     unprocessed_vouts.remove(idx);
                 }
 
-                total_bundle_balances.insert(token, token_bundle_balances);
+                // Iterate ofver the delta balances described by the transparent
+                // bundle and verify that these match the actual modifications
+                // in storage NOTE: this effectively prevent the
+                // same addresses/tokens couples from being
+                // involved in other transparent transfers in the same tx since
+                // that would lead to a different change in their balances
+                for (address, delta_bundle) in token_bundle_balances {
+                    let delta_balance = changed_balances
+                        .other
+                        .get(token)
+                        .and_then(|map| map.get(&address));
+
+                    match delta_balance {
+                        Some(delta_balance)
+                            if delta_balance == &delta_bundle => {}
+                        _ => {
+                            tracing::debug!(
+                                "The transparent bundle modifications for \
+                                 token {}, address: {:?} don't match the \
+                                 actual changes in storage. Transparent \
+                                 bundle changes: {:?}, Storage changes: {:?}",
+                                token,
+                                address,
+                                delta_bundle,
+                                delta_balance
+                            );
+                            return Ok(false);
+                        }
+                    }
+                }
             }
             if !(unprocessed_vins.is_empty() && unprocessed_vouts.is_empty()) {
                 tracing::debug!(
@@ -608,26 +630,6 @@ where
                 );
                 return Ok(false);
             }
-
-            total_bundle_balances
-        } else {
-            BTreeMap::default()
-        };
-
-        // FIXME: this is wrong, the bundle balances must be a subste of
-        // changed_balances.other, not the same otherwise I prevent other
-        // transparent transfers in parallel Check that the changed
-        // balance keys in storage match the modifications carried by
-        // the transparent bundle
-        if bundle_balances != changed_balances.other {
-            // NOTE: this effectively prevent addresses from being
-            // involved in other transparent transfers in the same tx since
-            // that would lead to a different change in their balances
-            tracing::debug!(
-                "The transparent bundle modifications don't match the actual \
-                 changes in storage."
-            );
-            return Ok(false);
         }
 
         Ok(true)

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -325,33 +325,26 @@ where
 
         let mut result = ChangedBalances::default();
         // Get the changed balance keys
-        // FIXME: can partiotion here?
         // FIXME: does this also contain temp modification? Yes, is this
         // correct? I don't think so, I might end up validating keys that are
         // not committed, so wrong validation FIXME: probably I need to
         // read post from storage to circumvent this
-        let balance_addresses: Vec<[&Address; 2]> = keys_changed
-            .iter()
-            .filter_map(is_any_shielded_action_balance_key)
-            .collect();
+        let (masp_balances, counterparts_balances): (Vec<_>, Vec<_>) =
+            keys_changed
+                .iter()
+                .filter_map(is_any_shielded_action_balance_key)
+                .partition(|addresses| {
+                    addresses[1] == &Address::Internal(Masp)
+                });
 
-        let masp_balances: Vec<&[&Address; 2]> = balance_addresses
-            .iter()
-            .filter(|addresses| addresses[1] == &Address::Internal(Masp))
-            .collect();
-        for &[token, _] in masp_balances {
+        for [token, _] in masp_balances {
             // NOTE: no need to extract the changes of the masp balances too,
             // we'll examine those of the other transparent addresses and the
             // multitoken vp ensures a correct match between the two sets
             result.masp.insert(token);
         }
 
-        let counterparts: Vec<&[&Address; 2]> = balance_addresses
-            .iter()
-            .filter(|addresses| addresses[1] != &Address::Internal(Masp))
-            .collect();
-
-        for &[token, counterpart] in counterparts {
+        for [token, counterpart] in counterparts_balances {
             // FIXME: incorrect use read_bytes like in the other places
             // otherwise I read temp modifications FIXME: also
             // mention this in red teaming. Also the fact that temporary keys

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -324,11 +324,9 @@ where
 
             if let ShieldedActionOwner::Minted = counterpart {
                 // When receiving ibc transfers we mint and also shield so we
-                // have two credits, we need to mock the mint balance as a
-                // negative change even if it is positive
-                if let SignedAmount::Positive(amt) = diff {
-                    diff = SignedAmount::Negative(amt);
-                }
+                // have two credits/debits, we need to mock the mint balance as
+                // the opposite change
+                diff = diff.opposite();
             }
 
             result

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -28,7 +28,8 @@ use token::storage_key::{
     balance_key, is_any_shielded_action_balance_key, is_masp_allowed_key,
     is_masp_key, is_masp_nullifier_key, is_masp_tx_pin_key,
     masp_commitment_anchor_key, masp_commitment_tree_key,
-    masp_convert_anchor_key, masp_nullifier_key,
+    masp_convert_anchor_key, masp_nullifier_key, minted_balance_key,
+    ShieldedActionOwner,
 };
 use token::Amount;
 
@@ -318,33 +319,48 @@ where
                 .iter()
                 .filter_map(is_any_shielded_action_balance_key)
                 .partition(|addresses| {
-                    addresses[1] == &Address::Internal(Masp)
+                    addresses.1.to_address_ref() == &Address::Internal(Masp)
                 });
 
-        for [token, _] in masp_balances {
+        for (token, _) in masp_balances {
             // NOTE: no need to extract the changes of the masp balances too,
             // we'll examine those of the other transparent addresses and the
             // multitoken vp ensures a correct match between the two sets
             result.masp.insert(token);
         }
 
-        for [token, counterpart] in counterparts_balances {
+        for (token, counterpart) in counterparts_balances {
+            let counterpart_balance_key = match counterpart {
+                ShieldedActionOwner::Owner(addr) => balance_key(token, addr),
+                ShieldedActionOwner::Minted => minted_balance_key(token),
+            };
             let pre_balance: Amount = self
                 .ctx
-                .read_pre(&balance_key(token, counterpart))?
+                .read_pre(&counterpart_balance_key)?
                 .unwrap_or_default();
             let post_balance: Amount = self
                 .ctx
-                .read_post(&balance_key(token, counterpart))?
+                .read_post(&counterpart_balance_key)?
                 .unwrap_or_default();
             // Public keys must be the hash of the sources/targets
             let address_hash = <[u8; 20]>::from(ripemd::Ripemd160::digest(
-                sha2::Sha256::digest(&counterpart.serialize_to_vec()),
+                sha2::Sha256::digest(
+                    &counterpart.to_address_ref().serialize_to_vec(),
+                ),
             ));
-            let diff = match post_balance.checked_sub(pre_balance) {
+            let mut diff = match post_balance.checked_sub(pre_balance) {
                 Some(diff) => DeltaBalance::Positive(diff),
                 None => DeltaBalance::Negative(pre_balance - post_balance),
             };
+
+            if let ShieldedActionOwner::Minted = counterpart {
+                // When receiving ibc transfers we mint and also shield so we
+                // have two credits, we need to mock the mint balance as a
+                // negative change even if it is positive
+                if let DeltaBalance::Positive(amt) = diff {
+                    diff = DeltaBalance::Negative(amt);
+                }
+            }
 
             result
                 .other
@@ -598,8 +614,11 @@ where
             BTreeMap::default()
         };
 
-        // Check that the changed balance keys in storage match the
-        // modifications carried by the transparent bundle
+        // FIXME: this is wrong, the bundle balances must be a subste of
+        // changed_balances.other, not the same otherwise I prevent other
+        // transparent transfers in parallel Check that the changed
+        // balance keys in storage match the modifications carried by
+        // the transparent bundle
         if bundle_balances != changed_balances.other {
             // NOTE: this effectively prevent addresses from being
             // involved in other transparent transfers in the same tx since

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -1,7 +1,7 @@
 //! MASP native VP
 
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use borsh_ext::BorshSerializeExt;
 use masp_primitives::asset_type::AssetType;
@@ -57,11 +57,14 @@ where
     pub ctx: Ctx<'a, S, CA>,
 }
 
-struct TransparentTransferData {
-    source: Address,
-    target: Address,
-    token: Address,
-    amount: Amount,
+// The balances changed by the transaction, split between masp and non-masp
+// balances. The masp collection carries the token addresses. The collection of
+// the other balances maps the token address to the addresses of the
+// senders/receivers and their pre and post amounts
+#[derive(Default)]
+struct ChangedBalances<'vp> {
+    masp: BTreeSet<&'vp Address>,
+    other: BTreeMap<&'vp Address, Vec<(&'vp Address, Amount, Amount)>>,
 }
 
 impl<'a, S, CA> MaspVp<'a, S, CA>
@@ -232,10 +235,10 @@ where
         Ok(true)
     }
 
-    fn validate_state_and_get_transfer_data(
-        &self,
-        keys_changed: &BTreeSet<Key>,
-    ) -> Result<TransparentTransferData> {
+    fn validate_state_and_get_transfer_data<'vp>(
+        &'vp self,
+        keys_changed: &'vp BTreeSet<Key>,
+    ) -> Result<ChangedBalances> {
         // Check that the transaction didn't write unallowed masp keys
         let masp_keys_changed: Vec<&Key> =
             keys_changed.iter().filter(|key| is_masp_key(key)).collect();
@@ -283,8 +286,14 @@ where
             }
         }
 
-        // Verify the changes to balance keys and return the transparent
-        // transfer data Get the token from the balance key of the MASP
+        // FIXME: I also need to update note fetching in the client? Yes more
+        // than one transfer
+
+        let mut result = ChangedBalances::default();
+        // Get the changed balance keys
+        // FIXME: can partiotion here?
+        // FIXME: does this also contain temp modification? Yes, is this
+        // correct?
         let balance_addresses: Vec<[&Address; 2]> = keys_changed
             .iter()
             .filter_map(is_any_shielded_action_balance_key)
@@ -294,84 +303,36 @@ where
             .iter()
             .filter(|addresses| addresses[1] == &Address::Internal(Masp))
             .collect();
-        let token = match masp_balances.len() {
-            0 => {
-                // No masp balance modification found, assume shielded
-                // transaction and return dummy transparent data
-                return Ok(TransparentTransferData {
-                    source: Address::Internal(Masp),
-                    target: Address::Internal(Masp),
-                    token: self.ctx.get_native_token()?,
-                    amount: Amount::zero(),
-                });
-            }
-            1 => masp_balances[0][0].to_owned(),
-            _ => {
-                // Only one transparent balance of MASP can be updated by the
-                // shielding or unshielding transaction
-                return Err(Error::NativeVpError(
-                    native_vp::Error::SimpleMessage(
-                        "More than one MASP transparent balance was modified",
-                    ),
-                ));
-            }
-        };
+        for &[token, _] in masp_balances {
+            // NOTE: no need to extract the changes of the masp balances too,
+            // we'll examine those of the other transparent addresses and the
+            // multitoken vp ensures a correct match between the two sets
+            result.masp.insert(token);
+        }
 
         let counterparts: Vec<&[&Address; 2]> = balance_addresses
             .iter()
             .filter(|addresses| addresses[1] != &Address::Internal(Masp))
             .collect();
-        // NOTE: since we don't allow more than one transfer per tx in this vp,
-        // there's no need to check the token address in the balance key nor the
-        // change to the actual balance, the multitoken VP will verify these
-        let counterpart = match counterparts.len() {
-            1 => counterparts[0][1].to_owned(),
-            _ => {
-                return Err(Error::NativeVpError(
-                    native_vp::Error::SimpleMessage(
-                        "An invalid number of non-MASP transparent balances \
-                         was modified",
-                    ),
-                ));
-            }
-        };
 
-        let pre_masp_balance: Amount = self
-            .ctx
-            .read_pre(&balance_key(&token, &Address::Internal(Masp)))?
-            .unwrap_or_default();
-        let post_masp_balance: Amount = self
-            .ctx
-            .read_post(&balance_key(&token, &Address::Internal(Masp)))?
-            .unwrap_or_default();
-        let (amount, source, target) =
-            match pre_masp_balance.cmp(&post_masp_balance) {
-                Ordering::Equal => {
-                    return Err(Error::NativeVpError(
-                        native_vp::Error::SimpleMessage(
-                            "Found a MASP transaction that moves no \
-                             transparent funds",
-                        ),
-                    ));
-                }
-                Ordering::Less => (
-                    post_masp_balance - pre_masp_balance,
-                    counterpart,
-                    Address::Internal(Masp),
-                ),
-                Ordering::Greater => (
-                    pre_masp_balance - post_masp_balance,
-                    Address::Internal(Masp),
-                    counterpart,
-                ),
-            };
+        for &[token, counterpart] in counterparts {
+            let pre_balance: Amount = self
+                .ctx
+                .read_pre(&balance_key(token, counterpart))?
+                .unwrap_or_default();
+            let post_balance: Amount = self
+                .ctx
+                .read_post(&balance_key(token, counterpart))?
+                .unwrap_or_default();
 
-        Ok(TransparentTransferData {
-            source,
-            target,
-            token,
-            amount,
-        })
+            result.other.entry(token).or_insert(vec![]).push((
+                counterpart,
+                pre_balance,
+                post_balance,
+            ));
+        }
+
+        Ok(result)
     }
 }
 
@@ -413,302 +374,349 @@ where
             return Ok(false);
         }
 
+        // FIXME: why do we need to look at the balance keys in the client?
+        // Isn't Transaction enough?
+
         let mut transparent_tx_pool = I128Sum::zero();
         // The Sapling value balance adds to the transparent tx pool
         transparent_tx_pool += shielded_tx.sapling_value_balance();
 
         // Check the validity of the keys and get the transfer data
-        let transfer =
+        let changed_balances =
             self.validate_state_and_get_transfer_data(keys_changed)?;
 
-        let denom = read_denom(&self.ctx.pre(), &transfer.token)?
-            .ok_or_err_msg(
-                "No denomination found in storage for the given token",
-            )?;
-
-        if transfer.source != Address::Internal(Masp) {
-            // No shielded spends nor shielded converts are allowed
-            if shielded_tx.sapling_bundle().is_some_and(|bundle| {
-                !(bundle.shielded_spends.is_empty()
-                    && bundle.shielded_converts.is_empty())
-            }) {
-                return Ok(false);
-            }
-
-            let transp_bundle =
-                shielded_tx.transparent_bundle().ok_or_err_msg(
-                    "Expected transparent outputs in shielding transaction",
-                )?;
-            let mut total_in_values = token::Amount::zero();
-            let source_enc = transfer.source.serialize_to_vec();
-            let hash =
-                ripemd::Ripemd160::digest(sha2::Sha256::digest(&source_enc));
-
-            // To help recognize asset types not in the conversion tree
-            let unepoched_tokens = unepoched_tokens(&transfer.token, denom)?;
-            // Handle transparent input
-            // The following boundary conditions must be satisfied
-            // 1. Total of transparent input values equals containing transfer
-            // amount 2. Asset type must be properly derived
-            // 3. Public key must be the hash of the source
-            for vin in &transp_bundle.vin {
-                // Non-masp sources add to the transparent tx pool
-                transparent_tx_pool = transparent_tx_pool
-                    .checked_add(
-                        &I128Sum::from_nonnegative(
-                            vin.asset_type,
-                            vin.value as i128,
-                        )
-                        .ok()
-                        .ok_or_err_msg(
-                            "invalid value or asset type for amount",
-                        )?,
-                    )
-                    .ok_or_err_msg("Overflow in input sum")?;
-
-                // Satisfies 3.
-                if <[u8; 20]>::from(hash) != vin.address.0 {
-                    tracing::debug!(
-                        "the public key of the output account does not match \
-                         the transfer target"
-                    );
-                    return Ok(false);
-                }
-                match conversion_state.assets.get(&vin.asset_type) {
-                    // Satisfies 2. Note how the asset's epoch must be equal to
-                    // the present: users must never be allowed to backdate
-                    // transparent inputs to a transaction for they would then
-                    // be able to claim rewards while locking their assets for
-                    // negligible time periods.
-                    Some((
-                        (address, asset_denom, digit),
-                        asset_epoch,
-                        _,
-                        _,
-                    )) if *address == transfer.token
-                        && *asset_denom == denom
-                        && *asset_epoch == epoch =>
-                    {
-                        total_in_values = total_in_values
-                            .checked_add(token::Amount::from_masp_denominated(
-                                vin.value, *digit,
-                            ))
-                            .ok_or_else(|| {
-                                Error::NativeVpError(
-                                    native_vp::Error::SimpleMessage(
-                                        "Overflow in total in value sum",
-                                    ),
-                                )
-                            })?;
-                    }
-                    // Maybe the asset type has no attached epoch
-                    None if unepoched_tokens.contains_key(&vin.asset_type) => {
-                        let (token, denom, digit) =
-                            &unepoched_tokens[&vin.asset_type];
-                        // Determine what the asset type would be if it were
-                        // epoched
-                        let epoched_asset_type = encode_asset_type(
-                            token.clone(),
-                            *denom,
-                            *digit,
-                            Some(epoch),
-                        )
-                        .wrap_err("unable to create asset type")?;
-                        if conversion_state
-                            .assets
-                            .contains_key(&epoched_asset_type)
-                        {
-                            // If such an epoched asset type is available in the
-                            // conversion tree, then we must reject the
-                            // unepoched variant
-                            tracing::debug!("epoch is missing from asset type");
-                            return Ok(false);
-                        } else {
-                            // Otherwise note the contribution to this
-                            // trransparent input
-                            total_in_values = total_in_values
-                                .checked_add(
-                                    token::Amount::from_masp_denominated(
-                                        vin.value, *digit,
-                                    ),
-                                )
-                                .ok_or_else(|| {
-                                    Error::NativeVpError(
-                                        native_vp::Error::SimpleMessage(
-                                            "Overflow in total in values sum",
-                                        ),
-                                    )
-                                })?;
-                        }
-                    }
-                    // unrecognized asset
-                    _ => return Ok(false),
-                };
-            }
-            // Satisfies 1.
-            if total_in_values != transfer.amount {
-                return Ok(false);
-            }
-        } else {
-            // Handle shielded input
-            // The following boundary conditions must be satisfied
-            // 1. Zero transparent input
-            // 2. At least one shielded input
-            // 3. The spend descriptions' anchors are valid
-            // 4. The convert descriptions's anchors are valid
-            if shielded_tx
-                .transparent_bundle()
-                .is_some_and(|bundle| !bundle.vin.is_empty())
-            {
-                tracing::debug!(
-                    "No transparent inputs are allowed when the source is masp",
-                );
-                return Ok(false);
-            }
-
-            if !shielded_tx
-                .sapling_bundle()
-                .is_some_and(|bundle| !bundle.shielded_spends.is_empty())
-            {
-                return Ok(false);
-            }
-
-            if !(self.valid_spend_descriptions_anchor(&shielded_tx)?
-                && self.valid_convert_descriptions_anchor(&shielded_tx)?)
-            {
-                return Ok(false);
-            }
-        }
-
-        // The transaction must correctly update the note commitment tree
-        // in storage with the new output descriptions and also reveal the
-        // nullifiers correctly (only if needed) NOTE: these two checks
-        // validate the keys that the transaction write in storage and therefore
-        // must be done regardless of the type of transaction (shielding,
-        // shielded, unshielding) since a malicious tx could try to write keys
-        // in an invalid way
-        if !(self.valid_note_commitment_update(&shielded_tx)?
-            && self.valid_nullifiers_reveal(keys_changed, &shielded_tx)?)
+        // Checks on the sapling bundle
+        // 1. The spend descriptions' anchors are valid
+        // 2. The convert descriptions's anchors are valid
+        // 3. The nullifiers provided by the transaction have not been
+        // revealed previously (even in the same tx) and no unneeded
+        // nullifier is being revealed by the tx
+        // 4. The transaction must correctly update the note commitment tree
+        // in storage with the new output descriptions
+        // FIXME: actually I need to review all of these functions, I should
+        // never assume that the sapling bundle is there
+        if !(self.valid_spend_descriptions_anchor(&shielded_tx)?
+            && self.valid_convert_descriptions_anchor(&shielded_tx)?
+            && self.valid_nullifiers_reveal(keys_changed, &shielded_tx)?
+            && self.valid_note_commitment_update(&shielded_tx)?)
         {
             return Ok(false);
         }
 
-        if transfer.target != Address::Internal(Masp) {
-            // Handle transparent output
-            // The following boundary conditions must be satisfied
-            // 1. Total of transparent output values equals containing transfer
-            // amount 2. Asset type must be properly derived
-            // 3. Public key must be the hash of the target
+        // FIXME: extract to function
+        // Checks on the transparent bundle, if present
+        let (mut vin_bundle_balances, mut vout_bundle_balances) =
+            if let Some(transp_bundle) = shielded_tx.transparent_bundle() {
+                let mut total_vin_bundle_balances: BTreeMap<
+                    &Address,
+                    BTreeMap<[u8; 20], Amount>,
+                > = BTreeMap::default();
+                let mut total_vout_bundle_balances: BTreeMap<
+                    &Address,
+                    BTreeMap<[u8; 20], Amount>,
+                > = BTreeMap::default();
 
-            let transp_bundle =
-                shielded_tx.transparent_bundle().ok_or_err_msg(
-                    "Expected transparent outputs in unshielding transaction",
-                )?;
+                let mut processed_vins = vec![false; transp_bundle.vin.len()];
+                let mut processed_vouts = vec![false; transp_bundle.vout.len()];
 
-            let mut total_out_values = token::Amount::zero();
-            let target_enc = transfer.target.serialize_to_vec();
-            let hash =
-                ripemd::Ripemd160::digest(sha2::Sha256::digest(&target_enc));
-            // To help recognize asset types not in the conversion tree
-            let unepoched_tokens = unepoched_tokens(&transfer.token, denom)?;
-
-            for out in &transp_bundle.vout {
-                // Non-masp destinations subtract from transparent tx
-                // pool
-                transparent_tx_pool = transparent_tx_pool
-                    .checked_sub(
-                        &I128Sum::from_nonnegative(
-                            out.asset_type,
-                            out.value as i128,
-                        )
-                        .ok()
+                // Run the checks fore every token involved in the transaction
+                for token in changed_balances.masp {
+                    let denom = read_denom(&self.ctx.pre(), token)?
                         .ok_or_err_msg(
-                            "invalid value or asset type for amount",
-                        )?,
-                    )
-                    .ok_or_err_msg("Underflow in output subtraction")?;
+                            "No denomination found in storage for the given \
+                             token",
+                        )?;
 
-                // Satisfies 3.
-                if <[u8; 20]>::from(hash) != out.address.0 {
+                    let mut vin_bundle_balances = BTreeMap::default();
+                    let mut vout_bundle_balances = BTreeMap::default();
+
+                    // To help recognize asset types not in the conversion tree
+                    let unepoched_tokens = unepoched_tokens(token, denom)?;
+
+                    // FIXME: can we support a fully transparent transfer
+                    // triggering the masp vp? Probably not if it carries the
+                    // Transaction object. Actually maybe yes, in protcol
+                    // instead of just checking that the masp vp was triggered
+                    // and was succesful I should ALSO check that at least one
+                    // masp key was changed
+
+                    // Handle transparent input
+                    // The following boundary condition must be satisfied: asset
+                    // type must be properly derived
+                    for (idx, vin) in transp_bundle.vin.iter().enumerate() {
+                        if processed_vins[idx] {
+                            continue;
+                        }
+                        // Non-masp sources add to the transparent tx pool
+                        transparent_tx_pool = transparent_tx_pool
+                            .checked_add(
+                                &I128Sum::from_nonnegative(
+                                    vin.asset_type,
+                                    vin.value as i128,
+                                )
+                                .ok()
+                                .ok_or_err_msg(
+                                    "invalid value or asset type for amount",
+                                )?,
+                            )
+                            .ok_or_err_msg("Overflow in input sum")?;
+
+                        match conversion_state.assets.get(&vin.asset_type) {
+                            // Note how the asset's epoch must be equal to
+                            // the present: users must never be allowed to
+                            // backdate transparent
+                            // inputs to a transaction for they would then
+                            // be able to claim rewards while locking their
+                            // assets for negligible
+                            // time periods.
+                            Some((
+                                (address, asset_denom, digit),
+                                asset_epoch,
+                                _,
+                                _,
+                            )) if address == token
+                                && *asset_denom == denom
+                                && *asset_epoch == epoch =>
+                            {
+                                let amount =
+                                    token::Amount::from_masp_denominated(
+                                        vin.value, *digit,
+                                    );
+                                vin_bundle_balances
+                                    .entry(vin.address.0)
+                                    .or_insert(Amount::default())
+                                    .checked_add(amount)
+                                    .ok_or_else(|| {
+                                        Error::NativeVpError(
+                                            native_vp::Error::SimpleMessage(
+                                                "Overflow in bundle balance",
+                                            ),
+                                        )
+                                    })?;
+                            }
+                            // Maybe the asset type has no attached epoch
+                            None if unepoched_tokens
+                                .contains_key(&vin.asset_type) =>
+                            {
+                                let (token, denom, digit) =
+                                    &unepoched_tokens[&vin.asset_type];
+                                // Determine what the asset type would be if it
+                                // were epoched
+                                let epoched_asset_type = encode_asset_type(
+                                    token.clone(),
+                                    *denom,
+                                    *digit,
+                                    Some(epoch),
+                                )
+                                .wrap_err("unable to create asset type")?;
+                                if conversion_state
+                                    .assets
+                                    .contains_key(&epoched_asset_type)
+                                {
+                                    // If such an epoched asset type is
+                                    // available in the
+                                    // conversion tree, then we must reject the
+                                    // unepoched variant
+                                    tracing::debug!(
+                                        "epoch is missing from asset type"
+                                    );
+                                    return Ok(false);
+                                } else {
+                                    // Otherwise note the contribution to this
+                                    // transparent input
+                                    let amount =
+                                        token::Amount::from_masp_denominated(
+                                            vin.value, *digit,
+                                        );
+                                    vin_bundle_balances
+                                        .entry(vin.address.0)
+                                        .or_insert(Amount::default())
+                                        .checked_add(amount)
+                                        .ok_or_else(|| {
+                                            Error::NativeVpError(
+                                                native_vp::Error::SimpleMessage(
+                                                    "Overflow in bundle \
+                                                     balance",
+                                                ),
+                                            )
+                                        })?;
+                                }
+                            }
+                            // FIXME: this is wrong, I could fin it in another
+                            // token unrecognized
+                            // asset
+                            _ => return Ok(false),
+                        };
+
+                        processed_vins[idx] = true;
+                    }
+
+                    // Handle transparent output
+                    // The following boundary condition must be satisfied: asset
+                    // type must be properly derived
+                    for (idx, out) in transp_bundle.vout.iter().enumerate() {
+                        if processed_vouts[idx] {
+                            continue;
+                        }
+                        // Non-masp destinations subtract from transparent tx
+                        // pool
+                        transparent_tx_pool = transparent_tx_pool
+                            .checked_sub(
+                                &I128Sum::from_nonnegative(
+                                    out.asset_type,
+                                    out.value as i128,
+                                )
+                                .ok()
+                                .ok_or_err_msg(
+                                    "invalid value or asset type for amount",
+                                )?,
+                            )
+                            .ok_or_err_msg("Underflow in output subtraction")?;
+
+                        match conversion_state.assets.get(&out.asset_type) {
+                            Some((
+                                (address, asset_denom, digit),
+                                asset_epoch,
+                                _,
+                                _,
+                            )) if address == token
+                                && *asset_denom == denom
+                                && *asset_epoch <= epoch =>
+                            {
+                                let amount =
+                                    token::Amount::from_masp_denominated(
+                                        out.value, *digit,
+                                    );
+                                vout_bundle_balances
+                                    .entry(out.address.0)
+                                    .or_insert(Amount::default())
+                                    .checked_add(amount)
+                                    .ok_or_else(|| {
+                                        Error::NativeVpError(
+                                            native_vp::Error::SimpleMessage(
+                                                "Overflow in bundle balance",
+                                            ),
+                                        )
+                                    })?;
+                            }
+                            // Maybe the asset type has no attached epoch
+                            None if unepoched_tokens
+                                .contains_key(&out.asset_type) =>
+                            {
+                                // Otherwise note the contribution to this
+                                // transparent output
+                                let (_token, _denom, digit) =
+                                    &unepoched_tokens[&out.asset_type];
+                                let amount =
+                                    token::Amount::from_masp_denominated(
+                                        out.value, *digit,
+                                    );
+                                vout_bundle_balances
+                                    .entry(out.address.0)
+                                    .or_insert(Amount::default())
+                                    .checked_add(amount)
+                                    .ok_or_else(|| {
+                                        Error::NativeVpError(
+                                            native_vp::Error::SimpleMessage(
+                                                "Overflow in bundle balance",
+                                            ),
+                                        )
+                                    })?;
+                            }
+                            // FIXME: this is wrong, I could fin it in another
+                            // token unrecognized
+                            // asset
+                            _ => return Ok(false),
+                        };
+
+                        processed_vouts[idx] = true;
+                    }
+
+                    total_vin_bundle_balances
+                        .insert(token, vin_bundle_balances);
+                    total_vout_bundle_balances
+                        .insert(token, vout_bundle_balances);
+                }
+                (total_vin_bundle_balances, total_vout_bundle_balances)
+            } else {
+                (BTreeMap::default(), BTreeMap::default())
+            };
+
+        // Check that the changed balance keys in storage match the
+        // modifications carried by the transparent bundle
+        // FIXME: improve if possible
+        for (token, balances) in changed_balances.other {
+            let mut token_vins = vin_bundle_balances.get_mut(token);
+            let mut token_vouts = vout_bundle_balances.get_mut(token);
+
+            // FIXME: better, transform the two collections to be the same,
+            // collections of tokens, address, delta and than just compare them
+            // for equality
+            for (address, pre_balance, post_balance) in balances {
+                // Public keys must be the hash of the sources/targets
+                let address_hash = <[u8; 20]>::from(ripemd::Ripemd160::digest(
+                    sha2::Sha256::digest(&address.serialize_to_vec()),
+                ));
+
+                // FIXME: actually should I check that the sign of the change is
+                // the same? (i.e. credit or debit?) If I don't I jsut need the
+                // absolute value of the difference
+                let storage_balance_diff =
+                    match post_balance.checked_sub(pre_balance) {
+                        Some(diff) => diff,
+                        None => pre_balance - post_balance, /* FIXME: is this ok?
+                                                             * Should use checked
+                                                             * op? Maybe not */
+                    };
+
+                // FIXME: improve
+                let bundle_vin = match &mut token_vins {
+                    Some(vins) => {
+                        vins.remove(&address_hash).unwrap_or_default()
+                    }
+                    None => Amount::zero(),
+                };
+                let bundle_vout = match &mut token_vouts {
+                    Some(vouts) => {
+                        vouts.remove(&address_hash).unwrap_or_default()
+                    }
+                    None => Amount::zero(),
+                };
+                let transparent_bundle_diff =
+                    match bundle_vout.checked_sub(bundle_vin) {
+                        Some(diff) => diff,
+                        None => bundle_vin - bundle_vout, /* FIXME: better
+                                                           * checked op? */
+                    };
+
+                // NOTE: this effectively prevent this address from being
+                // involved in other transparent transfers in the same tx since
+                // that would lead to a different change in the balance
+                if transparent_bundle_diff != storage_balance_diff {
                     tracing::debug!(
-                        "the public key of the output account does not match \
-                         the transfer target"
+                        "The transparent bundle modifications for token {} \
+                         and address {} don't match the actual changes in \
+                         storage.\nBundle balance delta: {}, storage balance \
+                         delta: {}",
+                        token,
+                        address,
+                        transparent_bundle_diff,
+                        storage_balance_diff
                     );
                     return Ok(false);
                 }
-                match conversion_state.assets.get(&out.asset_type) {
-                    // Satisfies 2.
-                    Some((
-                        (address, asset_denom, digit),
-                        asset_epoch,
-                        _,
-                        _,
-                    )) if *address == transfer.token
-                        && *asset_denom == denom
-                        && *asset_epoch <= epoch =>
-                    {
-                        total_out_values = total_out_values
-                            .checked_add(token::Amount::from_masp_denominated(
-                                out.value, *digit,
-                            ))
-                            .ok_or_else(|| {
-                                Error::NativeVpError(
-                                    native_vp::Error::SimpleMessage(
-                                        "Overflow in total out values sum",
-                                    ),
-                                )
-                            })?;
-                    }
-                    // Maybe the asset type has no attached epoch
-                    None if unepoched_tokens.contains_key(&out.asset_type) => {
-                        let (_token, _denom, digit) =
-                            &unepoched_tokens[&out.asset_type];
-                        // Otherwise note the contribution to this
-                        // trransparent input
-                        total_out_values = total_out_values
-                            .checked_add(token::Amount::from_masp_denominated(
-                                out.value, *digit,
-                            ))
-                            .ok_or_else(|| {
-                                Error::NativeVpError(
-                                    native_vp::Error::SimpleMessage(
-                                        "Overflow in total out values sum",
-                                    ),
-                                )
-                            })?;
-                    }
-                    // unrecognized asset
-                    _ => return Ok(false),
-                };
             }
-            // Satisfies 1.
-            if total_out_values != transfer.amount {
-                return Ok(false);
-            }
-        } else {
-            // Handle shielded output
-            // The following boundary conditions must be satisfied
-            // 1. Zero transparent output
-            // 2. At least one shielded output
-
-            // Satisfies 1.
-            if shielded_tx
-                .transparent_bundle()
-                .is_some_and(|bundle| !bundle.vout.is_empty())
-            {
-                tracing::debug!(
-                    "No transparent outputs are allowed when the target is \
-                     the masp",
-                );
-                return Ok(false);
-            }
-
-            // Staisfies 2.
-            if !shielded_tx
-                .sapling_bundle()
-                .is_some_and(|bundle| !bundle.shielded_outputs.is_empty())
-            {
-                return Ok(false);
+            // Check that no transparent bundle data is left for this token,
+            // which means that no matching balance keys in storage were found
+            for bundle in [token_vins, token_vouts] {
+                if bundle.as_ref().is_some_and(|map| !map.is_empty()) {
+                    tracing::debug!(
+                        "Data in the transparent bundle does not match the \
+                         storage modification: {:#?}",
+                        bundle
+                    );
+                    return Ok(false);
+                }
             }
         }
 

--- a/crates/namada/src/ledger/native_vp/mod.rs
+++ b/crates/namada/src/ledger/native_vp/mod.rs
@@ -713,4 +713,12 @@ impl SignedAmount {
             }
         }
     }
+
+    /// Get the additive inverse of the signed amount
+    pub fn opposite(&self) -> Self {
+        match self {
+            Self::Positive(amt) => Self::Negative(*amt),
+            Self::Negative(amt) => Self::Positive(*amt),
+        }
+    }
 }

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -1134,12 +1134,13 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
                             let addresses = balance_keys
                                 .iter()
                                 .find(|addresses| {
-                                    if addresses[1] != &MASP {
+                                    let owner = addresses.1.to_address_ref();
+                                    if owner != &MASP {
                                         let transp_addr_commit =
                                             TransparentAddress(
                                                 ripemd::Ripemd160::digest(
                                                     sha2::Sha256::digest(
-                                                        &addresses[1]
+                                                        &owner
                                                             .serialize_to_vec(),
                                                     ),
                                                 )
@@ -1173,8 +1174,8 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
                                 });
 
                             (
-                                addresses[1].to_owned(),
-                                addresses[0].to_owned(),
+                                addresses.1.to_address_ref().to_owned(),
+                                addresses.0.to_owned(),
                                 amount,
                             )
                         } else {
@@ -1186,12 +1187,12 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
                         let token = balance_keys
                             .iter()
                             .find(|addresses| {
-                                if addresses[1] != &MASP {
+                                let owner = addresses.1.to_address_ref();
+                                if owner != &MASP {
                                     let transp_addr_commit = TransparentAddress(
                                         ripemd::Ripemd160::digest(
                                             sha2::Sha256::digest(
-                                                &addresses[1]
-                                                    .serialize_to_vec(),
+                                                &owner.serialize_to_vec(),
                                             ),
                                         )
                                         .into(),
@@ -1214,7 +1215,8 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
                                     "Could not find target of MASP tx"
                                         .to_string(),
                                 )
-                            })?[0];
+                            })?
+                            .0;
 
                         let amount = transp_bundle
                             .vout

--- a/crates/trans_token/src/storage_key.rs
+++ b/crates/trans_token/src/storage_key.rs
@@ -81,10 +81,14 @@ pub fn is_balance_key<'a>(
     key: &'a storage::Key,
 ) -> Option<&'a Address> {
     match &key.segments[..] {
-        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(balance), DbKeySeg::AddressSeg(owner)]
-            if *addr == Address::Internal(InternalAddress::Multitoken)
-                && token == token_addr
-                && balance == BALANCE_STORAGE_KEY =>
+        [
+            DbKeySeg::AddressSeg(addr),
+            DbKeySeg::AddressSeg(token),
+            DbKeySeg::StringSeg(balance),
+            DbKeySeg::AddressSeg(owner),
+        ] if *addr == Address::Internal(InternalAddress::Multitoken)
+            && token == token_addr
+            && balance == BALANCE_STORAGE_KEY =>
         {
             Some(owner)
         }
@@ -96,9 +100,13 @@ pub fn is_balance_key<'a>(
 /// If it is, return the token address.
 pub fn is_any_token_parameter_key(key: &storage::Key) -> Option<&Address> {
     match &key.segments[..] {
-        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(parameter), DbKeySeg::StringSeg(_parameter_name)]
-            if *addr == Address::Internal(InternalAddress::Multitoken)
-                && parameter == PARAMETERS_STORAGE_KEY =>
+        [
+            DbKeySeg::AddressSeg(addr),
+            DbKeySeg::AddressSeg(token),
+            DbKeySeg::StringSeg(parameter),
+            DbKeySeg::StringSeg(_parameter_name),
+        ] if *addr == Address::Internal(InternalAddress::Multitoken)
+            && parameter == PARAMETERS_STORAGE_KEY =>
         {
             Some(token)
         }
@@ -110,9 +118,13 @@ pub fn is_any_token_parameter_key(key: &storage::Key) -> Option<&Address> {
 /// it is, return the token and owner address.
 pub fn is_any_token_balance_key(key: &storage::Key) -> Option<[&Address; 2]> {
     match &key.segments[..] {
-        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(balance), DbKeySeg::AddressSeg(owner)]
-            if *addr == Address::Internal(InternalAddress::Multitoken)
-                && balance == BALANCE_STORAGE_KEY =>
+        [
+            DbKeySeg::AddressSeg(addr),
+            DbKeySeg::AddressSeg(token),
+            DbKeySeg::StringSeg(balance),
+            DbKeySeg::AddressSeg(owner),
+        ] if *addr == Address::Internal(InternalAddress::Multitoken)
+            && balance == BALANCE_STORAGE_KEY =>
         {
             Some([token, owner])
         }
@@ -141,9 +153,12 @@ pub fn is_denom_key(token_addr: &Address, key: &storage::Key) -> bool {
 /// If it is, returns the token.
 pub fn is_any_minter_key(key: &storage::Key) -> Option<&Address> {
     match &key.segments[..] {
-        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(minter)]
-            if *addr == Address::Internal(InternalAddress::Multitoken)
-                && minter == MINTER_STORAGE_KEY =>
+        [
+            DbKeySeg::AddressSeg(addr),
+            DbKeySeg::AddressSeg(token),
+            DbKeySeg::StringSeg(minter),
+        ] if *addr == Address::Internal(InternalAddress::Multitoken)
+            && minter == MINTER_STORAGE_KEY =>
         {
             Some(token)
         }
@@ -155,10 +170,14 @@ pub fn is_any_minter_key(key: &storage::Key) -> Option<&Address> {
 /// If it is, returns the token.
 pub fn is_any_minted_balance_key(key: &storage::Key) -> Option<&Address> {
     match &key.segments[..] {
-        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(balance), DbKeySeg::StringSeg(owner)]
-            if *addr == Address::Internal(InternalAddress::Multitoken)
-                && balance == BALANCE_STORAGE_KEY
-                && owner == MINTED_STORAGE_KEY =>
+        [
+            DbKeySeg::AddressSeg(addr),
+            DbKeySeg::AddressSeg(token),
+            DbKeySeg::StringSeg(balance),
+            DbKeySeg::StringSeg(owner),
+        ] if *addr == Address::Internal(InternalAddress::Multitoken)
+            && balance == BALANCE_STORAGE_KEY
+            && owner == MINTED_STORAGE_KEY =>
         {
             Some(token)
         }

--- a/crates/trans_token/src/storage_key.rs
+++ b/crates/trans_token/src/storage_key.rs
@@ -81,14 +81,10 @@ pub fn is_balance_key<'a>(
     key: &'a storage::Key,
 ) -> Option<&'a Address> {
     match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::AddressSeg(token),
-            DbKeySeg::StringSeg(balance),
-            DbKeySeg::AddressSeg(owner),
-        ] if *addr == Address::Internal(InternalAddress::Multitoken)
-            && token == token_addr
-            && balance == BALANCE_STORAGE_KEY =>
+        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(balance), DbKeySeg::AddressSeg(owner)]
+            if *addr == Address::Internal(InternalAddress::Multitoken)
+                && token == token_addr
+                && balance == BALANCE_STORAGE_KEY =>
         {
             Some(owner)
         }
@@ -100,13 +96,9 @@ pub fn is_balance_key<'a>(
 /// If it is, return the token address.
 pub fn is_any_token_parameter_key(key: &storage::Key) -> Option<&Address> {
     match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::AddressSeg(token),
-            DbKeySeg::StringSeg(parameter),
-            DbKeySeg::StringSeg(_parameter_name),
-        ] if *addr == Address::Internal(InternalAddress::Multitoken)
-            && parameter == PARAMETERS_STORAGE_KEY =>
+        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(parameter), DbKeySeg::StringSeg(_parameter_name)]
+            if *addr == Address::Internal(InternalAddress::Multitoken)
+                && parameter == PARAMETERS_STORAGE_KEY =>
         {
             Some(token)
         }
@@ -118,13 +110,9 @@ pub fn is_any_token_parameter_key(key: &storage::Key) -> Option<&Address> {
 /// it is, return the token and owner address.
 pub fn is_any_token_balance_key(key: &storage::Key) -> Option<[&Address; 2]> {
     match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::AddressSeg(token),
-            DbKeySeg::StringSeg(balance),
-            DbKeySeg::AddressSeg(owner),
-        ] if *addr == Address::Internal(InternalAddress::Multitoken)
-            && balance == BALANCE_STORAGE_KEY =>
+        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(balance), DbKeySeg::AddressSeg(owner)]
+            if *addr == Address::Internal(InternalAddress::Multitoken)
+                && balance == BALANCE_STORAGE_KEY =>
         {
             Some([token, owner])
         }
@@ -153,12 +141,9 @@ pub fn is_denom_key(token_addr: &Address, key: &storage::Key) -> bool {
 /// If it is, returns the token.
 pub fn is_any_minter_key(key: &storage::Key) -> Option<&Address> {
     match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::AddressSeg(token),
-            DbKeySeg::StringSeg(minter),
-        ] if *addr == Address::Internal(InternalAddress::Multitoken)
-            && minter == MINTER_STORAGE_KEY =>
+        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(minter)]
+            if *addr == Address::Internal(InternalAddress::Multitoken)
+                && minter == MINTER_STORAGE_KEY =>
         {
             Some(token)
         }
@@ -170,14 +155,10 @@ pub fn is_any_minter_key(key: &storage::Key) -> Option<&Address> {
 /// If it is, returns the token.
 pub fn is_any_minted_balance_key(key: &storage::Key) -> Option<&Address> {
     match &key.segments[..] {
-        [
-            DbKeySeg::AddressSeg(addr),
-            DbKeySeg::AddressSeg(token),
-            DbKeySeg::StringSeg(balance),
-            DbKeySeg::StringSeg(owner),
-        ] if *addr == Address::Internal(InternalAddress::Multitoken)
-            && balance == BALANCE_STORAGE_KEY
-            && owner == MINTED_STORAGE_KEY =>
+        [DbKeySeg::AddressSeg(addr), DbKeySeg::AddressSeg(token), DbKeySeg::StringSeg(balance), DbKeySeg::StringSeg(owner)]
+            if *addr == Address::Internal(InternalAddress::Multitoken)
+                && balance == BALANCE_STORAGE_KEY
+                && owner == MINTED_STORAGE_KEY =>
         {
             Some(token)
         }
@@ -185,22 +166,36 @@ pub fn is_any_minted_balance_key(key: &storage::Key) -> Option<&Address> {
     }
 }
 
+/// The owner of a shielded action transfer, could be a proper address or the
+/// minted subkey
+pub enum ShieldedActionOwner<'key> {
+    /// A proper address
+    Owner(&'key Address),
+    /// The mint address
+    Minted,
+}
+
+impl ShieldedActionOwner<'_> {
+    pub fn to_address_ref(&self) -> &Address {
+        match self {
+            Self::Owner(addr) => addr,
+            Self::Minted => {
+                &Address::Internal(namada_core::address::InternalAddress::Ibc)
+            }
+        }
+    }
+}
+
 /// Check if the given storage key is a balance key for a shielded action. If it
 /// is, returns the token and the owner addresses.
 pub fn is_any_shielded_action_balance_key(
     key: &storage::Key,
-) -> Option<[&Address; 2]> {
+) -> Option<(&Address, ShieldedActionOwner)> {
     is_any_token_balance_key(key).map_or_else(
         || {
-            is_any_minted_balance_key(key).map(|token| {
-                [
-                    token,
-                    &Address::Internal(
-                        namada_core::address::InternalAddress::Ibc,
-                    ),
-                ]
-            })
+            is_any_minted_balance_key(key)
+                .map(|token| (token, ShieldedActionOwner::Minted))
         },
-        Some,
+        |[token, owner]| Some((token, ShieldedActionOwner::Owner(owner))),
     )
 }


### PR DESCRIPTION
## Describe your changes

Closes #2595.

Modifies the MASP vp to allow multiple transfers in a single transaction. To achieve this, some constraints had to be removes (like the checks on the presence/absence of the transparent bundle, transparent inputs and outputs). Since we cannot expect a singles source/target anymore some changes were made, most importantly:

- the checks on the sapling bundle have been modified to always run and to not expect the presence of shielded inputs
- the checks on the transparent bundle have been modified to run against against all the changed balance keys instead of expecting a specific source/target

No changes to the SDK have been done in this PR because, at least for the moment, we still rely on the `Transfer` object to recover the `Transaction`, and so other `tx_data` types won't work, leading to an impossibility to effectively take advantage of these vp updates.

## Indicate on which release or other PRs this topic is based on

#2621 

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
