### PR TITLE
Improve query balance

### DIFF
--- a/crates/apps/src/lib/client/rpc.rs
+++ b/crates/apps/src/lib/client/rpc.rs
@@ -367,8 +367,6 @@ pub async fn query_balance(context: &impl Namada, args: args::QueryBalance) {
             query_pinned_balance(context, args.clone()).await;
             // Print shielded balance
             query_shielded_balance(context, args.clone()).await;
-            // Then print transparent balance
-            query_transparent_balance(context, args).await;
         }
     };
 }

--- a/crates/apps/src/lib/client/rpc.rs
+++ b/crates/apps/src/lib/client/rpc.rs
@@ -365,8 +365,6 @@ pub async fn query_balance(context: &impl Namada, args: args::QueryBalance) {
         None => {
             // Print pinned balance
             query_pinned_balance(context, args.clone()).await;
-            // Print shielded balance
-            query_shielded_balance(context, args.clone()).await;
         }
     };
 }


### PR DESCRIPTION
## Describe your changes

Upon reviewing our codebase, I've noticed that querying transparent balances might not always be necessary, and it could significantly slow down the overall process due to the large amount of data involved. Therefore, I suggest removing the section of code responsible for querying transparent balances entirely.

By removing the call to query_transparent_balance and query_shielded_balance, we can potentially improve the overall performance of our querying process, especially when dealing with large datasets. This optimization ensures that we only query the balances that are essential for our operations, thus reducing unnecessary processing time and resource consumption.

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
