### PR TITLE
sdk: re-pub masp types from core

### DIFF
--- a/.changelog/unreleased/SDK/2762-pub-masp-types.md
+++ b/.changelog/unreleased/SDK/2762-pub-masp-types.md
@@ -1,0 +1,2 @@
+- Make more MASP types public.
+  ([\#2762](https://github.com/anoma/namada/pull/2762))

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -52,7 +52,7 @@ use masp_proofs::prover::LocalTxProver;
 use masp_proofs::sapling::SaplingVerificationContext;
 use namada_core::address::{Address, MASP};
 use namada_core::dec::Dec;
-use namada_core::masp::{
+pub use namada_core::masp::{
     encode_asset_type, AssetData, BalanceOwner, ExtendedViewingKey,
     PaymentAddress, TransferSource, TransferTarget,
 };


### PR DESCRIPTION
## Describe your changes

this got accidentally hidden in 0.31.7 with flattening of core types

## Indicate on which release or other PRs this topic is based on

0.31.7

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
