### PR TITLE
Add a panic when calling namadac reveal-pk and the passed public key is already revealed

### DIFF
--- a/.changelog/unreleased/improvements/3070-main.md
+++ b/.changelog/unreleased/improvements/3070-main.md
@@ -1,0 +1,2 @@
+- Added a panic when reveal-pk is called for an already revealed key
+  ([\#3070](https://github.com/anoma/namada/pull/3070))

--- a/crates/apps/src/lib/client/tx.rs
+++ b/crates/apps/src/lib/client/tx.rs
@@ -227,11 +227,7 @@ pub async fn submit_reveal_aux(
             sign(context, &mut tx, &args, signing_data).await?;
 
             context.submit(tx, &args).await?;
-        } else {
-	    println!(
-		"Public key for address {address} already revealed."
-	    );
-	}
+        }
     }
 
     Ok(())

--- a/crates/apps/src/lib/client/tx.rs
+++ b/crates/apps/src/lib/client/tx.rs
@@ -227,7 +227,11 @@ pub async fn submit_reveal_aux(
             sign(context, &mut tx, &args, signing_data).await?;
 
             context.submit(tx, &args).await?;
-        }
+        } else {
+	    println!(
+		"Public key for address {address} already revealed."
+	    );
+	}
     }
 
     Ok(())

--- a/crates/apps/src/lib/client/tx.rs
+++ b/crates/apps/src/lib/client/tx.rs
@@ -227,7 +227,9 @@ pub async fn submit_reveal_aux(
             sign(context, &mut tx, &args, signing_data).await?;
 
             context.submit(tx, &args).await?;
-        }
+        } else {
+	    panic!("Public key for address {} already revealed.", address);
+	}
     }
 
     Ok(())


### PR DESCRIPTION
## Describe your changes
Closes #3069
When the public key is already revealed, the program panics with message "Public key for address {} already revealed."

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state