### PR TITLE
Comply with RUSTSEC-2024-0320

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ clap = "4.3.4"
 clru = {git = "https://github.com/marmeladema/clru-rs.git", rev = "71ca566"}
 color-eyre = "0.6.2"
 concat-idents = "1.1.2"
-config = "0.11.0"
+config = { git = "https://github.com/mehcode/config-rs.git", rev = "e3c1d0b452639478662a44f15ef6d5b6d969bf9b" }
 data-encoding = "2.3.2"
 derivation-path = "0.2.0"
 derivative = "2.2.0"

--- a/crates/apps/src/lib/config/global.rs
+++ b/crates/apps/src/lib/config/global.rs
@@ -43,13 +43,14 @@ impl GlobalConfig {
     pub fn read(base_dir: impl AsRef<Path>) -> Result<Self> {
         let file_path = Self::file_path(base_dir.as_ref());
         let file_name = file_path.to_str().expect("Expected UTF-8 file path");
-        let mut config = config::Config::new();
+        let mut config = config::Config::default();
         if file_path.exists() {
-            config
-                .merge(config::File::with_name(file_name))
-                .map_err(Error::ReadError)?;
+            config = config::Config::builder()
+            .add_source(config::File::with_name(file_name))
+            .build()
+            .map_err(Error::ReadError)?;
         }
-        config.try_into().map_err(Error::DeserializationError)
+        config.try_deserialize().map_err(|e: config::ConfigError| Error::DeserializationError(e))
     }
 
     /// Write configuration to a file.

--- a/crates/apps/src/lib/config/global.rs
+++ b/crates/apps/src/lib/config/global.rs
@@ -46,11 +46,13 @@ impl GlobalConfig {
         let mut config = config::Config::default();
         if file_path.exists() {
             config = config::Config::builder()
-            .add_source(config::File::with_name(file_name))
-            .build()
-            .map_err(Error::ReadError)?;
+                .add_source(config::File::with_name(file_name))
+                .build()
+                .map_err(Error::ReadError)?;
         }
-        config.try_deserialize().map_err(|e: config::ConfigError| Error::DeserializationError(e))
+        config
+            .try_deserialize()
+            .map_err(|e: config::ConfigError| Error::DeserializationError(e))
     }
 
     /// Write configuration to a file.

--- a/crates/apps/src/lib/config/mod.rs
+++ b/crates/apps/src/lib/config/mod.rs
@@ -276,10 +276,14 @@ impl Config {
         let builder = config::Config::builder()
             .add_source(defaults)
             .add_source(config::File::with_name(file_name))
-            .add_source(config::Environment::with_prefix("NAMADA").separator("__"));
+            .add_source(
+                config::Environment::with_prefix("NAMADA").separator("__"),
+            );
 
         let config = builder.build().map_err(Error::ReadError)?;
-        config.try_deserialize().map_err(Error::DeserializationError)
+        config
+            .try_deserialize()
+            .map_err(Error::DeserializationError)
     }
 
     /// Generate configuration and write it to a file.

--- a/crates/apps/src/lib/config/mod.rs
+++ b/crates/apps/src/lib/config/mod.rs
@@ -273,17 +273,13 @@ impl Config {
             mode,
         ))
         .map_err(Error::ReadError)?;
-        let mut config = config::Config::new();
-        config
-            .merge(defaults)
-            .and_then(|c| c.merge(config::File::with_name(file_name)))
-            .and_then(|c| {
-                c.merge(
-                    config::Environment::with_prefix("NAMADA").separator("__"),
-                )
-            })
-            .map_err(Error::ReadError)?;
-        config.try_into().map_err(Error::DeserializationError)
+        let builder = config::Config::builder()
+            .add_source(defaults)
+            .add_source(config::File::with_name(file_name))
+            .add_source(config::Environment::with_prefix("NAMADA").separator("__"));
+
+        let config = builder.build().map_err(Error::ReadError)?;
+        config.try_deserialize().map_err(Error::DeserializationError)
     }
 
     /// Generate configuration and write it to a file.


### PR DESCRIPTION
## Describe your changes
As discussed in linked issue `yaml-rust` is not maintened and poses a risk as future vulnerabilities or bugs in yaml-rust will not be addressed. Also it makes noise if you run `cargo-audit`. As advised in [RUSTSEC-2024-0320](https://rustsec.org/advisories/RUSTSEC-2024-0320.html) `yaml-rust2` is a fully compliant YAML 1.2 implementation written in rust and works faster than its predecessor `yaml-rust` and fully compatible with it.
`crates/app` is the affected crate and it fetches `yaml-rust` from `config` crate. 
I've udpated `config` crate to the latest [version](https://github.com/mehcode/config-rs/pull/554) and fixed compilation errors and warnings.
The reason why I'm using commit version instead of release tag for `config` crate is that it's owner is looking for new maintainer and not releasing new tags until than. But `yaml-rust2` issue was tested and merged to main branch from this [pr](https://github.com/mehcode/config-rs/issues/549) so it should be safe to use.

## Indicate on which release or other PRs this topic is based on
https://github.com/mehcode/config-rs/issues/553
https://github.com/anoma/namada/issues/2993

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
