### PR TITLE
Fix typo in README.md (CometBFT instead of CombetBFT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To change the log level, set `NAMADA_LOG` environment variable to one of:
 * `debug`
 * `trace`
 
-The default is set to `info` for all the modules, expect for CombetBFT ABCI, which has a lot of `debug` logging.
+The default is set to `info` for all the modules, expect for CometBFT ABCI, which has a lot of `debug` logging.
 
 For more fine-grained logging levels settings, please refer to the [tracing subscriber docs](https://docs.rs/tracing-subscriber/0.2.18/tracing_subscriber/struct.EnvFilter.html#directives) for more information.
 


### PR DESCRIPTION
This commit addresses a minor typo in the README.md file, ensuring accurate and clear documentation. The fix contributes to the overall readability and understanding of the Namada project.

## Describe your changes

This commit addresses a minor typo in the README.md file, ensuring accurate and clear documentation. The fix contributes to the overall readability and understanding of the Namada project
## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [ ] Git history is in acceptable state
