### PR TITLE
Remove the superfluous addition of .0 to Ledger test vectors.

### DIFF
--- a/.changelog/unreleased/improvements/2932-fix-ledger-significant-digits.md
+++ b/.changelog/unreleased/improvements/2932-fix-ledger-significant-digits.md
@@ -1,0 +1,2 @@
+- Remove unnecessary decimal digits in Ledger test vectors.
+  ([\#2932](https://github.com/anoma/namada/pull/2932))

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -887,11 +887,11 @@ fn to_ledger_decimal(amount: &str) -> String {
     if amount.contains('.') {
         let mut amount = amount.trim_end_matches('0').to_string();
         if amount.ends_with('.') {
-            amount.push('0')
+            amount.pop();
         }
         amount
     } else {
-        amount.to_string() + ".0"
+        amount.to_string()
     }
 }
 


### PR DESCRIPTION
## Describe your changes
Modified the printing of numbers in Ledger test vectors so that the `.0` suffix is not added to whole numbers. So now all unnecessary zeros and decimals at the end of decimal numbers are removed before printing.

## Indicate on which release or other PRs this topic is based on
Namada v0.32.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
