### PR TITLE
upgrade docker base images to Debian 12 (Bookworm)

### DIFF
--- a/.changelog/unreleased/improvements/2975-upgrade-docker-images-to-bookworm.md
+++ b/.changelog/unreleased/improvements/2975-upgrade-docker-images-to-bookworm.md
@@ -1,0 +1,1 @@
+- Upgrade docker base images to Debian 12 (Bookworm) ([#2975](https://github.com/anoma/namada/pull/2975)).

--- a/docker/namada-wasm/Dockerfile
+++ b/docker/namada-wasm/Dockerfile
@@ -1,7 +1,7 @@
 # This docker is used for deterministic wasm builds
 
 # The version should be matching the version set in wasm/rust-toolchain.toml
-FROM rust:1.76.0-bullseye
+FROM rust:1.76.0-bookworm
 
 WORKDIR /__w/namada/namada
 

--- a/docker/namada/Dockerfile
+++ b/docker/namada/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.76.0-bullseye AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.76.0-bookworm AS chef
 WORKDIR /app
 
 FROM chef AS planner
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
     build-essential \
-    clang-tools-11 \
+    clang-tools-14 \
     git \
     libssl-dev \
     pkg-config \
@@ -29,7 +29,7 @@ WORKDIR /app
 
 RUN git clone -b v0.37.2 --single-branch https://github.com/cometbft/cometbft.git && cd cometbft && make build
 
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 ENV NAMADA_LOG_COLOR=false
 
 RUN apt-get update && apt-get install libcurl4-openssl-dev libudev-dev -y && apt-get clean


### PR DESCRIPTION
## Describe your changes

Bullseye official security support ends in 4 months (31 Jul 2024)   
Also, the `GLIBC` on bullseye is outdated, see https://github.com/anoma/namada-shielded-expedition/issues/360   

This PR includes:
- Upgrade docker base images to use Debian Bookworm (v12) instead of Bullseye (v11)    
- Upgrade GLIBC v2.31 to GLIBC to v2.36    


## Indicate on which release or other PRs this topic is based on
There was a failed attempt to upgrade docker images,  #2680 , but later reverted https://github.com/anoma/namada/commit/f38accc33af15d3a82622f197b9fe45fbbec8674 due to inconsistency between dependency versions 
## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
