### PR TITLE
fix: client side check to prevent threshold=0 on init/update

### DIFF
--- a/.changelog/unreleased/bug-fixes/2671-fix-thresold-0-init-update-account.md
+++ b/.changelog/unreleased/bug-fixes/2671-fix-thresold-0-init-update-account.md
@@ -1,0 +1,2 @@
+- Fix threshold=0 on init-account / update-account
+  ([\#2671](https://github.com/anoma/namada/issues/2671))

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -4183,8 +4183,8 @@ pub mod args {
                 ))
                 .arg(THRESHOLD.def().help(
                     "The minimum number of signature to be provided for \
-                     authorization. Must be more than 0 and less than the maximum number of \
-                     public keys provided.",
+                     authorization. Must be greater than 0 and less than or equal \
+                     to the maximum number of public keys provided.",
                 ))
         }
     }
@@ -4458,8 +4458,8 @@ pub mod args {
                 ))
                 .arg(THRESHOLD.def().help(
                     "The minimum number of signature to be provided for \
-                     authorization. Must be more than 0 and less than the maximum number of \
-                     public keys provided.",
+                     authorization. Must be greater than 0 and less than or equal \
+                     to the maximum number of public keys provided.",
                 ))
         }
     }
@@ -4524,8 +4524,8 @@ pub mod args {
                 ))
                 .arg(THRESHOLD.def().help(
                     "The minimum number of signature to be provided for \
-                     authorization. Must be more than 0 and less than the maximum number of \
-                     public keys provided.",
+                     authorization. Must be greater than 0 and less than or equal \
+                     to the maximum number of public keys provided.",
                 ))
         }
     }

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -4155,6 +4155,12 @@ pub mod args {
             let tx_code_path = PathBuf::from(TX_INIT_ACCOUNT_WASM);
             let public_keys = PUBLIC_KEYS.parse(matches);
             let threshold = THRESHOLD.parse(matches);
+
+            if threshold <= Some(0) {
+                eprintln!("Threshold must be higher than 0.");
+                std::process::exit(1);
+            }
+
             Self {
                 tx,
                 vp_code_path,
@@ -4177,7 +4183,7 @@ pub mod args {
                 ))
                 .arg(THRESHOLD.def().help(
                     "The minimum number of signature to be provided for \
-                     authorization. Must be less then the maximum number of \
+                     authorization. Must be more than 0 and less than the maximum number of \
                      public keys provided.",
                 ))
         }
@@ -4366,6 +4372,12 @@ pub mod args {
             let tx_become_validator_code_path =
                 PathBuf::from(TX_BECOME_VALIDATOR_WASM);
             let threshold = THRESHOLD.parse(matches);
+
+            if threshold <= Some(0) {
+                eprintln!("Threshold must be higher than 0.");
+                std::process::exit(1);
+            }
+
             Self {
                 tx,
                 scheme,
@@ -4446,7 +4458,7 @@ pub mod args {
                 ))
                 .arg(THRESHOLD.def().help(
                     "The minimum number of signature to be provided for \
-                     authorization. Must be less then the maximum number of \
+                     authorization. Must be more than 0 and less than the maximum number of \
                      public keys provided.",
                 ))
         }
@@ -4479,6 +4491,12 @@ pub mod args {
             let tx_code_path = PathBuf::from(TX_UPDATE_ACCOUNT_WASM);
             let public_keys = PUBLIC_KEYS.parse(matches);
             let threshold = THRESHOLD.parse(matches);
+
+            if threshold <= Some(0) {
+                eprintln!("Threshold must be higher than 0.");
+                std::process::exit(1);
+            }
+
             Self {
                 tx,
                 vp_code_path,
@@ -4506,7 +4524,7 @@ pub mod args {
                 ))
                 .arg(THRESHOLD.def().help(
                     "The minimum number of signature to be provided for \
-                     authorization. Must be less then the maximum number of \
+                     authorization. Must be more than 0 and less than the maximum number of \
                      public keys provided.",
                 ))
         }

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -4156,7 +4156,7 @@ pub mod args {
             let public_keys = PUBLIC_KEYS.parse(matches);
             let threshold = THRESHOLD.parse(matches);
 
-            if threshold <= Some(0) {
+            if threshold == Some(0) {
                 eprintln!("Threshold must be higher than 0.");
                 std::process::exit(1);
             }
@@ -4373,7 +4373,7 @@ pub mod args {
                 PathBuf::from(TX_BECOME_VALIDATOR_WASM);
             let threshold = THRESHOLD.parse(matches);
 
-            if threshold <= Some(0) {
+            if threshold == Some(0) {
                 eprintln!("Threshold must be higher than 0.");
                 std::process::exit(1);
             }
@@ -4492,9 +4492,16 @@ pub mod args {
             let public_keys = PUBLIC_KEYS.parse(matches);
             let threshold = THRESHOLD.parse(matches);
 
-            if threshold <= Some(0) {
+            if threshold == Some(0) {
                 eprintln!("Threshold must be higher than 0.");
                 std::process::exit(1);
+            }
+            let num_keys = public_keys.len() as u8;
+            if let Some(threshold) = threshold {
+                if (num_keys >= 1) && (num_keys < threshold) {
+                    eprintln!("Threshold must be less than the number of public keys provided.");
+                    std::process::exit(1);
+                }
             }
 
             Self {


### PR DESCRIPTION
Adding Client side check to ensure `threshold` > 0 in `init-account` and `update-account `(also `init-validator`)

## Describe your changes

Accounts (and validator accounts) should not be created/updated with less than 1 as threshold, otherwise this would allow transaction requiring to signature.

## Indicate on which release or other PRs this topic is based on
I initially first reported this in #2671.

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
