### PR TITLE
Fix timeout timestamp for PGF over IBC

### DIFF
--- a/.changelog/unreleased/bug-fixes/2774-fix-ibc-pgf-timestamp.md
+++ b/.changelog/unreleased/bug-fixes/2774-fix-ibc-pgf-timestamp.md
@@ -1,0 +1,2 @@
+- Fix the timeout timestamp for PGF over IBC
+  ([\#2774](https://github.com/anoma/namada/issues/2774))

--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -114,18 +114,18 @@ where
             req.byzantine_validators,
         )?;
 
-        // Take IBC events that may be emitted from PGF
-        for ibc_event in self.state.write_log_mut().take_ibc_events() {
-            let mut event = Event::from(ibc_event.clone());
-            // Add the height for IBC event query
-            let height = self.state.in_mem().get_last_block_height() + 1;
-            event["height"] = height.to_string();
-            response.events.push(event);
-        }
-
         if new_epoch {
             // Apply PoS and PGF inflation
             self.apply_inflation(current_epoch)?;
+
+            // Take IBC events that may be emitted from PGF
+            for ibc_event in self.state.write_log_mut().take_ibc_events() {
+                let mut event = Event::from(ibc_event.clone());
+                // Add the height for IBC event query
+                let height = self.state.in_mem().get_last_block_height() + 1;
+                event["height"] = height.to_string();
+                response.events.push(event);
+            }
         }
 
         let mut stats = InternalStats::default();

--- a/crates/ibc/src/actions.rs
+++ b/crates/ibc/src/actions.rs
@@ -11,7 +11,6 @@ use namada_core::ibc::core::channel::types::timeout::TimeoutHeight;
 use namada_core::ibc::primitives::Msg;
 use namada_core::ibc::IbcEvent;
 use namada_core::tendermint::Time as TmTime;
-use namada_core::time::DateTimeUtc;
 use namada_core::token::DenominatedAmount;
 use namada_governance::storage::proposal::PGFIbcTarget;
 use namada_parameters::read_epoch_duration_parameter;
@@ -285,8 +284,13 @@ where
         receiver: target.target.clone().into(),
         memo: String::default().into(),
     };
-    let timeout_timestamp =
-        DateTimeUtc::now() + read_epoch_duration_parameter(state)?.min_duration;
+    let timeout_timestamp = state
+        .in_mem()
+        .header
+        .as_ref()
+        .expect("The header should exist")
+        .time
+        + read_epoch_duration_parameter(state)?.min_duration;
     let timeout_timestamp =
         TmTime::try_from(timeout_timestamp).into_storage_result()?;
     let ibc_message = MsgTransfer {


### PR DESCRIPTION
## Describe your changes
- Non-deterministic issue happened because the timeout timestamp was set with `DateTimeUtc::now()` in PGF over IBC
- Taking IBC events after PGF inflation executing IBC transfers

## Indicate on which release or other PRs this topic is based on
v0.31.8

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
