### PR TITLE
Fix temporary values read

### DIFF
--- a/.changelog/unreleased/bug-fixes/2735-fix-vps-api.md
+++ b/.changelog/unreleased/bug-fixes/2735-fix-vps-api.md
@@ -1,0 +1,2 @@
+- Fixed the `StorageRead` implementation and vp host functions to ignore
+  temporary writes. ([\#2735](https://github.com/anoma/namada/pull/2735))

--- a/crates/namada/src/ledger/vp_host_fns.rs
+++ b/crates/namada/src/ledger/vp_host_fns.rs
@@ -188,7 +188,9 @@ where
             Ok(false)
         }
         Some(&write_log::StorageModification::InitAccount { .. }) => Ok(true),
-        Some(&write_log::StorageModification::Temp { .. }) => Ok(true),
+        Some(&write_log::StorageModification::Temp { .. }) => {
+            Err(RuntimeError::ReadTemporaryValueError)
+        }
         None => {
             // When not found in write log, try to check the storage
             let (present, gas) =
@@ -220,7 +222,9 @@ where
             Ok(false)
         }
         Some(&write_log::StorageModification::InitAccount { .. }) => Ok(true),
-        Some(&write_log::StorageModification::Temp { .. }) => Ok(true),
+        Some(&write_log::StorageModification::Temp { .. }) => {
+            Err(RuntimeError::ReadTemporaryValueError)
+        }
         None => {
             // When not found in write log, try to check the storage
             let (present, gas) =

--- a/crates/namada/src/ledger/vp_host_fns.rs
+++ b/crates/namada/src/ledger/vp_host_fns.rs
@@ -37,8 +37,6 @@ pub enum RuntimeError {
     NumConversionError(TryFromIntError),
     #[error("Memory error: {0}")]
     MemoryError(Box<dyn std::error::Error + Sync + Send + 'static>),
-    #[error("Trying to read a permanent value with read_temp")]
-    ReadPermanentValueError,
     #[error("Invalid transaction code hash")]
     InvalidCodeHash,
     #[error("No value found in result buffer")]
@@ -149,15 +147,13 @@ pub fn read_temp<S>(
 where
     S: StateRead + Debug,
 {
-    // Try to read from the write log first
     let (log_val, gas) = state.write_log().read(key);
     add_gas(gas_meter, gas, sentinel)?;
     match log_val {
         Some(write_log::StorageModification::Temp { ref value }) => {
             Ok(Some(value.clone()))
         }
-        None => Ok(None),
-        _ => Err(RuntimeError::ReadPermanentValueError),
+        _ => Ok(None),
     }
 }
 

--- a/crates/namada/src/vm/host_env.rs
+++ b/crates/namada/src/vm/host_env.rs
@@ -796,19 +796,9 @@ where
                 // a VP of a new account doesn't need to be iterated
                 continue;
             }
-            Some(write_log::StorageModification::Temp { ref value }) => {
-                let key_val = borsh::to_vec(&KeyVal {
-                    key,
-                    val: value.clone(),
-                })
-                .map_err(TxRuntimeError::EncodingError)?;
-                let len: i64 = key_val
-                    .len()
-                    .try_into()
-                    .map_err(TxRuntimeError::NumConversionError)?;
-                let result_buffer = unsafe { env.ctx.result_buffer.get() };
-                result_buffer.replace(key_val);
-                return Ok(len);
+            Some(write_log::StorageModification::Temp { .. }) => {
+                // temporary values are not returned by the iterator
+                continue;
             }
             None => {
                 let key_val = borsh::to_vec(&KeyVal { key, val })

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -200,15 +200,15 @@ macro_rules! impl_storage_read {
                 let (log_val, gas) = self.write_log().read_persistent(key);
                 self.charge_gas(gas).into_storage_result()?;
                 match log_val {
-                    Some(write_log::StorageModification::Write { ref value }) => {
+                    Some(write_log::PersistentStorageModification::Write { value }) => {
                         Ok(Some(value.clone()))
                     }
-                    Some(write_log::StorageModification::Delete) => Ok(None),
-                    Some(write_log::StorageModification::InitAccount {
+                    Some(write_log::PersistentStorageModification::Delete) => Ok(None),
+                    Some(write_log::PersistentStorageModification::InitAccount {
                         ref vp_code_hash,
                     }) => Ok(Some(vp_code_hash.to_vec())),
-                    Some(write_log::StorageModification::Temp { .. }) | None => {
-                        // when not found in write log or only found a temporary value, try to read from the storage
+                    None => {
+                        // when not found in write log try to read from the storage
                         let (value, gas) = self.db_read(key).into_storage_result()?;
                         self.charge_gas(gas).into_storage_result()?;
                         Ok(value)

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -192,13 +192,12 @@ macro_rules! impl_storage_read {
         {
             type PrefixIter<'iter> = PrefixIter<'iter, D> where Self: 'iter;
 
-            //FIXME: need a temp_read in this trait?
             fn read_bytes(
                 &self,
                 key: &storage::Key,
             ) -> namada_storage::Result<Option<Vec<u8>>> {
                 // try to read from the write log first
-                let (log_val, gas) = self.write_log().read(key);
+                let (log_val, gas) = self.write_log().read_persistent(key);
                 self.charge_gas(gas).into_storage_result()?;
                 match log_val {
                     Some(write_log::StorageModification::Write { ref value }) => {
@@ -208,31 +207,8 @@ macro_rules! impl_storage_read {
                     Some(write_log::StorageModification::InitAccount {
                         ref vp_code_hash,
                     }) => Ok(Some(vp_code_hash.to_vec())),
-                    Some(write_log::StorageModification::Temp { .. }) => {
-                        // Ignore temp writes, try to read from block write log first
-
-                let (log_val, gas) = self.write_log().read_pre(key);
-                self.charge_gas(gas).into_storage_result()?;
-                        match log_val {
-
- Some(write_log::StorageModification::Write { ref value }) => {
-                        Ok(Some(value.clone()))
-                    }
-                    Some(write_log::StorageModification::Delete) => Ok(None),
-                    Some(write_log::StorageModification::InitAccount {
-                        ref vp_code_hash,
-                    }) => Ok(Some(vp_code_hash.to_vec())),
                     Some(write_log::StorageModification::Temp { .. }) | None => {
-
-// when not found in write log, try to read from the storage
-                        let (value, gas) = self.db_read(key).into_storage_result()?;
-                        self.charge_gas(gas).into_storage_result()?;
-                        Ok(value)
-                            },
-                        }
-                    }
-                    None => {
-                        // when not found in write log, try to read from the storage
+                        // when not found in write log or only found a temporary value, try to read from the storage
                         let (value, gas) = self.db_read(key).into_storage_result()?;
                         self.charge_gas(gas).into_storage_result()?;
                         Ok(value)
@@ -247,33 +223,12 @@ macro_rules! impl_storage_read {
                 match log_val {
                     Some(&write_log::StorageModification::Write { .. })
                     | Some(&write_log::StorageModification::InitAccount { .. }) => Ok(true),
-                     Some(&write_log::StorageModification::Temp { .. }) => {
-                        // Ignore temporary writes
-
-                let (log_val, gas) = self.write_log().read_pre(key);
-                self.charge_gas(gas).into_storage_result()?;
-                        match log_val {
-
-                    Some(&write_log::StorageModification::Write { .. })
-                    | Some(&write_log::StorageModification::InitAccount { .. }) => Ok(true),
                     Some(&write_log::StorageModification::Delete) => {
                         // the given key has been deleted
                         Ok(false)
                     }
-                     Some(&write_log::StorageModification::Temp { .. }) | None => {
-                        // when not found in write log, try to check the storage
-                        let (present, gas) = self.db_has_key(key).into_storage_result()?;
-                        self.charge_gas(gas).into_storage_result()?;
-                        Ok(present)
-                                }
-                        }
-                    }
-                    Some(&write_log::StorageModification::Delete) => {
-                        // the given key has been deleted
-                        Ok(false)
-                    }
-                    None => {
-                        // when not found in write log, try to check the storage
+                    Some(&write_log::StorageModification::Temp { .. }) | None => {
+                        // when not found in write log or only found a temporary value, try to check the storage
                         let (present, gas) = self.db_has_key(key).into_storage_result()?;
                         self.charge_gas(gas).into_storage_result()?;
                         Ok(present)


### PR DESCRIPTION
## Describe your changes

Closes #2683.

Fixes the `has_key` method provided to the vp env to not return an error on temporary write values (the `read` method was already fine).

Adds a new `read_persistent` method on `WriteLog` that ignore temporary writes and modifies the `read` and `has_key` implementation of `impl_storage_read` to call this new method.
Modifies `tx_iter_next` to skip temporary writes.
Refactors `fetch_or_compile` to call `state.read` (which should include possible updated in the write log of the wasm codes).

Updates `write_temp` in `WriteLog` to return an error when trying to overwrite a `StorageModification::Write` with a `StorageModification::Temp`.
Updates `iter_prefix_post` in `WriteLog` to iterate also on the precommit bucket.
Updates `write`, `write_temp` and `delete` in `WriteLog` to take the precommit bucket into account.

## Indicate on which release or other PRs this topic is based on

v0.32.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
