### PR TITLE
Generate a parser for MASP transactions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?tag=v1.1.0#f24691c0eb76909e3c15ae03aef294dccebd2df3"
+source = "git+https://github.com/anoma/masp?branch=murisi/borsh-schemas#243544fac3957a259d70973315e41b99f3af6052"
 dependencies = [
  "borsh",
  "chacha20",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?tag=v1.1.0#f24691c0eb76909e3c15ae03aef294dccebd2df3"
+source = "git+https://github.com/anoma/masp?branch=murisi/borsh-schemas#243544fac3957a259d70973315e41b99f3af6052"
 dependencies = [
  "aes",
  "bip0039",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?tag=v1.1.0#f24691c0eb76909e3c15ae03aef294dccebd2df3"
+source = "git+https://github.com/anoma/masp?branch=murisi/borsh-schemas#243544fac3957a259d70973315e41b99f3af6052"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4418,6 +4418,7 @@ dependencies = [
 name = "namada_examples"
 version = "0.31.4"
 dependencies = [
+ "masp_primitives",
  "masp_proofs",
  "namada_sdk",
  "proptest",
@@ -5130,7 +5131,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.39",
@@ -5816,7 +5817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,8 +114,8 @@ ledger-transport-hid = "0.10.0"
 libc = "0.2.97"
 libloading = "0.7.2"
 # branch = "murisi/namada-integration"
-masp_primitives = { git = "https://github.com/anoma/masp", tag = "v1.1.0" }
-masp_proofs = { git = "https://github.com/anoma/masp", tag = "v1.1.0", default-features = false, features = ["local-prover"] }
+masp_primitives = { git = "https://github.com/anoma/masp", branch = "murisi/borsh-schemas" }
+masp_proofs = { git = "https://github.com/anoma/masp", branch = "murisi/borsh-schemas", default-features = false, features = ["local-prover"] }
 num256 = "0.3.5"
 num_cpus = "1.13.0"
 num-derive = "0.3.3"

--- a/crates/core/src/types/masp.rs
+++ b/crates/core/src/types/masp.rs
@@ -3,7 +3,7 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use masp_primitives::asset_type::AssetType;
 use serde::{Deserialize, Serialize};
@@ -31,6 +31,7 @@ use crate::types::token::{Denomination, MaspDigitPos};
     Hash,
     Serialize,
     Deserialize,
+    BorshSchema,
 )]
 pub struct AssetData {
     /// The token associated with this asset type

--- a/crates/core/src/types/token.rs
+++ b/crates/core/src/types/token.rs
@@ -943,6 +943,7 @@ impl From<Amount> for Uint {
     BorshDeserialize,
     Serialize,
     Deserialize,
+    BorshSchema,
 )]
 #[repr(u8)]
 #[allow(missing_docs)]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -990,7 +990,7 @@ pub mod testing {
     }
 
     // Maximum number of notes to include in a transaction
-    const MAX_ASSETS: usize = 10;
+    const MAX_ASSETS: usize = 2;
 
     // Type of MASP transaction
     #[derive(Debug, Clone)]

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -3184,7 +3184,7 @@ pub mod testing {
     // Maximum value for a note partition
     const MAX_MONEY: u64 = 100;
     // Maximum number of partitions for a note
-    const MAX_SPLITS: usize = 10;
+    const MAX_SPLITS: usize = 3;
 
     prop_compose! {
         // Arbitrarily partition the given vector of integers into sets and sum

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -653,7 +653,13 @@ impl From<SaplingMetadataSerde> for Vec<u8> {
 /// A section providing the auxiliary inputs used to construct a MASP
 /// transaction
 #[derive(
-    Clone, Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+    Clone,
+    Debug,
+    BorshSerialize,
+    BorshDeserialize,
+    Serialize,
+    Deserialize,
+    BorshSchema,
 )]
 pub struct MaspBuilder {
     /// The MASP transaction that this section witnesses
@@ -681,20 +687,6 @@ impl MaspBuilder {
     pub fn hash<'a>(&self, hasher: &'a mut Sha256) -> &'a mut Sha256 {
         hasher.update(self.serialize_to_vec());
         hasher
-    }
-}
-
-impl borsh::BorshSchema for MaspBuilder {
-    fn add_definitions_recursively(
-        _definitions: &mut BTreeMap<
-            borsh::schema::Declaration,
-            borsh::schema::Definition,
-        >,
-    ) {
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        "Builder".into()
     }
 }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,12 @@ version.workspace = true
 name = "generate-txs"
 path = "generate_txs.rs"
 
+[[example]]
+name = "generate-parser"
+path = "generate_parser.rs"
+
 [dev-dependencies]
+masp_primitives.workspace = true
 masp_proofs = { workspace = true, default-features = false, features = ["local-prover", "download-params"] }
 namada_sdk = { path = "../crates/sdk", default-features = false, features = ["namada-sdk", "std", "testing"] }
 proptest.workspace = true

--- a/examples/generate_parser.rs
+++ b/examples/generate_parser.rs
@@ -1,0 +1,565 @@
+use std::collections::BTreeMap;
+
+use masp_primitives::transaction::Transaction;
+use namada_sdk::borsh::schema::{Declaration, Definition, FieldName, Fields};
+use namada_sdk::borsh::BorshSchema;
+use namada_sdk::tx::MaspBuilder;
+use proptest::test_runner::Reason;
+
+fn is_fixed_sized_array(
+    decl: &Declaration,
+    defs: &BTreeMap<Declaration, Definition>,
+) -> Option<(Declaration, u64)> {
+    match defs.get(decl)? {
+        Definition::Sequence {
+            length_width,
+            length_range,
+            elements,
+        } if *length_width == 0
+            && length_range.start() == length_range.end() =>
+        {
+            Some((elements.clone(), *length_range.start()))
+        }
+        _ => None,
+    }
+}
+
+fn is_variable_length_array(
+    decl: &Declaration,
+    defs: &BTreeMap<Declaration, Definition>,
+) -> Option<(Declaration, u8)> {
+    match defs.get(decl)? {
+        Definition::Sequence {
+            length_width,
+            length_range,
+            elements,
+        } if length_range.start() < length_range.end() => {
+            Some((elements.clone(), *length_width))
+        }
+        _ => None,
+    }
+}
+
+fn is_primitive(decl: &Declaration) -> Option<(&'static str, &'static str)> {
+    match decl.as_str() {
+        "u8" => Some(("uint8_t", "readByte")),
+        "u16" => Some(("uint16_t", "readUint16")),
+        "u32" => Some(("uint32_t", "readUint32")),
+        "u64" => Some(("uint64_t", "readUint64")),
+        "u128" => Some(("uint128_t", "readUint128")),
+        "i8" => Some(("int8_t", "readInt8")),
+        "i16" => Some(("int16_t", "readInt16")),
+        "i32" => Some(("int32_t", "readInt32")),
+        "i64" => Some(("int64_t", "readInt64")),
+        "i128" => Some(("int128_t", "readInt128")),
+        _ => None,
+    }
+}
+
+fn is_unit(
+    decl: &Declaration,
+    defs: &BTreeMap<Declaration, Definition>,
+) -> Option<Definition> {
+    match defs.get(decl)? {
+        def @ Definition::Primitive(0) => Some(def.clone()),
+        _ => None,
+    }
+}
+
+fn is_tuple(
+    decl: &Declaration,
+    defs: &BTreeMap<Declaration, Definition>,
+) -> Option<Declaration> {
+    match defs.get(decl)? {
+        Definition::Tuple { elements: _ } => {
+            Some(decl.replace(['(', ')'], "").replace(", ", "_"))
+        }
+        _ => None,
+    }
+}
+
+fn mangle_name(decl: &Declaration) -> Declaration {
+    decl.replace(['<', '>', '(', ')', '[', ']'], "")
+        .replace(", ", "_")
+        .replace("; ", "_")
+        .replace("::", "_")
+}
+
+fn process_field(
+    name: &FieldName,
+    decl: &Declaration,
+    definitions: &BTreeMap<Declaration, Definition>,
+    struct_decls: &mut Vec<String>,
+    parse_instrs: &mut Vec<String>,
+) {
+    if let Some(_decl) = is_unit(decl, definitions) {
+    } else if let Some((decl, parser)) = is_primitive(decl) {
+        parse_instrs.push(format!(
+            "  CHECK_ERROR({}(ctx, &obj->{}))",
+            parser,
+            mangle_name(name)
+        ));
+        struct_decls.push(format!("  {} {};", decl, mangle_name(name)));
+    } else if let Some((decl, len)) = is_fixed_sized_array(decl, definitions) {
+        if let Some((decl, parser)) = is_primitive(&decl) {
+            if decl == "uint8_t" {
+                parse_instrs.push(format!(
+                    "  CHECK_ERROR(readBytesAlt(ctx, obj->{}, {}))",
+                    mangle_name(name),
+                    len
+                ));
+            } else {
+                parse_instrs.push(format!(
+                    "  for(uint32_t i = 0; i < {}; i++) {{",
+                    len
+                ));
+                parse_instrs.push(format!(
+                    "    {}(ctx, &obj->{}[i])",
+                    parser,
+                    mangle_name(name)
+                ));
+                parse_instrs.push("  }}".to_string());
+            }
+            struct_decls.push(format!(
+                "  {} {}[{}];",
+                decl,
+                mangle_name(name),
+                len
+            ));
+        } else if let Some(decl) = is_tuple(&decl, definitions) {
+            struct_decls.push(format!(
+                "  {} {}[{}];",
+                mangle_name(&decl),
+                mangle_name(name),
+                len
+            ));
+        } else {
+            struct_decls.push(format!(
+                "  {} {}[{}];",
+                mangle_name(&decl),
+                mangle_name(name),
+                len
+            ));
+        }
+    } else if let Some((decl, length_tag_len)) =
+        is_variable_length_array(decl, definitions)
+    {
+        let length_tag = match length_tag_len {
+            0 => "unk_size".to_string(),
+            1 => {
+                struct_decls
+                    .push(format!("  uint8_t {}Len;", mangle_name(name)));
+                parse_instrs.push(format!(
+                    "  CHECK_ERROR(readByte(ctx, &obj->{}Len))",
+                    mangle_name(name)
+                ));
+                format!("obj->{}Len", mangle_name(name))
+            }
+            2 => {
+                struct_decls
+                    .push(format!("  uint16_t {}Len;", mangle_name(name)));
+                parse_instrs.push(format!(
+                    "  CHECK_ERROR(readUint16(ctx, &obj->{}Len))",
+                    mangle_name(name)
+                ));
+                format!("obj->{}Len", mangle_name(name))
+            }
+            4 => {
+                struct_decls
+                    .push(format!("  uint32_t {}Len;", mangle_name(name)));
+                parse_instrs.push(format!(
+                    "  CHECK_ERROR(readUint32(ctx, &obj->{}Len))",
+                    mangle_name(name)
+                ));
+                format!("obj->{}Len", mangle_name(name))
+            }
+            8 => {
+                struct_decls
+                    .push(format!("  uint64_t {}Len;", mangle_name(name)));
+                parse_instrs.push(format!(
+                    "  CHECK_ERROR(readUint64(ctx, &obj->{}Len))",
+                    mangle_name(name)
+                ));
+                format!("obj->{}Len", mangle_name(name))
+            }
+            _ => panic!("invalid length tag length"),
+        };
+        if let Some((decl, parser)) = is_primitive(&decl) {
+            parse_instrs.push(format!(
+                "  if((obj->{} = mem_alloc({} * sizeof({}))) == NULL) {{",
+                mangle_name(name),
+                length_tag,
+                decl
+            ));
+            parse_instrs
+                .push("    return parser_unexpected_error;".to_string());
+            parse_instrs.push("  }}".to_string());
+            parse_instrs.push(format!(
+                "  for(uint32_t i = 0; i < {}; i++) {{",
+                length_tag
+            ));
+            parse_instrs.push(format!(
+                "    CHECK_ERROR({}(ctx, &obj->{}[i]))",
+                parser,
+                mangle_name(name)
+            ));
+            parse_instrs.push("  }}".to_string());
+            struct_decls.push(format!("  {} *{};", decl, mangle_name(name)));
+        } else if let Some(decl) = is_tuple(&decl, definitions) {
+            parse_instrs.push(format!(
+                "  if((obj->{} = mem_alloc({} * sizeof({}))) == NULL) {{",
+                mangle_name(name),
+                length_tag,
+                mangle_name(&decl)
+            ));
+            parse_instrs
+                .push("    return parser_unexpected_error;".to_string());
+            parse_instrs.push("  }}".to_string());
+            parse_instrs.push(format!(
+                "  for(uint32_t i = 0; i < {}; i++) {{",
+                length_tag
+            ));
+            parse_instrs.push(format!(
+                "    CHECK_ERROR(read{}(ctx, &obj->{}[i]))",
+                mangle_name(&decl),
+                mangle_name(name)
+            ));
+            parse_instrs.push("  }}".to_string());
+            struct_decls.push(format!(
+                "  {} *{};",
+                mangle_name(&decl),
+                mangle_name(name)
+            ));
+        } else if let Some((decl, len)) =
+            is_fixed_sized_array(&decl, definitions)
+        {
+            if let Some((decl, _parser)) = is_primitive(&decl) {
+                if decl == "uint8_t" {
+                    parse_instrs.push(format!(
+                        "  if((obj->{} = mem_alloc({} * sizeof({}[{}]))) == \
+                         NULL) {{",
+                        mangle_name(name),
+                        length_tag,
+                        decl,
+                        len
+                    ));
+                    parse_instrs.push(
+                        "    return parser_unexpected_error;".to_string(),
+                    );
+                    parse_instrs.push("  }}".to_string());
+                    parse_instrs.push(format!(
+                        "  for(uint32_t i = 0; i < {}; i++) {{",
+                        length_tag
+                    ));
+                    parse_instrs.push(format!(
+                        "    CHECK_ERROR(readBytesAlt(ctx, obj->{}[i], {}))",
+                        mangle_name(name),
+                        len
+                    ));
+                    parse_instrs.push("  }}".to_string());
+                }
+                struct_decls.push(format!(
+                    "  {} (*{})[{}];",
+                    decl,
+                    mangle_name(name),
+                    len
+                ));
+            } else if let Some(decl) = is_tuple(&decl, definitions) {
+                struct_decls.push(format!(
+                    "  {} (*{})[{}];",
+                    mangle_name(&decl),
+                    mangle_name(name),
+                    len
+                ));
+            } else {
+                struct_decls.push(format!(
+                    "  {} (*{})[{}];",
+                    mangle_name(&decl),
+                    mangle_name(name),
+                    len
+                ));
+            }
+        } else {
+            parse_instrs.push(format!(
+                "  if((obj->{} = mem_alloc({} * sizeof({}))) == NULL) {{",
+                mangle_name(name),
+                length_tag,
+                mangle_name(&decl)
+            ));
+            parse_instrs
+                .push("    return parser_unexpected_error;".to_string());
+            parse_instrs.push("  }}".to_string());
+            parse_instrs.push(format!(
+                "  for(uint32_t i = 0; i < {}; i++) {{",
+                length_tag
+            ));
+            parse_instrs.push(format!(
+                "    CHECK_ERROR(read{}(ctx, &obj->{}[i]))",
+                mangle_name(&decl),
+                mangle_name(name)
+            ));
+            parse_instrs.push("  }}".to_string());
+            struct_decls.push(format!(
+                "  {} *{};",
+                mangle_name(&decl),
+                mangle_name(name)
+            ));
+        }
+    } else {
+        parse_instrs.push(format!(
+            "  CHECK_ERROR(read{}(ctx, &obj->{}))",
+            mangle_name(decl),
+            mangle_name(name)
+        ));
+        struct_decls.push(format!(
+            "  {} {};",
+            mangle_name(decl),
+            mangle_name(name)
+        ));
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Reason> {
+    let mut definitions = BTreeMap::new();
+    Transaction::add_definitions_recursively(&mut definitions);
+    MaspBuilder::add_definitions_recursively(&mut definitions);
+    let mut struct_decls = Vec::new();
+    let mut parser_decls = Vec::new();
+    let mut parse_instrs = Vec::new();
+
+    println!("{:#?}", definitions);
+
+    for (declaration, definition) in &definitions {
+        struct_decls.push("".to_string());
+        parse_instrs.push("".to_string());
+        let declaration = mangle_name(declaration);
+        match definition {
+            Definition::Struct {
+                fields: Fields::Empty,
+            } => {
+                struct_decls
+                    .push(format!("typedef struct {{}} {};", declaration));
+                parser_decls.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj);",
+                    declaration, declaration,
+                ));
+                parse_instrs.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj) {{",
+                    declaration, declaration,
+                ));
+                parse_instrs.push(format!("  return parser_ok;"));
+                parse_instrs.push(format!("}}"));
+            }
+            Definition::Struct {
+                fields: Fields::UnnamedFields(fields),
+            } => {
+                struct_decls.push(format!("typedef struct {{"));
+                parser_decls.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj);",
+                    declaration, declaration,
+                ));
+                parse_instrs.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj) {{",
+                    declaration, declaration,
+                ));
+                for (idx, decl) in fields.iter().enumerate() {
+                    process_field(
+                        &format!("f{}", idx),
+                        decl,
+                        &definitions,
+                        &mut struct_decls,
+                        &mut parse_instrs,
+                    );
+                }
+                struct_decls.push(format!("}} {};", declaration));
+                parse_instrs.push(format!("  return parser_ok;"));
+                parse_instrs.push(format!("}}"));
+            }
+            Definition::Struct {
+                fields: Fields::NamedFields(fields),
+            } => {
+                struct_decls.push(format!("typedef struct {{"));
+                parser_decls.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj);",
+                    declaration, declaration,
+                ));
+                parse_instrs.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj) {{",
+                    declaration, declaration,
+                ));
+                for (name, decl) in fields {
+                    process_field(
+                        name,
+                        decl,
+                        &definitions,
+                        &mut struct_decls,
+                        &mut parse_instrs,
+                    );
+                }
+                struct_decls.push(format!("}} {};", declaration));
+                parse_instrs.push(format!("  return parser_ok;"));
+                parse_instrs.push(format!("}}"));
+            }
+            Definition::Tuple { elements } => {
+                parser_decls.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj);",
+                    declaration, declaration,
+                ));
+                parse_instrs.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj) {{",
+                    declaration, declaration,
+                ));
+                struct_decls.push(format!("typedef struct {{"));
+                for (idx, decl) in elements.iter().enumerate() {
+                    process_field(
+                        &format!("f{}", idx),
+                        decl,
+                        &definitions,
+                        &mut struct_decls,
+                        &mut parse_instrs,
+                    );
+                }
+                struct_decls.push(format!("}} {};", declaration));
+                parse_instrs.push(format!("  return parser_ok;"));
+                parse_instrs.push(format!("}}"));
+            }
+            Definition::Enum {
+                tag_width: 0,
+                variants,
+            } => {
+                parser_decls.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj);",
+                    declaration, declaration,
+                ));
+                parse_instrs.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj) {{",
+                    declaration, declaration,
+                ));
+                parse_instrs.push(format!("  switch(unk_tag) {{"));
+                struct_decls.push(format!("typedef struct {{"));
+                struct_decls.push(format!("  union {{"));
+                for (discr, name, decl) in variants {
+                    parse_instrs.push(format!("  case {}:", discr));
+                    process_field(
+                        name,
+                        decl,
+                        &definitions,
+                        &mut struct_decls,
+                        &mut parse_instrs,
+                    );
+                    parse_instrs.push(format!("  break;"));
+                }
+                struct_decls.push(format!("  }};"));
+                struct_decls.push(format!("}} {};", declaration));
+                parse_instrs.push(format!("  }}"));
+                parse_instrs.push(format!("  return parser_ok;"));
+                parse_instrs.push(format!("}}"));
+            }
+            Definition::Enum {
+                tag_width: 1,
+                variants,
+            } => {
+                parser_decls.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj);",
+                    declaration, declaration,
+                ));
+                parse_instrs.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj) {{",
+                    declaration, declaration,
+                ));
+                parse_instrs
+                    .push(format!("  CHECK_ERROR(readByte(ctx, &obj->tag))"));
+                parse_instrs.push(format!("  switch(obj->tag) {{"));
+                struct_decls.push(format!("typedef struct {{"));
+                struct_decls.push(format!("  uint8_t tag;"));
+                struct_decls.push(format!("  union {{"));
+                for (discr, name, decl) in variants {
+                    parse_instrs.push(format!("  case {}:", discr));
+                    process_field(
+                        name,
+                        decl,
+                        &definitions,
+                        &mut struct_decls,
+                        &mut parse_instrs,
+                    );
+                    parse_instrs.push(format!("  break;"));
+                }
+                struct_decls.push(format!("  }};"));
+                struct_decls.push(format!("}} {};", declaration));
+                parse_instrs.push(format!("  }}"));
+                parse_instrs.push(format!("  return parser_ok;"));
+                parse_instrs.push(format!("}}"));
+            }
+            Definition::Enum {
+                tag_width: 2,
+                variants,
+            } => {
+                struct_decls.push(format!("typedef struct {{"));
+                struct_decls.push(format!("  uint16_t tag;"));
+                struct_decls.push(format!("  union {{"));
+                for (_discr, name, decl) in variants {
+                    process_field(
+                        name,
+                        decl,
+                        &definitions,
+                        &mut struct_decls,
+                        &mut parse_instrs,
+                    );
+                }
+                struct_decls.push(format!("  }};"));
+                struct_decls.push(format!("}} {};", declaration));
+            }
+            Definition::Enum {
+                tag_width: 4,
+                variants,
+            } => {
+                parser_decls.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj);",
+                    declaration, declaration,
+                ));
+                parse_instrs.push(format!(
+                    "parser_error_t read{}(parser_context_t *ctx, {} *obj) {{",
+                    declaration, declaration,
+                ));
+                parse_instrs
+                    .push(format!("  CHECK_ERROR(readUint32(ctx, &obj->tag))"));
+                parse_instrs.push(format!("  switch(obj->tag) {{"));
+                struct_decls.push(format!("typedef struct {{"));
+                struct_decls.push(format!("  uint32_t tag;"));
+                struct_decls.push(format!("  union {{"));
+                for (_discr, name, decl) in variants {
+                    process_field(
+                        name,
+                        decl,
+                        &definitions,
+                        &mut struct_decls,
+                        &mut parse_instrs,
+                    );
+                }
+                struct_decls.push(format!("  }};"));
+                struct_decls.push(format!("}} {};", declaration));
+                parse_instrs.push(format!("  }}"));
+                parse_instrs.push(format!("  return parser_ok;"));
+                parse_instrs.push(format!("}}"));
+            }
+            _ => {
+                struct_decls.pop();
+                parse_instrs.pop();
+            }
+        }
+    }
+    for struct_decl in struct_decls {
+        println!("{}", struct_decl);
+    }
+    println!();
+    for parser_decl in parser_decls {
+        println!("{}", parser_decl);
+    }
+    println!();
+    for parse_instr in parse_instrs {
+        println!("{}", parse_instr);
+    }
+    println!();
+    Ok(())
+}

--- a/examples/generate_txs.rs
+++ b/examples/generate_txs.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Reason> {
     let json = serde_json::to_string(&test_vectors)
         .expect("unable to serialize test vectors");
     std::fs::write(&args[1], json).expect("unable to save test vectors");
-    std::fs::write(&args[2], format!("{:?}", debug_vectors))
+    std::fs::write(&args[2], format!("{:#?}", debug_vectors))
         .expect("unable to save test vectors");
     Ok(())
 }

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3134,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?tag=v1.1.0#f24691c0eb76909e3c15ae03aef294dccebd2df3"
+source = "git+https://github.com/anoma/masp?branch=murisi/borsh-schemas#243544fac3957a259d70973315e41b99f3af6052"
 dependencies = [
  "borsh",
  "chacha20",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?tag=v1.1.0#f24691c0eb76909e3c15ae03aef294dccebd2df3"
+source = "git+https://github.com/anoma/masp?branch=murisi/borsh-schemas#243544fac3957a259d70973315e41b99f3af6052"
 dependencies = [
  "aes",
  "bip0039",
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?tag=v1.1.0#f24691c0eb76909e3c15ae03aef294dccebd2df3"
+source = "git+https://github.com/anoma/masp?branch=murisi/borsh-schemas#243544fac3957a259d70973315e41b99f3af6052"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -3134,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?tag=v1.1.0#f24691c0eb76909e3c15ae03aef294dccebd2df3"
+source = "git+https://github.com/anoma/masp?branch=murisi/borsh-schemas#243544fac3957a259d70973315e41b99f3af6052"
 dependencies = [
  "borsh",
  "chacha20",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?tag=v1.1.0#f24691c0eb76909e3c15ae03aef294dccebd2df3"
+source = "git+https://github.com/anoma/masp?branch=murisi/borsh-schemas#243544fac3957a259d70973315e41b99f3af6052"
 dependencies = [
  "aes",
  "bip0039",
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?tag=v1.1.0#f24691c0eb76909e3c15ae03aef294dccebd2df3"
+source = "git+https://github.com/anoma/masp?branch=murisi/borsh-schemas#243544fac3957a259d70973315e41b99f3af6052"
 dependencies = [
  "bellman",
  "blake2b_simd",


### PR DESCRIPTION
## Describe your changes
Wrote a utility to convert the Borsh schemas for MASP `Transaction`s and `MaspBuilder`s into C parsers for Ledger hardware wallets. More specifically, the changes are as follows:
* Now use a MASP branch with more correct Borsh schemas
* Implemented a C parser generator supporting a range of schema `Definition`s

## Indicate on which release or other PRs this topic is based on
Namada v0.31.4

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
