### PR TITLE
fix CVE-2022-23639 + CVE-2021-27378

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,12 +842,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,16 +1293,6 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
@@ -1333,17 +1323,6 @@ dependencies = [
  "crossbeam-utils 0.8.16",
  "memoffset 0.9.0",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -7174,7 +7153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94aecbdccbc4b557649b2d1b1a4bfc27ec85205e00fb8020fce044245a4c9e3f"
 dependencies = [
  "contracts",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel 0.5.8",
  "derive_more",
  "flex-error",
  "futures",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-23639
https://nvd.nist.gov/vuln/detail/CVE-2021-27378
https://nvd.nist.gov/vuln/detail/CVE-2021-29932

https://nvd.nist.gov/vuln/detail/CVE-2021-29932

======
```
cargo tree -p rand_core
error: There are multiple `rand_core` packages in your project, and the specification `rand_core` is ambiguous.
Please re-run this command with one of the following specifications:
  rand_core@0.5.1
  rand_core@0.6.4

====
cargo tree -p rand_core@0.5.1
rand_core v0.5.1
└── getrandom v0.1.16
    ├── cfg-if v1.0.0
    └── libc v0.2.150

=======

argo tree -p crossbeam-utils
error: There are multiple `crossbeam-utils` packages in your project, and the specification `crossbeam-utils` is ambiguous.
Please re-run this command with one of the following specifications:
  crossbeam-utils@0.7.2
  crossbeam-utils@0.8.16

cargo tree -p crossbeam-utils@0.7.2
crossbeam-utils v0.7.2
├── cfg-if v0.1.10
└── lazy_static v1.4.0
[build-dependencies]
└── autocfg v1.1.0

cargo tree -p crossbeam-channel
error: There are multiple `crossbeam-channel` packages in your project, and the specification `crossbeam-channel` is ambiguous.
Please re-run this command with one of the following specifications:
  crossbeam-channel@0.4.4
  crossbeam-channel@0.5.8
===
 cargo tree -p crossbeam-channel@0.4.4
crossbeam-channel v0.4.4
├── crossbeam-utils v0.7.2
│   ├── cfg-if v0.1.10
│   └── lazy_static v1.4.0
│   [build-dependencies]
│   └── autocfg v1.1.0
└── maybe-uninit v2.0.0


cargo tree -p cfg-if
error: There are multiple `cfg-if` packages in your project, and the specification `cfg-if` is ambiguous.
Please re-run this command with one of the following specifications:
  cfg-if@0.1.10
  cfg-if@1.0.0

===
```
This issue still open : 
https://rustsec.org/advisories/RUSTSEC-2021-0041.html no patch available yet