### PR TITLE
wasm: switch to cranelift compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,32 +1700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
-name = "dynasm"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
-dependencies = [
- "byteorder",
- "dynasm",
- "memmap2",
-]
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,7 +4334,7 @@ dependencies = [
  "wasm-instrument",
  "wasmer",
  "wasmer-cache",
- "wasmer-compiler-singlepass",
+ "wasmer-compiler-cranelift",
  "wasmer-engine-dylib",
  "wasmer-engine-universal",
  "wasmer-vm",
@@ -4497,7 +4471,7 @@ dependencies = [
  "tempfile",
  "wasm-instrument",
  "wasmer",
- "wasmer-compiler-singlepass",
+ "wasmer-compiler-cranelift",
  "wasmer-engine-universal",
 ]
 
@@ -8578,25 +8552,6 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tracing",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-compiler-singlepass"
-version = "2.3.0"
-source = "git+https://github.com/heliaxdev/wasmer?rev=255054f7f58b7b4a525f2fee6b9b86422d1ca15b#255054f7f58b7b4a525f2fee6b9b86422d1ca15b"
-dependencies = [
- "byteorder",
- "dynasm",
- "dynasmrt",
- "gimli 0.26.2",
- "lazy_static",
- "loupe",
- "more-asserts",
- "rayon",
- "smallvec",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ tracing-subscriber = {version = "0.3.7", default-features = false, features = ["
 wasmparser = "0.107.0"
 wasm-instrument = {version = "0.4.0", features = ["sign_ext"]}
 wasmer = {git = "https://github.com/heliaxdev/wasmer", rev = "255054f7f58b7b4a525f2fee6b9b86422d1ca15b"}
-wasmer-compiler-singlepass = { git = "https://github.com/heliaxdev/wasmer", rev = "255054f7f58b7b4a525f2fee6b9b86422d1ca15b" }
+wasmer-compiler-cranelift = { git = "https://github.com/heliaxdev/wasmer", rev = "255054f7f58b7b4a525f2fee6b9b86422d1ca15b" }
 wasmer-engine-universal = { git = "https://github.com/heliaxdev/wasmer", rev = "255054f7f58b7b4a525f2fee6b9b86422d1ca15b" }
 winapi = "0.3.9"
 yansi = "0.5.1"

--- a/crates/benches/Cargo.toml
+++ b/crates/benches/Cargo.toml
@@ -65,6 +65,6 @@ rand.workspace = true
 tempfile.workspace = true
 sha2.workspace = true
 wasm-instrument.workspace = true
-wasmer-compiler-singlepass.workspace = true
+wasmer-compiler-cranelift.workspace = true
 wasmer-engine-universal.workspace = true
 wasmer.workspace = true

--- a/crates/benches/wasm_opcodes.rs
+++ b/crates/benches/wasm_opcodes.rs
@@ -406,13 +406,13 @@ impl Display for WatBuilder {
     }
 }
 
-// Use singlepass compiler (the same one used in protocol) to prevent
+// Use Cranelift compiler (the same one used in protocol) to prevent
 // optimizations that would compile out the benchmarks since most of them are
 // trivial operations
 fn get_wasm_store() -> Store {
     wasmer::Store::new(
         &wasmer_engine_universal::Universal::new(
-            wasmer_compiler_singlepass::Singlepass::default(),
+            wasmer_compiler_cranelift::Cranelift::default(),
         )
         .engine(),
     )

--- a/crates/namada/Cargo.toml
+++ b/crates/namada/Cargo.toml
@@ -25,7 +25,7 @@ wasm-runtime = [
   "rayon",
   "wasm-instrument",
   "wasmer-cache",
-  "wasmer-compiler-singlepass",
+  "wasmer-compiler-cranelift",
   "wasmer-engine-dylib",
   "wasmer-engine-universal",
   "wasmer-vm",
@@ -151,7 +151,7 @@ tracing.workspace = true
 wasm-instrument = { workspace = true, optional = true }
 wasmer = { workspace = true, optional = true }
 wasmer-cache = { git = "https://github.com/heliaxdev/wasmer", rev = "255054f7f58b7b4a525f2fee6b9b86422d1ca15b", optional = true }
-wasmer-compiler-singlepass = { workspace = true, optional = true }
+wasmer-compiler-cranelift = { workspace = true, optional = true }
 wasmer-engine-dylib = { git = "https://github.com/heliaxdev/wasmer", rev = "255054f7f58b7b4a525f2fee6b9b86422d1ca15b", optional = true }
 wasmer-engine-universal = { workspace = true, optional = true }
 wasmer-vm = { git = "https://github.com/heliaxdev/wasmer", rev = "255054f7f58b7b4a525f2fee6b9b86422d1ca15b", optional = true }

--- a/crates/namada/src/vm/wasm/compilation_cache/common.rs
+++ b/crates/namada/src/vm/wasm/compilation_cache/common.rs
@@ -597,7 +597,7 @@ mod dylib {
     /// Dylib WASM store
     #[allow(dead_code)]
     pub fn store() -> Store {
-        let compiler = wasmer_compiler_singlepass::Singlepass::default();
+        let compiler = wasmer_compiler_cranelift::Cranelift::default();
         let engine = wasmer_engine_dylib::Dylib::new(compiler).engine();
         Store::new_with_tunables(&engine, memory::vp_limit())
     }

--- a/crates/namada/src/vm/wasm/run.rs
+++ b/crates/namada/src/vm/wasm/run.rs
@@ -545,8 +545,8 @@ where
 
 /// Prepare a wasm store for untrusted code.
 pub fn untrusted_wasm_store(limit: Limit<BaseTunables>) -> wasmer::Store {
-    // Use Singlepass compiler with the default settings
-    let compiler = wasmer_compiler_singlepass::Singlepass::default();
+    // Use Cranelift compiler with the default settings
+    let compiler = wasmer_compiler_cranelift::Cranelift::default();
     wasmer::Store::new_with_tunables(
         &wasmer_engine_universal::Universal::new(compiler).engine(),
         limit,

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1307,32 +1307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
-name = "dynasm"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
-dependencies = [
- "byteorder",
- "dynasm",
- "memmap2",
-]
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,7 +3535,7 @@ dependencies = [
  "wasm-instrument",
  "wasmer",
  "wasmer-cache",
- "wasmer-compiler-singlepass",
+ "wasmer-compiler-cranelift",
  "wasmer-engine-dylib",
  "wasmer-engine-universal",
  "wasmer-vm",
@@ -7147,25 +7121,6 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tracing",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-compiler-singlepass"
-version = "2.3.0"
-source = "git+https://github.com/heliaxdev/wasmer?rev=255054f7f58b7b4a525f2fee6b9b86422d1ca15b#255054f7f58b7b4a525f2fee6b9b86422d1ca15b"
-dependencies = [
- "byteorder",
- "dynasm",
- "dynasmrt",
- "gimli 0.26.2",
- "lazy_static",
- "loupe",
- "more-asserts",
- "rayon",
- "smallvec",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -1307,32 +1307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
-name = "dynasm"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
-dependencies = [
- "byteorder",
- "dynasm",
- "memmap2",
-]
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,7 +3513,7 @@ dependencies = [
  "wasm-instrument",
  "wasmer",
  "wasmer-cache",
- "wasmer-compiler-singlepass",
+ "wasmer-compiler-cranelift",
  "wasmer-engine-dylib",
  "wasmer-engine-universal",
  "wasmer-vm",
@@ -7090,25 +7064,6 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tracing",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-compiler-singlepass"
-version = "2.3.0"
-source = "git+https://github.com/heliaxdev/wasmer?rev=255054f7f58b7b4a525f2fee6b9b86422d1ca15b#255054f7f58b7b4a525f2fee6b9b86422d1ca15b"
-dependencies = [
- "byteorder",
- "dynasm",
- "dynasmrt",
- "gimli 0.26.2",
- "lazy_static",
- "loupe",
- "more-asserts",
- "rayon",
- "smallvec",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",


### PR DESCRIPTION
## Describe your changes

Taking advantage of tx allowlist that prohibit execution of untrusted wasm, we can switch to cranelift compiler to improve wasm performance

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
