### PR TITLE
sdk: add logic about TxSubmitError::LowerBondThanUnbond

### DIFF
--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -1637,6 +1637,13 @@ pub async fn build_unbond(
             amount.to_string_native(),
             bond_amount.to_string_native(),
         );
+        if !tx_args.force {
+            return Err(Error::from(TxSubmitError::LowerBondThanUnbond(
+                bond_source,
+                amount.to_string_native(),
+                bond_amount.to_string_native(),
+            )));
+        }
     }
 
     // Query the unbonds before submitting the tx


### PR DESCRIPTION
## Describe your changes
Closes #2810 

Reject and return `TxSubmitError::LowerBondThanUnbond` when the total bonds of the source is lower than the amount to be unbonded

## Indicate on which release or other PRs this topic is based on
main branch

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
