### PR TITLE
Update Dockerfile base image to use bullseye instead of bookworm

### DIFF
--- a/docker/namada/Dockerfile
+++ b/docker/namada/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.76-bullseye AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.76.0-bullseye AS chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/docker/namada/Dockerfile
+++ b/docker/namada/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.76.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.76-bullseye AS chef
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
## Describe your changes
The updated Dockerfile in #2687 implicitly uses Debian Bookworm instead of Bullseye, which causes the following issues:     
1. it doesn't have clang-tools-11
2. it is inconsistence with the base image used by namada-wasm Dockerfile which explicitly uses bullseye image 

## Indicate on which release or other PRs this topic is based on
Fixes https://github.com/anoma/namada/actions/runs/8192271541/job/22403401963

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
