### PR TITLE
cli: Propagating errors from fallible `CliToSdk` conversions

### DIFF
--- a/.changelog/unreleased/improvements/2832-cli-fallible-conversions.md
+++ b/.changelog/unreleased/improvements/2832-cli-fallible-conversions.md
@@ -1,0 +1,2 @@
+- Refactor CliToSdk to propagate errors from fallible conversions
+  ([\#2832](https://github.com/anoma/namada/pull/2832))

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -3569,7 +3569,7 @@ pub mod args {
         {
             match self.to_sdk(ctx).map_err(Into::into) {
                 Ok(x) => x,
-                Err(e) => match e {}
+                Err(e) => match e {},
             }
         }
     }
@@ -3595,7 +3595,10 @@ pub mod args {
     impl CliToSdk<QueryResult<SdkTypes>> for QueryResult<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryResult<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryResult<SdkTypes>, Self::Error> {
             Ok(QueryResult::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 tx_hash: self.tx_hash,
@@ -3622,7 +3625,10 @@ pub mod args {
     impl CliToSdk<EthereumBridgePool<SdkTypes>> for EthereumBridgePool<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<EthereumBridgePool<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<EthereumBridgePool<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_chain_or_exit();
             Ok(EthereumBridgePool::<SdkTypes> {
@@ -3711,10 +3717,13 @@ pub mod args {
     impl CliToSdk<RecommendBatch<SdkTypes>> for RecommendBatch<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<RecommendBatch<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<RecommendBatch<SdkTypes>, Self::Error> {
             let query = self.query.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_chain_or_exit();
-            
+
             Ok(RecommendBatch::<SdkTypes> {
                 query,
                 max_gas: self.max_gas,
@@ -4120,7 +4129,10 @@ pub mod args {
     impl CliToSdk<TxCustom<SdkTypes>> for TxCustom<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxCustom<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxCustom<SdkTypes>, Self::Error> {
             Ok(TxCustom::<SdkTypes> {
                 tx: self.tx.to_sdk(ctx)?,
                 code_path: self.code_path,
@@ -4190,7 +4202,10 @@ pub mod args {
     impl CliToSdk<TxTransfer<SdkTypes>> for TxTransfer<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxTransfer<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -4241,7 +4256,10 @@ pub mod args {
     impl CliToSdk<TxIbcTransfer<SdkTypes>> for TxIbcTransfer<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxIbcTransfer<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxIbcTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -4322,7 +4340,10 @@ pub mod args {
     impl CliToSdk<TxInitAccount<SdkTypes>> for TxInitAccount<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxInitAccount<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxInitAccount<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -4380,7 +4401,10 @@ pub mod args {
     impl CliToSdk<TxBecomeValidator<SdkTypes>> for TxBecomeValidator<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxBecomeValidator<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxBecomeValidator<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -4503,7 +4527,10 @@ pub mod args {
     impl CliToSdk<TxInitValidator<SdkTypes>> for TxInitValidator<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxInitValidator<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxInitValidator<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -4655,7 +4682,10 @@ pub mod args {
     impl CliToSdk<TxUpdateAccount<SdkTypes>> for TxUpdateAccount<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxUpdateAccount<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxUpdateAccount<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -4718,7 +4748,10 @@ pub mod args {
     impl CliToSdk<Bond<SdkTypes>> for Bond<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<Bond<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<Bond<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_chain_or_exit();
 
@@ -4770,7 +4803,10 @@ pub mod args {
     impl CliToSdk<Unbond<SdkTypes>> for Unbond<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<Unbond<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<Unbond<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_chain_or_exit();
 
@@ -4873,7 +4909,10 @@ pub mod args {
     impl CliToSdk<ResignSteward<SdkTypes>> for ResignSteward<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<ResignSteward<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<ResignSteward<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
 
             Ok(ResignSteward::<SdkTypes> {
@@ -4905,7 +4944,10 @@ pub mod args {
     impl CliToSdk<Redelegate<SdkTypes>> for Redelegate<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<Redelegate<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<Redelegate<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_chain_or_exit();
 
@@ -4967,7 +5009,10 @@ pub mod args {
     impl CliToSdk<InitProposal<SdkTypes>> for InitProposal<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<InitProposal<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<InitProposal<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let _proposal_data = std::fs::read(self.proposal_data)?;
 
@@ -5058,11 +5103,13 @@ pub mod args {
     impl CliToSdk<VoteProposal<SdkTypes>> for VoteProposal<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<VoteProposal<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<VoteProposal<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let _proposal_data = self.proposal_data.map(|path| {
-                std::fs::read(path)
-                    .expect("Should be able to read the file.")
+                std::fs::read(path).expect("Should be able to read the file.")
             });
 
             Ok(VoteProposal::<SdkTypes> {
@@ -5135,7 +5182,10 @@ pub mod args {
     impl CliToSdk<RevealPk<SdkTypes>> for RevealPk<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<RevealPk<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<RevealPk<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -5163,7 +5213,10 @@ pub mod args {
     impl CliToSdk<QueryProposal<SdkTypes>> for QueryProposal<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryProposal<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryProposal<SdkTypes>, Self::Error> {
             Ok(QueryProposal::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 proposal_id: self.proposal_id,
@@ -5188,7 +5241,10 @@ pub mod args {
     impl CliToSdk<QueryProposalVotes<SdkTypes>> for QueryProposalVotes<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryProposalVotes<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryProposalVotes<SdkTypes>, Self::Error> {
             Ok(QueryProposalVotes::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 proposal_id: self.proposal_id,
@@ -5232,7 +5288,10 @@ pub mod args {
     impl CliToSdk<QueryProposalResult<SdkTypes>> for QueryProposalResult<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryProposalResult<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryProposalResult<SdkTypes>, Self::Error> {
             Ok(QueryProposalResult::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 proposal_id: self.proposal_id,
@@ -5291,7 +5350,7 @@ pub mod args {
         }
     }
 
-    impl CliToSdk<QueryProtocolParameters<SdkTypes>> 
+    impl CliToSdk<QueryProtocolParameters<SdkTypes>>
         for QueryProtocolParameters<CliTypes>
     {
         type Error = std::convert::Infallible;
@@ -5333,7 +5392,10 @@ pub mod args {
     impl CliToSdk<QueryPgf<SdkTypes>> for QueryPgf<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryPgf<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryPgf<SdkTypes>, Self::Error> {
             Ok(QueryPgf::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
             })
@@ -5343,7 +5405,10 @@ pub mod args {
     impl CliToSdk<Withdraw<SdkTypes>> for Withdraw<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<Withdraw<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<Withdraw<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_chain_or_exit();
 
@@ -5384,7 +5449,10 @@ pub mod args {
     impl CliToSdk<ClaimRewards<SdkTypes>> for ClaimRewards<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<ClaimRewards<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<ClaimRewards<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_chain_or_exit();
 
@@ -5424,7 +5492,10 @@ pub mod args {
     impl CliToSdk<QueryConversions<SdkTypes>> for QueryConversions<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryConversions<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryConversions<SdkTypes>, Self::Error> {
             Ok(QueryConversions::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 token: self.token.map(|x| ctx.borrow_chain_or_exit().get(&x)),
@@ -5463,7 +5534,10 @@ pub mod args {
     impl CliToSdk<QueryAccount<SdkTypes>> for QueryAccount<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryAccount<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryAccount<SdkTypes>, Self::Error> {
             Ok(QueryAccount::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 owner: ctx.borrow_chain_or_exit().get(&self.owner),
@@ -5491,7 +5565,10 @@ pub mod args {
     impl CliToSdk<QueryBalance<SdkTypes>> for QueryBalance<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryBalance<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryBalance<SdkTypes>, Self::Error> {
             let query = self.query.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -5541,7 +5618,10 @@ pub mod args {
     impl CliToSdk<QueryTransfers<SdkTypes>> for QueryTransfers<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryTransfers<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryTransfers<SdkTypes>, Self::Error> {
             let query = self.query.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -5579,7 +5659,10 @@ pub mod args {
     impl CliToSdk<QueryBonds<SdkTypes>> for QueryBonds<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryBonds<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryBonds<SdkTypes>, Self::Error> {
             let query = self.query.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_chain_or_exit();
 
@@ -5621,7 +5704,10 @@ pub mod args {
     impl CliToSdk<QueryBondedStake<SdkTypes>> for QueryBondedStake<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryBondedStake<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryBondedStake<SdkTypes>, Self::Error> {
             Ok(QueryBondedStake::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 validator: self
@@ -5659,7 +5745,10 @@ pub mod args {
     impl CliToSdk<QueryValidatorState<SdkTypes>> for QueryValidatorState<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryValidatorState<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryValidatorState<SdkTypes>, Self::Error> {
             Ok(QueryValidatorState::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 validator: ctx.borrow_chain_or_exit().get(&self.validator),
@@ -5699,7 +5788,10 @@ pub mod args {
     {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<CommissionRateChange<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<CommissionRateChange<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
 
             Ok(CommissionRateChange::<SdkTypes> {
@@ -5741,7 +5833,10 @@ pub mod args {
     impl CliToSdk<ConsensusKeyChange<SdkTypes>> for ConsensusKeyChange<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<ConsensusKeyChange<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<ConsensusKeyChange<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
@@ -5790,7 +5885,10 @@ pub mod args {
     impl CliToSdk<MetaDataChange<SdkTypes>> for MetaDataChange<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<MetaDataChange<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<MetaDataChange<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
 
             Ok(MetaDataChange::<SdkTypes> {
@@ -5869,7 +5967,10 @@ pub mod args {
     impl CliToSdk<TxUnjailValidator<SdkTypes>> for TxUnjailValidator<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxUnjailValidator<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxUnjailValidator<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
 
             Ok(TxUnjailValidator::<SdkTypes> {
@@ -5906,7 +6007,10 @@ pub mod args {
     {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxDeactivateValidator<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxDeactivateValidator<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
 
             Ok(TxDeactivateValidator::<SdkTypes> {
@@ -5943,7 +6047,10 @@ pub mod args {
     {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<TxReactivateValidator<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<TxReactivateValidator<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
 
             Ok(TxReactivateValidator::<SdkTypes> {
@@ -5978,7 +6085,10 @@ pub mod args {
     impl CliToSdk<SignTx<SdkTypes>> for SignTx<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<SignTx<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<SignTx<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let tx_data = std::fs::read(self.tx_data)?;
 
@@ -6059,7 +6169,10 @@ pub mod args {
     impl CliToSdk<ShieldedSync<SdkTypes>> for ShieldedSync<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<ShieldedSync<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<ShieldedSync<SdkTypes>, Self::Error> {
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
             Ok(ShieldedSync {
@@ -6086,7 +6199,10 @@ pub mod args {
     {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<GenIbcShieldedTransfer<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<GenIbcShieldedTransfer<SdkTypes>, Self::Error> {
             let query = self.query.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_chain_or_exit();
 
@@ -6146,7 +6262,10 @@ pub mod args {
     impl CliToSdk<QueryCommissionRate<SdkTypes>> for QueryCommissionRate<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryCommissionRate<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryCommissionRate<SdkTypes>, Self::Error> {
             Ok(QueryCommissionRate::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 validator: ctx.borrow_chain_or_exit().get(&self.validator),
@@ -6182,7 +6301,10 @@ pub mod args {
     impl CliToSdk<QueryMetaData<SdkTypes>> for QueryMetaData<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryMetaData<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryMetaData<SdkTypes>, Self::Error> {
             Ok(QueryMetaData::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 validator: ctx.borrow_chain_or_exit().get(&self.validator),
@@ -6209,7 +6331,10 @@ pub mod args {
     impl CliToSdk<QuerySlashes<SdkTypes>> for QuerySlashes<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QuerySlashes<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QuerySlashes<SdkTypes>, Self::Error> {
             Ok(QuerySlashes::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 validator: self
@@ -6238,7 +6363,10 @@ pub mod args {
     impl CliToSdk<QueryRewards<SdkTypes>> for QueryRewards<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryRewards<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryRewards<SdkTypes>, Self::Error> {
             Ok(QueryRewards::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 validator: ctx.borrow_chain_or_exit().get(&self.validator),
@@ -6292,7 +6420,10 @@ pub mod args {
     impl CliToSdk<QueryDelegations<SdkTypes>> for QueryDelegations<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryDelegations<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryDelegations<SdkTypes>, Self::Error> {
             Ok(QueryDelegations::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 owner: ctx.borrow_chain_or_exit().get(&self.owner),
@@ -6330,7 +6461,10 @@ pub mod args {
     impl CliToSdk<QueryFindValidator<SdkTypes>> for QueryFindValidator<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryFindValidator<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryFindValidator<SdkTypes>, Self::Error> {
             Ok(QueryFindValidator::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 tm_addr: self.tm_addr,
@@ -6344,7 +6478,10 @@ pub mod args {
     impl CliToSdk<QueryRawBytes<SdkTypes>> for QueryRawBytes<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<QueryRawBytes<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<QueryRawBytes<SdkTypes>, Self::Error> {
             Ok(QueryRawBytes::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
                 storage_key: self.storage_key,
@@ -6389,7 +6526,10 @@ pub mod args {
     impl CliToSdk<Tx<SdkTypes>> for Tx<CliTypes> {
         type Error = std::io::Error;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<Tx<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<Tx<SdkTypes>, Self::Error> {
             let ctx = ctx.borrow_mut_chain_or_exit();
 
             Ok(Tx::<SdkTypes> {
@@ -6416,12 +6556,19 @@ pub mod args {
                 signatures: self
                     .signatures
                     .iter()
-                    .map(|path| std::fs::read(path).map_err(|e| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
-                            format!("Error reading signature file: {}", e),
-                        )
-                    }).unwrap())
+                    .map(|path| {
+                        std::fs::read(path)
+                            .map_err(|e| {
+                                std::io::Error::new(
+                                    std::io::ErrorKind::InvalidInput,
+                                    format!(
+                                        "Error reading signature file: {}",
+                                        e
+                                    ),
+                                )
+                            })
+                            .unwrap()
+                    })
                     .collect(),
                 disposable_signing_key: self.disposable_signing_key,
                 tx_reveal_code_path: self.tx_reveal_code_path,
@@ -6610,7 +6757,10 @@ pub mod args {
     impl CliToSdk<Query<SdkTypes>> for Query<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<Query<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<Query<SdkTypes>, Self::Error> {
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
             Ok(Query::<SdkTypes> {
                 ledger_address: chain_ctx.get(&self.ledger_address),
@@ -6663,7 +6813,10 @@ pub mod args {
     impl CliToSdk<PayAddressGen<SdkTypes>> for PayAddressGen<CliTypes> {
         type Error = std::convert::Infallible;
 
-        fn to_sdk(self, ctx: &mut Context) -> Result<PayAddressGen<SdkTypes>, Self::Error> {
+        fn to_sdk(
+            self,
+            ctx: &mut Context,
+        ) -> Result<PayAddressGen<SdkTypes>, Self::Error> {
             use namada_sdk::wallet::Wallet;
 
             use crate::wallet::CliWalletUtils;

--- a/crates/apps/src/lib/cli/client.rs
+++ b/crates/apps/src/lib/cli/client.rs
@@ -35,7 +35,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         let dry_run =
                             args.tx.dry_run || args.tx.dry_run_wrapper;
@@ -61,7 +61,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_transfer(&namada, args).await?;
                     }
@@ -73,7 +73,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_ibc_transfer(&namada, args).await?;
                     }
@@ -85,7 +85,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_update_account(&namada, args).await?;
                     }
@@ -97,7 +97,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         let dry_run =
                             args.tx.dry_run || args.tx.dry_run_wrapper;
@@ -123,7 +123,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let cli::context::ChainContext {
                             wallet,
                             mut config,
@@ -148,7 +148,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let cli::context::ChainContext {
                             wallet,
                             mut config,
@@ -173,7 +173,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_init_proposal(&namada, args).await?;
                     }
@@ -185,7 +185,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_vote_proposal(&namada, args).await?;
                     }
@@ -197,7 +197,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_reveal_pk(&namada, args).await?;
                     }
@@ -209,7 +209,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_bond(&namada, args).await?;
                     }
@@ -221,7 +221,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_unbond(&namada, args).await?;
                     }
@@ -233,7 +233,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_withdraw(&namada, args).await?;
                     }
@@ -245,7 +245,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_claim_rewards(&namada, args).await?;
                     }
@@ -257,7 +257,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_redelegate(&namada, args).await?;
                     }
@@ -271,7 +271,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_validator_commission_change(&namada, args)
                             .await?;
@@ -284,7 +284,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let cli::context::ChainContext {
                             wallet,
                             mut config,
@@ -313,7 +313,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_validator_metadata_change(&namada, args)
                             .await?;
@@ -323,7 +323,7 @@ impl CliApi {
                             C::from_tendermint_address(&args.ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let chain_ctx = ctx.take_chain_or_exit();
                         let vks = chain_ctx
                             .wallet
@@ -362,7 +362,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_bridge_pool_tx(&namada, args).await?;
                     }
@@ -374,7 +374,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_unjail_validator(&namada, args).await?;
                     }
@@ -386,7 +386,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_deactivate_validator(&namada, args).await?;
                     }
@@ -398,7 +398,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_reactivate_validator(&namada, args).await?;
                     }
@@ -412,7 +412,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_update_steward_commission(&namada, args)
                             .await?;
@@ -425,7 +425,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_resign_steward(&namada, args).await?;
                     }
@@ -470,7 +470,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_and_print_validator_state(&namada, args)
                             .await;
@@ -483,7 +483,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_transfers(&namada, args).await;
                     }
@@ -495,7 +495,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_conversions(&namada, args).await;
                     }
@@ -529,7 +529,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_balance(&namada, args).await;
                     }
@@ -541,7 +541,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_bonds(&namada, args)
                             .await
@@ -555,7 +555,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_bonded_stake(&namada, args).await;
                     }
@@ -567,7 +567,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_and_print_commission_rate(&namada, args)
                             .await;
@@ -580,7 +580,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_and_print_metadata(&namada, args).await;
                     }
@@ -592,7 +592,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_slashes(&namada, args).await;
                     }
@@ -604,7 +604,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_and_print_rewards(&namada, args).await;
                     }
@@ -616,7 +616,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_delegations(&namada, args).await;
                     }
@@ -628,7 +628,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_find_validator(&namada, args).await;
                     }
@@ -640,7 +640,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_result(&namada, args).await;
                     }
@@ -652,7 +652,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_raw_bytes(&namada, args).await;
                     }
@@ -664,7 +664,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_proposal(&namada, args).await;
                     }
@@ -676,7 +676,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_proposal_result(&namada, args).await;
                     }
@@ -688,7 +688,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_proposal_votes(&namada, args).await;
                     }
@@ -702,7 +702,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_protocol_parameters(&namada, args).await;
                     }
@@ -714,7 +714,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_pgf(&namada, args).await;
                     }
@@ -726,7 +726,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_account(&namada, args).await;
                     }
@@ -738,7 +738,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::sign_tx(&namada, args).await?;
                     }
@@ -752,7 +752,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         tx::gen_ibc_shielded_transfer(&namada, args).await?;
                     }
@@ -797,7 +797,7 @@ impl CliApi {
                     let ledger_address = chain_ctx.get(&args.ledger_address);
                     let client = C::from_tendermint_address(&ledger_address);
                     client.wait_until_node_is_synced(&io).await?;
-                    let args = args.to_sdk(&mut ctx);
+                    let args = args.to_sdk(&mut ctx)?;
                     let namada = ctx.to_sdk(client, io);
                     rpc::epoch_sleep(&namada, args).await;
                 }

--- a/crates/apps/src/lib/cli/relayer.rs
+++ b/crates/apps/src/lib/cli/relayer.rs
@@ -31,7 +31,7 @@ impl CliApi {
                             C::from_tendermint_address(&ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx);
+                        let args = args.to_sdk(&mut ctx)?;
                         let namada = ctx.to_sdk(client, io);
                         bridge_pool::recommend_batch(&namada, args).await?;
                     }

--- a/crates/apps/src/lib/cli/wallet.rs
+++ b/crates/apps/src/lib/cli/wallet.rs
@@ -70,7 +70,7 @@ impl CliApi {
             cmds::NamadaWallet::PayAddrGen(cmds::WalletGenPaymentAddress(
                 args,
             )) => {
-                let args = args.to_sdk(&mut ctx);
+                let args = args.to_sdk(&mut ctx)?;
                 payment_address_gen(ctx, io, args)
             }
         }


### PR DESCRIPTION
## Describe your changes

This PR closes #1815. I've refactored the `CliToSdk` trait to propagate errors (such as I/O) from _fallible_ conversions between SDK and CLI types, this way we can avoid panics.

## Indicate on which release or other PRs this topic is based on
Based on `v0.31.8`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
