### PR TITLE
Murisi/expose randomness

### DIFF
--- a/.changelog/unreleased/improvements/3105-expose-randomness.md
+++ b/.changelog/unreleased/improvements/3105-expose-randomness.md
@@ -1,0 +1,2 @@
+- Expose the randomness used to generate the value commitments in the MASP
+  Transaction descriptions. ([\#3105](https://github.com/anoma/namada/pull/3105))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=b5f570f80157606b16b0520190e59d666b6916e3#b5f570f80157606b16b0520190e59d666b6916e3"
 dependencies = [
  "borsh 1.2.1",
  "chacha20",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=b5f570f80157606b16b0520190e59d666b6916e3#b5f570f80157606b16b0520190e59d666b6916e3"
 dependencies = [
  "aes",
  "bip0039",
@@ -4095,7 +4095,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=b5f570f80157606b16b0520190e59d666b6916e3#b5f570f80157606b16b0520190e59d666b6916e3"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ libc = "0.2.97"
 libloading = "0.7.2"
 linkme = "0.3.24"
 # branch = "murisi/namada-integration"
-masp_primitives = { git = "https://github.com/anoma/masp", rev = "6cbc8bd90a71cc280492c44bc3415162093daa76" }
-masp_proofs = { git = "https://github.com/anoma/masp", rev = "6cbc8bd90a71cc280492c44bc3415162093daa76", default-features = false, features = ["local-prover"] }
+masp_primitives = { git = "https://github.com/anoma/masp", rev = "b5f570f80157606b16b0520190e59d666b6916e3" }
+masp_proofs = { git = "https://github.com/anoma/masp", rev = "b5f570f80157606b16b0520190e59d666b6916e3", default-features = false, features = ["local-prover"] }
 num256 = "0.3.5"
 num_cpus = "1.13.0"
 num-derive = "0.3.3"

--- a/crates/apps/src/lib/client/tx.rs
+++ b/crates/apps/src/lib/client/tx.rs
@@ -13,7 +13,7 @@ use namada::governance::cli::onchain::{
 };
 use namada::io::Io;
 use namada::state::EPOCH_SWITCH_BLOCKS_DELAY;
-use namada::tx::{CompressedSignature, Section, Signer, Tx};
+use namada::tx::{CompressedAuthorization, Section, Signer, Tx};
 use namada_sdk::args::TxBecomeValidator;
 use namada_sdk::rpc::{InnerTxResult, TxBroadcastData, TxResponse};
 use namada_sdk::wallet::alias::validator_consensus_key;
@@ -115,7 +115,7 @@ pub async fn with_hardware_wallet<'a, U: WalletIo + Clone>(
                 .expect("unable to parse signature from Ledger");
         // Signatures from the Ledger come back in compressed
         // form
-        let compressed = CompressedSignature {
+        let compressed = CompressedAuthorization {
             targets: response.raw_indices,
             signer: Signer::PubKeys(vec![pubkey]),
             signatures: [(0, signature)].into(),
@@ -133,7 +133,7 @@ pub async fn with_hardware_wallet<'a, U: WalletIo + Clone>(
                 .expect("unable to parse signature from Ledger");
         // Signatures from the Ledger come back in compressed
         // form
-        let compressed = CompressedSignature {
+        let compressed = CompressedAuthorization {
             targets: response.wrapper_indices,
             signer: Signer::PubKeys(vec![pubkey]),
             signatures: [(0, signature)].into(),

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::str::FromStr;
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use masp_primitives::asset_type::AssetType;
 use namada_macros::BorshDeserializer;
@@ -27,6 +27,7 @@ use crate::token::{Denomination, MaspDigitPos};
     BorshSerialize,
     BorshDeserialize,
     BorshDeserializer,
+    BorshSchema,
     Clone,
     Debug,
     PartialOrd,

--- a/crates/core/src/token.rs
+++ b/crates/core/src/token.rs
@@ -921,6 +921,7 @@ impl From<Amount> for Uint {
     BorshSerialize,
     BorshDeserialize,
     BorshDeserializer,
+    BorshSchema,
     Serialize,
     Deserialize,
 )]

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -3108,7 +3108,12 @@ pub mod testing {
             _anchor: bls12_381::Scalar,
             _merkle_path: MerklePath<Node>,
         ) -> Result<
-            ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, PublicKey),
+            (
+                [u8; GROTH_PROOF_SIZE],
+                jubjub::ExtendedPoint,
+                jubjub::Fr,
+                PublicKey,
+            ),
             (),
         > {
             // Initialize secure RNG
@@ -3150,7 +3155,7 @@ pub mod testing {
             proof
                 .write(&mut zkproof[..])
                 .expect("should be able to serialize a proof");
-            Ok((zkproof, value_commitment, rk))
+            Ok((zkproof, value_commitment, rcv, rk))
         }
 
         fn output_proof(
@@ -3161,7 +3166,8 @@ pub mod testing {
             _rcm: jubjub::Fr,
             asset_type: AssetType,
             value: u64,
-        ) -> ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint) {
+        ) -> ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, jubjub::Fr)
+        {
             // Initialize secure RNG
             let mut rng = self.0.lock().unwrap();
 
@@ -3200,7 +3206,7 @@ pub mod testing {
                 .write(&mut zkproof[..])
                 .expect("should be able to serialize a proof");
 
-            (zkproof, value_commitment_point)
+            (zkproof, value_commitment_point, rcv)
         }
 
         fn convert_proof(
@@ -3210,8 +3216,10 @@ pub mod testing {
             value: u64,
             _anchor: bls12_381::Scalar,
             _merkle_path: MerklePath<Node>,
-        ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint), ()>
-        {
+        ) -> Result<
+            ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, jubjub::Fr),
+            (),
+        > {
             // Initialize secure RNG
             let mut rng = self.0.lock().unwrap();
 
@@ -3248,7 +3256,7 @@ pub mod testing {
                 .write(&mut zkproof[..])
                 .expect("should be able to serialize a proof");
 
-            Ok((zkproof, value_commitment))
+            Ok((zkproof, value_commitment, rcv))
         }
 
         fn binding_sig(

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -12,7 +12,7 @@ pub use namada_core::key::SignableEthMessage;
 pub use namada_core::sign::SignatureIndex;
 pub use types::{
     standalone_signature, verify_standalone_sig, Authorization, Code,
-    Commitment, CompressedSignature, Data, DecodeError, Header, MaspBuilder,
+    Commitment, CompressedAuthorization, Data, DecodeError, Header, MaspBuilder,
     Memo, Section, Signed, Signer, Tx, TxError, VerifySigError,
 };
 

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -12,8 +12,8 @@ pub use namada_core::key::SignableEthMessage;
 pub use namada_core::sign::SignatureIndex;
 pub use types::{
     standalone_signature, verify_standalone_sig, Authorization, Code,
-    Commitment, CompressedAuthorization, Data, DecodeError, Header, MaspBuilder,
-    Memo, Section, Signed, Signer, Tx, TxError, VerifySigError,
+    Commitment, CompressedAuthorization, Data, DecodeError, Header,
+    MaspBuilder, Memo, Section, Signed, Signer, Tx, TxError, VerifySigError,
 };
 
 #[cfg(test)]

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -554,7 +554,7 @@ impl Authorization {
     Serialize,
     Deserialize,
 )]
-pub struct CompressedSignature {
+pub struct CompressedAuthorization {
     /// The hash of the section being signed
     pub targets: Vec<u8>,
     /// The public keys against which the signatures should be verified
@@ -563,7 +563,7 @@ pub struct CompressedSignature {
     pub signatures: BTreeMap<u8, common::Signature>,
 }
 
-impl CompressedSignature {
+impl CompressedAuthorization {
     /// Decompress this signature object with respect to the given transaction
     /// by looking up the necessary section hashes. Used by constrained hardware
     /// wallets.

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -1586,3 +1586,19 @@ impl Tx {
         self
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use borsh::schema::BorshSchema;
+
+    /// Test that the BorshSchema for Tx gets generated without any name
+    /// conflicts
+    #[test]
+    fn test_tx_schema() {
+        let _declaration = super::Tx::declaration();
+        let mut definitions = BTreeMap::new();
+        super::Tx::add_definitions_recursively(&mut definitions);
+    }
+}

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -688,7 +688,13 @@ impl From<SaplingMetadataSerde> for Vec<u8> {
 /// A section providing the auxiliary inputs used to construct a MASP
 /// transaction
 #[derive(
-    Clone, Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+    Clone,
+    Debug,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Serialize,
+    Deserialize,
 )]
 pub struct MaspBuilder {
     /// The MASP transaction that this section witnesses
@@ -716,20 +722,6 @@ impl MaspBuilder {
     pub fn hash<'a>(&self, hasher: &'a mut Sha256) -> &'a mut Sha256 {
         hasher.update(self.serialize_to_vec());
         hasher
-    }
-}
-
-impl borsh::BorshSchema for MaspBuilder {
-    fn add_definitions_recursively(
-        _definitions: &mut BTreeMap<
-            borsh::schema::Declaration,
-            borsh::schema::Definition,
-        >,
-    ) {
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        "Builder".into()
     }
 }
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3304,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=b5f570f80157606b16b0520190e59d666b6916e3#b5f570f80157606b16b0520190e59d666b6916e3"
 dependencies = [
  "borsh 1.4.0",
  "chacha20",
@@ -3317,7 +3317,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=b5f570f80157606b16b0520190e59d666b6916e3#b5f570f80157606b16b0520190e59d666b6916e3"
 dependencies = [
  "aes",
  "bip0039",
@@ -3349,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=b5f570f80157606b16b0520190e59d666b6916e3#b5f570f80157606b16b0520190e59d666b6916e3"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=b5f570f80157606b16b0520190e59d666b6916e3#b5f570f80157606b16b0520190e59d666b6916e3"
 dependencies = [
  "borsh 1.2.1",
  "chacha20",
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=b5f570f80157606b16b0520190e59d666b6916e3#b5f570f80157606b16b0520190e59d666b6916e3"
 dependencies = [
  "aes",
  "bip0039",
@@ -3329,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=b5f570f80157606b16b0520190e59d666b6916e3#b5f570f80157606b16b0520190e59d666b6916e3"
 dependencies = [
  "bellman",
  "blake2b_simd",


### PR DESCRIPTION
## Describe your changes
In the course of hardware wallet implementation, it became apparent that value commitment randomness needs to be communicated to the hardware in order to allow the signing of MASP transactions in one round. This PR addresses this issue, more specifically it does the following:
* Updated the MASP crate dependency to one that exposes the value commitment randomness
* Corrected the `BorshSchema` generation for `MaspBuilder` sections from its previous stub
* Added a test to ensure that `Tx` `BorshSchema`s always get generated (given that name conflicts are possible)
  * This is important because the schema is the means by which these changes will be communicated

## Indicate on which release or other PRs this topic is based on
Namada v0.33.0
https://github.com/anoma/masp/pull/77

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
