### PR TITLE
Merklize commitment tree anchor keys

### DIFF
--- a/.changelog/unreleased/improvements/2794-merkle-masp-hashes.md
+++ b/.changelog/unreleased/improvements/2794-merkle-masp-hashes.md
@@ -1,0 +1,2 @@
+- Adds masp commitment tree anchor keys to the merkle tree.
+  ([\#2794](https://github.com/anoma/namada/issues/2794))

--- a/crates/apps/src/lib/node/ledger/shell/mod.rs
+++ b/crates/apps/src/lib/node/ledger/shell/mod.rs
@@ -361,6 +361,7 @@ pub fn is_merklized_storage_key(key: &namada_sdk::storage::Key) -> bool {
         && *key != token::storage_key::masp_convert_anchor_key()
         && *key != token::storage_key::masp_token_map_key()
         && *key != token::storage_key::masp_assets_hash_key()
+        && !token::storage_key::is_masp_commitment_anchor_key(key)
         || namada::ibc::storage::is_ibc_counter_key(key))
 }
 

--- a/crates/shielded_token/src/storage_key.rs
+++ b/crates/shielded_token/src/storage_key.rs
@@ -112,6 +112,15 @@ pub fn is_masp_nullifier_key(key: &storage::Key) -> bool {
         ] if *addr == address::MASP && prefix == MASP_NULLIFIERS_KEY)
 }
 
+/// Check if the given key is a masp commitment anchor
+pub fn is_masp_commitment_anchor_key(key: &storage::Key) -> bool {
+    matches!(&key.segments[..],
+    [DbKeySeg::AddressSeg(addr),
+             DbKeySeg::StringSeg(prefix),
+            ..
+        ] if *addr == address::MASP && prefix == MASP_NOTE_COMMITMENT_ANCHOR_PREFIX)
+}
+
 /// Get a key for a masp pin
 pub fn masp_pin_tx_key(key: &str) -> storage::Key {
     storage::Key::from(address::MASP.to_db_key())


### PR DESCRIPTION
## Describe your changes

Closes #2794.

Adds the masp commitment tree anchor keys to the merkle tree so that they can be tracked in the app hash.

## Indicate on which release or other PRs this topic is based on

v0.33.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
