### PR TITLE
ci+docker: update toolchain versions to 1.76

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         wasm_cache_version: ["v2"]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         mold_version: [2.4.0]
 
     steps:
@@ -164,7 +164,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         wasm_cache_version: ["v2"]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         mold_version: [2.4.0]
 
     steps:
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         mold_version: [2.4.0]
         make:
           - name: ABCI
@@ -291,7 +291,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         mold_version: [2.4.0]
         make:
           - name: ABCI
@@ -380,7 +380,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         mold_version: [2.4.0]
         make:
           - name: ABCI
@@ -568,7 +568,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         mold_version: [2.4.0]
         comet_bft: [0.37.2]
         hermes: [1.7.4-namada-beta7]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         make:
           - name: Clippy
             command: clippy

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         make:
           - name: Audit
             command: audit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         mdbook_version: [rust-lang/mdbook@v0.4.18]
         mdbook_mermaid: [badboy/mdbook-mermaid@v0.11.1]
         mdbook_linkcheck: [Michael-F-Bryan/mdbook-linkcheck@v0.7.6]

--- a/.github/workflows/triggerable_sync.yml
+++ b/.github/workflows/triggerable_sync.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2023-06-01]
+        nightly_version: [nightly-2024-02-20]
         mold_version: [2.4.0]
         comet_bft: [0.37.2]
         name: ["Run chain sync test"]

--- a/docker/namada-wasm/Dockerfile
+++ b/docker/namada-wasm/Dockerfile
@@ -1,12 +1,12 @@
 # This docker is used for deterministic wasm builds
 
 # The version should be matching the version set in wasm/rust-toolchain.toml
-FROM rust:1.70.0-bullseye
+FROM rust:1.76.0-bullseye
 
 WORKDIR /__w/namada/namada
 
 # The version should be matching the version set above
-RUN rustup toolchain install 1.70.0 --profile minimal
+RUN rustup toolchain install 1.76.0 --profile minimal
 RUN rustup target add wasm32-unknown-unknown
 
 RUN apt-get update && apt-get install -y \

--- a/docker/namada/Dockerfile
+++ b/docker/namada/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.70.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.76.0 AS chef
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
to merge before #2687 release