### PR TITLE
test/e2e/init_validator: restart new validator node right after its tx

### DIFF
--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -1684,6 +1684,34 @@ fn pos_init_validator() -> Result<()> {
     client.exp_string(TX_APPLIED_SUCCESS)?;
     client.assert_success();
 
+    // Stop the non-validator node and run it as the new validator
+    let mut non_validator = bg_non_validator.foreground();
+    non_validator.interrupt()?;
+    non_validator.exp_eof()?;
+
+    // it takes a bit before the node is shutdown. We dont want flasky test.
+    if is_debug_mode() {
+        sleep(10);
+    } else {
+        sleep(5);
+    }
+
+    let loc = format!("{}:{}", std::file!(), std::line!());
+    let validator_1_base_dir = test.get_base_dir(Who::NonValidator);
+    let mut validator_1 = setup::run_cmd(
+        Bin::Node,
+        ["ledger"],
+        Some(60),
+        &test.working_dir,
+        validator_1_base_dir,
+        loc,
+    )?;
+
+    validator_1.exp_string(LEDGER_STARTED)?;
+    validator_1.exp_string(VALIDATOR_NODE)?;
+    validator_1.exp_string("Committed block hash")?;
+    let _bg_validator_1 = validator_1.background();
+
     // 3. Submit a delegation to the new validator First, transfer some tokens
     //    to the validator's key for fees:
     let tx_args = vec![
@@ -1758,34 +1786,6 @@ fn pos_init_validator() -> Result<()> {
     let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string(TX_APPLIED_SUCCESS)?;
     client.assert_success();
-
-    // Stop the non-validator node and run it as the new validator
-    let mut non_validator = bg_non_validator.foreground();
-    non_validator.interrupt()?;
-    non_validator.exp_eof()?;
-
-    // it takes a bit before the node is shutdown. We dont want flasky test.
-    if is_debug_mode() {
-        sleep(10);
-    } else {
-        sleep(5);
-    }
-
-    let loc = format!("{}:{}", std::file!(), std::line!());
-    let validator_1_base_dir = test.get_base_dir(Who::NonValidator);
-    let mut validator_1 = setup::run_cmd(
-        Bin::Node,
-        ["ledger"],
-        Some(60),
-        &test.working_dir,
-        validator_1_base_dir,
-        loc,
-    )?;
-
-    validator_1.exp_string(LEDGER_STARTED)?;
-    validator_1.exp_string(VALIDATOR_NODE)?;
-    validator_1.exp_string("Committed block hash")?;
-    let _bg_validator_1 = validator_1.background();
 
     // 6. Wait for the pipeline epoch when the validator's bonded stake should
     // be non-zero


### PR DESCRIPTION
## Describe your changes

The test often fails with `InsufficientVotes` on the first node as the second validator is bonded with the same stake and when it's not signing by the time it enters the consensus set we don't get enough votes to continue.

To fix this I moved the calls to restart the new validator's node right after its `init-validator` tx.

## Indicate on which release or other PRs this topic is based on

v0.32.1

## Checklist before merging to `draft`
- ~~[ ] I have added a changelog~~ - tests only
- [x] Git history is in acceptable state
