### PR TITLE
Murisi/receive randomness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=d1e0876b304968edfa36707ffe4fb8fbbee131d2#d1e0876b304968edfa36707ffe4fb8fbbee131d2"
 dependencies = [
  "borsh 1.2.1",
  "chacha20",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=d1e0876b304968edfa36707ffe4fb8fbbee131d2#d1e0876b304968edfa36707ffe4fb8fbbee131d2"
 dependencies = [
  "aes",
  "bip0039",
@@ -4095,7 +4095,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=d1e0876b304968edfa36707ffe4fb8fbbee131d2#d1e0876b304968edfa36707ffe4fb8fbbee131d2"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ libc = "0.2.97"
 libloading = "0.7.2"
 linkme = "0.3.24"
 # branch = "murisi/namada-integration"
-masp_primitives = { git = "https://github.com/anoma/masp", rev = "6cbc8bd90a71cc280492c44bc3415162093daa76" }
-masp_proofs = { git = "https://github.com/anoma/masp", rev = "6cbc8bd90a71cc280492c44bc3415162093daa76", default-features = false, features = ["local-prover"] }
+masp_primitives = { git = "https://github.com/anoma/masp", rev = "d1e0876b304968edfa36707ffe4fb8fbbee131d2" }
+masp_proofs = { git = "https://github.com/anoma/masp", rev = "d1e0876b304968edfa36707ffe4fb8fbbee131d2", default-features = false, features = ["local-prover"] }
 num256 = "0.3.5"
 num_cpus = "1.13.0"
 num-derive = "0.3.3"

--- a/crates/apps/src/lib/client/tx.rs
+++ b/crates/apps/src/lib/client/tx.rs
@@ -13,7 +13,7 @@ use namada::governance::cli::onchain::{
 };
 use namada::io::Io;
 use namada::state::EPOCH_SWITCH_BLOCKS_DELAY;
-use namada::tx::{CompressedSignature, Section, Signer, Tx};
+use namada::tx::{CompressedAuthorization, Section, Signer, Tx};
 use namada_sdk::args::TxBecomeValidator;
 use namada_sdk::rpc::{InnerTxResult, TxBroadcastData, TxResponse};
 use namada_sdk::wallet::alias::validator_consensus_key;
@@ -115,7 +115,7 @@ pub async fn with_hardware_wallet<'a, U: WalletIo + Clone>(
                 .expect("unable to parse signature from Ledger");
         // Signatures from the Ledger come back in compressed
         // form
-        let compressed = CompressedSignature {
+        let compressed = CompressedAuthorization {
             targets: response.raw_indices,
             signer: Signer::PubKeys(vec![pubkey]),
             signatures: [(0, signature)].into(),
@@ -133,7 +133,7 @@ pub async fn with_hardware_wallet<'a, U: WalletIo + Clone>(
                 .expect("unable to parse signature from Ledger");
         // Signatures from the Ledger come back in compressed
         // form
-        let compressed = CompressedSignature {
+        let compressed = CompressedAuthorization {
             targets: response.wrapper_indices,
             signer: Signer::PubKeys(vec![pubkey]),
             signatures: [(0, signature)].into(),

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::str::FromStr;
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use masp_primitives::asset_type::AssetType;
 use namada_macros::BorshDeserializer;
@@ -27,6 +27,7 @@ use crate::token::{Denomination, MaspDigitPos};
     BorshSerialize,
     BorshDeserialize,
     BorshDeserializer,
+    BorshSchema,
     Clone,
     Debug,
     PartialOrd,

--- a/crates/core/src/token.rs
+++ b/crates/core/src/token.rs
@@ -921,6 +921,7 @@ impl From<Amount> for Uint {
     BorshSerialize,
     BorshDeserialize,
     BorshDeserializer,
+    BorshSchema,
     Serialize,
     Deserialize,
 )]

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -31,7 +31,9 @@ use masp_primitives::sapling::{
     Diversifier, Node, Note, Nullifier, ViewingKey,
 };
 use masp_primitives::transaction::builder::{self, *};
-use masp_primitives::transaction::components::sapling::builder::SaplingMetadata;
+use masp_primitives::transaction::components::sapling::builder::{
+    RngBuildParams, SaplingMetadata,
+};
 use masp_primitives::transaction::components::transparent::builder::TransparentBuilder;
 use masp_primitives::transaction::components::{
     ConvertDescription, I128Sum, OutputDescription, SpendDescription, TxOut,
@@ -124,7 +126,7 @@ pub type IndexedNoteEntry = (
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshDeserializer)]
 pub struct ShieldedTransfer {
     /// Shielded transfer builder
-    pub builder: Builder<(), (), ExtendedFullViewingKey, ()>,
+    pub builder: Builder<(), ExtendedFullViewingKey, ()>,
     /// MASP transaction
     pub masp_tx: Transaction,
     /// Metadata
@@ -449,20 +451,10 @@ impl<P1>
     }
 }
 
-impl<P1, R1, N1>
-    MapBuilder<
-        P1,
-        R1,
-        ExtendedSpendingKey,
-        N1,
-        (),
-        (),
-        ExtendedFullViewingKey,
-        (),
-    > for WalletMap
+impl<P1, N1>
+    MapBuilder<P1, ExtendedSpendingKey, N1, (), ExtendedFullViewingKey, ()>
+    for WalletMap
 {
-    fn map_rng(&self, _s: R1) {}
-
     fn map_notifier(&self, _s: N1) {}
 }
 
@@ -1986,9 +1978,10 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
         let memo = MemoBytes::empty();
 
         // Try to get a seed from env var, if any.
-        let rng = StdRng::from_rng(OsRng).unwrap();
+        #[allow(unused_mut)]
+        let mut rng = StdRng::from_rng(OsRng).unwrap();
         #[cfg(feature = "testing")]
-        let rng = if let Ok(seed) = env::var(ENV_VAR_MASP_TEST_SEED)
+        let mut rng = if let Ok(seed) = env::var(ENV_VAR_MASP_TEST_SEED)
             .map_err(|e| Error::Other(e.to_string()))
             .and_then(|seed| {
                 let exp_str =
@@ -2044,13 +2037,12 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
                 u32::MAX - 20
             }
         };
-        let mut builder = Builder::<TestNetwork, _>::new_with_rng(
+        let mut builder = Builder::<TestNetwork, _>::new(
             NETWORK,
             // NOTE: this is going to add 20 more blocks to the actual
             // expiration but there's no other exposed function that we could
             // use from the masp crate to specify the expiration better
             expiration_height.into(),
-            rng,
         );
 
         // Convert transaction amount into MASP types
@@ -2302,8 +2294,12 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
         let prover = context.shielded().await.utils.local_tx_prover();
         #[cfg(feature = "testing")]
         let prover = testing::MockTxProver(std::sync::Mutex::new(OsRng));
-        let (masp_tx, metadata) =
-            builder.build(&prover, &FeeRule::non_standard(U64Sum::zero()))?;
+        let (masp_tx, metadata) = builder.build(
+            &prover,
+            &FeeRule::non_standard(U64Sum::zero()),
+            &mut rng,
+            &mut RngBuildParams::new(OsRng),
+        )?;
 
         if update_ctx {
             // Cache the generated transfer
@@ -2901,7 +2897,6 @@ pub mod testing {
     use bls12_381::{G1Affine, G2Affine};
     use masp_primitives::consensus::testing::arb_height;
     use masp_primitives::constants::SPENDING_KEY_GENERATOR;
-    use masp_primitives::ff::Field;
     use masp_primitives::sapling::prover::TxProver;
     use masp_primitives::sapling::redjubjub::Signature;
     use masp_primitives::sapling::{ProofGenerationKey, Rseed};
@@ -3107,16 +3102,11 @@ pub mod testing {
             value: u64,
             _anchor: bls12_381::Scalar,
             _merkle_path: MerklePath<Node>,
+            rcv: jubjub::Fr,
         ) -> Result<
             ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint, PublicKey),
             (),
         > {
-            // Initialize secure RNG
-            let mut rng = self.0.lock().unwrap();
-
-            // We create the randomness of the value commitment
-            let rcv = jubjub::Fr::random(&mut *rng);
-
             // Accumulate the value commitment randomness in the context
             {
                 let mut tmp = rcv;
@@ -3161,15 +3151,8 @@ pub mod testing {
             _rcm: jubjub::Fr,
             asset_type: AssetType,
             value: u64,
+            rcv: jubjub::Fr,
         ) -> ([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint) {
-            // Initialize secure RNG
-            let mut rng = self.0.lock().unwrap();
-
-            // We construct ephemeral randomness for the value commitment. This
-            // randomness is not given back to the caller, but the synthetic
-            // blinding factor `bsk` is accumulated in the context.
-            let rcv = jubjub::Fr::random(&mut *rng);
-
             // Accumulate the value commitment randomness in the context
             {
                 let mut tmp = rcv.neg(); // Outputs subtract from the total.
@@ -3210,14 +3193,9 @@ pub mod testing {
             value: u64,
             _anchor: bls12_381::Scalar,
             _merkle_path: MerklePath<Node>,
+            rcv: jubjub::Fr,
         ) -> Result<([u8; GROTH_PROOF_SIZE], jubjub::ExtendedPoint), ()>
         {
-            // Initialize secure RNG
-            let mut rng = self.0.lock().unwrap();
-
-            // We create the randomness of the value commitment
-            let rcv = jubjub::Fr::random(&mut *rng);
-
             // Accumulate the value commitment randomness in the context
             {
                 let mut tmp = rcv;
@@ -3371,6 +3349,7 @@ pub mod testing {
             address in arb_transparent_address(),
             expiration_height in arb_height(BranchId::MASP, &TestNetwork),
             mut rng in arb_rng().prop_map(TestCsprng),
+            bparams_rng in arb_rng().prop_map(TestCsprng),
             prover_rng in arb_rng().prop_map(TestCsprng),
         ) -> (ExtendedSpendingKey, Diversifier, Note, Node) {
             let mut spending_key_seed = [0; 32];
@@ -3383,13 +3362,12 @@ pub mod testing {
                 .to_payment_address(div)
                 .expect("a PaymentAddress");
 
-            let mut builder = Builder::<TestNetwork, _>::new_with_rng(
+            let mut builder = Builder::<TestNetwork, _>::new(
                 NETWORK,
                 // NOTE: this is going to add 20 more blocks to the actual
                 // expiration but there's no other exposed function that we could
                 // use from the masp crate to specify the expiration better
                 expiration_height.unwrap(),
-                rng,
             );
             // Add a transparent input to support our desired shielded output
             builder.add_transparent_input(TxOut { asset_type, value, address }).unwrap();
@@ -3399,6 +3377,8 @@ pub mod testing {
             let (transaction, metadata) = builder.build(
                 &MockTxProver(Mutex::new(prover_rng)),
                 &FeeRule::non_standard(U64Sum::zero()),
+                &mut rng,
+                &mut RngBuildParams::new(bparams_rng),
             ).unwrap();
             // Extract the shielded output from the transaction
             let shielded_output = &transaction
@@ -3529,7 +3509,6 @@ pub mod testing {
             ),
         )(
             expiration_height in arb_height(BranchId::MASP, &TestNetwork),
-            rng in arb_rng().prop_map(TestCsprng),
             spend_descriptions in assets
                 .iter()
                 .map(|(asset, values)| arb_spend_descriptions(asset.clone(), values.clone()))
@@ -3540,16 +3519,15 @@ pub mod testing {
                 .collect::<Vec<_>>(),
             assets in Just(assets),
         ) -> (
-            Builder::<TestNetwork, TestCsprng<TestRng>>,
+            Builder::<TestNetwork>,
             HashMap<AssetData, u64>,
         ) {
-            let mut builder = Builder::<TestNetwork, _>::new_with_rng(
+            let mut builder = Builder::<TestNetwork, _>::new(
                 NETWORK,
                 // NOTE: this is going to add 20 more blocks to the actual
                 // expiration but there's no other exposed function that we could
                 // use from the masp crate to specify the expiration better
                 expiration_height.unwrap(),
-                rng,
             );
             let mut leaves = Vec::new();
             // First construct a Merkle tree containing all notes to be used
@@ -3598,7 +3576,6 @@ pub mod testing {
             ),
         )(
             expiration_height in arb_height(BranchId::MASP, &TestNetwork),
-            rng in arb_rng().prop_map(TestCsprng),
             txins in assets
                 .iter()
                 .map(|(asset, values)| arb_txouts(asset.clone(), values.clone(), source))
@@ -3609,16 +3586,15 @@ pub mod testing {
                 .collect::<Vec<_>>(),
             assets in Just(assets),
         ) -> (
-            Builder::<TestNetwork, TestCsprng<TestRng>>,
+            Builder::<TestNetwork>,
             HashMap<AssetData, u64>,
         ) {
-            let mut builder = Builder::<TestNetwork, _>::new_with_rng(
+            let mut builder = Builder::<TestNetwork, _>::new(
                 NETWORK,
                 // NOTE: this is going to add 20 more blocks to the actual
                 // expiration but there's no other exposed function that we could
                 // use from the masp crate to specify the expiration better
                 expiration_height.unwrap(),
-                rng,
             );
             for txin in txins.into_iter().flatten() {
                 builder.add_transparent_input(txin).unwrap();
@@ -3643,7 +3619,6 @@ pub mod testing {
             ),
         )(
             expiration_height in arb_height(BranchId::MASP, &TestNetwork),
-            rng in arb_rng().prop_map(TestCsprng),
             spend_descriptions in assets
                 .iter()
                 .map(|(asset, values)| arb_spend_descriptions(asset.clone(), values.clone()))
@@ -3654,16 +3629,15 @@ pub mod testing {
                 .collect::<Vec<_>>(),
             assets in Just(assets),
         ) -> (
-            Builder::<TestNetwork, TestCsprng<TestRng>>,
+            Builder::<TestNetwork>,
             HashMap<AssetData, u64>,
         ) {
-            let mut builder = Builder::<TestNetwork, _>::new_with_rng(
+            let mut builder = Builder::<TestNetwork, _>::new(
                 NETWORK,
                 // NOTE: this is going to add 20 more blocks to the actual
                 // expiration but there's no other exposed function that we could
                 // use from the masp crate to specify the expiration better
                 expiration_height.unwrap(),
-                rng,
             );
             let mut leaves = Vec::new();
             // First construct a Merkle tree containing all notes to be used
@@ -3689,11 +3663,15 @@ pub mod testing {
         )(asset_range in Just(asset_range.into()))(
             (builder, asset_types) in arb_shielded_builder(asset_range),
             epoch in arb_epoch(),
-            rng in arb_rng().prop_map(TestCsprng),
+            prover_rng in arb_rng().prop_map(TestCsprng),
+            mut rng in arb_rng().prop_map(TestCsprng),
+            bparams_rng in arb_rng().prop_map(TestCsprng),
         ) -> (ShieldedTransfer, HashMap<AssetData, u64>) {
             let (masp_tx, metadata) = builder.clone().build(
-                &MockTxProver(Mutex::new(rng)),
+                &MockTxProver(Mutex::new(prover_rng)),
                 &FeeRule::non_standard(U64Sum::zero()),
+                &mut rng,
+                &mut RngBuildParams::new(bparams_rng),
             ).unwrap();
             (ShieldedTransfer {
                 builder: builder.map_builder(WalletMap),
@@ -3715,11 +3693,15 @@ pub mod testing {
                 asset_range,
             ),
             epoch in arb_epoch(),
-            rng in arb_rng().prop_map(TestCsprng),
+            prover_rng in arb_rng().prop_map(TestCsprng),
+            mut rng in arb_rng().prop_map(TestCsprng),
+            bparams_rng in arb_rng().prop_map(TestCsprng),
         ) -> (ShieldedTransfer, HashMap<AssetData, u64>) {
             let (masp_tx, metadata) = builder.clone().build(
-                &MockTxProver(Mutex::new(rng)),
+                &MockTxProver(Mutex::new(prover_rng)),
                 &FeeRule::non_standard(U64Sum::zero()),
+                &mut rng,
+                &mut RngBuildParams::new(bparams_rng),
             ).unwrap();
             (ShieldedTransfer {
                 builder: builder.map_builder(WalletMap),
@@ -3741,11 +3723,15 @@ pub mod testing {
                 asset_range,
             ),
             epoch in arb_epoch(),
-            rng in arb_rng().prop_map(TestCsprng),
+            prover_rng in arb_rng().prop_map(TestCsprng),
+            mut rng in arb_rng().prop_map(TestCsprng),
+            bparams_rng in arb_rng().prop_map(TestCsprng),
         ) -> (ShieldedTransfer, HashMap<AssetData, u64>) {
             let (masp_tx, metadata) = builder.clone().build(
-                &MockTxProver(Mutex::new(rng)),
+                &MockTxProver(Mutex::new(prover_rng)),
                 &FeeRule::non_standard(U64Sum::zero()),
+                &mut rng,
+                &mut RngBuildParams::new(bparams_rng),
             ).unwrap();
             (ShieldedTransfer {
                 builder: builder.map_builder(WalletMap),

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2850,9 +2850,9 @@ async fn add_asset_type(
 /// Collect the asset types used in the given Builder and decode them. This
 /// function provides the data necessary for offline wallets to present asset
 /// type information.
-async fn used_asset_types<P, R, K, N>(
+async fn used_asset_types<P, K, N>(
     context: &impl Namada,
-    builder: &Builder<P, R, K, N>,
+    builder: &Builder<P, K, N>,
 ) -> std::result::Result<HashSet<AssetData>, RpcError> {
     let mut asset_types = HashSet::new();
     // Collect all the asset types used in the Sapling inputs

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -12,7 +12,7 @@ pub use namada_core::key::SignableEthMessage;
 pub use namada_core::sign::SignatureIndex;
 pub use types::{
     standalone_signature, verify_standalone_sig, Authorization, Code,
-    Commitment, CompressedSignature, Data, DecodeError, Header, MaspBuilder,
+    Commitment, CompressedAuthorization, Data, DecodeError, Header, MaspBuilder,
     Memo, Section, Signed, Signer, Tx, TxError, VerifySigError,
 };
 

--- a/crates/tx/src/lib.rs
+++ b/crates/tx/src/lib.rs
@@ -12,8 +12,8 @@ pub use namada_core::key::SignableEthMessage;
 pub use namada_core::sign::SignatureIndex;
 pub use types::{
     standalone_signature, verify_standalone_sig, Authorization, Code,
-    Commitment, CompressedAuthorization, Data, DecodeError, Header, MaspBuilder,
-    Memo, Section, Signed, Signer, Tx, TxError, VerifySigError,
+    Commitment, CompressedAuthorization, Data, DecodeError, Header,
+    MaspBuilder, Memo, Section, Signed, Signer, Tx, TxError, VerifySigError,
 };
 
 #[cfg(test)]

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -554,7 +554,7 @@ impl Authorization {
     Serialize,
     Deserialize,
 )]
-pub struct CompressedSignature {
+pub struct CompressedAuthorization {
     /// The hash of the section being signed
     pub targets: Vec<u8>,
     /// The public keys against which the signatures should be verified
@@ -563,7 +563,7 @@ pub struct CompressedSignature {
     pub signatures: BTreeMap<u8, common::Signature>,
 }
 
-impl CompressedSignature {
+impl CompressedAuthorization {
     /// Decompress this signature object with respect to the given transaction
     /// by looking up the necessary section hashes. Used by constrained hardware
     /// wallets.

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -713,7 +713,7 @@ pub struct MaspBuilder {
         serialize_with = "borsh_serde::<BuilderSerde, _>",
         deserialize_with = "serde_borsh::<BuilderSerde, _, _>"
     )]
-    pub builder: Builder<(), (), ExtendedFullViewingKey, ()>,
+    pub builder: Builder<(), ExtendedFullViewingKey, ()>,
 }
 
 impl MaspBuilder {

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -1586,3 +1586,19 @@ impl Tx {
         self
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use borsh::schema::BorshSchema;
+
+    /// Test that the BorshSchema for Tx gets generated without any name
+    /// conflicts
+    #[test]
+    fn test_tx_schema() {
+        let _declaration = super::Tx::declaration();
+        let mut definitions = BTreeMap::new();
+        super::Tx::add_definitions_recursively(&mut definitions);
+    }
+}

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -688,7 +688,13 @@ impl From<SaplingMetadataSerde> for Vec<u8> {
 /// A section providing the auxiliary inputs used to construct a MASP
 /// transaction
 #[derive(
-    Clone, Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+    Clone,
+    Debug,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Serialize,
+    Deserialize,
 )]
 pub struct MaspBuilder {
     /// The MASP transaction that this section witnesses
@@ -716,20 +722,6 @@ impl MaspBuilder {
     pub fn hash<'a>(&self, hasher: &'a mut Sha256) -> &'a mut Sha256 {
         hasher.update(self.serialize_to_vec());
         hasher
-    }
-}
-
-impl borsh::BorshSchema for MaspBuilder {
-    fn add_definitions_recursively(
-        _definitions: &mut BTreeMap<
-            borsh::schema::Declaration,
-            borsh::schema::Definition,
-        >,
-    ) {
-    }
-
-    fn declaration() -> borsh::schema::Declaration {
-        "Builder".into()
     }
 }
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3304,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=d1e0876b304968edfa36707ffe4fb8fbbee131d2#d1e0876b304968edfa36707ffe4fb8fbbee131d2"
 dependencies = [
  "borsh 1.4.0",
  "chacha20",
@@ -3317,7 +3317,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=d1e0876b304968edfa36707ffe4fb8fbbee131d2#d1e0876b304968edfa36707ffe4fb8fbbee131d2"
 dependencies = [
  "aes",
  "bip0039",
@@ -3349,7 +3349,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=d1e0876b304968edfa36707ffe4fb8fbbee131d2#d1e0876b304968edfa36707ffe4fb8fbbee131d2"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=d1e0876b304968edfa36707ffe4fb8fbbee131d2#d1e0876b304968edfa36707ffe4fb8fbbee131d2"
 dependencies = [
  "borsh 1.2.1",
  "chacha20",
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=d1e0876b304968edfa36707ffe4fb8fbbee131d2#d1e0876b304968edfa36707ffe4fb8fbbee131d2"
 dependencies = [
  "aes",
  "bip0039",
@@ -3329,7 +3329,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6cbc8bd90a71cc280492c44bc3415162093daa76#6cbc8bd90a71cc280492c44bc3415162093daa76"
+source = "git+https://github.com/anoma/masp?rev=d1e0876b304968edfa36707ffe4fb8fbbee131d2#d1e0876b304968edfa36707ffe4fb8fbbee131d2"
 dependencies = [
  "bellman",
  "blake2b_simd",


### PR DESCRIPTION
## Describe your changes
In the course of hardware wallet implementation, it became apparent that value commitment randomness needs to be communicated from the hardware in order to allow the signing and proving of MASP transactions in one round. This PR addresses this issue, more specifically it does the following:
* Updated the MASP crate dependency to one that receives value commitment randomness
* Corrected the `BorshSchema` generation for `MaspBuilder` sections from its previous stub
* Added a test to ensure that `Tx` `BorshSchema`s always get generated (given that name conflicts are possible)
  * This is important because the schema is the means by which these changes will be communicated

## Indicate on which release or other PRs this topic is based on
Namada v0.33.0
https://github.com/anoma/masp/pull/78

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
