### PR TITLE
fix: mint and burn prelude functions

### DIFF
--- a/crates/tx_prelude/src/ibc.rs
+++ b/crates/tx_prelude/src/ibc.rs
@@ -12,6 +12,8 @@ pub use namada_ibc::{
     IbcActions, IbcCommonContext, IbcStorageContext, NftTransferModule,
     ProofSpec, TransferModule,
 };
+use namada_storage::StorageWrite;
+use namada_token::storage_key::minter_key;
 use namada_tx_env::TxEnv;
 
 use crate::token::{burn, mint, transfer};
@@ -73,13 +75,10 @@ impl IbcStorageContext for Ctx {
         token: &Address,
         amount: Amount,
     ) -> Result<(), Error> {
-        mint(
-            self,
-            &Address::Internal(InternalAddress::Ibc),
-            target,
-            token,
-            amount,
-        )
+        mint(self, target, token, amount)?;
+
+        let minter_key = minter_key(token);
+        self.write(&minter_key, &Address::Internal(InternalAddress::Ibc))
     }
 
     fn burn_token(

--- a/wasm/tx_change_bridge_pool/src/lib.rs
+++ b/wasm/tx_change_bridge_pool/src/lib.rs
@@ -22,13 +22,7 @@ fn apply_tx(ctx: &mut Ctx, signed: Tx) -> TxResult {
         amount,
         ref payer,
     } = transfer.gas_fee;
-    token::undenominated_transfer(
-        ctx,
-        payer,
-        &BRIDGE_POOL_ADDRESS,
-        fee_token_addr,
-        amount,
-    )?;
+    token::transfer(ctx, payer, &BRIDGE_POOL_ADDRESS, fee_token_addr, amount)?;
     debug_log!("Bridge pool token transfer succeeded");
     let TransferToEthereum {
         asset,
@@ -39,23 +33,11 @@ fn apply_tx(ctx: &mut Ctx, signed: Tx) -> TxResult {
     // if minting wNam, escrow the correct amount
     if asset == native_erc20_address(ctx)? {
         let nam_addr = ctx.get_native_token()?;
-        token::undenominated_transfer(
-            ctx,
-            sender,
-            &address::ETH_BRIDGE,
-            &nam_addr,
-            amount,
-        )?;
+        token::transfer(ctx, sender, &address::ETH_BRIDGE, &nam_addr, amount)?;
     } else {
         // Otherwise we escrow ERC20 tokens.
         let token = transfer.token_address();
-        token::undenominated_transfer(
-            ctx,
-            sender,
-            &BRIDGE_POOL_ADDRESS,
-            &token,
-            amount,
-        )?;
+        token::transfer(ctx, sender, &BRIDGE_POOL_ADDRESS, &token, amount)?;
     }
     debug_log!("Bridge pool escrow succeeded");
     // add transfer into the pool


### PR DESCRIPTION
## Describe your changes
Reusing the `burn` and `credit` functions from the token crate
## Indicate on which release or other PRs this topic is based on
v0.33.0
## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
