### PR TITLE
feat: Enhance panic message in multisig account creation

### DIFF
--- a/crates/core/src/account.rs
+++ b/crates/core/src/account.rs
@@ -37,7 +37,8 @@ impl FromIterator<common::PublicKey> for AccountPublicKeysMap {
         for (index, public_key) in iter.into_iter().enumerate() {
             if hints::unlikely(index > u8::MAX as usize) {
                 panic!(
-                    "Only up to 255 signers are allowed in a multisig account"
+                    "Only up to 255 signers are allowed in a multisig account. Requested index: {}",
+        index
                 );
             }
             pk_to_idx.insert(public_key.to_owned(), index as u8);


### PR DESCRIPTION
## Describe your changes
This commit enhances the panic message in the `from_iter` function of the `AccountPublicKeysMap` struct. Previously, when the maximum allowed index for a multisig account was exceeded, the panic message only indicated the maximum number of allowed signers without providing information about the requested index. This enhancement adds the requested index value to the panic message, making it more informative for debugging purposes.

Changes Made:
- Modified panic message to include the requested index value when exceeding the maximum allowed index for a multisig account.

Related Issue:
None

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
