### PR TITLE
Always use storage errors on native VPs

### DIFF
--- a/.changelog/unreleased/improvements/2852-vps-use-storage-err.md
+++ b/.changelog/unreleased/improvements/2852-vps-use-storage-err.md
@@ -1,0 +1,2 @@
+- Replace `eyre!()` errors with `namada_storage` errors.
+  ([\#2852](https://github.com/anoma/namada/pull/2852))

--- a/crates/ethereum_bridge/src/storage/parameters.rs
+++ b/crates/ethereum_bridge/src/storage/parameters.rs
@@ -1,7 +1,6 @@
 //! Parameters for configuring the Ethereum bridge
 use std::num::NonZeroU64;
 
-use eyre::{eyre, Result};
 use namada_core::borsh::{BorshDeserialize, BorshSerialize};
 use namada_core::ethereum_events::EthAddress;
 use namada_core::ethereum_structs;
@@ -11,7 +10,7 @@ use namada_macros::BorshDeserializer;
 #[cfg(feature = "migrations")]
 use namada_migrations::*;
 use namada_state::{DBIter, StorageHasher, WlState, DB};
-use namada_storage::{StorageRead, StorageWrite};
+use namada_storage::{Error, Result, StorageRead, StorageWrite};
 use serde::{Deserialize, Serialize};
 
 use super::whitelist;
@@ -332,17 +331,10 @@ where
     S: StorageRead,
 {
     let native_erc20 = bridge_storage::native_erc20_key();
-    match StorageRead::read(storage, &native_erc20) {
-        Ok(Some(eth_address)) => Ok(eth_address),
-        Ok(None) => {
-            Err(eyre!("The Ethereum bridge storage is not initialized"))
-        }
-        Err(e) => Err(eyre!(
-            "Failed to read storage when fetching the native ERC20 address \
-             with: {}",
-            e.to_string()
-        )),
-    }
+
+    storage.read(&native_erc20)?.ok_or_else(|| {
+        Error::SimpleMessage("The Ethereum bridge storage is not initialized")
+    })
 }
 
 /// Reads the value of `key` from `storage` and deserializes it, or panics
@@ -371,6 +363,7 @@ where
 #[cfg(test)]
 mod tests {
     use namada_state::testing::TestState;
+    use namada_storage::ResultExt;
 
     use super::*;
 
@@ -391,8 +384,9 @@ mod tests {
                 },
             },
         };
-        let serialized = toml::to_string(&config)?;
-        let deserialized: EthereumBridgeParams = toml::from_str(&serialized)?;
+        let serialized = toml::to_string(&config).into_storage_result()?;
+        let deserialized: EthereumBridgeParams =
+            toml::from_str(&serialized).into_storage_result()?;
 
         assert_eq!(config, deserialized);
         Ok(())

--- a/crates/namada/src/ledger/native_vp/ethereum_bridge/nut.rs
+++ b/crates/namada/src/ledger/native_vp/ethereum_bridge/nut.rs
@@ -2,14 +2,13 @@
 
 use std::collections::BTreeSet;
 
-use eyre::WrapErr;
 use namada_core::address::{Address, InternalAddress};
 use namada_core::storage::Key;
 use namada_state::StateRead;
 use namada_tx::Tx;
 use namada_vp_env::VpEnv;
 
-use crate::ledger::native_vp::{Ctx, NativeVp};
+use crate::ledger::native_vp::{self, Ctx, NativeVp};
 use crate::token::storage_key::is_any_token_balance_key;
 use crate::token::Amount;
 use crate::vm::WasmCacheAccess;
@@ -17,7 +16,7 @@ use crate::vm::WasmCacheAccess;
 /// Generic error that may be returned by the validity predicate
 #[derive(thiserror::Error, Debug)]
 #[error(transparent)]
-pub struct Error(#[from] eyre::Report);
+pub struct Error(#[from] native_vp::Error);
 
 /// Validity predicate for non-usable tokens.
 ///
@@ -72,13 +71,11 @@ where
             let pre: Amount = self
                 .ctx
                 .read_pre(changed_key)
-                .context("Reading pre amount failed")
                 .map_err(Error)?
                 .unwrap_or_default();
             let post: Amount = self
                 .ctx
                 .read_post(changed_key)
-                .context("Reading post amount failed")
                 .map_err(Error)?
                 .unwrap_or_default();
 

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     #[error("{0}")]
     SimpleMessage(&'static str),
     #[error("{0}")]
+    AllocMessage(String),
+    #[error("{0}")]
     Custom(CustomError),
     #[error("{0}: {1}")]
     CustomWithMessage(&'static str, CustomError),


### PR DESCRIPTION
## Describe your changes

Replace `eyre!()` errors with `namada_storage` errors. This change will be useful in a future PR, to allow easily downcasting to the error contained in a boxed `namada_storage` result.

## Indicate on which release or other PRs this topic is based on

`v0.32.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
