### PR TITLE
Allows merkle roots to be recalculated and validated on bootup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,6 +3543,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6916,12 +6925,13 @@ dependencies = [
 [[package]]
 name = "sparse-merkle-tree"
 version = "0.3.1-pre"
-source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=515687fe7884cb365067ac86c66ac3613de176bb#515687fe7884cb365067ac86c66ac3613de176bb"
+source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=bab8cb96872db22cc9a139b2d3dfc4e00521d097#bab8cb96872db22cc9a139b2d3dfc4e00521d097"
 dependencies = [
  "blake2b-rs",
  "borsh",
  "cfg-if 1.0.0",
  "ics23",
+ "itertools 0.12.1",
  "sha2 0.9.9",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ version = "0.31.8"
 ark-bls12-381 = {version = "0.3"}
 ark-serialize = {version = "0.3"}
 ark-std = "0.3.0"
-# branch = "bat/arse-merkle-tree"
-arse-merkle-tree = {package = "sparse-merkle-tree", git = "https://github.com/heliaxdev/sparse-merkle-tree", rev = "515687fe7884cb365067ac86c66ac3613de176bb", default-features = false, features = ["std", "borsh"]}
+# branch = "bat/feat/validate-root"
+arse-merkle-tree = {package = "sparse-merkle-tree", git = "https://github.com/heliaxdev/sparse-merkle-tree", rev = "bab8cb96872db22cc9a139b2d3dfc4e00521d097", default-features = false, features = ["std", "borsh"]}
 assert_cmd = "1.0.7"
 assert_matches = "1.5.0"
 async-trait = {version = "0.1.51"}

--- a/crates/apps/src/bin/namada-node/cli.rs
+++ b/crates/apps/src/bin/namada-node/cli.rs
@@ -11,7 +11,10 @@ pub fn main() -> Result<()> {
     match cmd {
         cmds::NamadaNode::Ledger(sub) => match sub {
             cmds::Ledger::Run(cmds::LedgerRun(args)) => {
-                let chain_ctx = ctx.take_chain_or_exit();
+                let mut chain_ctx = ctx.take_chain_or_exit();
+                if args.validate_merkle_tree {
+                    chain_ctx.config.ledger.shell.validate_merkle_tree = true;
+                }
                 let wasm_dir = chain_ctx.wasm_dir();
                 sleep_until(args.start_time);
                 ledger::run(chain_ctx.config.ledger, wasm_dir);

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -859,6 +859,7 @@ pub mod cmds {
                     // The `run` command is the default if no sub-command given
                     .or(Some(Self::Run(LedgerRun(args::LedgerRun {
                         start_time: None,
+                        validate_merkle_tree: false,
                     }))))
             })
         }
@@ -3189,6 +3190,7 @@ pub mod args {
     pub const UNSAFE_DONT_ENCRYPT: ArgFlag = flag("unsafe-dont-encrypt");
     pub const UNSAFE_SHOW_SECRET: ArgFlag = flag("unsafe-show-secret");
     pub const USE_DEVICE: ArgFlag = flag("use-device");
+    pub const VALIDATE_MERKLE_TREE: ArgFlag = flag("validate-merkle-tree");
     pub const VALIDATOR: Arg<WalletAddress> = arg("validator");
     pub const VALIDATOR_OPT: ArgOpt<WalletAddress> = VALIDATOR.opt();
     pub const VALIDATOR_ACCOUNT_KEY: ArgOpt<WalletPublicKey> =
@@ -3272,12 +3274,17 @@ pub mod args {
     #[derive(Clone, Debug)]
     pub struct LedgerRun {
         pub start_time: Option<DateTimeUtc>,
+        pub validate_merkle_tree: bool,
     }
 
     impl Args for LedgerRun {
         fn parse(matches: &ArgMatches) -> Self {
             let start_time = NAMADA_START_TIME.parse(matches);
-            Self { start_time }
+            let validate_merkle_tree = VALIDATE_MERKLE_TREE.parse(matches);
+            Self {
+                start_time,
+                validate_merkle_tree,
+            }
         }
 
         fn def(app: App) -> App {
@@ -3288,6 +3295,10 @@ pub mod args {
                  allowed between each component.\nAll of these examples are \
                  equivalent:\n2023-01-20T12:12:12Z\n2023-01-20 \
                  12:12:12Z\n2023-  01-20T12:  12:12Z",
+            ))
+            .arg(VALIDATE_MERKLE_TREE.def().help(
+                "Recompute the merkle tree root of storage and check that it \
+                 matches the saved one.",
             ))
         }
     }

--- a/crates/apps/src/lib/config/mod.rs
+++ b/crates/apps/src/lib/config/mod.rs
@@ -113,6 +113,8 @@ pub struct Shell {
     pub storage_read_past_height_limit: Option<u64>,
     /// Use the [`Ledger::db_dir()`] method to read the value.
     db_dir: PathBuf,
+    /// Validate that the merkelized data matches the save root.
+    pub validate_merkle_tree: bool,
     /// Use the [`Ledger::cometbft_dir()`] method to read the value.
     cometbft_dir: PathBuf,
     /// An optional action to take when a given blockheight is reached.
@@ -144,6 +146,7 @@ impl Ledger {
                 // Default corresponds to 1 hour of past blocks at 1 block/sec
                 storage_read_past_height_limit: Some(3600),
                 db_dir: DB_DIR.into(),
+                validate_merkle_tree: false,
                 cometbft_dir: COMETBFT_DIR.into(),
                 action_at_height: None,
                 tendermint_mode: mode,

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -436,6 +436,7 @@ where
             db_cache,
             chain_id.clone(),
             native_token,
+            config.shell.validate_merkle_tree,
             config.shell.storage_read_past_height_limit,
             is_merklized_storage_key,
         );

--- a/crates/apps/src/lib/node/ledger/storage/mod.rs
+++ b/crates/apps/src/lib/node/ledger/storage/mod.rs
@@ -89,6 +89,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             None,
             is_merklized_storage_key,
         );
@@ -141,6 +142,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             None,
             is_merklized_storage_key,
         );
@@ -201,6 +203,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             None,
             is_merklized_storage_key,
         );
@@ -223,6 +226,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             None,
             is_merklized_storage_key,
         );
@@ -267,6 +271,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             None,
             is_merklized_storage_key,
         );
@@ -339,6 +344,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             None,
             is_merklized_storage_key,
         );
@@ -434,6 +440,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             None,
             is_merklized_storage_key,
         );
@@ -558,6 +565,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             Some(5),
             is_merklized_storage_key,
         );
@@ -680,6 +688,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             None,
             is_merklized_storage_key,
         );
@@ -791,6 +800,7 @@ mod tests {
             None,
             ChainId::default(),
             address::testing::nam(),
+            false,
             None,
             merkle_tree_key_filter,
         );

--- a/crates/merkle_tree/src/eth_bridge_pool.rs
+++ b/crates/merkle_tree/src/eth_bridge_pool.rs
@@ -118,6 +118,12 @@ impl BridgePoolTree {
         self.root.clone()
     }
 
+    /// Recomputes the root and check if it matches the pre-computed root.
+    /// Used for checking if the underlying store is incorrect.
+    pub fn validate(&self) -> bool {
+        self.compute_root() == self.root
+    }
+
     /// Get a reference to the backing store
     pub fn store(&self) -> &BTreeMap<KeccakHash, BlockHeight> {
         &self.leaves
@@ -942,6 +948,17 @@ mod test_bridge_pool_tree {
             to_prove.sort_by_key(|t| t.keccak256());
             let proof = tree.get_membership_proof(to_prove).expect("Test failed");
             assert!(proof.verify(tree.root()));
+        }
+
+        /// Check that validate root passes when the tree is constructed correctly
+        #[test]
+        fn test_validate_root((transfers, _) in arb_transfers_and_subset()) {
+            let mut tree = BridgePoolTree::default();
+            for transfer in &transfers {
+                let key = Key::from(transfer);
+                let _ = tree.insert_key(&key, BlockHeight(1)).expect("Test failed");
+            }
+            assert!(tree.validate());
         }
     }
 }

--- a/crates/merkle_tree/src/lib.rs
+++ b/crates/merkle_tree/src/lib.rs
@@ -33,10 +33,17 @@ use thiserror::Error;
 pub trait SubTreeRead {
     /// Get the root of a subtree in raw bytes.
     fn root(&self) -> MerkleRoot;
+
+    /// Recompute the merkle root from the backing storage
+    /// and check it matches the saved root.
+    fn validate(&self) -> bool;
+
     /// Check if a key is present in the sub-tree
     fn subtree_has_key(&self, key: &Key) -> Result<bool>;
+
     /// Get the height at which the key is inserted
     fn subtree_get(&self, key: &Key) -> Result<Vec<u8>>;
+
     /// Get a membership proof for various key-value pairs
     fn subtree_membership_proof(
         &self,
@@ -101,6 +108,10 @@ pub enum Error {
     Ics23MultiLeaf,
     #[error("A Tendermint proof can only be constructed from an ICS23 proof.")]
     TendermintProof,
+    #[error(
+        "The merklized data did not produce that same hash as the stored root."
+    )]
+    RootValidationError,
 }
 
 /// Result for functions that may fail
@@ -507,6 +518,41 @@ impl<H: StorageHasher + Default> MerkleTree<H> {
         self.base.root().into()
     }
 
+    /// Recalculate the merkle tree root of storage and compare it against the
+    /// old value.
+    pub fn validate(&self) -> Result<()> {
+        if self.account.validate()
+            && self.ibc.validate()
+            && self.pos.validate()
+            && self.bridge_pool.validate()
+        {
+            let mut reconstructed = Smt::<H>::default();
+            reconstructed.update(
+                H::hash(StoreType::Account.to_string()).into(),
+                self.account.root().into(),
+            )?;
+            reconstructed.update(
+                H::hash(StoreType::PoS.to_string()).into(),
+                self.pos.root().into(),
+            )?;
+            reconstructed.update(
+                H::hash(StoreType::Ibc.to_string()).into(),
+                self.ibc.root().into(),
+            )?;
+            reconstructed.update(
+                H::hash(StoreType::BridgePool.to_string()).into(),
+                self.bridge_pool.root().into(),
+            )?;
+            if self.base.root() == reconstructed.root() {
+                Ok(())
+            } else {
+                Err(Error::RootValidationError)
+            }
+        } else {
+            Err(Error::RootValidationError)
+        }
+    }
+
     /// Get the root of a sub-tree
     pub fn sub_root(&self, store_type: &StoreType) -> MerkleRoot {
         self.tree(store_type).root()
@@ -817,6 +863,10 @@ impl<'a, H: StorageHasher + Default> SubTreeRead for &'a Smt<H> {
         Smt::<H>::root(self).into()
     }
 
+    fn validate(&self) -> bool {
+        Smt::<H>::validate(self)
+    }
+
     fn subtree_has_key(&self, key: &Key) -> Result<bool> {
         match self.get(&H::hash(key.to_string()).into()) {
             Ok(hash) => Ok(!hash.is_zero()),
@@ -882,6 +932,10 @@ impl<'a, H: StorageHasher + Default> SubTreeWrite for &'a mut Smt<H> {
 impl<'a, H: StorageHasher + Default> SubTreeRead for &'a Amt<H> {
     fn root(&self) -> MerkleRoot {
         Amt::<H>::root(self).into()
+    }
+
+    fn validate(&self) -> bool {
+        Amt::<H>::validate(self)
     }
 
     fn subtree_has_key(&self, key: &Key) -> Result<bool> {
@@ -953,6 +1007,10 @@ impl<'a> SubTreeRead for &'a BridgePoolTree {
         BridgePoolTree::root(self).into()
     }
 
+    fn validate(&self) -> bool {
+        BridgePoolTree::validate(self)
+    }
+
     fn subtree_has_key(&self, key: &Key) -> Result<bool> {
         self.contains_key(key)
             .map_err(|err| Error::MerkleTree(err.to_string()))
@@ -1001,6 +1059,7 @@ impl<'a> SubTreeWrite for &'a mut BridgePoolTree {
 
 #[cfg(test)]
 mod test {
+    use assert_matches::assert_matches;
     use ics23::HostFunctionsManager;
     use namada_core::hash::Sha256Hasher;
 
@@ -1116,6 +1175,40 @@ mod test {
             MerkleTree::<Sha256Hasher>::new(stores_read).unwrap();
         assert!(restored_tree.has_key(&ibc_key).unwrap());
         assert!(restored_tree.has_key(&pos_key).unwrap());
+    }
+
+    #[test]
+    fn test_validate_root() {
+        let mut tree = MerkleTree::<Sha256Hasher>::default();
+
+        let key_prefix: Key =
+            Address::Internal(InternalAddress::Ibc).to_db_key().into();
+        let ibc_key = key_prefix.push(&"test".to_string()).unwrap();
+        let key_prefix: Key =
+            Address::Internal(InternalAddress::PoS).to_db_key().into();
+        let pos_key = key_prefix.push(&"test".to_string()).unwrap();
+        let account_key_prefix: Key =
+            Address::Internal(InternalAddress::Masp).to_db_key().into();
+        let account_key = account_key_prefix.push(&"test".to_string()).unwrap();
+
+        let ibc_val = [1u8; 8].to_vec();
+        tree.update(&ibc_key, ibc_val.clone()).unwrap();
+        let pos_val = [2u8; 8].to_vec();
+        tree.update(&pos_key, pos_val).unwrap();
+        let account_val = [3u8; 16].to_vec();
+        tree.update(&account_key, account_val).unwrap();
+
+        assert!(tree.validate().is_ok());
+        let (store_type, sub_key) =
+            StoreType::sub_key(&ibc_key).expect("Test failed");
+        _ = tree
+            .tree_mut(&store_type)
+            .subtree_update(&sub_key, [2u8; 8].as_ref())
+            .expect("Test failed");
+        assert_matches!(
+            tree.validate().unwrap_err(),
+            Error::RootValidationError
+        );
     }
 
     #[test]

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -95,6 +95,7 @@ where
         cache: Option<&D::Cache>,
         chain_id: ChainId,
         native_token: Address,
+        validate_merkle_root: bool,
         storage_read_past_height_limit: Option<u64>,
         merkle_tree_key_filter: fn(&storage::Key) -> bool,
     ) -> Self {
@@ -111,7 +112,7 @@ where
             in_mem,
             merkle_tree_key_filter,
         });
-        state.load_last_state();
+        state.load_last_state(validate_merkle_root);
         state
     }
 
@@ -453,7 +454,7 @@ where
 
     /// Load the full state at the last committed height, if any. Returns the
     /// Merkle root hash and the height of the committed block.
-    fn load_last_state(&mut self) {
+    fn load_last_state(&mut self, validate: bool) {
         if let Some(BlockStateRead {
             merkle_tree_stores,
             hash,
@@ -496,6 +497,9 @@ where
             let tree = MerkleTree::new(merkle_tree_stores)
                 .or_else(|_| self.rebuild_full_merkle_tree(height))
                 .unwrap();
+            if validate {
+                tree.validate().map_err(Error::MerkleTreeError).unwrap();
+            }
 
             let in_mem = &mut self.0.in_mem;
             in_mem.block.tree = tree;

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2952,6 +2952,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5562,11 +5571,12 @@ dependencies = [
 [[package]]
 name = "sparse-merkle-tree"
 version = "0.3.1-pre"
-source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=515687fe7884cb365067ac86c66ac3613de176bb#515687fe7884cb365067ac86c66ac3613de176bb"
+source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=bab8cb96872db22cc9a139b2d3dfc4e00521d097#bab8cb96872db22cc9a139b2d3dfc4e00521d097"
 dependencies = [
  "borsh",
  "cfg-if 1.0.0",
  "ics23",
+ "itertools 0.12.1",
  "sha2 0.9.9",
 ]
 

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -2952,6 +2952,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,11 +5565,12 @@ dependencies = [
 [[package]]
 name = "sparse-merkle-tree"
 version = "0.3.1-pre"
-source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=515687fe7884cb365067ac86c66ac3613de176bb#515687fe7884cb365067ac86c66ac3613de176bb"
+source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=bab8cb96872db22cc9a139b2d3dfc4e00521d097#bab8cb96872db22cc9a139b2d3dfc4e00521d097"
 dependencies = [
  "borsh",
  "cfg-if 1.0.0",
  "ics23",
+ "itertools 0.12.1",
  "sha2 0.9.9",
 ]
 


### PR DESCRIPTION
## Describe your changes
Previously on startup, the merkle root persisted was trusted to agree with the persisted db. Now a flag can be see to remerkelize storage and check against the saved root.
## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
