### PR TITLE
disable default features for git2

### DIFF
--- a/.changelog/unreleased/improvements/2724-git2-deps.md
+++ b/.changelog/unreleased/improvements/2724-git2-deps.md
@@ -1,0 +1,2 @@
+- Improve build time of git2 dependency by disabling the default features.
+  ([\#2724](https://github.com/anoma/namada/pull/2724))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,8 +2547,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -3729,9 +3727,7 @@ checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -3791,20 +3787,6 @@ dependencies = [
  "sha2 0.8.2",
  "subtle 2.4.1",
  "typenum",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ fd-lock = "3.0.12"
 flate2 = "1.0.22"
 fs_extra = "1.2.0"
 futures = "0.3"
-git2 = "0.18.1"
+git2 = { version = "0.18.1", default-features = false }
 ibc = {version = "0.48.1", default-features = false, features = ["serde"]}
 ibc-derive = "0.4.0"
 ibc-testkit = {version = "0.48.1", default-features = false}


### PR DESCRIPTION
## Describe your changes
We are using `git2` dependency only to fetch git data and create `version.rs`. The build script of `git2` with default feature is very heavy, taking 90s to build and we don't need any of the default features.
## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
