### PR TITLE
Fix enqueued slashes in SM test

### DIFF
--- a/.changelog/unreleased/improvements/2574-imrpove-slash-queue.md
+++ b/.changelog/unreleased/improvements/2574-imrpove-slash-queue.md
@@ -1,0 +1,2 @@
+- Only process 1 slash per validator per block height.
+  ([\#2574](https://github.com/anoma/namada/pull/2574))

--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -3953,6 +3953,7 @@ mod test_finalize_block {
         let enqueued_slash = enqueued_slashes_handle()
             .at(&processing_epoch)
             .at(&val1.address)
+            .at(&height.0)
             .front(&shell.state)
             .unwrap()
             .unwrap();
@@ -3990,7 +3991,7 @@ mod test_finalize_block {
                     address: pkh1,
                     power: Default::default(),
                 },
-                height: height.try_into().unwrap(),
+                height: height.next_height().try_into().unwrap(),
                 time: tendermint::Time::unix_epoch(),
                 total_voting_power: Default::default(),
             },
@@ -4023,8 +4024,13 @@ mod test_finalize_block {
             .at(&processing_epoch.next())
             .at(&val1.address);
 
-        assert_eq!(enqueued_slashes_8.len(&shell.state).unwrap(), 2_u64);
-        assert_eq!(enqueued_slashes_9.len(&shell.state).unwrap(), 1_u64);
+        let num_enqueued_8 =
+            enqueued_slashes_8.iter(&shell.state).unwrap().count();
+        let num_enqueued_9 =
+            enqueued_slashes_9.iter(&shell.state).unwrap().count();
+
+        assert_eq!(num_enqueued_8, 2);
+        assert_eq!(num_enqueued_9, 1);
         let last_slash =
             namada_proof_of_stake::storage::read_validator_last_slash_epoch(
                 &shell.state,

--- a/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
+++ b/crates/apps/src/lib/node/ledger/shell/finalize_block.rs
@@ -3953,8 +3953,7 @@ mod test_finalize_block {
         let enqueued_slash = enqueued_slashes_handle()
             .at(&processing_epoch)
             .at(&val1.address)
-            .at(&height.0)
-            .front(&shell.state)
+            .get(&shell.state, &height.0)
             .unwrap()
             .unwrap();
         assert_eq!(enqueued_slash.epoch, misbehavior_epoch);

--- a/crates/proof_of_stake/src/slashing.rs
+++ b/crates/proof_of_stake/src/slashing.rs
@@ -167,7 +167,7 @@ where
     if enqueued.contains(storage, &evidence_block_height)? {
         return Ok(());
     } else {
-        enqueued.at(&evidence_block_height).push(storage, slash)?;
+        enqueued.insert(storage, evidence_block_height, slash)?;
     }
 
     // Update the most recent slash (infraction) epoch for the validator

--- a/crates/proof_of_stake/src/tests/state_machine.rs
+++ b/crates/proof_of_stake/src/tests/state_machine.rs
@@ -1393,8 +1393,7 @@ impl ConcretePosState {
         let slash = enqueued_slashes_handle()
             .at(&processing_epoch)
             .at(validator)
-            .at(&infraction_height)
-            .back(&self.s)
+            .get(&self.s, &infraction_height)
             .unwrap();
         if let Some(slash) = slash {
             assert_eq!(slash.epoch, infraction_epoch);

--- a/crates/proof_of_stake/src/tests/state_machine.rs
+++ b/crates/proof_of_stake/src/tests/state_machine.rs
@@ -140,7 +140,7 @@ struct AbstractPosState {
     /// Validator slashes post-processing
     validator_slashes: BTreeMap<Address, Vec<Slash>>,
     /// Enqueued slashes pre-processing
-    enqueued_slashes: BTreeMap<Epoch, BTreeMap<Address, Vec<Slash>>>,
+    enqueued_slashes: BTreeMap<Epoch, BTreeMap<Address, BTreeMap<u64, Slash>>>,
     /// The last epoch in which a validator committed an infraction
     validator_last_slash_epochs: BTreeMap<Address, Epoch>,
     /// Validator's total unbonded required for slashing.
@@ -1412,8 +1412,10 @@ impl ConcretePosState {
     ) {
         // Check the enqueued slashes
         let abs_enqueued = ref_state.enqueued_slashes.clone();
-        let mut conc_enqueued: BTreeMap<Epoch, BTreeMap<Address, Vec<Slash>>> =
-            BTreeMap::new();
+        let mut conc_enqueued: BTreeMap<
+            Epoch,
+            BTreeMap<Address, BTreeMap<u64, Slash>>,
+        > = BTreeMap::new();
         enqueued_slashes_handle()
             .get_data_handler()
             .iter(&self.s)
@@ -1425,7 +1427,7 @@ impl ConcretePosState {
                         nested_sub_key:
                             NestedSubKey::Data {
                                 key: address,
-                                nested_sub_key: _,
+                                nested_sub_key: SubKey::Data(height),
                             },
                     },
                     slash,
@@ -1435,7 +1437,7 @@ impl ConcretePosState {
                     .or_default()
                     .entry(address)
                     .or_default();
-                slashes.push(slash);
+                slashes.insert(height, slash);
             });
         assert_eq!(abs_enqueued, conc_enqueued);
     }
@@ -2502,7 +2504,7 @@ impl ReferenceStateMachine for AbstractPosState {
                     .or_default()
                     .entry(address.clone())
                     .or_default()
-                    .push(slash);
+                    .insert(*height, slash);
 
                 // Remove the validator from either the consensus or
                 // below-capacity set and place it into the jailed validator set
@@ -3843,7 +3845,7 @@ impl AbstractPosState {
             |mut acc, (validator, slashes)| {
                 let mut tot_rate =
                     acc.get(validator).cloned().unwrap_or_default();
-                for slash in slashes {
+                for slash in slashes.values() {
                     debug_assert_eq!(slash.epoch, infraction_epoch);
                     let rate = cmp::max(
                         slash.r#type.get_slash_rate(&self.params),
@@ -3917,7 +3919,7 @@ impl AbstractPosState {
             let cur_slashes =
                 self.validator_slashes.entry(validator.clone()).or_default();
 
-            for slash in slashes {
+            for (_, slash) in slashes {
                 let rate = cmp::max(
                     slash.r#type.get_slash_rate(&self.params),
                     cubic_rate,

--- a/crates/proof_of_stake/src/tests/state_machine_v2.rs
+++ b/crates/proof_of_stake/src/tests/state_machine_v2.rs
@@ -3103,8 +3103,7 @@ impl ConcretePosState {
         let slash = enqueued_slashes_handle()
             .at(&processing_epoch)
             .at(validator)
-            .at(&infraction_height)
-            .back(&self.s)
+            .get(&self.s, &infraction_height)
             .unwrap();
         if let Some(slash) = slash {
             assert_eq!(slash.epoch, infraction_epoch);

--- a/crates/proof_of_stake/src/types/mod.rs
+++ b/crates/proof_of_stake/src/types/mod.rs
@@ -133,7 +133,7 @@ pub type ValidatorAddresses = crate::epoched::NestedEpoched<
 
 /// Slashes indexed by validator address and then block height (for easier
 /// retrieval and iteration when processing)
-pub type ValidatorSlashes = NestedMap<Address, Slashes>;
+pub type ValidatorSlashes = NestedMap<Address, NestedMap<u64, Slashes>>;
 
 /// Epoched slashes, where the outer epoch key is the epoch in which the slash
 /// is processed

--- a/crates/proof_of_stake/src/types/mod.rs
+++ b/crates/proof_of_stake/src/types/mod.rs
@@ -133,7 +133,7 @@ pub type ValidatorAddresses = crate::epoched::NestedEpoched<
 
 /// Slashes indexed by validator address and then block height (for easier
 /// retrieval and iteration when processing)
-pub type ValidatorSlashes = NestedMap<Address, NestedMap<u64, Slashes>>;
+pub type ValidatorSlashes = NestedMap<Address, LazyMap<u64, Slash>>;
 
 /// Epoched slashes, where the outer epoch key is the epoch in which the slash
 /// is processed


### PR DESCRIPTION
## Describe your changes
Make the enqueued slashes in the PoS state machine test compatible with #2574

## Indicate on which release or other PRs this topic is based on

#2574

 - diff https://github.com/anoma/namada/pull/3072/commits/e77da8a934760de081f8139de8191b9973dad182

## Checklist before merging to `draft`
- ~~[ ] I have added a changelog~~ - testing only
- [x] Git history is in acceptable state
