### PR TITLE
Adjusted test vector printing to simplify hardware wallet implementations

### DIFF
--- a/.changelog/unreleased/improvements/3122-test-vectors-0.33.0.md
+++ b/.changelog/unreleased/improvements/3122-test-vectors-0.33.0.md
@@ -1,0 +1,2 @@
+- Adjusted hardware wallet test vectors to simplify hardware wallet app
+  ([\#3122](https://github.com/anoma/namada/pull/3122))

--- a/crates/governance/src/storage/proposal.rs
+++ b/crates/governance/src/storage/proposal.rs
@@ -461,7 +461,7 @@ impl Display for ProposalType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ProposalType::Default => write!(f, "Default"),
-            ProposalType::DefaultWithWasm(_) => write!(f, "DefaultWithWasm"),
+            ProposalType::DefaultWithWasm(_) => write!(f, "Default with Wasm"),
             ProposalType::PGFSteward(_) => write!(f, "PGF steward"),
             ProposalType::PGFPayment(_) => write!(f, "PGF funding"),
         }
@@ -732,6 +732,7 @@ pub mod testing {
     /// Generate an arbitrary proposal type
     pub fn arb_proposal_type() -> impl Strategy<Value = ProposalType> {
         prop_oneof![
+            Just(ProposalType::Default),
             arb_hash().prop_map(ProposalType::DefaultWithWasm),
             collection::btree_set(
                 arb_add_remove(arb_non_internal_address()),

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -910,30 +910,6 @@ impl<'a> Display for LedgerProposalVote<'a> {
     }
 }
 
-/// A ProposalType wrapper that prints the hash of the contained WASM code if it
-/// is present.
-struct LedgerProposalType<'a>(&'a ProposalType, &'a Tx);
-
-impl<'a> Display for LedgerProposalType<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self.0 {
-            ProposalType::Default => write!(f, "Default"),
-            ProposalType::DefaultWithWasm(hash) => {
-                let extra = self
-                    .1
-                    .get_section(hash)
-                    .and_then(|x| Section::extra_data_sec(x.as_ref()))
-                    .expect("unable to load vp code")
-                    .code
-                    .hash();
-                write!(f, "{}", HEXLOWER.encode(&extra.0))
-            }
-            ProposalType::PGFSteward(_) => write!(f, "PGF Steward"),
-            ProposalType::PGFPayment(_) => write!(f, "PGF Payment"),
-        }
-    }
-}
-
 fn proposal_type_to_ledger_vector(
     proposal_type: &ProposalType,
     tx: &Tx,
@@ -1787,17 +1763,14 @@ pub async fn to_ledger_vector(
             format!("Type : Update Steward Commission"),
             format!("Steward : {}", update.steward),
         ]);
-        let mut commission = update.commission.iter().collect::<Vec<_>>();
-        // Print the test vectors in the same order as the serializations
-        commission.sort_by(|(a, _), (b, _)| a.cmp(b));
-        for (address, dec) in &commission {
+        for (address, dec) in update.commission.iter() {
             tv.output.push(format!("Validator : {}", address));
             tv.output.push(format!("Commission Rate : {}", dec));
         }
 
         tv.output_expert
             .push(format!("Steward : {}", update.steward));
-        for (address, dec) in &commission {
+        for (address, dec) in update.commission.iter() {
             tv.output_expert.push(format!("Validator : {}", address));
             tv.output_expert.push(format!("Commission Rate : {}", dec));
         }


### PR DESCRIPTION
## Describe your changes
Made the adjustments to facilitate the hardware wallet's printing of transactions. More specifically, the ordering used to print the `commission` field of an update steward commission transaction has been changed to reflect its serialization order. Also removed some dead code pertaining to printing out proposal types.

## Indicate on which release or other PRs this topic is based on
Namada v0.33.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
