### PR TITLE
deps: switch back to upstream tower-abci v0.11.1

### DIFF
--- a/.changelog/unreleased/miscellaneous/3137-tower-abci-upstream.md
+++ b/.changelog/unreleased/miscellaneous/3137-tower-abci-upstream.md
@@ -1,0 +1,2 @@
+- Switched back to upstream tower-abci v0.11.1.
+  ([\#3137](https://github.com/anoma/namada/pull/3137))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7985,7 +7985,8 @@ dependencies = [
 [[package]]
 name = "tower-abci"
 version = "0.11.1"
-source = "git+https://github.com/heliaxdev/tower-abci.git?rev=a41ab4b336875084e04f4803868adf41ef62a67c#a41ab4b336875084e04f4803868adf41ef62a67c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4826f3df3e9a37083d978cae73f020bcdf6143956b7dfc1bd6050b4e16367c"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,8 +175,7 @@ tonic = "0.8.3"
 tonic-build = "0.8.4"
 tower = "0.4"
 # Also, using the same version of tendermint-rs as we do here.
-# https://github.com/penumbra-zone/tower-abci/pull/40 based on 0.11.1
-tower-abci = {git = "https://github.com/heliaxdev/tower-abci.git", rev = "a41ab4b336875084e04f4803868adf41ef62a67c"}
+tower-abci = "0.11.1"
 tracing = "0.1.30"
 tracing-appender = "0.2.2"
 tracing-log = "0.1.2"


### PR DESCRIPTION
## Describe your changes

I can no longer reproduce the issue that we fixed in #2152 with the query error handling. When the service is overloaded, CometBFT simply reports e.g. `failed to write responses module=rpc-server err="write tcp 127.0.0.1:27657->127.0.0.1:36888: i/o timeout` and both Namada and Comet continue to run without any issues.

## Indicate on which release or other PRs this topic is based on

v0.33.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
