### PR TITLE
Update speculative shielded context only when required

### DIFF
--- a/.changelog/unreleased/SDK/2775-fix-shielded-context-dry-run.md
+++ b/.changelog/unreleased/SDK/2775-fix-shielded-context-dry-run.md
@@ -1,0 +1,3 @@
+- `gen_shielded_transfer` now takes an extra `update_ctx`
+  argument to conditionally update the shielded context.
+  ([\#2775](https://github.com/anoma/namada/pull/2775))

--- a/.changelog/unreleased/bug-fixes/2775-fix-shielded-context-dry-run.md
+++ b/.changelog/unreleased/bug-fixes/2775-fix-shielded-context-dry-run.md
@@ -1,0 +1,3 @@
+- Fixed a bug in the client for which the speculative
+  shielded context was updated event in a dry run.
+  ([\#2775](https://github.com/anoma/namada/pull/2775))

--- a/crates/apps/src/lib/bench_utils.rs
+++ b/crates/apps/src/lib/bench_utils.rs
@@ -1020,6 +1020,7 @@ impl BenchShieldedCtx {
                     &target,
                     &address::testing::nam(),
                     denominated_amount,
+                    true,
                 ),
             )
             .unwrap()

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -1944,6 +1944,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
         target: &TransferTarget,
         token: &Address,
         amount: token::DenominatedAmount,
+        update_ctx: bool,
     ) -> Result<Option<ShieldedTransfer>, TransferErr> {
         // No shielded components are needed when neither source nor destination
         // are shielded
@@ -2291,13 +2292,15 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
         let (masp_tx, metadata) =
             builder.build(&prover, &FeeRule::non_standard(U64Sum::zero()))?;
 
-        // Cache the generated transfer
-        let mut shielded_ctx = context.shielded_mut().await;
-        shielded_ctx
-            .pre_cache_transaction(
-                context, &masp_tx, source, target, token, epoch,
-            )
-            .await?;
+        if update_ctx {
+            // Cache the generated transfer
+            let mut shielded_ctx = context.shielded_mut().await;
+            shielded_ctx
+                .pre_cache_transaction(
+                    context, &masp_tx, source, target, token, epoch,
+                )
+                .await?;
+        }
 
         Ok(Some(ShieldedTransfer {
             builder: builder_clone,

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -516,6 +516,7 @@ pub async fn validate_fee_and_gen_unshield<N: Namada>(
                         &target,
                         &args.fee_token,
                         fee_amount,
+                    !(args.dry_run || args.dry_run_wrapper)
                     )
                     .await
                 {

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2181,6 +2181,7 @@ pub async fn build_ibc_transfer(
         &TransferTarget::Address(Address::Internal(InternalAddress::Ibc)),
         &args.token,
         validated_amount,
+        !(args.tx.dry_run || args.tx.dry_run_wrapper),
     )
     .await?;
     let shielded_tx_epoch = shielded_parts.as_ref().map(|trans| trans.0.epoch);
@@ -2504,6 +2505,7 @@ pub async fn build_transfer<N: Namada>(
         &args.target,
         &args.token,
         validated_amount,
+        !(args.tx.dry_run || args.tx.dry_run_wrapper),
     )
     .await?;
     let shielded_tx_epoch = shielded_parts.as_ref().map(|trans| trans.0.epoch);
@@ -2570,6 +2572,7 @@ async fn construct_shielded_parts<N: Namada>(
     target: &TransferTarget,
     token: &Address,
     amount: token::DenominatedAmount,
+    update_ctx: bool,
 ) -> Result<Option<(ShieldedTransfer, HashSet<AssetData>)>> {
     // Precompute asset types to increase chances of success in decoding
     let token_map = context.wallet().await.get_addresses();
@@ -2581,7 +2584,7 @@ async fn construct_shielded_parts<N: Namada>(
         .await;
     let stx_result =
         ShieldedContext::<N::ShieldedUtils>::gen_shielded_transfer(
-            context, source, target, token, amount,
+            context, source, target, token, amount, update_ctx,
         )
         .await;
 
@@ -2877,6 +2880,7 @@ pub async fn gen_ibc_shielded_transfer<N: Namada>(
             &args.target,
             &token,
             validated_amount,
+            true,
         )
         .await
         .map_err(|err| TxSubmitError::MaspError(err.to_string()))?;


### PR DESCRIPTION
## Describe your changes

Closes #2750.

Fixed a bug for which the speculative shielded context was updated even when dry running a transaction.

## Indicate on which release or other PRs this topic is based on

v0.31.8

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
