### PR TITLE
Refactor epoch pairs

### DIFF
--- a/crates/proof_of_stake/src/lib.rs
+++ b/crates/proof_of_stake/src/lib.rs
@@ -1381,7 +1381,7 @@ where
     }
 
     let mut unbonds_and_redelegated_unbonds: BTreeMap<
-        (Epoch, Epoch),
+        EpochBounds,
         (token::Amount, EagerRedelegatedBondsMap),
     > = BTreeMap::new();
 
@@ -1426,7 +1426,10 @@ where
         }
 
         unbonds_and_redelegated_unbonds.insert(
-            (start_epoch, withdraw_epoch),
+            EpochBounds {
+                start: start_epoch,
+                end: withdraw_epoch,
+            },
             (amount, eager_redelegated_unbonds),
         );
     }

--- a/crates/proof_of_stake/src/parameters.rs
+++ b/crates/proof_of_stake/src/parameters.rs
@@ -209,7 +209,7 @@ impl OwnedPosParams {
     pub fn cubic_slash_epoch_window(
         &self,
         infraction_epoch: Epoch,
-    ) -> (Epoch, Epoch) {
+    ) -> EpochBounds {
         let start = infraction_epoch
             .sub_or_default(Epoch(self.cubic_slashing_window_length));
         let end = infraction_epoch + self.cubic_slashing_window_length;

--- a/crates/proof_of_stake/src/types/mod.rs
+++ b/crates/proof_of_stake/src/types/mod.rs
@@ -685,6 +685,12 @@ pub struct UnbondDetails {
     pub slashed_amount: Option<token::Amount>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EpochBounds {
+    pub start: Epoch,
+    pub end: Epoch,
+}
+
 impl Display for BondId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(


### PR DESCRIPTION
## Describe your changes
The PoS code has lots of instances of an (Epoch, Epoch) being passed around, and it is not always intuitive as to what this epoch pair is exactly. It would be cleaner and enhance readability to instead pass around a struct, perhaps named EpochBounds or similar, that contains explicit start and end epoch fields that can be used for various operations.

## Indicate on which release or other PRs this topic is based on
#1732 
