### PR TITLE
Common default gas limit

### DIFF
--- a/.changelog/unreleased/improvements/2981-default-gas-limit.md
+++ b/.changelog/unreleased/improvements/2981-default-gas-limit.md
@@ -1,0 +1,3 @@
+- Set a shared gas limit default value for both the client and
+  the SDK. Removed the default implementation of gas limit.
+  ([\#2981](https://github.com/anoma/namada/issues/2981))

--- a/crates/apps/src/lib/cli.rs
+++ b/crates/apps/src/lib/cli.rs
@@ -3029,6 +3029,7 @@ pub mod args {
         TX_UPDATE_STEWARD_COMMISSION, TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM,
         VP_USER_WASM,
     };
+    use namada_sdk::DEFAULT_GAS_LIMIT;
 
     use super::context::*;
     use super::utils::*;
@@ -3141,8 +3142,10 @@ pub mod args {
     pub const FEE_PAYER_OPT: ArgOpt<WalletPublicKey> = arg_opt("gas-payer");
     pub const FILE_PATH: Arg<String> = arg("file");
     pub const FORCE: ArgFlag = flag("force");
-    pub const GAS_LIMIT: ArgDefault<GasLimit> =
-        arg_default("gas-limit", DefaultFn(|| GasLimit::from(25_000)));
+    pub const GAS_LIMIT: ArgDefault<GasLimit> = arg_default(
+        "gas-limit",
+        DefaultFn(|| GasLimit::from(DEFAULT_GAS_LIMIT)),
+    );
     pub const FEE_TOKEN: ArgDefaultFromCtx<WalletAddrOrNativeToken> =
         arg_default_from_ctx("gas-token", DefaultFn(|| "".parse().unwrap()));
     pub const FEE_PAYER: Arg<WalletAddress> = arg("fee-payer");

--- a/crates/apps/src/lib/config/genesis/transactions.rs
+++ b/crates/apps/src/lib/config/genesis/transactions.rs
@@ -86,7 +86,7 @@ fn get_tx_args(use_device: bool) -> TxArgs {
         wrapper_fee_payer: None,
         fee_token: genesis_fee_token_address(),
         fee_unshield: None,
-        gas_limit: Default::default(),
+        gas_limit: 0.into(),
         expiration: None,
         disposable_signing_key: false,
         chain_id: None,
@@ -131,7 +131,7 @@ fn get_tx_to_sign(tag: impl AsRef<str>, data: impl BorshSerialize) -> Tx {
         },
         fee_payer,
         Default::default(),
-        Default::default(),
+        0.into(),
         None,
     );
     tx

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -2293,7 +2293,7 @@ mod shell_tests {
                 },
                 keypair.ref_to(),
                 Epoch(0),
-                Default::default(),
+                0.into(),
                 None,
             ))));
         unsigned_wrapper.header.chain_id = shell.chain_id.clone();
@@ -2332,7 +2332,7 @@ mod shell_tests {
                 },
                 keypair.ref_to(),
                 Epoch(0),
-                Default::default(),
+                0.into(),
                 None,
             ))));
         invalid_wrapper.header.chain_id = shell.chain_id.clone();

--- a/crates/apps/src/lib/node/ledger/shell/prepare_proposal.rs
+++ b/crates/apps/src/lib/node/ledger/shell/prepare_proposal.rs
@@ -443,7 +443,7 @@ mod test_prepare_proposal {
                 },
                 keypair.ref_to(),
                 Epoch(0),
-                Default::default(),
+                0.into(),
                 None,
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
@@ -719,7 +719,7 @@ mod test_prepare_proposal {
                 },
                 keypair.ref_to(),
                 Epoch(0),
-                Default::default(),
+                0.into(),
                 None,
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
@@ -800,7 +800,7 @@ mod test_prepare_proposal {
                 },
                 keypair.ref_to(),
                 Epoch(0),
-                Default::default(),
+                0.into(),
                 None,
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
@@ -897,7 +897,7 @@ mod test_prepare_proposal {
                 },
                 keypair.ref_to(),
                 Epoch(0),
-                Default::default(),
+                0.into(),
                 None,
             ))));
         wrapper_tx.header.chain_id = shell.chain_id.clone();

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -68,6 +68,8 @@ use crate::tx::{
 };
 use crate::wallet::{Wallet, WalletIo, WalletStorage};
 
+pub const DEFAULT_GAS_LIMIT: u64 = 25_000;
+
 #[cfg(not(feature = "async-send"))]
 pub trait MaybeSync {}
 #[cfg(not(feature = "async-send"))]
@@ -138,7 +140,7 @@ pub trait Namada: Sized + MaybeSync + MaybeSend {
             wrapper_fee_payer: None,
             fee_token: self.native_token(),
             fee_unshield: None,
-            gas_limit: GasLimit::from(20_000),
+            gas_limit: GasLimit::from(DEFAULT_GAS_LIMIT),
             expiration: None,
             disposable_signing_key: false,
             chain_id: None,
@@ -663,7 +665,7 @@ where
                 wrapper_fee_payer: None,
                 fee_token: native_token,
                 fee_unshield: None,
-                gas_limit: GasLimit::from(20_000),
+                gas_limit: GasLimit::from(DEFAULT_GAS_LIMIT),
                 expiration: None,
                 disposable_signing_key: false,
                 chain_id: None,

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -480,7 +480,7 @@ mod test_process_tx {
             },
             keypair.ref_to(),
             Epoch(0),
-            Default::default(),
+            0.into(),
             None,
         ))));
         tx.set_code(Code::new("wasm code".as_bytes().to_owned(), None));
@@ -509,7 +509,7 @@ mod test_process_tx {
             },
             keypair.ref_to(),
             Epoch(0),
-            Default::default(),
+            0.into(),
             None,
         ))));
         tx.set_code(Code::new("wasm code".as_bytes().to_owned(), None));

--- a/crates/tx/src/data/wrapper.rs
+++ b/crates/tx/src/data/wrapper.rs
@@ -86,7 +86,6 @@ pub mod wrapper_tx {
     /// This struct only stores the multiple of GAS_LIMIT_RESOLUTION,
     /// not the raw amount
     #[derive(
-        Default,
         Debug,
         Clone,
         Copy,


### PR DESCRIPTION
## Describe your changes

Closes #2981.

Defines a common default value for `GasLimit` shared between the sdk and the client.
Removes the `Default` derive from `GasLimit`.

## Indicate on which release or other PRs this topic is based on

v0.33.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
