### PR TITLE
create basic disperse command for cli

### DIFF
--- a/.changelog/unreleased/2945-create-disperse-command-cli.md
+++ b/.changelog/unreleased/2945-create-disperse-command-cli.md
@@ -1,0 +1,2 @@
+- Add a Disperse command in the CLI
+  ([\#2945](https://github.com/anoma/namada/pull/2945))

--- a/crates/apps/src/lib/cli/client.rs
+++ b/crates/apps/src/lib/cli/client.rs
@@ -65,6 +65,18 @@ impl CliApi {
                         let namada = ctx.to_sdk(client, io);
                         tx::submit_transfer(&namada, args).await?;
                     }
+                    Sub::TxDisperse(TxDisperse(args)) => {
+                        let chain_ctx = ctx.borrow_mut_chain_or_exit();
+                        let ledger_address =
+                            chain_ctx.get(&args.tx.ledger_address);
+                        let client = client.unwrap_or_else(|| {
+                            C::from_tendermint_address(&ledger_address)
+                        });
+                        client.wait_until_node_is_synced(&io).await?;
+                        let args = args.to_sdk(&mut ctx);
+                        let namada = ctx.to_sdk(client, io);
+                        tx::submit_disperse(&namada, args).await?;
+                    }
                     Sub::TxIbcTransfer(TxIbcTransfer(args)) => {
                         let chain_ctx = ctx.borrow_mut_chain_or_exit();
                         let ledger_address =

--- a/crates/apps/src/lib/client/tx.rs
+++ b/crates/apps/src/lib/client/tx.rs
@@ -983,6 +983,26 @@ pub async fn submit_transfer(
 
     Ok(())
 }
+pub async fn submit_disperse(
+    namada: &impl Namada,
+    transfers: Vec<args::TxTransfer>,
+) -> Result<(), error::Error> {
+    for transfer in transfers {
+        loop {
+            let result = submit_transfer(namada, transfer.clone()).await;
+            match result {
+                Ok(_) => {
+                    break;
+                },
+                Err(e) => {
+                    eprintln!("Error submitting transfer: {:?}", e);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
 
 pub async fn submit_ibc_transfer<N: Namada>(
     namada: &N,


### PR DESCRIPTION
## Describe your changes

This PR is a suggestion of addition for a new command in the CLI for Namada, which could be very useful for a data protection oriented blockchain.
It gets its inspiration from the "disperse" contract on Ethereum, which allows a user to send X to N addresses in one single transaction.

I know the implementation is not perfect/complete, because as it is, it sends N txs, instead of a single one, but Im not advanced enough in Rust or my comprehension of Namada codebase to go further than that. But I hope this provides a useful starter to add this command !

This would probably benefit from having its own VP and wasm, as it looks a lot like a simple transfer but to be able to run it in a single tx, it requires to wrap multiple tx inside the inner/wrapper txs. Not sure how to do that, way beyond me :smile: 

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
