### PR TITLE
only trigger VPs from a fst addr of a key segment

### DIFF
--- a/.changelog/unreleased/bug-fixes/2928-fst-addr-vps.md
+++ b/.changelog/unreleased/bug-fixes/2928-fst-addr-vps.md
@@ -1,0 +1,3 @@
+- Only use addresses from first storage key segments to
+  determine which VPs should be triggered by storage changes.
+  ([\#2928](https://github.com/anoma/namada/pull/2928))

--- a/crates/apps/src/lib/bench_utils.rs
+++ b/crates/apps/src/lib/bench_utils.rs
@@ -387,7 +387,8 @@ impl BenchShell {
         self.generate_ibc_tx(TX_IBC_WASM, msg)
     }
 
-    pub fn execute_tx(&mut self, tx: &Tx) {
+    /// Execute the tx and retur a set of verifiers inserted by the tx.
+    pub fn execute_tx(&mut self, tx: &Tx) -> BTreeSet<Address> {
         let gas_meter =
             RefCell::new(TxGasMeter::new_from_sub_limit(u64::MAX.into()));
         run::tx(
@@ -398,7 +399,7 @@ impl BenchShell {
             &mut self.inner.vp_wasm_cache,
             &mut self.inner.tx_wasm_cache,
         )
-        .unwrap();
+        .unwrap()
     }
 
     pub fn advance_epoch(&mut self) {

--- a/crates/benches/vps.rs
+++ b/crates/benches/vps.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::BTreeSet;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use namada::account::UpdateAccount;
@@ -136,11 +135,11 @@ fn vp_user(c: &mut Criterion) {
         "vp",
     ]) {
         let mut shell = BenchShell::default();
-        shell.execute_tx(signed_tx);
+        let verifiers_from_tx = shell.execute_tx(signed_tx);
         let (verifiers, keys_changed) = shell
             .state
             .write_log()
-            .verifiers_and_changed_keys(&BTreeSet::default());
+            .verifiers_and_changed_keys(&verifiers_from_tx);
 
         group.bench_function(bench_name, |b| {
             b.iter(|| {
@@ -284,11 +283,11 @@ fn vp_implicit(c: &mut Criterion) {
         }
 
         // Run the tx to validate
-        shell.execute_tx(tx);
+        let verifiers_from_tx = shell.execute_tx(tx);
         let (verifiers, keys_changed) = shell
             .state
             .write_log()
-            .verifiers_and_changed_keys(&BTreeSet::default());
+            .verifiers_and_changed_keys(&verifiers_from_tx);
 
         group.bench_function(bench_name, |b| {
             b.iter(|| {
@@ -436,11 +435,11 @@ fn vp_validator(c: &mut Criterion) {
     ]) {
         let mut shell = BenchShell::default();
 
-        shell.execute_tx(signed_tx);
+        let verifiers_from_tx = shell.execute_tx(signed_tx);
         let (verifiers, keys_changed) = shell
             .state
             .write_log()
-            .verifiers_and_changed_keys(&BTreeSet::default());
+            .verifiers_and_changed_keys(&verifiers_from_tx);
 
         group.bench_function(bench_name, |b| {
             b.iter(|| {

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -653,6 +653,14 @@ impl Key {
         self.iter_addresses().cloned().collect()
     }
 
+    /// Returns the address from the first key segment if it's an address.
+    pub fn fst_address(&self) -> Option<&Address> {
+        self.segments.first().and_then(|s| match s {
+            DbKeySeg::AddressSeg(addr) => Some(addr),
+            DbKeySeg::StringSeg(_) => None,
+        })
+    }
+
     /// Iterates over all addresses in the key segments
     pub fn iter_addresses<'k, 'this: 'k>(
         &'this self,

--- a/crates/tx_prelude/src/proof_of_stake.rs
+++ b/crates/tx_prelude/src/proof_of_stake.rs
@@ -26,6 +26,10 @@ impl Ctx {
         validator: &Address,
         amount: token::Amount,
     ) -> TxResult {
+        // The tx must be authorized by the source address
+        let verifier = source.as_ref().unwrap_or(&validator);
+        self.insert_verifier(verifier)?;
+
         let current_epoch = self.get_block_epoch()?;
         bond_tokens(self, source, validator, amount, current_epoch, None)
     }
@@ -39,6 +43,10 @@ impl Ctx {
         validator: &Address,
         amount: token::Amount,
     ) -> EnvResult<ResultSlashing> {
+        // The tx must be authorized by the source address
+        let verifier = source.as_ref().unwrap_or(&validator);
+        self.insert_verifier(verifier)?;
+
         let current_epoch = self.get_block_epoch()?;
         unbond_tokens(self, source, validator, amount, current_epoch, false)
     }
@@ -51,6 +59,10 @@ impl Ctx {
         source: Option<&Address>,
         validator: &Address,
     ) -> EnvResult<token::Amount> {
+        // The tx must be authorized by the source address
+        let verifier = source.as_ref().unwrap_or(&validator);
+        self.insert_verifier(verifier)?;
+
         let current_epoch = self.get_block_epoch()?;
         withdraw_tokens(self, source, validator, current_epoch)
     }
@@ -61,6 +73,9 @@ impl Ctx {
         validator: &Address,
         consensus_key: &common::PublicKey,
     ) -> TxResult {
+        // The tx must be authorized by the source address
+        self.insert_verifier(validator)?;
+
         let current_epoch = self.get_block_epoch()?;
         change_consensus_key(self, validator, consensus_key, current_epoch)
     }
@@ -71,12 +86,18 @@ impl Ctx {
         validator: &Address,
         rate: &Dec,
     ) -> TxResult {
+        // The tx must be authorized by the source address
+        self.insert_verifier(validator)?;
+
         let current_epoch = self.get_block_epoch()?;
         change_validator_commission_rate(self, validator, *rate, current_epoch)
     }
 
     /// Unjail a jailed validator and re-enter the validator sets.
     pub fn unjail_validator(&mut self, validator: &Address) -> TxResult {
+        // The tx must be authorized by the source address
+        self.insert_verifier(validator)?;
+
         let current_epoch = self.get_block_epoch()?;
         unjail_validator(self, validator, current_epoch)
     }
@@ -89,6 +110,9 @@ impl Ctx {
         dest_validator: &Address,
         amount: token::Amount,
     ) -> TxResult {
+        // The tx must be authorized by the source address
+        self.insert_verifier(owner)?;
+
         let current_epoch = self.get_block_epoch()?;
         redelegate_tokens(
             self,
@@ -106,6 +130,10 @@ impl Ctx {
         source: Option<&Address>,
         validator: &Address,
     ) -> EnvResult<token::Amount> {
+        // The tx must be authorized by the source address
+        let verifier = source.as_ref().unwrap_or(&validator);
+        self.insert_verifier(verifier)?;
+
         let current_epoch = self.get_block_epoch()?;
         claim_reward_tokens(self, source, validator, current_epoch)
     }
@@ -133,6 +161,9 @@ impl Ctx {
         let eth_cold_key = key::common::PublicKey::Secp256k1(eth_cold_key);
         let eth_hot_key = key::common::PublicKey::Secp256k1(eth_hot_key);
         let params = read_pos_params(self)?;
+
+        // The tx must be authorized by the source address
+        self.insert_verifier(&address)?;
 
         become_validator(
             self,
@@ -162,12 +193,18 @@ impl Ctx {
 
     /// Deactivate validator
     pub fn deactivate_validator(&mut self, validator: &Address) -> TxResult {
+        // The tx must be authorized by the source address
+        self.insert_verifier(validator)?;
+
         let current_epoch = self.get_block_epoch()?;
         deactivate_validator(self, validator, current_epoch)
     }
 
     /// Reactivate validator
     pub fn reactivate_validator(&mut self, validator: &Address) -> TxResult {
+        // The tx must be authorized by the source address
+        self.insert_verifier(validator)?;
+
         let current_epoch = self.get_block_epoch()?;
         reactivate_validator(self, validator, current_epoch)
     }
@@ -184,6 +221,9 @@ impl Ctx {
         avatar: Option<String>,
         commission_rate: Option<Dec>,
     ) -> TxResult {
+        // The tx must be authorized by the source address
+        self.insert_verifier(validator)?;
+
         let current_epoch = self.get_block_epoch()?;
         change_validator_metadata(
             self,

--- a/crates/tx_prelude/src/token.rs
+++ b/crates/tx_prelude/src/token.rs
@@ -4,6 +4,7 @@ use namada_proof_of_stake::token::storage_key::{
 };
 use namada_storage::{Error as StorageError, ResultExt};
 pub use namada_token::*;
+use namada_tx_env::TxEnv;
 
 use crate::{Ctx, StorageRead, StorageWrite, TxResult};
 
@@ -16,6 +17,9 @@ pub fn transfer(
     token: &Address,
     amount: DenominatedAmount,
 ) -> TxResult {
+    // The tx must be authorized by the source address
+    ctx.insert_verifier(src)?;
+
     let amount = denom_to_amount(amount, token, ctx)?;
     if amount != Amount::default() && src != dest {
         let src_key = balance_key(token, src);
@@ -41,6 +45,9 @@ pub fn undenominated_transfer(
     token: &Address,
     amount: Amount,
 ) -> TxResult {
+    // The tx must be authorized by the source address
+    ctx.insert_verifier(src)?;
+
     if amount != Amount::default() && src != dest {
         let src_key = balance_key(token, src);
         let dest_key = balance_key(token, dest);

--- a/wasm/wasm_source/src/tx_init_proposal.rs
+++ b/wasm/wasm_source/src/tx_init_proposal.rs
@@ -11,6 +11,9 @@ fn apply_tx(ctx: &mut Ctx, tx: Tx) -> TxResult {
     let tx_data = governance::InitProposalData::try_from_slice(&data[..])
         .wrap_err("failed to decode InitProposalData")?;
 
+    // The tx must be authorized by the author address
+    ctx.insert_verifier(&tx_data.author)?;
+
     // Get the content from the referred to section
     let content = tx
         .get_section(&tx_data.content)

--- a/wasm/wasm_source/src/tx_resign_steward.rs
+++ b/wasm/wasm_source/src/tx_resign_steward.rs
@@ -12,6 +12,9 @@ fn apply_tx(ctx: &mut Ctx, tx_data: Tx) -> TxResult {
     let steward_address = Address::try_from_slice(&data[..])
         .wrap_err("failed to decode an Address")?;
 
+    // The tx must be authorized by the source address
+    ctx.insert_verifier(&steward_address)?;
+
     pgf::remove_steward(ctx, &steward_address)?;
 
     Ok(())

--- a/wasm/wasm_source/src/tx_update_account.rs
+++ b/wasm/wasm_source/src/tx_update_account.rs
@@ -17,6 +17,9 @@ fn apply_tx(ctx: &mut Ctx, tx: Tx) -> TxResult {
     let owner = &tx_data.addr;
     debug_log!("update VP for: {:#?}", tx_data.addr);
 
+    // The tx must be authorized by the source address
+    ctx.insert_verifier(owner)?;
+
     if let Some(hash) = tx_data.vp_code_hash {
         let vp_code_sec = signed
             .get_section(&hash)

--- a/wasm/wasm_source/src/tx_update_steward_commission.rs
+++ b/wasm/wasm_source/src/tx_update_steward_commission.rs
@@ -13,6 +13,9 @@ fn apply_tx(ctx: &mut Ctx, tx_data: Tx) -> TxResult {
     let steward_commission = UpdateStewardCommission::try_from_slice(&data[..])
         .wrap_err("failed to decode an UpdateStewardCommission")?;
 
+    // The tx must be authorized by the source address
+    ctx.insert_verifier(&steward_commission.steward)?;
+
     pgf::update_steward_commission(ctx, steward_commission)?;
 
     Ok(())

--- a/wasm/wasm_source/src/tx_vote_proposal.rs
+++ b/wasm/wasm_source/src/tx_vote_proposal.rs
@@ -12,6 +12,9 @@ fn apply_tx(ctx: &mut Ctx, tx_data: Tx) -> TxResult {
     let tx_data = governance::VoteProposalData::try_from_slice(&data[..])
         .wrap_err("failed to decode VoteProposalData")?;
 
+    // The tx must be authorized by the source address
+    ctx.insert_verifier(&tx_data.voter)?;
+
     debug_log!("apply_tx called to vote a governance proposal");
 
     governance::vote_proposal(ctx, tx_data)


### PR DESCRIPTION
## Describe your changes

first step toward #2629 - the next step is to update VPs to enforce that `insert_verifier` has been called with an address that has to authorize the tx (#2934).

## Indicate on which release or other PRs this topic is based on

0.32.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
