### PR TITLE
Generate Tx Borsh schema

### DIFF
--- a/.changelog/unreleased/features/2931-generate-tx-schema.md
+++ b/.changelog/unreleased/features/2931-generate-tx-schema.md
@@ -1,0 +1,2 @@
+- Added a utility to generate Borsh schemas for external collaborators.
+  ([\#2931](https://github.com/anoma/namada/pull/2931))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=30492323d98b0531fd18b6285cd94afcaa4066d2#30492323d98b0531fd18b6285cd94afcaa4066d2"
+source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
 dependencies = [
  "borsh",
  "chacha20",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=30492323d98b0531fd18b6285cd94afcaa4066d2#30492323d98b0531fd18b6285cd94afcaa4066d2"
+source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
 dependencies = [
  "aes",
  "bip0039",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=30492323d98b0531fd18b6285cd94afcaa4066d2#30492323d98b0531fd18b6285cd94afcaa4066d2"
+source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,8 +116,8 @@ libc = "0.2.97"
 libloading = "0.7.2"
 linkme = "0.3.24"
 # branch = "murisi/namada-integration"
-masp_primitives = { git = "https://github.com/anoma/masp", rev = "30492323d98b0531fd18b6285cd94afcaa4066d2" }
-masp_proofs = { git = "https://github.com/anoma/masp", rev = "30492323d98b0531fd18b6285cd94afcaa4066d2", default-features = false, features = ["local-prover"] }
+masp_primitives = { git = "https://github.com/anoma/masp", rev = "6cbc8bd90a71cc280492c44bc3415162093daa76" }
+masp_proofs = { git = "https://github.com/anoma/masp", rev = "6cbc8bd90a71cc280492c44bc3415162093daa76", default-features = false, features = ["local-prover"] }
 num256 = "0.3.5"
 num_cpus = "1.13.0"
 num-derive = "0.3.3"

--- a/crates/apps/src/lib/bench_utils.rs
+++ b/crates/apps/src/lib/bench_utils.rs
@@ -72,7 +72,7 @@ use namada::ledger::queries::{
 use namada::state::StorageRead;
 use namada::tx::data::pos::Bond;
 use namada::tx::data::{TxResult, VpsResult};
-use namada::tx::{Code, Data, Section, Signature, Tx};
+use namada::tx::{Authorization, Code, Data, Section, Tx};
 use namada::vm::wasm::run;
 use namada::{proof_of_stake, tendermint};
 use namada_sdk::masp::{
@@ -319,7 +319,7 @@ impl BenchShell {
         }
 
         for signer in signers {
-            tx.add_section(Section::Signature(Signature::new(
+            tx.add_section(Section::Authorization(Authorization::new(
                 vec![tx.raw_header_hash()],
                 [(0, signer.clone())].into_iter().collect(),
                 None,
@@ -586,7 +586,7 @@ pub fn generate_foreign_key_tx(signer: &SecretKey) -> Tx {
         }
         .serialize_to_vec(),
     ));
-    tx.add_section(Section::Signature(Signature::new(
+    tx.add_section(Section::Authorization(Authorization::new(
         vec![tx.raw_header_hash()],
         [(0, signer.clone())].into_iter().collect(),
         None,

--- a/crates/apps/src/lib/client/tx.rs
+++ b/crates/apps/src/lib/client/tx.rs
@@ -133,7 +133,7 @@ pub async fn with_hardware_wallet<'a, U: WalletIo + Clone>(
         };
         // Expand out the signature before adding it to the
         // transaction
-        tx.add_section(Section::Signature(compressed.expand(&tx)));
+        tx.add_section(Section::Authorization(compressed.expand(&tx)));
     }
     // Sign the fee header if that is requested
     if parts.contains(&signing::Signable::FeeHeader) {
@@ -151,7 +151,7 @@ pub async fn with_hardware_wallet<'a, U: WalletIo + Clone>(
         };
         // Expand out the signature before adding it to the
         // transaction
-        tx.add_section(Section::Signature(compressed.expand(&tx)));
+        tx.add_section(Section::Authorization(compressed.expand(&tx)));
     }
     Ok(tx)
 }

--- a/crates/apps/src/lib/config/genesis/transactions.rs
+++ b/crates/apps/src/lib/config/genesis/transactions.rs
@@ -802,7 +802,7 @@ impl<T> Signed<T> {
             .sections
             .into_iter()
             .find_map(|sec| {
-                if let Section::Signature(signatures) = sec {
+                if let Section::Authorization(signatures) = sec {
                     if [raw_header_hash] == signatures.targets.as_slice() {
                         Some(signatures)
                     } else {

--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -780,7 +780,7 @@ mod test_finalize_block {
     use namada::tendermint::abci::types::{Misbehavior, MisbehaviorKind};
     use namada::token::{Amount, DenominatedAmount, NATIVE_MAX_DECIMAL_PLACES};
     use namada::tx::data::Fee;
-    use namada::tx::{Code, Data, Signature};
+    use namada::tx::{Authorization, Code, Data};
     use namada::vote_ext::ethereum_events;
     use namada_sdk::eth_bridge::MinimumConfirmations;
     use namada_sdk::governance::ProposalVote;
@@ -825,7 +825,7 @@ mod test_finalize_block {
         wrapper_tx.set_data(Data::new(
             "Encrypted transaction data".as_bytes().to_owned(),
         ));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, keypair.clone())].into_iter().collect(),
             None,
@@ -2779,12 +2779,12 @@ mod test_finalize_block {
             GAS_LIMIT_MULTIPLIER.into(),
             None,
         ))));
-        new_wrapper.add_section(Section::Signature(Signature::new(
+        new_wrapper.add_section(Section::Authorization(Authorization::new(
             new_wrapper.sechashes(),
             [(0, keypair_2)].into_iter().collect(),
             None,
         )));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -3068,7 +3068,7 @@ mod test_finalize_block {
         wrapper.set_data(Data::new(
             "Encrypted transaction data".as_bytes().to_owned(),
         ));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -3147,7 +3147,7 @@ mod test_finalize_block {
         wrapper.set_data(Data::new(
             "Encrypted transaction data".as_bytes().to_owned(),
         ));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair.clone())].into_iter().collect(),
             None,
@@ -3230,7 +3230,7 @@ mod test_finalize_block {
         wrapper.set_data(Data::new(
             "Enxrypted transaction data".as_bytes().to_owned(),
         ));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -2085,7 +2085,7 @@ mod shell_tests {
     use namada::token::read_denom;
     use namada::tx::data::protocol::{ProtocolTx, ProtocolTxType};
     use namada::tx::data::Fee;
-    use namada::tx::{Code, Data, Signature, Signed};
+    use namada::tx::{Authorization, Code, Data, Signed};
     use namada::vote_ext::{
         bridge_pool_roots, ethereum_events, ethereum_tx_data_variants,
     };
@@ -2375,7 +2375,7 @@ mod shell_tests {
             // invalid tx type, it doesn't match the
             // tx type declared in the header
             tx.set_data(Data::new(ext.serialize_to_vec()));
-            tx.add_section(Section::Signature(Signature::new(
+            tx.add_section(Section::Authorization(Authorization::new(
                 tx.sechashes(),
                 [(0, protocol_key)].into_iter().collect(),
                 None,
@@ -2452,11 +2452,13 @@ mod shell_tests {
             .set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         invalid_wrapper
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        invalid_wrapper.add_section(Section::Signature(Signature::new(
-            invalid_wrapper.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        invalid_wrapper.add_section(Section::Authorization(
+            Authorization::new(
+                invalid_wrapper.sechashes(),
+                [(0, keypair)].into_iter().collect(),
+                None,
+            ),
+        ));
 
         // we mount a malleability attack to try and remove the fee
         let mut new_wrapper =
@@ -2522,7 +2524,7 @@ mod shell_tests {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -2675,7 +2677,7 @@ mod shell_tests {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -2708,7 +2710,7 @@ mod shell_tests {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -2747,7 +2749,7 @@ mod shell_tests {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -2782,7 +2784,7 @@ mod shell_tests {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -2818,7 +2820,7 @@ mod shell_tests {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -2854,7 +2856,7 @@ mod shell_tests {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -2902,7 +2904,7 @@ mod shell_tests {
             wrapper
                 .set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
             wrapper.set_data(Data::new(vec![0; size as usize]));
-            wrapper.add_section(Section::Signature(Signature::new(
+            wrapper.add_section(Section::Authorization(Authorization::new(
                 wrapper.sechashes(),
                 [(0, keypair)].into_iter().collect(),
                 None,

--- a/crates/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/crates/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -440,7 +440,7 @@ mod test_prepare_proposal {
     use namada::state::collections::lazy_map::{NestedSubKey, SubKey};
     use namada::token::{read_denom, Amount, DenominatedAmount};
     use namada::tx::data::Fee;
-    use namada::tx::{Code, Data, Header, Section, Signature, Signed};
+    use namada::tx::{Authorization, Code, Data, Header, Section, Signed};
     use namada::vote_ext::{ethereum_events, ethereum_tx_data_variants};
     use namada::{replay_protection, token};
     use namada_sdk::storage::StorageWrite;
@@ -812,7 +812,7 @@ mod test_prepare_proposal {
             tx.set_data(Data::new(
                 format!("transaction data: {}", i).as_bytes().to_owned(),
             ));
-            tx.add_section(Section::Signature(Signature::new(
+            tx.add_section(Section::Authorization(Authorization::new(
                 tx.sechashes(),
                 [(0, keypair.clone())].into_iter().collect(),
                 None,
@@ -879,7 +879,7 @@ mod test_prepare_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -923,7 +923,7 @@ mod test_prepare_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -960,7 +960,7 @@ mod test_prepare_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1008,7 +1008,7 @@ mod test_prepare_proposal {
         let tx_data = Data::new("transaction data".as_bytes().to_owned());
         wrapper.set_data(tx_data);
         let mut new_wrapper = wrapper.clone();
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1024,7 +1024,7 @@ mod test_prepare_proposal {
             GAS_LIMIT_MULTIPLIER.into(),
             None,
         ))));
-        new_wrapper.add_section(Section::Signature(Signature::new(
+        new_wrapper.add_section(Section::Authorization(Authorization::new(
             new_wrapper.sechashes(),
             [(0, keypair_2)].into_iter().collect(),
             None,
@@ -1059,7 +1059,7 @@ mod test_prepare_proposal {
         wrapper_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper_tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1107,7 +1107,7 @@ mod test_prepare_proposal {
         wrapper_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper_tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1147,7 +1147,7 @@ mod test_prepare_proposal {
         wrapper_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper_tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1203,7 +1203,7 @@ mod test_prepare_proposal {
         wrapper_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper_tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -1251,7 +1251,7 @@ mod test_prepare_proposal {
         wrapper_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper_tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -1301,7 +1301,7 @@ mod test_prepare_proposal {
         wrapper_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper_tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -1341,7 +1341,7 @@ mod test_prepare_proposal {
         wrapper_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper_tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -1382,7 +1382,7 @@ mod test_prepare_proposal {
         wrapper_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper_tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -1423,7 +1423,7 @@ mod test_prepare_proposal {
         wrapper_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper_tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper_tx.add_section(Section::Signature(Signature::new(
+        wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()

--- a/crates/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/crates/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -660,7 +660,7 @@ mod test_process_proposal {
     use namada::state::StorageWrite;
     use namada::token::{read_denom, Amount, DenominatedAmount};
     use namada::tx::data::Fee;
-    use namada::tx::{Code, Data, Signature, Signed};
+    use namada::tx::{Authorization, Code, Data, Signed};
     use namada::vote_ext::{bridge_pool_roots, ethereum_events};
 
     use super::*;
@@ -958,7 +958,7 @@ mod test_process_proposal {
         outer_tx.header.chain_id = shell.chain_id.clone();
         outer_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         outer_tx.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             outer_tx.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1032,7 +1032,7 @@ mod test_process_proposal {
         outer_tx.header.chain_id = shell.chain_id.clone();
         outer_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         outer_tx.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             outer_tx.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1100,7 +1100,7 @@ mod test_process_proposal {
         outer_tx.header.chain_id = shell.chain_id.clone();
         outer_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         outer_tx.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             outer_tx.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1380,7 +1380,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1450,7 +1450,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1504,7 +1504,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1565,7 +1565,7 @@ mod test_process_proposal {
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
         let mut new_wrapper = wrapper.clone();
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1581,7 +1581,7 @@ mod test_process_proposal {
             GAS_LIMIT_MULTIPLIER.into(),
             None,
         ))));
-        new_wrapper.add_section(Section::Signature(Signature::new(
+        new_wrapper.add_section(Section::Authorization(Authorization::new(
             new_wrapper.sechashes(),
             [(0, keypair_2)].into_iter().collect(),
             None,
@@ -1621,7 +1621,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = wrong_chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1683,7 +1683,7 @@ mod test_process_proposal {
         wrapper.header.expiration = Some(DateTimeUtc::default());
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1726,7 +1726,7 @@ mod test_process_proposal {
         wrapper.header.expiration = Some(DateTimeUtc::default());
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1777,7 +1777,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1819,7 +1819,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1867,7 +1867,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -1910,7 +1910,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -1955,7 +1955,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -2000,7 +2000,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, crate::wallet::defaults::albert_keypair())]
                 .into_iter()
@@ -2046,7 +2046,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -2116,7 +2116,7 @@ mod test_process_proposal {
             wrapper
                 .set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
             wrapper.set_data(Data::new(vec![0; size as usize]));
-            wrapper.add_section(Section::Signature(Signature::new(
+            wrapper.add_section(Section::Authorization(Authorization::new(
                 wrapper.sechashes(),
                 [(0, keypair)].into_iter().collect(),
                 None,

--- a/crates/benches/host_env.rs
+++ b/crates/benches/host_env.rs
@@ -5,7 +5,7 @@ use namada::core::account::AccountPublicKeysMap;
 use namada::core::address;
 use namada::ledger::storage::DB;
 use namada::token::{Amount, Transfer};
-use namada::tx::Signature;
+use namada::tx::Authorization;
 use namada::vm::wasm::TxCache;
 use namada_apps::bench_utils::{
     BenchShell, TX_INIT_PROPOSAL_WASM, TX_REVEAL_PK_WASM, TX_TRANSFER_WASM,
@@ -39,7 +39,7 @@ fn tx_section_signature_validation(c: &mut Criterion) {
         defaults::albert_keypair().to_public()
     ]);
 
-    let multisig = Signature::new(
+    let multisig = Authorization::new(
         vec![section_hash],
         pkim.index_secret_keys(vec![defaults::albert_keypair()]),
         None,

--- a/crates/benches/process_wrapper.rs
+++ b/crates/benches/process_wrapper.rs
@@ -5,7 +5,7 @@ use namada::core::storage::BlockHeight;
 use namada::core::time::DateTimeUtc;
 use namada::token::{Amount, DenominatedAmount, Transfer};
 use namada::tx::data::{Fee, WrapperTx};
-use namada::tx::Signature;
+use namada::tx::Authorization;
 use namada_apps::bench_utils::{BenchShell, TX_TRANSFER_WASM};
 use namada_apps::node::ledger::shell::process_proposal::ValidationMeta;
 use namada_apps::wallet::defaults;
@@ -46,7 +46,7 @@ fn process_tx(c: &mut Criterion) {
             None,
         ),
     )));
-    tx.add_section(namada::tx::Section::Signature(Signature::new(
+    tx.add_section(namada::tx::Section::Authorization(Authorization::new(
         tx.sechashes(),
         [(0, defaults::albert_keypair())].into_iter().collect(),
         None,

--- a/crates/core/src/key/common.rs
+++ b/crates/core/src/key/common.rs
@@ -36,12 +36,15 @@ use crate::{impl_display_and_from_str_via_format, string_encoding};
     BorshDeserializer,
     BorshSchema,
 )]
-pub enum PublicKey {
+pub enum CommonPublicKey {
     /// Encapsulate Ed25519 public keys
     Ed25519(ed25519::PublicKey),
     /// Encapsulate Secp256k1 public keys
     Secp256k1(secp256k1::PublicKey),
 }
+
+/// Public key
+pub type PublicKey = CommonPublicKey;
 
 const ED25519_PK_PREFIX: &str = "ED25519_PK_PREFIX";
 const SECP256K1_PK_PREFIX: &str = "SECP256K1_PK_PREFIX";
@@ -311,12 +314,15 @@ impl FromStr for SecretKey {
     BorshDeserializer,
     BorshSchema,
 )]
-pub enum Signature {
+pub enum CommonSignature {
     /// Encapsulate Ed25519 signatures
     Ed25519(ed25519::Signature),
     /// Encapsulate Secp256k1 signatures
     Secp256k1(secp256k1::Signature),
 }
+
+/// Signature
+pub type Signature = CommonSignature;
 
 impl string_encoding::Format for Signature {
     type EncodedBytes<'a> = Vec<u8>;

--- a/crates/light_sdk/src/transaction/account.rs
+++ b/crates/light_sdk/src/transaction/account.rs
@@ -4,7 +4,7 @@ use namada_sdk::key::common;
 use namada_sdk::storage::Epoch;
 use namada_sdk::token::DenominatedAmount;
 use namada_sdk::tx::data::GasLimit;
-use namada_sdk::tx::{Signature, Tx, TxError};
+use namada_sdk::tx::{Authorization, Tx, TxError};
 
 use super::{attach_fee, attach_fee_signature, GlobalArgs};
 use crate::transaction;
@@ -90,7 +90,7 @@ impl InitAccount {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -162,7 +162,7 @@ impl RevealPk {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -246,7 +246,7 @@ impl UpdateAccount {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }

--- a/crates/light_sdk/src/transaction/bridge.rs
+++ b/crates/light_sdk/src/transaction/bridge.rs
@@ -5,7 +5,7 @@ use namada_sdk::key::common;
 use namada_sdk::storage::Epoch;
 use namada_sdk::token::DenominatedAmount;
 use namada_sdk::tx::data::GasLimit;
-use namada_sdk::tx::{Signature, Tx, TxError};
+use namada_sdk::tx::{Authorization, Tx, TxError};
 
 use super::{attach_fee, attach_fee_signature, GlobalArgs};
 use crate::transaction;
@@ -85,7 +85,7 @@ impl BridgeTransfer {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }

--- a/crates/light_sdk/src/transaction/governance.rs
+++ b/crates/light_sdk/src/transaction/governance.rs
@@ -5,7 +5,7 @@ use namada_sdk::key::common;
 use namada_sdk::storage::Epoch;
 use namada_sdk::token::DenominatedAmount;
 use namada_sdk::tx::data::GasLimit;
-use namada_sdk::tx::{Signature, Tx, TxError};
+use namada_sdk::tx::{Authorization, Tx, TxError};
 
 use super::{attach_fee, attach_fee_signature, GlobalArgs};
 use crate::transaction;
@@ -178,7 +178,7 @@ impl VoteProposal {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }

--- a/crates/light_sdk/src/transaction/ibc.rs
+++ b/crates/light_sdk/src/transaction/ibc.rs
@@ -9,7 +9,7 @@ use namada_sdk::storage::Epoch;
 use namada_sdk::time::DateTimeUtc;
 use namada_sdk::token::DenominatedAmount;
 use namada_sdk::tx::data::GasLimit;
-use namada_sdk::tx::{Signature, Tx, TxError};
+use namada_sdk::tx::{Authorization, Tx, TxError};
 
 use super::{attach_fee, attach_fee_signature, GlobalArgs};
 use crate::transaction;
@@ -94,7 +94,7 @@ impl IbcTransfer {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }

--- a/crates/light_sdk/src/transaction/mod.rs
+++ b/crates/light_sdk/src/transaction/mod.rs
@@ -10,7 +10,7 @@ use namada_sdk::storage::Epoch;
 use namada_sdk::time::DateTimeUtc;
 use namada_sdk::token::DenominatedAmount;
 use namada_sdk::tx::data::{Fee, GasLimit};
-use namada_sdk::tx::{Section, Signature, Signer, Tx};
+use namada_sdk::tx::{Authorization, Section, Signer, Tx};
 
 pub mod account;
 pub mod bridge;
@@ -53,7 +53,7 @@ pub(in crate::transaction) fn get_sign_bytes(tx: &Tx) -> Vec<Hash> {
 pub(in crate::transaction) fn get_wrapper_sign_bytes(tx: &Tx) -> Hash {
     let targets = tx.sechashes();
     // Commit to the given targets
-    let partial = Signature {
+    let partial = Authorization {
         targets,
         signer: Signer::PubKeys(vec![]),
         signatures: BTreeMap::new(),
@@ -67,7 +67,7 @@ pub(in crate::transaction) fn attach_raw_signatures(
     signature: common::Signature,
 ) -> Tx {
     tx.protocol_filter();
-    tx.add_section(Section::Signature(Signature {
+    tx.add_section(Section::Authorization(Authorization {
         targets: vec![tx.raw_header_hash()],
         signer: Signer::PubKeys(vec![signer]),
         signatures: [(0, signature)].into_iter().collect(),
@@ -102,7 +102,7 @@ pub(in crate::transaction) fn attach_fee_signature(
     signature: common::Signature,
 ) -> Tx {
     tx.protocol_filter();
-    tx.add_section(Section::Signature(Signature {
+    tx.add_section(Section::Authorization(Authorization {
         targets: tx.sechashes(),
         signer: Signer::PubKeys(vec![signer]),
         signatures: [(0, signature)].into_iter().collect(),

--- a/crates/light_sdk/src/transaction/pgf.rs
+++ b/crates/light_sdk/src/transaction/pgf.rs
@@ -7,7 +7,7 @@ use namada_sdk::key::common;
 use namada_sdk::storage::Epoch;
 use namada_sdk::token::DenominatedAmount;
 use namada_sdk::tx::data::GasLimit;
-use namada_sdk::tx::{Signature, Tx, TxError};
+use namada_sdk::tx::{Authorization, Tx, TxError};
 
 use super::{attach_fee, attach_fee_signature, GlobalArgs};
 use crate::transaction;
@@ -81,7 +81,7 @@ impl ResignSteward {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -163,7 +163,7 @@ impl UpdateStewardCommission {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }

--- a/crates/light_sdk/src/transaction/pos.rs
+++ b/crates/light_sdk/src/transaction/pos.rs
@@ -7,7 +7,7 @@ use namada_sdk::token;
 use namada_sdk::token::{Amount, DenominatedAmount};
 use namada_sdk::tx::data::pos::Redelegation;
 use namada_sdk::tx::data::GasLimit;
-use namada_sdk::tx::{Signature, Tx, TxError};
+use namada_sdk::tx::{Authorization, Tx, TxError};
 
 use super::{attach_fee, attach_fee_signature, GlobalArgs};
 use crate::transaction;
@@ -76,7 +76,7 @@ impl Bond {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -132,7 +132,7 @@ impl Unbond {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -207,7 +207,7 @@ impl BecomeValidator {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -252,7 +252,7 @@ impl UnjailValidator {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -297,7 +297,7 @@ impl DeactivateValidator {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -368,7 +368,7 @@ impl ReactivateValidator {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -446,7 +446,7 @@ impl ClaimRewards {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -537,7 +537,7 @@ impl ChangeMetaData {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -617,7 +617,7 @@ impl ChangeConsensusKey {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -693,7 +693,7 @@ impl ChangeCommission {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -771,7 +771,7 @@ impl Withdraw {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }
@@ -855,7 +855,7 @@ impl Redelegate {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }

--- a/crates/light_sdk/src/transaction/transfer.rs
+++ b/crates/light_sdk/src/transaction/transfer.rs
@@ -5,7 +5,7 @@ use namada_sdk::key::common;
 use namada_sdk::storage::Epoch;
 use namada_sdk::token::DenominatedAmount;
 use namada_sdk::tx::data::GasLimit;
-use namada_sdk::tx::{Signature, Tx, TxError};
+use namada_sdk::tx::{Authorization, Tx, TxError};
 
 use super::{attach_fee, attach_fee_signature, GlobalArgs};
 use crate::transaction;
@@ -96,7 +96,7 @@ impl Transfer {
     }
 
     /// Validate this wrapper transaction
-    pub fn validate_tx(&self) -> Result<Option<&Signature>, TxError> {
+    pub fn validate_tx(&self) -> Result<Option<&Authorization>, TxError> {
         self.0.validate_tx()
     }
 }

--- a/crates/namada/src/ledger/native_vp/ibc/mod.rs
+++ b/crates/namada/src/ledger/native_vp/ibc/mod.rs
@@ -319,7 +319,7 @@ mod tests {
     use namada_state::testing::TestState;
     use namada_state::StorageRead;
     use namada_tx::data::TxType;
-    use namada_tx::{Code, Data, Section, Signature};
+    use namada_tx::{Authorization, Code, Data, Section};
     use prost::Message;
     use sha2::Digest;
 
@@ -720,7 +720,7 @@ mod tests {
         outer_tx.header.chain_id = state.in_mem().chain_id.clone();
         outer_tx.set_code(Code::new(tx_code, None));
         outer_tx.set_data(Data::new(tx_data));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             vec![outer_tx.header_hash()],
             [(0, keypair_1())].into_iter().collect(),
             None,
@@ -1031,7 +1031,7 @@ mod tests {
         outer_tx.header.chain_id = state.in_mem().chain_id.clone();
         outer_tx.set_code(Code::new(tx_code, None));
         outer_tx.set_data(Data::new(tx_data));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             vec![outer_tx.header_hash()],
             [(0, keypair_1())].into_iter().collect(),
             None,
@@ -1363,7 +1363,7 @@ mod tests {
         outer_tx.header.chain_id = state.in_mem().chain_id.clone();
         outer_tx.set_code(Code::new(tx_code, None));
         outer_tx.set_data(Data::new(tx_data));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             vec![outer_tx.header_hash()],
             [(0, keypair_1())].into_iter().collect(),
             None,
@@ -1461,7 +1461,7 @@ mod tests {
         outer_tx.header.chain_id = state.in_mem().chain_id.clone();
         outer_tx.set_code(Code::new(tx_code, None));
         outer_tx.set_data(Data::new(tx_data));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             vec![outer_tx.header_hash()],
             [(0, keypair_1())].into_iter().collect(),
             None,
@@ -1587,7 +1587,7 @@ mod tests {
         outer_tx.header.chain_id = state.in_mem().chain_id.clone();
         outer_tx.set_code(Code::new(tx_code, None));
         outer_tx.set_data(Data::new(tx_data));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             vec![outer_tx.header_hash()],
             [(0, keypair_1())].into_iter().collect(),
             None,
@@ -1712,7 +1712,7 @@ mod tests {
         outer_tx.header.chain_id = state.in_mem().chain_id.clone();
         outer_tx.set_code(Code::new(tx_code, None));
         outer_tx.set_data(Data::new(tx_data));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             vec![outer_tx.header_hash()],
             [(0, keypair_1())].into_iter().collect(),
             None,
@@ -1822,7 +1822,7 @@ mod tests {
         outer_tx.header.chain_id = state.in_mem().chain_id.clone();
         outer_tx.set_code(Code::new(tx_code, None));
         outer_tx.set_data(Data::new(tx_data));
-        outer_tx.add_section(Section::Signature(Signature::new(
+        outer_tx.add_section(Section::Authorization(Authorization::new(
             vec![outer_tx.header_hash()],
             [(0, keypair_1())].into_iter().collect(),
             None,

--- a/crates/namada/src/ledger/native_vp/multitoken.rs
+++ b/crates/namada/src/ledger/native_vp/multitoken.rs
@@ -219,7 +219,7 @@ mod tests {
     use namada_gas::TxGasMeter;
     use namada_state::testing::TestState;
     use namada_tx::data::TxType;
-    use namada_tx::{Code, Data, Section, Signature};
+    use namada_tx::{Authorization, Code, Data, Section};
 
     use super::*;
     use crate::core::address::testing::{
@@ -241,7 +241,7 @@ mod tests {
         tx.header.chain_id = state.in_mem().chain_id.clone();
         tx.set_code(Code::new(tx_code, None));
         tx.set_data(Data::new(tx_data));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             tx.sechashes(),
             [(0, keypair_1())].into_iter().collect(),
             None,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -811,7 +811,7 @@ pub mod testing {
         arb_withdraw,
     };
     use crate::tx::{
-        Code, Commitment, Header, MaspBuilder, Section, Signature,
+        Authorization, Code, Commitment, Header, MaspBuilder, Section,
     };
 
     #[derive(Debug, Clone)]
@@ -1505,16 +1505,16 @@ pub mod testing {
                 1..3,
             ),
             signer in option::of(arb_non_internal_address()),
-        ) -> Signature {
+        ) -> Authorization {
             if signer.is_some() {
-                Signature::new(targets, secret_keys, signer)
+                Authorization::new(targets, secret_keys, signer)
             } else {
                 let secret_keys = secret_keys
                     .into_values()
                     .enumerate()
                     .map(|(k, v)| (k as u8, v))
                     .collect();
-                Signature::new(targets, secret_keys, signer)
+                Authorization::new(targets, secret_keys, signer)
             }
         }
     }
@@ -1527,7 +1527,7 @@ pub mod testing {
         ) -> (Tx, TxData) {
             for sig in sigs {
                 // Add all the generated signature sections
-                tx.0.add_section(Section::Signature(sig));
+                tx.0.add_section(Section::Authorization(sig));
             }
             (tx.0, tx.1)
         }

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -50,7 +50,7 @@ use namada_token::storage_key::balance_key;
 use namada_token::DenominatedAmount;
 use namada_tx::data::pgf::UpdateStewardCommission;
 use namada_tx::data::{pos, ResultCode, TxResult};
-pub use namada_tx::{Signature, *};
+pub use namada_tx::{Authorization, *};
 
 use crate::args::{self, InputAmount};
 use crate::control_flow::time;

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -353,7 +353,7 @@ mod test_process_tx {
     use namada_core::token::{Amount, DenominatedAmount};
 
     use super::*;
-    use crate::{Code, Data, Section, Signature, Tx, TxError};
+    use crate::{Authorization, Code, Data, Section, Tx, TxError};
 
     fn gen_keypair() -> common::SecretKey {
         use rand::prelude::ThreadRng;
@@ -414,7 +414,7 @@ mod test_process_tx {
         let data_sec = tx
             .set_data(Data::new("transaction data".as_bytes().to_owned()))
             .clone();
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             vec![tx.raw_header_hash()],
             [(0, gen_keypair())].into_iter().collect(),
             None,
@@ -450,7 +450,7 @@ mod test_process_tx {
         ))));
         tx.set_code(Code::new("wasm code".as_bytes().to_owned(), None));
         tx.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             tx.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -513,7 +513,7 @@ fn test_process_tx_decrypted_unsigned() {
 fn test_process_tx_decrypted_signed() {
     use namada_core::key::*;
 
-    use crate::{Code, Data, Section, Signature, Tx};
+    use crate::{Authorization, Code, Data, Section, Tx};
 
     fn gen_keypair() -> common::SecretKey {
         use rand::prelude::ThreadRng;
@@ -529,7 +529,7 @@ fn test_process_tx_decrypted_signed() {
     // Invalid signed data
     let ed_sig =
         ed25519::Signature::try_from_slice([0u8; 64].as_ref()).unwrap();
-    let mut sig_sec = Signature::new(
+    let mut sig_sec = Authorization::new(
         vec![decrypted.header_hash()],
         [(0, gen_keypair())].into_iter().collect(),
         None,
@@ -537,7 +537,7 @@ fn test_process_tx_decrypted_signed() {
     sig_sec
         .signatures
         .insert(0, common::Signature::try_from_sig(&ed_sig).unwrap());
-    decrypted.add_section(Section::Signature(sig_sec));
+    decrypted.add_section(Section::Authorization(sig_sec));
     // create the tx with signed decrypted data
     let code_sec = decrypted
         .set_code(Code::new("transaction data".as_bytes().to_owned(), None))

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -11,9 +11,9 @@ use namada_core::event::{Event, EventLevel, EventType};
 pub use namada_core::key::SignableEthMessage;
 pub use namada_core::sign::SignatureIndex;
 pub use types::{
-    standalone_signature, verify_standalone_sig, Code, Commitment,
-    CompressedSignature, Data, DecodeError, Header, MaspBuilder, Memo, Section,
-    Signature, Signed, Signer, Tx, TxError, VerifySigError,
+    standalone_signature, verify_standalone_sig, Authorization, Code,
+    Commitment, CompressedSignature, Data, DecodeError, Header, MaspBuilder,
+    Memo, Section, Signed, Signer, Tx, TxError, VerifySigError,
 };
 
 /// Creates a new event with the hash and height of the transaction

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -389,7 +389,7 @@ pub enum Signer {
     Serialize,
     Deserialize,
 )]
-pub struct Signature {
+pub struct Authorization {
     /// The hash of the section being signed
     pub targets: Vec<namada_core::hash::Hash>,
     /// The public keys against which the signatures should be verified
@@ -398,7 +398,7 @@ pub struct Signature {
     pub signatures: BTreeMap<u8, common::Signature>,
 }
 
-impl Signature {
+impl Authorization {
     /// Sign the given section hash with the given key and return a section
     pub fn new(
         targets: Vec<namada_core::hash::Hash>,
@@ -548,7 +548,7 @@ impl CompressedSignature {
     /// Decompress this signature object with respect to the given transaction
     /// by looking up the necessary section hashes. Used by constrained hardware
     /// wallets.
-    pub fn expand(self, tx: &Tx) -> Signature {
+    pub fn expand(self, tx: &Tx) -> Authorization {
         let mut targets = Vec::new();
         for idx in self.targets {
             if idx == 0 {
@@ -561,7 +561,7 @@ impl CompressedSignature {
                 targets.push(tx.sections[idx as usize - 1].get_hash());
             }
         }
-        Signature {
+        Authorization {
             targets,
             signer: self.signer,
             signatures: self.signatures,
@@ -734,7 +734,7 @@ pub enum Section {
     /// Transaction code. Sending to hardware wallets optional
     Code(Code),
     /// A transaction header/protocol signature
-    Signature(Signature),
+    Authorization(Authorization),
     /// Ciphertext obtained by encrypting arbitrary transaction sections
     Ciphertext(Ciphertext),
     /// Embedded MASP transaction section
@@ -762,7 +762,7 @@ impl Section {
             Self::Data(data) => data.hash(hasher),
             Self::ExtraData(extra) => extra.hash(hasher),
             Self::Code(code) => code.hash(hasher),
-            Self::Signature(signature) => signature.hash(hasher),
+            Self::Authorization(signature) => signature.hash(hasher),
             Self::Ciphertext(ct) => ct.hash(hasher),
             Self::MaspBuilder(mb) => mb.hash(hasher),
             Self::MaspTx(tx) => {
@@ -826,8 +826,8 @@ impl Section {
     }
 
     /// Extract the signature from this section if possible
-    pub fn signature(&self) -> Option<Signature> {
-        if let Self::Signature(data) = self {
+    pub fn signature(&self) -> Option<Authorization> {
+        if let Self::Authorization(data) = self {
             Some(data.clone())
         } else {
             None
@@ -1204,7 +1204,7 @@ impl Tx {
         threshold: u8,
         max_signatures: Option<u8>,
         mut consume_verify_sig_gas: F,
-    ) -> std::result::Result<Vec<&Signature>, VerifySigError>
+    ) -> std::result::Result<Vec<&Authorization>, VerifySigError>
     where
         F: FnMut() -> std::result::Result<(), namada_gas::Error>,
     {
@@ -1215,7 +1215,7 @@ impl Tx {
         let mut witnesses = Vec::new();
 
         for section in &self.sections {
-            if let Section::Signature(signatures) = section {
+            if let Section::Authorization(signatures) = section {
                 // Check that the hashes being checked are a subset of those in
                 // this section. Also ensure that all the sections the signature
                 // signs over are present.
@@ -1272,7 +1272,7 @@ impl Tx {
         &self,
         public_key: &common::PublicKey,
         hashes: &[namada_core::hash::Hash],
-    ) -> Result<&Signature, VerifySigError> {
+    ) -> Result<&Authorization, VerifySigError> {
         self.verify_signatures(
             hashes,
             AccountPublicKeysMap::from_iter([public_key.clone()]),
@@ -1293,7 +1293,7 @@ impl Tx {
     ) -> Vec<SignatureIndex> {
         let targets = vec![self.raw_header_hash()];
         let mut signatures = Vec::new();
-        let section = Signature::new(
+        let section = Authorization::new(
             targets,
             public_keys_index_map.index_secret_keys(secret_keys.to_vec()),
             signer,
@@ -1339,7 +1339,7 @@ impl Tx {
     /// 2. The signature is valid
     pub fn validate_tx(
         &self,
-    ) -> std::result::Result<Option<&Signature>, TxError> {
+    ) -> std::result::Result<Option<&Authorization>, TxError> {
         match &self.header.tx_type {
             // verify signature and extract signed data
             TxType::Wrapper(wrapper) => self
@@ -1512,7 +1512,7 @@ impl Tx {
     /// Add fee payer keypair to the tx builder
     pub fn sign_wrapper(&mut self, keypair: common::SecretKey) -> &mut Self {
         self.protocol_filter();
-        self.add_section(Section::Signature(Signature::new(
+        self.add_section(Section::Authorization(Authorization::new(
             self.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,
@@ -1537,7 +1537,7 @@ impl Tx {
             (0..).zip(keypairs).collect()
         };
 
-        self.add_section(Section::Signature(Signature::new(
+        self.add_section(Section::Authorization(Authorization::new(
             hashes,
             secret_keys,
             signer,
@@ -1551,7 +1551,7 @@ impl Tx {
         signatures: Vec<SignatureIndex>,
     ) -> &mut Self {
         self.protocol_filter();
-        let mut pk_section = Signature {
+        let mut pk_section = Authorization {
             targets: vec![self.raw_header_hash()],
             signatures: BTreeMap::new(),
             signer: Signer::PubKeys(vec![]),
@@ -1562,10 +1562,12 @@ impl Tx {
             if let Some((addr, idx)) = &signature.index {
                 // Add the signature under the given multisig address
                 let section =
-                    sections.entry(addr.clone()).or_insert_with(|| Signature {
-                        targets: vec![self.raw_header_hash()],
-                        signatures: BTreeMap::new(),
-                        signer: Signer::Address(addr.clone()),
+                    sections.entry(addr.clone()).or_insert_with(|| {
+                        Authorization {
+                            targets: vec![self.raw_header_hash()],
+                            signatures: BTreeMap::new(),
+                            signer: Signer::Address(addr.clone()),
+                        }
                     });
                 section.signatures.insert(*idx, signature.signature);
             } else if let Signer::PubKeys(pks) = &mut pk_section.signer {
@@ -1578,7 +1580,7 @@ impl Tx {
         }
         for section in std::iter::once(pk_section).chain(sections.into_values())
         {
-            self.add_section(Section::Signature(section));
+            self.add_section(Section::Authorization(section));
         }
         self
     }

--- a/crates/vote_ext/src/lib.rs
+++ b/crates/vote_ext/src/lib.rs
@@ -14,7 +14,7 @@ use namada_macros::BorshDeserializer;
 use namada_migrations::*;
 use namada_tx::data::protocol::{ProtocolTx, ProtocolTxType};
 use namada_tx::data::TxType;
-use namada_tx::{Signature, Signed, Tx, TxError};
+use namada_tx::{Authorization, Signed, Tx, TxError};
 
 /// This type represents the data we pass to the extension of
 /// a vote at the PreCommit phase of Tendermint.
@@ -151,11 +151,13 @@ impl EthereumTxData {
             })));
         outer_tx.header.chain_id = chain_id;
         outer_tx.set_data(namada_tx::Data::new(tx_data));
-        outer_tx.add_section(namada_tx::Section::Signature(Signature::new(
-            outer_tx.sechashes(),
-            [(0, signing_key.clone())].into_iter().collect(),
-            None,
-        )));
+        outer_tx.add_section(namada_tx::Section::Authorization(
+            Authorization::new(
+                outer_tx.sechashes(),
+                [(0, signing_key.clone())].into_iter().collect(),
+                None,
+            ),
+        ));
         outer_tx
     }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,6 +17,10 @@ name = "generate-txs"
 path = "generate_txs.rs"
 
 [[example]]
+name = "tx-schema"
+path = "tx_schema.rs"
+
+[[example]]
 name = "make-db-migration"
 path = "make-db-migration.rs"
 

--- a/examples/generate_txs.rs
+++ b/examples/generate_txs.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Reason> {
     }
     let args: Vec<_> = std::env::args().collect();
     if args.len() < 3 {
-        eprintln!("Usage: namada-generator <vectors.json> <debugs.txt>");
+        eprintln!("Usage: generate-txs <vectors.json> <debugs.txt>");
         return Result::Err(Reason::from("Incorrect command line arguments."));
     }
     let json = serde_json::to_string(&test_vectors)

--- a/examples/tx_schema.rs
+++ b/examples/tx_schema.rs
@@ -1,0 +1,18 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+
+use namada_sdk::borsh::BorshSchema;
+use namada_sdk::tx::Tx;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<_> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: tx-schema <schema.txt>");
+        return Result::Err("Incorrect command line arguments.".into());
+    }
+    let mut definitions = BTreeMap::new();
+    Tx::add_definitions_recursively(&mut definitions);
+    std::fs::write(&args[1], format!("{:#?}", definitions))
+        .expect("unable to save schema");
+    Ok(())
+}

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3154,7 +3154,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=30492323d98b0531fd18b6285cd94afcaa4066d2#30492323d98b0531fd18b6285cd94afcaa4066d2"
+source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
 dependencies = [
  "borsh",
  "chacha20",
@@ -3167,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=30492323d98b0531fd18b6285cd94afcaa4066d2#30492323d98b0531fd18b6285cd94afcaa4066d2"
+source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
 dependencies = [
  "aes",
  "bip0039",
@@ -3199,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=30492323d98b0531fd18b6285cd94afcaa4066d2#30492323d98b0531fd18b6285cd94afcaa4066d2"
+source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/wasm/wasm_source/src/vp_implicit.rs
+++ b/wasm/wasm_source/src/vp_implicit.rs
@@ -290,7 +290,7 @@ mod tests {
     use namada::core::storage::Epoch;
     use namada::ledger::pos::{GenesisValidator, PosParams};
     use namada::tx::data::TxType;
-    use namada::tx::{Code, Data, Signature};
+    use namada::tx::{Authorization, Code, Data};
     use namada_test_utils::TestWasms;
     use namada_tests::log::test;
     use namada_tests::native_vp::pos::init_pos;
@@ -638,7 +638,7 @@ mod tests {
         let mut tx = vp_env.tx.clone();
         tx.set_data(Data::new(vec![]));
         tx.set_code(Code::new(vec![], None));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             vec![tx.raw_header_hash()],
             pks_map.index_secret_keys(vec![secret_key]),
             None,
@@ -768,7 +768,7 @@ mod tests {
         let mut tx = vp_env.tx.clone();
         tx.set_data(Data::new(vec![]));
         tx.set_code(Code::new(vec![], None));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             vec![tx.raw_header_hash()],
             pks_map.index_secret_keys(vec![secret_key]),
             None,
@@ -933,7 +933,7 @@ mod tests {
             let mut tx = vp_env.tx.clone();
             tx.set_data(Data::new(vec![]));
             tx.set_code(Code::new(vec![], None));
-            tx.add_section(Section::Signature(Signature::new(
+            tx.add_section(Section::Authorization(Authorization::new(
                 vec![tx.raw_header_hash()],
                 pks_map.index_secret_keys(vec![secret_key]),
                 None,

--- a/wasm/wasm_source/src/vp_user.rs
+++ b/wasm/wasm_source/src/vp_user.rs
@@ -336,7 +336,7 @@ mod tests {
     use namada::core::storage::Epoch;
     use namada::ledger::pos::{GenesisValidator, PosParams};
     use namada::tx::data::{self, TxType};
-    use namada::tx::{Code, Data, Signature};
+    use namada::tx::{Authorization, Code, Data};
     use namada_test_utils::TestWasms;
     // Use this as `#[test]` annotation to enable logging
     use namada_tests::log::test;
@@ -532,7 +532,7 @@ mod tests {
         let mut tx = vp_env.tx.clone();
         tx.set_data(Data::new(vec![]));
         tx.set_code(Code::new(vec![], None));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             vec![tx.raw_header_hash()],
             pks_map.index_secret_keys(vec![keypair]),
             None,
@@ -738,7 +738,7 @@ mod tests {
         let mut tx_data = Tx::from_type(TxType::Raw);
         tx_data.set_data(Data::new(vec![]));
         tx_data.set_code(Code::new(vec![], None));
-        tx_data.add_section(Section::Signature(Signature::new(
+        tx_data.add_section(Section::Authorization(Authorization::new(
             vec![tx_data.raw_header_hash()],
             pks_map.index_secret_keys(vec![sk3]),
             None,
@@ -1031,7 +1031,7 @@ mod tests {
         let mut tx = vp_env.tx.clone();
         tx.set_data(Data::new(vec![]));
         tx.set_code(Code::new(vec![], None));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             vec![tx.raw_header_hash()],
             pks_map.index_secret_keys(vec![secret_key]),
             None,
@@ -1126,7 +1126,7 @@ mod tests {
         let mut tx = vp_env.tx.clone();
         tx.set_data(Data::new(vec![]));
         tx.set_code(Code::new(vec![], None));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             vec![tx.raw_header_hash()],
             pks_map.index_secret_keys(vec![secret_key]),
             None,
@@ -1232,7 +1232,7 @@ mod tests {
         let mut tx = vp_env.tx.clone();
         tx.set_data(Data::new(vec![]));
         tx.set_code(Code::new(vec![], None));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             vec![tx.raw_header_hash()],
             pks_map.index_secret_keys(vec![secret_key]),
             None,
@@ -1391,7 +1391,7 @@ mod tests {
                 let mut tx = vp_env.tx.clone();
                 tx.set_code(Code::new(vec![], None));
                 tx.set_data(Data::new(vec![]));
-                tx.add_section(Section::Signature(Signature::new(
+                tx.add_section(Section::Authorization(Authorization::new(
     vec![                tx.raw_header_hash()],
                     pks_map.index_secret_keys(vec![keypair]),
                     None,
@@ -1478,7 +1478,7 @@ mod tests {
         let mut tx = vp_env.tx.clone();
         tx.set_data(Data::new(vec![]));
         tx.set_code(Code::new(vec![], None));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             vec![tx.raw_header_hash()],
             pks_map.index_secret_keys(vec![keypair]),
             None,
@@ -1534,7 +1534,7 @@ mod tests {
         let mut tx = vp_env.tx.clone();
         tx.set_data(Data::new(vec![]));
         tx.set_code(Code::new(vec![], None));
-        tx.add_section(Section::Signature(Signature::new(
+        tx.add_section(Section::Authorization(Authorization::new(
             vec![tx.raw_header_hash()],
             pks_map.index_secret_keys(vec![keypair]),
             None,

--- a/wasm_for_tests/wasm_source/Cargo.lock
+++ b/wasm_for_tests/wasm_source/Cargo.lock
@@ -3134,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=30492323d98b0531fd18b6285cd94afcaa4066d2#30492323d98b0531fd18b6285cd94afcaa4066d2"
+source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
 dependencies = [
  "borsh",
  "chacha20",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=30492323d98b0531fd18b6285cd94afcaa4066d2#30492323d98b0531fd18b6285cd94afcaa4066d2"
+source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
 dependencies = [
  "aes",
  "bip0039",
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=30492323d98b0531fd18b6285cd94afcaa4066d2#30492323d98b0531fd18b6285cd94afcaa4066d2"
+source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
 dependencies = [
  "bellman",
  "blake2b_simd",


### PR DESCRIPTION
## Describe your changes
Made the necessary changes to successfully generate an accurate `Tx` Borsh schema. This is useful for describing the transaction format to external collaborators. More specifically, the changes were as follows:
* Now using the latest MASP crate, which has the correct Borsh schemas
* Renaming certain structures to avoid name collisions in the Schema
* Adding an example to the repo allowing the generation of a `Tx` schema to a file

Note: Because the MASP crate update fixes serialization of a certain `Transaction` component in corner cases, this PR is breaking.

## Indicate on which release or other PRs this topic is based on
Namada v0.32.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
