### PR TITLE
Fix default node param protocol for cli calls

### DIFF
--- a/.changelog/unreleased/bug-fixes/2701-fix-default-node.md
+++ b/.changelog/unreleased/bug-fixes/2701-fix-default-node.md
@@ -1,0 +1,2 @@
+- Fixed the default `--node` argument when no specified.
+  ([\#2701](https://github.com/anoma/namada/pull/2701))

--- a/crates/apps/src/lib/cli/context.rs
+++ b/crates/apps/src/lib/cli/context.rs
@@ -476,7 +476,7 @@ impl ArgFromContext for tendermint_rpc::Url {
                     .rpc
                     .laddr
                     .to_string()
-                    .replace("tpc", "http"),
+                    .replace("tcp", "http"),
             )
             .map_err(|err| format!("Invalid Tendermint address: {err}"));
         }

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -210,7 +210,6 @@ fn test_node_connectivity_and_consensus() -> Result<()> {
     let _bg_validator_1 = validator_1.background();
 
     let validator_0_rpc = get_actor_rpc(&test, Who::Validator(0));
-    let validator_1_rpc = get_actor_rpc(&test, Who::Validator(1));
     let non_validator_rpc = get_actor_rpc(&test, Who::NonValidator);
 
     // Find the block height on the validator
@@ -219,14 +218,12 @@ fn test_node_connectivity_and_consensus() -> Result<()> {
     // Wait for the non-validator to be synced to at least the same height
     wait_for_block_height(&test, &non_validator_rpc, after_tx_height, 10)?;
 
-    let query_balance_args = |ledger_rpc| {
-        vec![
-            "balance", "--owner", ALBERT, "--token", NAM, "--node", ledger_rpc,
-        ]
-    };
-    for ledger_rpc in &[validator_0_rpc, validator_1_rpc, non_validator_rpc] {
+    let query_balance_args = ["balance", "--owner", ALBERT, "--token", NAM];
+    for who in
+        [Who::Validator(0), Who::Validator(1), Who::NonValidator].into_iter()
+    {
         let mut client =
-            run!(test, Bin::Client, query_balance_args(ledger_rpc), Some(40))?;
+            run_as!(test, who, Bin::Client, query_balance_args, Some(40))?;
         client.exp_string("nam: 2000010.1")?;
         client.assert_success();
     }


### PR DESCRIPTION
## Describe your changes

Closes #2702

This fixes a bug introduced in #2658 which causes all cli requests to fail when no `--node` param is provided:
```
builder error for url (tcp://127.0.0.1:26657): URL scheme is not allowed
```
## Indicate on which release or other PRs this topic is based on

0.31.6

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
