### PR TITLE
Harden max proposal bytes configuration and deserialization

### DIFF
--- a/.changelog/unreleased/bug-fixes/3220-max-proposal-bytes-validation.md
+++ b/.changelog/unreleased/bug-fixes/3220-max-proposal-bytes-validation.md
@@ -1,0 +1,3 @@
+- Harden the implementation of `BorshDeserialize` on `ProposalBytes`.
+  Moreover, avoid using magic numbers when configuring CometBFT.
+  ([\#3220](https://github.com/anoma/namada/pull/3220))

--- a/crates/apps/src/lib/node/ledger/tendermint_node.rs
+++ b/crates/apps/src/lib/node/ledger/tendermint_node.rs
@@ -4,7 +4,7 @@ use std::process::Stdio;
 use std::str::FromStr;
 
 use borsh_ext::BorshSerializeExt;
-use namada::core::chain::ChainId;
+use namada::core::chain::{ChainId, ProposalBytes};
 use namada::core::key::*;
 use namada::core::storage::BlockHeight;
 use namada::core::time::DateTimeUtc;
@@ -418,10 +418,7 @@ async fn update_tendermint_config(
         config.mempool.max_tx_bytes = 1024 * 1024;
 
         // Hold 50x the max amount of txs in a block
-        //
-        // 6 MiB is the default Namada max proposal size governance
-        // parameter -> 50 * 6 MiB
-        config.mempool.max_txs_bytes = 50 * 6 * 1024 * 1024;
+        config.mempool.max_txs_bytes = 50 * ProposalBytes::MAX.get();
 
         // Hold up to 4k txs in the mempool
         config.mempool.size = 4000;
@@ -475,12 +472,13 @@ async fn write_tm_genesis(
             .try_into()
             .expect("Failed to convert initial genesis height");
     }
+    const EVIDENCE_AND_PROTOBUF_OVERHEAD: u64 = 10 * 1024 * 1024;
     let size = block::Size {
         // maximum size of a serialized Tendermint block.
         // on Namada, we have a hard-cap of 16 MiB (6 MiB max
         // txs in a block + 10 MiB reserved for evidence data,
         // block headers and protobuf serialization overhead)
-        max_bytes: 16 * 1024 * 1024,
+        max_bytes: EVIDENCE_AND_PROTOBUF_OVERHEAD + ProposalBytes::MAX.get(),
         // gas is metered app-side, so we disable it
         // at the Tendermint level
         max_gas: -1,


### PR DESCRIPTION
## Describe your changes

Closes #3189

Indeed, Namada ignores the `max_tx_bytes` parameter from CometBFT, which may shrink dynamically based on the presence of evidence of misbehavior data in blocks.

This parameter is only passed as an argument to `PrepareProposal` ABCI calls, and (crucially) never to `ProcessProposal` calls, forcing it to be available under `ProcessProposal` via some other means.

As such, `max_proposal_bytes` (a semantically equivalent Namada-only parameter) was introduced in #843. To ensure the application never exceeds `max_tx_bytes`, CometBFT was configured with a much larger maximum block size (100 MiB, and 90 MiB max for `max_proposal_bytes`).

In #2187, we modified these bounds, setting the max block size to 16 MiB and the max value of `max_proposal_bytes` to 6 MiB. Evidence data is the only reason the space reserved for txs may shrink; as 10 MiB is plenty of available space for misbehavior reports, we should never exceed the maximum block size.

It is also important to state CometBFT faces a problem of the same nature. [During CometBFT block validation](https://github.com/cometbft/cometbft/blob/v0.37.6/state/validation.go#L15), `MaxTxBytes` is never checked. The only place where it is checked is [during block construction](https://github.com/cometbft/cometbft/blob/v0.37.6/state/execution.go#L139-L141), leaving the burden of this validation to ABCI apps. Unfortunately, as we stated, `ProcessProposal` is not called with `max_tx_bytes`...

That said, this PR does the following:

* Hardens `BorshDeserialize` for `ProposalBytes`.
* Avoids using "magic numbers" to configure CometBFT, and uses `ProposalBytes::MAX` instead.

## Indicate on which release or other PRs this topic is based on

`v0.35.1`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
