### PR TITLE
Replay protection refactor

### DIFF
--- a/.changelog/unreleased/improvements/2956-refactor-reprot.md
+++ b/.changelog/unreleased/improvements/2956-refactor-reprot.md
@@ -1,0 +1,2 @@
+- Simplified the replay protection implementation. Improved tests.
+  ([\#2956](https://github.com/anoma/namada/pull/2956))

--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -463,14 +463,15 @@ where
                             protocol::Error::ReplayAttempt(_),
                         ) = msg
                         {
-                            // Remove the wrapper hash but keep the inner tx
+                            // Mark the wrapper hash as redundant but keep the
+                            // inner tx
                             // hash. A replay of the wrapper is impossible since
                             // the inner tx hash is committed to storage and
                             // we validate the wrapper against that hash too
                             let header_hash = replay_protection_hashes
                                 .expect("This cannot fail")
                                 .header_hash;
-                            self.state.delete_tx_hash(header_hash);
+                            self.state.redundant_tx_hash(header_hash);
                         }
                     }
 
@@ -638,8 +639,8 @@ where
         Ok(())
     }
 
-    // Write the inner tx hash to storage and remove the corresponding wrapper
-    // hash since it's redundant (we check the inner tx hash too when validating
+    // Write the inner tx hash to storage and mark the corresponding wrapper
+    // hash as redundant (we check the inner tx hash too when validating
     // the wrapper). Requires the wrapper transaction as argument to recover
     // both the hashes.
     fn commit_inner_tx_hash(&mut self, hashes: Option<ReplayProtectionHashes>) {
@@ -652,7 +653,7 @@ where
                 .write_tx_hash(raw_header_hash)
                 .expect("Error while writing tx hash to storage");
 
-            self.state.delete_tx_hash(header_hash)
+            self.state.redundant_tx_hash(header_hash)
         }
     }
 }

--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -471,7 +471,7 @@ where
                             let header_hash = replay_protection_hashes
                                 .expect("This cannot fail")
                                 .header_hash;
-                            self.state.redundant_tx_hash(header_hash).expect(
+                            self.state.redundant_tx_hash(&header_hash).expect(
                                 "Error while marking tx hash as redundant",
                             );
                         }
@@ -656,7 +656,7 @@ where
                 .expect("Error while writing tx hash to storage");
 
             self.state
-                .redundant_tx_hash(header_hash)
+                .redundant_tx_hash(&header_hash)
                 .expect("Error while marking tx hash as redundant");
         }
     }
@@ -2560,7 +2560,7 @@ mod test_finalize_block {
                     .has_replay_protection_entry(&wrapper.raw_header_hash())
             );
             assert!(
-                shell
+                !shell
                     .state
                     .write_log()
                     .has_replay_protection_entry(&wrapper.header_hash())
@@ -2856,7 +2856,7 @@ mod test_finalize_block {
             )
         );
         assert!(
-            shell
+            !shell
                 .state
                 .write_log()
                 .has_replay_protection_entry(&failing_wrapper.header_hash())

--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -2602,7 +2602,7 @@ mod test_finalize_block {
                 },
                 keypair.ref_to(),
                 Epoch(0),
-                GAS_LIMIT_MULTIPLIER.into(),
+                WRAPPER_GAS_LIMIT.into(),
                 None,
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
@@ -2626,27 +2626,27 @@ mod test_finalize_block {
             },
             keypair_2.ref_to(),
             Epoch(0),
-            GAS_LIMIT_MULTIPLIER.into(),
+            WRAPPER_GAS_LIMIT.into(),
             None,
         ))));
-        new_wrapper.add_section(Section::Signature(Signature::new(
+        new_wrapper.add_section(Section::Authorization(Authorization::new(
             vec![new_wrapper.raw_header_hash()],
             [(0, keypair_2.clone())].into_iter().collect(),
             None,
         )));
         // This is a signature coming from the wrong signer which will be
         // rejected by the vp
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             vec![wrapper.raw_header_hash()],
             [(0, keypair.clone())].into_iter().collect(),
             None,
         )));
-        new_wrapper.add_section(Section::Signature(Signature::new(
+        new_wrapper.add_section(Section::Authorization(Authorization::new(
             new_wrapper.sechashes(),
             [(0, keypair_2)].into_iter().collect(),
             None,
         )));
-        wrapper.add_section(Section::Signature(Signature::new(
+        wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),
             None,

--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -88,16 +88,6 @@ where
             self.state.in_mem().update_epoch_blocks_delay
         );
 
-        // Finalize the transactions' hashes from the previous block. Also cache
-        // "last" hashes from the previous block in case of a rollback
-        let (write_log, _in_mem, db) = self.state.split_borrow();
-        for (raw_key, _, _) in db.iter_replay_protection() {
-            let hash = raw_key.parse().expect("Failed hash conversion");
-            write_log
-                .finalize_tx_hash(hash)
-                .expect("Failed tx hashes finalization")
-        }
-
         let emit_events = &mut response.events;
         // Get the actual votes from cometBFT in the preferred format
         let votes = pos_votes_from_abci(&self.state, &req.votes);
@@ -2459,25 +2449,21 @@ mod test_finalize_block {
         assert_eq!(root_pre.0, root_post.0);
 
         // Check transaction's hash in storage
-        assert!(
-            shell
-                .shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper_tx.raw_header_hash())
-                .unwrap_or_default()
-        );
+        assert!(shell
+            .shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&wrapper_tx.raw_header_hash())
+            .unwrap_or_default());
         // Check that the hash is present in the merkle tree
-        assert!(
-            !shell
-                .shell
-                .state
-                .in_mem()
-                .block
-                .tree
-                .has_key(&wrapper_hash_key)
-                .unwrap()
-        );
+        assert!(!shell
+            .shell
+            .state
+            .in_mem()
+            .block
+            .tree
+            .has_key(&wrapper_hash_key)
+            .unwrap());
     }
 
     /// Test that a tx that has already been applied in the same block
@@ -2559,20 +2545,16 @@ mod test_finalize_block {
         assert_eq!(code, String::from(ResultCode::WasmRuntimeError).as_str());
 
         for wrapper in [&wrapper, &new_wrapper] {
-            assert!(
-                shell
-                    .state
-                    .write_log()
-                    .has_replay_protection_entry(&wrapper.raw_header_hash())
-                    .unwrap_or_default()
-            );
-            assert!(
-                !shell
-                    .state
-                    .write_log()
-                    .has_replay_protection_entry(&wrapper.header_hash())
-                    .unwrap_or_default()
-            );
+            assert!(shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper.raw_header_hash())
+                .unwrap_or_default());
+            assert!(!shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper.header_hash())
+                .unwrap_or_default());
         }
     }
 
@@ -2678,34 +2660,26 @@ mod test_finalize_block {
 
         // This hash must be present as succesfully added by the second
         // transaction
-        assert!(
-            shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper.raw_header_hash())
-                .unwrap_or_default()
-        );
-        assert!(
-            shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper.header_hash())
-                .unwrap_or_default()
-        );
-        assert!(
-            shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&new_wrapper.raw_header_hash())
-                .unwrap_or_default()
-        );
-        assert!(
-            !shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&new_wrapper.header_hash())
-                .unwrap_or_default()
-        );
+        assert!(shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&wrapper.raw_header_hash())
+            .unwrap_or_default());
+        assert!(shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&wrapper.header_hash())
+            .unwrap_or_default());
+        assert!(shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&new_wrapper.raw_header_hash())
+            .unwrap_or_default());
+        assert!(!shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&new_wrapper.header_hash())
+            .unwrap_or_default());
     }
 
     /// Test that if a transaction fails because of out-of-gas,
@@ -2858,37 +2832,27 @@ mod test_finalize_block {
             unsigned_wrapper,
             wrong_commitment_wrapper,
         ] {
-            assert!(
-                !shell
-                    .state
-                    .write_log()
-                    .has_replay_protection_entry(
-                        &valid_wrapper.raw_header_hash()
-                    )
-                    .unwrap_or_default()
-            );
-            assert!(
-                shell
-                    .state
-                    .write_log()
-                    .has_replay_protection_entry(&valid_wrapper.header_hash())
-                    .unwrap_or_default()
-            );
+            assert!(!shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&valid_wrapper.raw_header_hash())
+                .unwrap_or_default());
+            assert!(shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&valid_wrapper.header_hash())
+                .unwrap_or_default());
         }
-        assert!(
-            shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&failing_wrapper.raw_header_hash())
-                .expect("test failed")
-        );
-        assert!(
-            !shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&failing_wrapper.header_hash())
-                .unwrap_or_default()
-        );
+        assert!(shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&failing_wrapper.raw_header_hash())
+            .expect("test failed"));
+        assert!(!shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&failing_wrapper.header_hash())
+            .unwrap_or_default());
     }
 
     #[test]
@@ -2954,20 +2918,16 @@ mod test_finalize_block {
             .as_str();
         assert_eq!(code, String::from(ResultCode::InvalidTx).as_str());
 
-        assert!(
-            shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper_hash)
-                .unwrap_or_default()
-        );
-        assert!(
-            !shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper.raw_header_hash())
-                .unwrap_or_default()
-        );
+        assert!(shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&wrapper_hash)
+            .unwrap_or_default());
+        assert!(!shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&wrapper.raw_header_hash())
+            .unwrap_or_default());
     }
 
     // Test that the fees are paid even if the inner transaction fails and its
@@ -3360,11 +3320,9 @@ mod test_finalize_block {
                 .unwrap(),
             Some(ValidatorState::Consensus)
         );
-        assert!(
-            enqueued_slashes_handle()
-                .at(&Epoch::default())
-                .is_empty(&shell.state)?
-        );
+        assert!(enqueued_slashes_handle()
+            .at(&Epoch::default())
+            .is_empty(&shell.state)?);
         assert_eq!(
             get_num_consensus_validators(&shell.state, Epoch::default())
                 .unwrap(),
@@ -3383,21 +3341,17 @@ mod test_finalize_block {
                     .unwrap(),
                 Some(ValidatorState::Jailed)
             );
-            assert!(
-                enqueued_slashes_handle()
-                    .at(&epoch)
-                    .is_empty(&shell.state)?
-            );
+            assert!(enqueued_slashes_handle()
+                .at(&epoch)
+                .is_empty(&shell.state)?);
             assert_eq!(
                 get_num_consensus_validators(&shell.state, epoch).unwrap(),
                 5_u64
             );
         }
-        assert!(
-            !enqueued_slashes_handle()
-                .at(&processing_epoch)
-                .is_empty(&shell.state)?
-        );
+        assert!(!enqueued_slashes_handle()
+            .at(&processing_epoch)
+            .is_empty(&shell.state)?);
 
         // Advance to the processing epoch
         loop {
@@ -3420,11 +3374,9 @@ mod test_finalize_block {
                 // println!("Reached processing epoch");
                 break;
             } else {
-                assert!(
-                    enqueued_slashes_handle()
-                        .at(&shell.state.in_mem().block.epoch)
-                        .is_empty(&shell.state)?
-                );
+                assert!(enqueued_slashes_handle()
+                    .at(&shell.state.in_mem().block.epoch)
+                    .is_empty(&shell.state)?);
                 let stake1 = read_validator_stake(
                     &shell.state,
                     &params,
@@ -3911,13 +3863,11 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(misbehavior_epoch));
-        assert!(
-            namada_proof_of_stake::storage::validator_slashes_handle(
-                &val1.address
-            )
-            .is_empty(&shell.state)
-            .unwrap()
-        );
+        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
+            &val1.address
+        )
+        .is_empty(&shell.state)
+        .unwrap());
 
         tracing::debug!("Advancing to epoch 7");
 
@@ -3982,22 +3932,18 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(Epoch(4)));
-        assert!(
-            namada_proof_of_stake::is_validator_frozen(
-                &shell.state,
-                &val1.address,
-                current_epoch,
-                &params
-            )
-            .unwrap()
-        );
-        assert!(
-            namada_proof_of_stake::storage::validator_slashes_handle(
-                &val1.address
-            )
-            .is_empty(&shell.state)
-            .unwrap()
-        );
+        assert!(namada_proof_of_stake::is_validator_frozen(
+            &shell.state,
+            &val1.address,
+            current_epoch,
+            &params
+        )
+        .unwrap());
+        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
+            &val1.address
+        )
+        .is_empty(&shell.state)
+        .unwrap());
 
         let pre_stake_10 =
             namada_proof_of_stake::storage::read_validator_stake(

--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -2454,8 +2454,7 @@ mod test_finalize_block {
             .shell
             .state
             .write_log()
-            .has_replay_protection_entry(&wrapper_tx.raw_header_hash())
-            .unwrap_or_default());
+            .has_replay_protection_entry(&wrapper_tx.raw_header_hash()));
         // Check that the hash is present in the merkle tree
         assert!(!shell
             .shell
@@ -2549,13 +2548,11 @@ mod test_finalize_block {
             assert!(shell
                 .state
                 .write_log()
-                .has_replay_protection_entry(&wrapper.raw_header_hash())
-                .unwrap_or_default());
+                .has_replay_protection_entry(&wrapper.raw_header_hash()));
             assert!(!shell
                 .state
                 .write_log()
-                .has_replay_protection_entry(&wrapper.header_hash())
-                .unwrap_or_default());
+                .has_replay_protection_entry(&wrapper.header_hash()));
         }
     }
 
@@ -2661,26 +2658,6 @@ mod test_finalize_block {
 
         // This hash must be present as succesfully added by the second
         // transaction
-        assert!(shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&wrapper.raw_header_hash())
-            .unwrap_or_default());
-        assert!(shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&wrapper.header_hash())
-            .unwrap_or_default());
-        assert!(shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&new_wrapper.raw_header_hash())
-            .unwrap_or_default());
-        assert!(!shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&new_wrapper.header_hash())
-            .unwrap_or_default());
     }
 
     /// Test that if a transaction fails because of out-of-gas,
@@ -2836,24 +2813,20 @@ mod test_finalize_block {
             assert!(!shell
                 .state
                 .write_log()
-                .has_replay_protection_entry(&valid_wrapper.raw_header_hash())
-                .unwrap_or_default());
+                .has_replay_protection_entry(&valid_wrapper.raw_header_hash()));
             assert!(shell
                 .state
                 .write_log()
-                .has_replay_protection_entry(&valid_wrapper.header_hash())
-                .unwrap_or_default());
+                .has_replay_protection_entry(&valid_wrapper.header_hash()));
         }
         assert!(shell
             .state
             .write_log()
-            .has_replay_protection_entry(&failing_wrapper.raw_header_hash())
-            .expect("test failed"));
+            .has_replay_protection_entry(&failing_wrapper.raw_header_hash()));
         assert!(!shell
             .state
             .write_log()
-            .has_replay_protection_entry(&failing_wrapper.header_hash())
-            .unwrap_or_default());
+            .has_replay_protection_entry(&failing_wrapper.header_hash()));
     }
 
     #[test]
@@ -2922,13 +2895,11 @@ mod test_finalize_block {
         assert!(shell
             .state
             .write_log()
-            .has_replay_protection_entry(&wrapper_hash)
-            .unwrap_or_default());
+            .has_replay_protection_entry(&wrapper_hash));
         assert!(!shell
             .state
             .write_log()
-            .has_replay_protection_entry(&wrapper.raw_header_hash())
-            .unwrap_or_default());
+            .has_replay_protection_entry(&wrapper.raw_header_hash()));
     }
 
     // Test that the fees are paid even if the inner transaction fails and its

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -2421,7 +2421,7 @@ mod shell_tests {
         // Write wrapper hash to storage
         let mut batch = namada::state::testing::TestState::batch();
         let wrapper_hash = wrapper.header_hash();
-        let wrapper_hash_key = replay_protection::last_key(&wrapper_hash);
+        let wrapper_hash_key = replay_protection::current_key(&wrapper_hash);
         shell
             .state
             .write_replay_protection_entry(&mut batch, &wrapper_hash_key)
@@ -2458,7 +2458,7 @@ mod shell_tests {
 
         let inner_tx_hash = wrapper.raw_header_hash();
         // Write inner hash in storage
-        let inner_hash_key = replay_protection::last_key(&inner_tx_hash);
+        let inner_hash_key = replay_protection::current_key(&inner_tx_hash);
         shell
             .state
             .write_replay_protection_entry(&mut batch, &inner_hash_key)

--- a/crates/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/crates/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -733,7 +733,7 @@ mod test_prepare_proposal {
 
         // Write wrapper hash to storage
         let wrapper_unsigned_hash = wrapper.header_hash();
-        let hash_key = replay_protection::last_key(&wrapper_unsigned_hash);
+        let hash_key = replay_protection::current_key(&wrapper_unsigned_hash);
         shell
             .state
             .write_bytes(&hash_key, vec![])
@@ -814,7 +814,7 @@ mod test_prepare_proposal {
         let inner_unsigned_hash = wrapper.raw_header_hash();
 
         // Write inner hash to storage
-        let hash_key = replay_protection::last_key(&inner_unsigned_hash);
+        let hash_key = replay_protection::current_key(&inner_unsigned_hash);
         shell
             .state
             .write_bytes(&hash_key, vec![])

--- a/crates/apps/src/lib/node/ledger/shell/process_proposal.rs
+++ b/crates/apps/src/lib/node/ledger/shell/process_proposal.rs
@@ -1156,7 +1156,7 @@ mod test_process_proposal {
         // Write wrapper hash to storage
         let mut batch = namada::state::testing::TestState::batch();
         let wrapper_unsigned_hash = wrapper.header_hash();
-        let hash_key = replay_protection::last_key(&wrapper_unsigned_hash);
+        let hash_key = replay_protection::current_key(&wrapper_unsigned_hash);
         shell
             .state
             .write_replay_protection_entry(&mut batch, &hash_key)
@@ -1279,7 +1279,8 @@ mod test_process_proposal {
 
         // Write inner hash to storage
         let mut batch = namada::state::testing::TestState::batch();
-        let hash_key = replay_protection::last_key(&wrapper.raw_header_hash());
+        let hash_key =
+            replay_protection::current_key(&wrapper.raw_header_hash());
         shell
             .state
             .write_replay_protection_entry(&mut batch, &hash_key)

--- a/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -390,18 +390,12 @@ impl RocksDB {
         }
 
         // replay protection
-        // Dump of replay protection keys is possible only at the last height or
-        // the previous one
+        // Dump of replay protection keys is possible only at the last height
         if height == last_height {
             let cf = self
                 .get_column_family(REPLAY_PROTECTION_CF)
                 .expect("Replay protection column family should exist");
             self.dump_it(cf, None, &mut file);
-        } else if height == last_height - 1 {
-            let cf = self
-                .get_column_family(REPLAY_PROTECTION_CF)
-                .expect("Replay protection column family should exist");
-            self.dump_it(cf, Some("all".to_string()), &mut file);
         }
 
         println!("Done writing to {}", full_path.to_string_lossy());
@@ -517,26 +511,9 @@ impl RocksDB {
         // Restore the state of replay protection to the last block
         let reprot_cf = self.get_column_family(REPLAY_PROTECTION_CF)?;
         tracing::info!("Restoring replay protection state");
-        // Remove the "last" tx hashes
-        for (ref hash_str, _, _) in self.iter_replay_protection() {
-            let hash = namada::core::hash::Hash::from_str(hash_str)
-                .expect("Failed hash conversion");
-            let key = replay_protection::last_key(&hash);
-            batch.delete_cf(reprot_cf, key.to_string());
-        }
-
-        for (ref hash_str, _, _) in self.iter_replay_protection_buffer() {
-            let hash = namada::core::hash::Hash::from_str(hash_str)
-                .expect("Failed hash conversion");
-            let last_key = replay_protection::last_key(&hash);
-            // Restore "buffer" bucket to "last"
-            batch.put_cf(reprot_cf, last_key.to_string(), vec![]);
-
-            // Remove anything in the buffer from the "all" prefix. Note that
-            // some hashes might be missing from "all" if they have been
-            // deleted, this is fine, in this case just continue
-            let all_key = replay_protection::all_key(&hash);
-            batch.delete_cf(reprot_cf, all_key.to_string());
+        // Remove the "current" tx hashes
+        for (ref hash_str, _, _) in self.iter_current_replay_protection() {
+            batch.delete_cf(reprot_cf, hash_str);
         }
 
         // Execute next step in parallel
@@ -1231,8 +1208,8 @@ impl DB for RocksDB {
             self.get_column_family(REPLAY_PROTECTION_CF)?;
 
         for key in [
-            replay_protection::last_key(hash),
-            replay_protection::all_key(hash),
+            replay_protection::current_key(hash),
+            replay_protection::key(hash),
         ] {
             if self
                 .0
@@ -1570,31 +1547,32 @@ impl DB for RocksDB {
         Ok(())
     }
 
-    fn delete_replay_protection_entry(
-        &mut self,
-        batch: &mut Self::WriteBatch,
-        key: &Key,
-    ) -> Result<()> {
-        let replay_protection_cf =
-            self.get_column_family(REPLAY_PROTECTION_CF)?;
-
-        batch.0.delete_cf(replay_protection_cf, key.to_string());
-
-        Ok(())
-    }
-
-    fn prune_replay_protection_buffer(
+    fn move_current_replay_protection_entries(
         &mut self,
         batch: &mut Self::WriteBatch,
     ) -> Result<()> {
         let replay_protection_cf =
             self.get_column_family(REPLAY_PROTECTION_CF)?;
+        let stripped_prefix = Some(replay_protection::current_prefix());
 
-        for (ref hash_str, _, _) in self.iter_replay_protection_buffer() {
+        for (ref hash_str, _, _) in iter_prefix(
+            self,
+            replay_protection_cf,
+            stripped_prefix.as_ref(),
+            None,
+        ) {
             let hash = namada::core::hash::Hash::from_str(hash_str)
                 .expect("Failed hash conversion");
-            let key = replay_protection::buffer_key(&hash);
-            batch.0.delete_cf(replay_protection_cf, key.to_string());
+            let current_key = replay_protection::current_key(&hash);
+            let key = replay_protection::key(&hash);
+
+            // Delete the current key and move it to the general bucket
+            batch
+                .0
+                .delete_cf(replay_protection_cf, current_key.to_string());
+            batch
+                .0
+                .put_cf(replay_protection_cf, key.to_string(), vec![]);
         }
 
         Ok(())
@@ -1843,21 +1821,12 @@ impl<'iter> DBIter<'iter> for RocksDB {
         iter_diffs_prefix(self, diffs_cf, height, prefix, false)
     }
 
-    fn iter_replay_protection(&'iter self) -> Self::PrefixIter {
+    fn iter_current_replay_protection(&'iter self) -> Self::PrefixIter {
         let replay_protection_cf = self
             .get_column_family(REPLAY_PROTECTION_CF)
             .expect("{REPLAY_PROTECTION_CF} column family should exist");
 
-        let stripped_prefix = Some(replay_protection::last_prefix());
-        iter_prefix(self, replay_protection_cf, stripped_prefix.as_ref(), None)
-    }
-
-    fn iter_replay_protection_buffer(&'iter self) -> Self::PrefixIter {
-        let replay_protection_cf = self
-            .get_column_family(REPLAY_PROTECTION_CF)
-            .expect("{REPLAY_PROTECTION_CF} column family should exist");
-
-        let stripped_prefix = Some(replay_protection::buffer_prefix());
+        let stripped_prefix = Some(replay_protection::current_prefix());
         iter_prefix(self, replay_protection_cf, stripped_prefix.as_ref(), None)
     }
 }
@@ -2339,23 +2308,21 @@ mod test {
                 persist_diffs,
             )
             .unwrap();
+            db.write_replay_protection_entry(
+                &mut batch,
+                &replay_protection::key(&Hash::sha256(tx)),
+            )
+            .unwrap();
             for tx in [b"tx1", b"tx2"] {
                 db.write_replay_protection_entry(
                     &mut batch,
-                    &replay_protection::all_key(&Hash::sha256(tx)),
+                    &replay_protection::key(&Hash::sha256(tx)),
                 )
-                .unwrap();
-                db.write_replay_protection_entry(
-                    &mut batch,
-                    &replay_protection::buffer_key(&Hash::sha256(tx)),
-                )
-                .unwrap();
-            }
 
             for tx in [b"tx3", b"tx4"] {
                 db.write_replay_protection_entry(
                     &mut batch,
-                    &replay_protection::last_key(&Hash::sha256(tx)),
+                    &replay_protection::current_key(&Hash::sha256(tx)),
                 )
                 .unwrap();
             }
@@ -2402,30 +2369,13 @@ mod test {
             )
             .unwrap();
 
-            db.prune_replay_protection_buffer(&mut batch).unwrap();
-            db.write_replay_protection_entry(
-                &mut batch,
-                &replay_protection::all_key(&Hash::sha256(b"tx3")),
-            )
-            .unwrap();
 
-            for tx in [b"tx3", b"tx4"] {
-                db.delete_replay_protection_entry(
-                    &mut batch,
-                    &replay_protection::last_key(&Hash::sha256(tx)),
-                )
-                .unwrap();
-                db.write_replay_protection_entry(
-                    &mut batch,
-                    &replay_protection::buffer_key(&Hash::sha256(tx)),
-                )
-                .unwrap();
-            }
+    db.move_current_replay_protection_entries(&mut batch).unwrap();
 
             for tx in [b"tx5", b"tx6"] {
                 db.write_replay_protection_entry(
                     &mut batch,
-                    &replay_protection::last_key(&Hash::sha256(tx)),
+                    &replay_protection::current_key(&Hash::sha256(tx)),
                 )
                 .unwrap();
             }
@@ -2449,15 +2399,11 @@ mod test {
             let deleted = db.read_subspace_val(&delete_key).unwrap();
             assert_eq!(deleted, None);
 
-            for tx in [b"tx1", b"tx2", b"tx3", b"tx5", b"tx6"] {
+            for tx in [b"tx1", b"tx2", b"tx3", b"tx4", b"tx5", b"tx6"] {
                 assert!(
                     db.has_replay_protection_entry(&Hash::sha256(tx)).unwrap()
                 );
             }
-            assert!(
-                !db.has_replay_protection_entry(&Hash::sha256(b"tx4"))
-                    .unwrap()
-            );
 
             // Rollback to the first block height
             db.rollback(height_0).unwrap();

--- a/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -42,8 +42,8 @@
 //!     - `address_gen`: established address generator
 //!     - `header`: block's header
 //! - `replay_protection`: hashes of processed tx for replay protection purposes
-//!     - `current/{hash}`: an hash included in the current block
-//!     - `{hash}`: an hash included in previous blocks
+//!     - `current/{hash}`: a hash included in the current block
+//!     - `{hash}`: a hash included in previous blocks
 
 use std::fs::File;
 use std::io::{BufWriter, Write};

--- a/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -512,8 +512,8 @@ impl RocksDB {
         let reprot_cf = self.get_column_family(REPLAY_PROTECTION_CF)?;
         tracing::info!("Restoring replay protection state");
         // Remove the "current" tx hashes
-        for (ref hash_str, _, _) in self.iter_current_replay_protection() {
-            batch.delete_cf(reprot_cf, hash_str);
+        for (ref current_key, _, _) in self.iter_current_replay_protection() {
+            batch.delete_cf(reprot_cf, current_key);
         }
 
         // Execute next step in parallel
@@ -1826,8 +1826,8 @@ impl<'iter> DBIter<'iter> for RocksDB {
             .get_column_family(REPLAY_PROTECTION_CF)
             .expect("{REPLAY_PROTECTION_CF} column family should exist");
 
-        let stripped_prefix = Some(replay_protection::current_prefix());
-        iter_prefix(self, replay_protection_cf, stripped_prefix.as_ref(), None)
+        let prefix = Some(replay_protection::current_prefix());
+        iter_prefix(self, replay_protection_cf, None, prefix.as_ref())
     }
 }
 

--- a/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -2308,16 +2308,13 @@ mod test {
                 persist_diffs,
             )
             .unwrap();
-            db.write_replay_protection_entry(
-                &mut batch,
-                &replay_protection::key(&Hash::sha256(tx)),
-            )
-            .unwrap();
             for tx in [b"tx1", b"tx2"] {
                 db.write_replay_protection_entry(
                     &mut batch,
                     &replay_protection::key(&Hash::sha256(tx)),
                 )
+                .unwrap();
+            }
 
             for tx in [b"tx3", b"tx4"] {
                 db.write_replay_protection_entry(
@@ -2369,8 +2366,8 @@ mod test {
             )
             .unwrap();
 
-
-    db.move_current_replay_protection_entries(&mut batch).unwrap();
+            db.move_current_replay_protection_entries(&mut batch)
+                .unwrap();
 
             for tx in [b"tx5", b"tx6"] {
                 db.write_replay_protection_entry(

--- a/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
+++ b/crates/apps/src/lib/node/ledger/storage/rocksdb.rs
@@ -41,9 +41,9 @@
 //!     - `epoch`: block epoch
 //!     - `address_gen`: established address generator
 //!     - `header`: block's header
-//! - `replay_protection`: hashes of processed tx
-//!     - `all`: the hashes included up to the last block
-//!     - `last`: the hashes included in the last block
+//! - `replay_protection`: hashes of processed tx for replay protection purposes
+//!     - `current/{hash}`: an hash included in the current block
+//!     - `{hash}`: an hash included in previous blocks
 
 use std::fs::File;
 use std::io::{BufWriter, Write};

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -601,8 +601,7 @@ where
     } = shell_params;
 
     let tx_hash = tx.raw_header_hash();
-    if let Some(true) = state.write_log().has_replay_protection_entry(&tx_hash)
-    {
+    if state.write_log().has_replay_protection_entry(&tx_hash) {
         // If the same transaction has already been applied in this block, skip
         // execution and return
         return Err(Error::ReplayAttempt(tx_hash));

--- a/crates/replay_protection/src/lib.rs
+++ b/crates/replay_protection/src/lib.rs
@@ -5,32 +5,17 @@ use namada_core::storage::Key;
 
 const ERROR_MSG: &str = "Cannot obtain a valid db key";
 
-/// Get the transaction hash prefix under the `all` subkey
-pub fn all_prefix() -> Key {
-    Key::parse("all").expect(ERROR_MSG)
+/// Get the transaction hash key
+pub fn key(hash: &Hash) -> Key {
+    Key::parse(hash.to_string()).expect(ERROR_MSG)
 }
 
-/// Get the transaction hash key under the `all` subkey
-pub fn all_key(hash: &Hash) -> Key {
-    all_prefix().push(&hash.to_string()).expect(ERROR_MSG)
+/// Get the transaction hash prefix under the `current` subkey
+pub fn current_prefix() -> Key {
+    Key::parse("current").expect(ERROR_MSG)
 }
 
-/// Get the full transaction hash prefix under the `last` subkey
-pub fn last_prefix() -> Key {
-    Key::parse("last").expect(ERROR_MSG)
-}
-
-/// Get the full transaction hash key under the `last` subkey
-pub fn last_key(hash: &Hash) -> Key {
-    last_prefix().push(&hash.to_string()).expect(ERROR_MSG)
-}
-
-/// Get the full transaction hash prefix under the `buffer` subkey
-pub fn buffer_prefix() -> Key {
-    Key::parse("buffer").expect(ERROR_MSG)
-}
-
-/// Get the full transaction hash key under the `buffer` subkey
-pub fn buffer_key(hash: &Hash) -> Key {
-    buffer_prefix().push(&hash.to_string()).expect(ERROR_MSG)
+/// Get the transaction hash key under the `current` subkey
+pub fn current_key(hash: &Hash) -> Key {
+    current_prefix().push(&hash.to_string()).expect(ERROR_MSG)
 }

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -1063,10 +1063,8 @@ where
 
     /// Check if the given tx hash has already been processed
     pub fn has_replay_protection_entry(&self, hash: &Hash) -> Result<bool> {
-        // FIXME: review this
-        if let Some(present) = self.write_log.has_replay_protection_entry(hash)
-        {
-            return Ok(present);
+        if self.write_log.has_replay_protection_entry(hash) {
+            return Ok(true);
         }
 
         self.db()

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -238,26 +238,12 @@ where
 
                     self.delete_replay_protection_entry(
                         batch,
+                        // FIXME: now I can only delete hashes in the same
+                        // block, so probably I should never get to this point
                         // Can only delete tx hashes from the previous block,
                         // no further
                         &replay_protection::last_key(&hash),
-                    )?
-                }
-                ReProtStorageModification::Finalize => {
-                    self.write_replay_protection_entry(
-                        batch,
-                        &replay_protection::all_key(&hash),
-                    )?;
-                    // Cache in case of a rollback
-                    self.write_replay_protection_entry(
-                        batch,
-                        &replay_protection::buffer_key(&hash),
-                    )?;
-                    self.delete_replay_protection_entry(
-                        batch,
-                        &replay_protection::last_key(&hash),
-                    )?;
-                }
+                    )?,
             }
         }
         debug_assert!(self.0.write_log.replay_protection.is_empty());

--- a/crates/state/src/write_log.rs
+++ b/crates/state/src/write_log.rs
@@ -676,14 +676,9 @@ impl WriteLog {
         PrefixIter { iter }
     }
 
-    /// Check if the given tx hash has already been processed. Returns `None` if
-    /// the key is not known.
-    pub fn has_replay_protection_entry(&self, hash: &Hash) -> Option<bool> {
-        self.replay_protection
-            .get(hash)
-            // FIXME: is this correct? Probably I should also consider the
-            // deleted ones
-            .map(|action| matches!(action, ReProtStorageModification::Write))
+    /// Check if the given tx hash has already been processed
+    pub fn has_replay_protection_entry(&self, hash: &Hash) -> bool {
+        self.replay_protection.contains_key(hash)
     }
 
     /// Write the transaction hash

--- a/crates/storage/src/db.rs
+++ b/crates/storage/src/db.rs
@@ -255,15 +255,8 @@ pub trait DB: Debug {
         key: &Key,
     ) -> Result<()>;
 
-    /// Delete a replay protection entry
-    fn delete_replay_protection_entry(
-        &mut self,
-        batch: &mut Self::WriteBatch,
-        key: &Key,
-    ) -> Result<()>;
-
-    /// Delete the entire replay protection buffer
-    fn prune_replay_protection_buffer(
+    /// Move the current replay protection bucket to the general one
+    fn move_current_replay_protection_entries(
         &mut self,
         batch: &mut Self::WriteBatch,
     ) -> Result<()>;
@@ -330,11 +323,8 @@ pub trait DBIter<'iter> {
         prefix: Option<&'iter Key>,
     ) -> Self::PrefixIter;
 
-    /// Read replay protection storage from the last block
-    fn iter_replay_protection(&'iter self) -> Self::PrefixIter;
-
-    /// Read replay protection storage from the the buffer
-    fn iter_replay_protection_buffer(&'iter self) -> Self::PrefixIter;
+    /// Read replay protection storage from the current bucket
+    fn iter_current_replay_protection(&'iter self) -> Self::PrefixIter;
 }
 
 /// Atomic batch write.

--- a/crates/storage/src/mockdb.rs
+++ b/crates/storage/src/mockdb.rs
@@ -425,14 +425,13 @@ impl DB for MockDB {
     fn has_replay_protection_entry(&self, hash: &Hash) -> Result<bool> {
         let prefix_key =
             Key::parse("replay_protection").map_err(Error::KeyError)?;
-        for subkey in [
-            replay_protection::last_key(hash),
-            replay_protection::all_key(hash),
-        ] {
-            let key = prefix_key.join(&subkey);
-            if self.0.borrow().contains_key(&key.to_string()) {
-                return Ok(true);
-            }
+        let key = prefix_key.join(&replay_protection::key(hash));
+        let current_key =
+            prefix_key.join(&replay_protection::current_key(hash));
+        if self.0.borrow().contains_key(&key.to_string())
+            || self.0.borrow().contains_key(&current_key.to_string())
+        {
+            return Ok(true);
         }
 
         Ok(false)
@@ -672,31 +671,38 @@ impl DB for MockDB {
         }
     }
 
-    fn delete_replay_protection_entry(
-        &mut self,
-        _batch: &mut Self::WriteBatch,
-        key: &Key,
-    ) -> Result<()> {
-        let key = Key::parse("replay_protection")
-            .map_err(Error::KeyError)?
-            .join(key);
-
-        self.0.borrow_mut().remove(&key.to_string());
-
-        Ok(())
-    }
-
-    fn prune_replay_protection_buffer(
+    fn move_current_replay_protection_entries(
         &mut self,
         _batch: &mut Self::WriteBatch,
     ) -> Result<()> {
-        let buffer_key = Key::parse("replay_protection")
+        let current_key_prefix = Key::parse("replay_protection")
             .map_err(Error::KeyError)?
-            .push(&"buffer".to_string())
+            .push(&"current".to_string())
             .map_err(Error::KeyError)?;
-        self.0
-            .borrow_mut()
-            .retain(|key, _| !key.starts_with(&buffer_key.to_string()));
+        let mut target_hashes = vec![];
+
+        for (key, _) in self.0.borrow().iter() {
+            if key.starts_with(&current_key_prefix.to_string()) {
+                let hash = key
+                    .rsplit(KEY_SEGMENT_SEPARATOR)
+                    .last()
+                    .unwrap()
+                    .to_string();
+                target_hashes.push(hash);
+            }
+        }
+
+        for hash in target_hashes {
+            let current_key =
+                current_key_prefix.push(&hash).map_err(Error::KeyError)?;
+            let key = Key::parse("replay_protection")
+                .map_err(Error::KeyError)?
+                .push(&hash)
+                .map_err(Error::KeyError)?;
+
+            self.0.borrow_mut().remove(&current_key.to_string());
+            self.0.borrow_mut().insert(key.to_string(), vec![]);
+        }
 
         Ok(())
     }
@@ -810,18 +816,10 @@ impl<'iter> DBIter<'iter> for MockDB {
         MockPrefixIterator::new(MockIterator { prefix, iter }, stripped_prefix)
     }
 
-    fn iter_replay_protection(&'iter self) -> Self::PrefixIter {
-        let stripped_prefix =
-            format!("replay_protection/{}/", replay_protection::last_prefix());
-        let prefix = stripped_prefix.clone();
-        let iter = self.0.borrow().clone().into_iter();
-        MockPrefixIterator::new(MockIterator { prefix, iter }, stripped_prefix)
-    }
-
-    fn iter_replay_protection_buffer(&'iter self) -> Self::PrefixIter {
+    fn iter_current_replay_protection(&'iter self) -> Self::PrefixIter {
         let stripped_prefix = format!(
             "replay_protection/{}/",
-            replay_protection::buffer_prefix()
+            replay_protection::current_prefix()
         );
         let prefix = stripped_prefix.clone();
         let iter = self.0.borrow().clone().into_iter();


### PR DESCRIPTION
## Describe your changes

Closes #2922.

Since there's no more need to keep track and possibly act on tx cases from different block, this PR removes the `ReProtStorageModification` enum and uses a simple `HashSet` to keep track of the transaction hashes.

Also improves replay protection unit tests.

## Indicate on which release or other PRs this topic is based on

v0.33.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
