### PR TITLE
Tiago/addr generator randomness

### DIFF
--- a/crates/core/src/address.rs
+++ b/crates/core/src/address.rs
@@ -652,17 +652,13 @@ pub fn gen_established_address(seed: impl AsRef<str>) -> Address {
     use rand::prelude::ThreadRng;
     use rand::{thread_rng, RngCore};
 
-    let mut key_gen = EstablishedAddressGen::new(seed);
+    EstablishedAddressGen::new(seed).generate_address({
+        let mut thread_local_rng: ThreadRng = thread_rng();
+        let mut buffer = [0u8; 32];
 
-    let mut rng: ThreadRng = thread_rng();
-    let mut rng_bytes = [0u8; 32];
-    rng.fill_bytes(&mut rng_bytes[..]);
-    let rng_source = rng_bytes
-        .iter()
-        .map(|b| format!("{:02X}", b))
-        .collect::<Vec<String>>()
-        .join("");
-    key_gen.generate_address(rng_source)
+        thread_local_rng.fill_bytes(&mut buffer[..]);
+        buffer
+    })
 }
 
 /// Generate a new established address. Unlike `gen_established_address`, this

--- a/crates/state/src/write_log.rs
+++ b/crates/state/src/write_log.rs
@@ -353,14 +353,14 @@ impl WriteLog {
         &mut self,
         storage_address_gen: &EstablishedAddressGen,
         vp_code_hash: Hash,
+        entropy_source: &[u8],
     ) -> (Address, u64) {
         // If we've previously generated a new account, we use the local copy of
         // the generator. Otherwise, we create a new copy from the storage
         let address_gen = self
             .address_gen
             .get_or_insert_with(|| storage_address_gen.clone());
-        let addr =
-            address_gen.generate_address("TODO more randomness".as_bytes());
+        let addr = address_gen.generate_address(entropy_source);
         let key = storage::Key::validity_predicate(&addr);
         let gas = (key.len() + vp_code_hash.len()) as u64
             * STORAGE_WRITE_GAS_PER_BYTE;
@@ -744,7 +744,7 @@ mod tests {
         // init
         let init_vp = "initialized".as_bytes().to_vec();
         let vp_hash = Hash::sha256(init_vp);
-        let (addr, gas) = write_log.init_account(&address_gen, vp_hash);
+        let (addr, gas) = write_log.init_account(&address_gen, vp_hash, &[]);
         let vp_key = storage::Key::validity_predicate(&addr);
         assert_eq!(
             gas,
@@ -777,7 +777,7 @@ mod tests {
 
         let init_vp = "initialized".as_bytes().to_vec();
         let vp_hash = Hash::sha256(init_vp);
-        let (addr, _) = write_log.init_account(&address_gen, vp_hash);
+        let (addr, _) = write_log.init_account(&address_gen, vp_hash, &[]);
         let vp_key = storage::Key::validity_predicate(&addr);
 
         // update should fail
@@ -796,7 +796,7 @@ mod tests {
 
         let init_vp = "initialized".as_bytes().to_vec();
         let vp_hash = Hash::sha256(init_vp);
-        let (addr, _) = write_log.init_account(&address_gen, vp_hash);
+        let (addr, _) = write_log.init_account(&address_gen, vp_hash, &[]);
         let vp_key = storage::Key::validity_predicate(&addr);
 
         // delete should fail
@@ -831,7 +831,7 @@ mod tests {
 
         // initialize an account
         let vp1 = Hash::sha256("vp1".as_bytes());
-        let (addr1, _) = state.write_log.init_account(&address_gen, vp1);
+        let (addr1, _) = state.write_log.init_account(&address_gen, vp1, &[]);
         state.write_log.commit_tx();
 
         // write values

--- a/crates/state/src/write_log.rs
+++ b/crates/state/src/write_log.rs
@@ -356,8 +356,9 @@ impl WriteLog {
     ) -> (Address, u64) {
         // If we've previously generated a new account, we use the local copy of
         // the generator. Otherwise, we create a new copy from the storage
-        let address_gen =
-            self.address_gen.get_or_insert(storage_address_gen.clone());
+        let address_gen = self
+            .address_gen
+            .get_or_insert_with(|| storage_address_gen.clone());
         let addr =
             address_gen.generate_address("TODO more randomness".as_bytes());
         let key = storage::Key::validity_predicate(&addr);

--- a/crates/tests/src/vm_host_env/ibc.rs
+++ b/crates/tests/src/vm_host_env/ibc.rs
@@ -239,11 +239,15 @@ pub fn init_storage() -> (Address, Address) {
     });
 
     // initialize a token
-    let token = tx_host_env::ctx().init_account(code_hash, &None).unwrap();
+    let token = tx_host_env::ctx()
+        .init_account(code_hash, &None, &[])
+        .unwrap();
     let denom_key = token::storage_key::denom_key(&token);
     let token_denom = token::Denomination(ANY_DENOMINATION);
     // initialize an account
-    let account = tx_host_env::ctx().init_account(code_hash, &None).unwrap();
+    let account = tx_host_env::ctx()
+        .init_account(code_hash, &None, &[])
+        .unwrap();
     let key = token::storage_key::balance_key(&token, &account);
     let init_bal = Amount::from_uint(100, token_denom).unwrap();
     tx_host_env::with(|env| {

--- a/crates/tests/src/vm_host_env/mod.rs
+++ b/crates/tests/src/vm_host_env/mod.rs
@@ -214,7 +214,7 @@ mod tests {
         tx_host_env::init();
 
         let code = vec![];
-        tx::ctx().init_account(code, &None).unwrap();
+        tx::ctx().init_account(code, &None, &[]).unwrap();
     }
 
     #[test]
@@ -229,7 +229,7 @@ mod tests {
             let key = Key::wasm_code(&code_hash);
             env.state.write_bytes(&key, &code).unwrap();
         });
-        tx::ctx().init_account(code_hash, &None).unwrap();
+        tx::ctx().init_account(code_hash, &None, &[]).unwrap();
     }
 
     /// Test that a tx updating validity predicate that is not in the allowlist
@@ -329,7 +329,7 @@ mod tests {
         });
 
         // Initializing a new account with the VP should fail
-        tx::ctx().init_account(vp_hash, &None).unwrap();
+        tx::ctx().init_account(vp_hash, &None, &[]).unwrap();
     }
 
     #[test]

--- a/crates/tests/src/vm_host_env/tx.rs
+++ b/crates/tests/src/vm_host_env/tx.rs
@@ -485,6 +485,8 @@ mod native_tx_host_env {
         code_hash_len: u64,
         code_tag_ptr: u64,
         code_tag_len: u64,
+        entropy_source_ptr: u64,
+        entropy_source_len: u64,
         result_ptr: u64
     ));
     native_host_fn!(tx_emit_ibc_event(event_ptr: u64, event_len: u64));

--- a/crates/tx_env/src/lib.rs
+++ b/crates/tx_env/src/lib.rs
@@ -38,6 +38,7 @@ pub trait TxEnv: StorageRead + StorageWrite {
         &mut self,
         code_hash: impl AsRef<[u8]>,
         code_tag: &Option<String>,
+        entropy_source: &[u8],
     ) -> Result<Address>;
 
     /// Update a validity predicate

--- a/crates/tx_prelude/src/lib.rs
+++ b/crates/tx_prelude/src/lib.rs
@@ -290,6 +290,7 @@ impl TxEnv for Ctx {
         &mut self,
         code_hash: impl AsRef<[u8]>,
         code_tag: &Option<String>,
+        entropy_source: &[u8],
     ) -> Result<Address, Error> {
         let code_hash = code_hash.as_ref();
         let code_tag = code_tag.serialize_to_vec();
@@ -300,6 +301,8 @@ impl TxEnv for Ctx {
                 code_hash.len() as _,
                 code_tag.as_ptr() as _,
                 code_tag.len() as _,
+                entropy_source.as_ptr() as _,
+                entropy_source.len() as _,
                 result.as_ptr() as _,
             )
         };

--- a/crates/vm_env/src/lib.rs
+++ b/crates/vm_env/src/lib.rs
@@ -76,6 +76,8 @@ pub mod tx {
             code_hash_len: u64,
             code_tag_ptr: u64,
             code_tag_len: u64,
+            entropy_source_ptr: u64,
+            entropy_source_len: u64,
             result_ptr: u64,
         );
 


### PR DESCRIPTION
## Describe your changes

Closes #7

Adds a transaction's code and data section hashes as additional sources of entropy, to compute an established account's address.

## Indicate on which release or other PRs this topic is based on

`v0.31.8`

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
