### PR TITLE
Keep generated dates in the current era so that parsing RFC 3339 works.

### DIFF
--- a/.changelog/unreleased/bug-fixes/3130-gen-in-current-era.md
+++ b/.changelog/unreleased/bug-fixes/3130-gen-in-current-era.md
@@ -1,0 +1,2 @@
+- Ensure that date-time generator conforms to RFC 3339.
+  ([\#3130](https://github.com/anoma/namada/pull/3130))

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -813,7 +813,7 @@ pub mod testing {
     use crate::masp::testing::{
         arb_deshielding_transfer, arb_shielded_transfer, arb_shielding_transfer,
     };
-    use crate::time::{DateTime, DateTimeUtc, Utc};
+    use crate::time::{DateTime, DateTimeUtc, TimeZone, Utc};
     use crate::tx::data::pgf::tests::arb_update_steward_commission;
     use crate::tx::data::pos::tests::{
         arb_become_validator, arb_bond, arb_commission_change,
@@ -917,7 +917,7 @@ pub mod testing {
     prop_compose! {
         // Generate a date and time
         pub fn arb_date_time_utc()(
-            secs in DateTime::<Utc>::MIN_UTC.timestamp()..=DateTime::<Utc>::MAX_UTC.timestamp(),
+            secs in Utc.with_ymd_and_hms(0, 1, 1, 0, 0, 0).unwrap().timestamp()..=Utc.with_ymd_and_hms(9999, 12, 31, 23, 59, 59).unwrap().timestamp(),
             nsecs in ..1000000000u32,
         ) -> DateTimeUtc {
             DateTimeUtc(DateTime::<Utc>::from_timestamp(secs, nsecs).unwrap())


### PR DESCRIPTION
## Describe your changes
Restricted the date-time generator to only generate valid RFC 3339 dates. This means that the date-time generator now only generates date-times in the current era, which ranges from 0000AD to 9999AD. This change is necessary to ensure that `DateTimeUtc`s, and hence `Tx`s (whose `Tx::header` contains the fields `Header::expiration` and `Header::timestamp`) deserialize correctly.

## Indicate on which release or other PRs this topic is based on
Namada v0.33.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
