### PR TITLE
Update clang-tools and add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+---
+version: "3.9"
+
+x-common-env: &cenv
+  CHAIN_ID: shielded-expedition.88f17d1d14
+  NAMADA_BASE_DIR: /home/namada/
+  NAMADA_LOG: info
+  CMT_LOG_LEVEL: p2p:none,pex:error
+  NAMADA_CMT_STDOUT: true
+
+services:
+  namada-init:
+    container_name: namada-init
+    image: ghcr.io/anoma/namada:namada-v0.31.6
+    command: client utils join-network --chain-id shielded-expedition.88f17d1d14
+    environment:
+      <<: *cenv
+    network_mode: "host"
+    volumes:
+      - namada_data:/home/namada/
+  namada-node:
+    container_name: namada-node
+    image: ghcr.io/anoma/namada:namada-v0.31.6
+    #build:
+    #  context: .
+    #  dockerfile: docker/namada/Dockerfile
+    command: node ledger run
+    # restart: always
+    environment:
+      <<: *cenv
+    network_mode: "host"
+    volumes:
+      - namada_data:/home/namada/
+    depends_on:
+      - namada-init
+
+volumes:
+  namada_data:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ./volumes/namada_data

--- a/docker/namada/Dockerfile
+++ b/docker/namada/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
     build-essential \
-    clang-tools-11 \
+    clang-tools-14 \
     git \
     libssl-dev \
     pkg-config \
@@ -29,7 +29,9 @@ WORKDIR /app
 
 RUN git clone -b v0.37.2 --single-branch https://github.com/cometbft/cometbft.git && cd cometbft && make build
 
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-20240110-slim AS runtime
+
+ENV NAMADA_BASE_DIR=/home/namada
 ENV NAMADA_LOG_COLOR=false
 
 RUN apt-get update && apt-get install libcurl4-openssl-dev libudev-dev -y && apt-get clean


### PR DESCRIPTION
## Update clang-tools and add docker-compose.yml

- add docker-compose.yml 
  add docker-compose.yml file for easy start / update / build namada node use commands:
How to use:
```
docker compose up -d             (init container)
docker compose logs --tail=50 -f (read logs)
docker compose build namada-node (build: uncomment build section and comment image section)
```

- update clang-tools-11 to clang-tools-14 on last chef (debian12)  and last security updates for base image

on current namada docker image namada-v0.31.6 when run namada node ledger run got error:
/usr/local/bin/namadac: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory 


## Indicate on which release or other PRs this topic is based on

For release v0.31.6-v0.31.7

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [*] Git history is in acceptable state
