### PR TITLE
Remove masp vp dependency on `Transfer`

### DIFF
--- a/.changelog/unreleased/improvements/3232-masp-no-transfer-dep.md
+++ b/.changelog/unreleased/improvements/3232-masp-no-transfer-dep.md
@@ -1,0 +1,2 @@
+- Removed any dependency on the specific transaction data from the masp vp.
+  ([\#3232](https://github.com/anoma/namada/pull/3232))

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -534,28 +534,17 @@ impl FromStr for MaspValue {
     }
 }
 
-/// Reference to a masp transaction inside a [`BatchedTx`]
-#[derive(Clone, Serialize, Deserialize)]
-pub struct MaspTxRef {
-    // FIXME: actually, are we using the commitment? Probably if I give the
-    // masp section ref I don't need the commitment anymore right?
-    /// The inner tx commitment's hash
-    pub cmt: Hash,
-    /// The hash of the masp [`Section::MaspTx`]
-    pub masp_section_ref: Hash,
-}
-
 /// The masp transactions' references of a given batch
 #[derive(Default, Clone, Serialize, Deserialize)]
-pub struct BatchMaspTxRefs(pub Vec<MaspTxRef>);
+pub struct MaspTxRefs(pub Vec<Hash>);
 
-impl Display for BatchMaspTxRefs {
+impl Display for MaspTxRefs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", serde_json::to_string(self).unwrap())
     }
 }
 
-impl FromStr for BatchMaspTxRefs {
+impl FromStr for MaspTxRefs {
     type Err = serde_json::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::address::{Address, DecodeError, HASH_HEX_LEN, MASP};
+use crate::hash::Hash;
 use crate::impl_display_and_from_str_via_format;
 use crate::storage::Epoch;
 use crate::string_encoding::{
@@ -530,5 +531,34 @@ impl FromStr for MaspValue {
             .or_else(|_err| {
                 ExtendedViewingKey::from_str(s).map(Self::FullViewingKey)
             })
+    }
+}
+
+/// Reference to a masp transaction inside a [`BatchedTx`]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct MaspTxRef {
+    // FIXME: actually, are we using the commitment? Probably if I give the
+    // masp section ref I don't need the commitment anymore right?
+    /// The inner tx commitment's hash
+    pub cmt: Hash,
+    /// The hash of the masp [`Section::MaspTx`]
+    pub masp_section_ref: Hash,
+}
+
+/// The masp transactions' references of a given batch
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct BatchMaspTxRefs(pub Vec<MaspTxRef>);
+
+impl Display for BatchMaspTxRefs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
+}
+
+impl FromStr for BatchMaspTxRefs {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
     }
 }

--- a/crates/events/src/extend.rs
+++ b/crates/events/src/extend.rs
@@ -2,12 +2,12 @@
 
 use std::fmt::Display;
 use std::marker::PhantomData;
-use std::ops::{ControlFlow, DerefMut};
+use std::ops::ControlFlow;
 use std::str::FromStr;
 
 use namada_core::collections::HashMap;
 use namada_core::hash::Hash;
-use namada_core::masp::BatchMaspTxRefs;
+use namada_core::masp::MaspTxRefs;
 use namada_core::storage::{BlockHeight, TxIndex};
 
 use super::*;
@@ -502,10 +502,10 @@ impl EventAttributeEntry<'static> for MaspTxBlockIndex {
 /// Extend an [`Event`] with `masp_tx_batch_refs` data, indicating the specific
 /// inner transactions inside the batch that are valid masp txs and the
 /// references to the relative masp sections.
-pub struct MaspTxBatchRefs(pub BatchMaspTxRefs);
+pub struct MaspTxBatchRefs(pub MaspTxRefs);
 
 impl EventAttributeEntry<'static> for MaspTxBatchRefs {
-    type Value = BatchMaspTxRefs;
+    type Value = MaspTxRefs;
     type ValueOwned = Self::Value;
 
     const KEY: &'static str = "masp_tx_batch_refs";
@@ -607,8 +607,8 @@ where
 }
 
 /// Return a new implementation of [`EventAttributeChecker`].
-pub fn attribute_checker<'value, DATA, ATTR>(
-) -> Box<dyn EventAttributeChecker<'value, ATTR>>
+pub fn attribute_checker<'value, DATA, ATTR>()
+-> Box<dyn EventAttributeChecker<'value, ATTR>>
 where
     DATA: EventAttributeEntry<'value> + 'static,
     ATTR: AttributesMap,

--- a/crates/events/src/extend.rs
+++ b/crates/events/src/extend.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 
 use namada_core::collections::HashMap;
 use namada_core::hash::Hash;
+use namada_core::masp::BatchMaspTxRefs;
 use namada_core::storage::{BlockHeight, TxIndex};
 
 use super::*;
@@ -498,42 +499,13 @@ impl EventAttributeEntry<'static> for MaspTxBlockIndex {
     }
 }
 
-//FIXME: move to tx crate?
-/// Reference to a valid masp transaction
-#[derive(Clone, Serialize, Deserialize)]
-pub struct MaspTxRef {
-    //FIXME: actually, are we using the commitment? Probably if I give the masp section ref I don't need the commitment anymore right?
-    //FIXME: If we don't need the commitment then we definetely need to section ref to be in the event and not in the result otherwise we need to loop
-    pub cmt: Hash,
-    pub masp_section_ref: Hash,
-}
-
-/// The collection of valid masp transactions
-#[derive(Default, Clone, Serialize, Deserialize)]
-//FIXME: move somewhere else?
-//FIXME: maybe rename, yes
-pub struct ValidMaspTxs(pub Vec<MaspTxRef>);
-
-impl Display for ValidMaspTxs {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).unwrap())
-    }
-}
-
-impl FromStr for ValidMaspTxs {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s)
-    }
-}
-
 /// Extend an [`Event`] with `masp_tx_batch_refs` data, indicating the specific
-/// inner transactions inside the batch that are valid masp txs and the references to the relative masp sections..
-pub struct MaspTxBatchRefs(pub ValidMaspTxs);
+/// inner transactions inside the batch that are valid masp txs and the
+/// references to the relative masp sections.
+pub struct MaspTxBatchRefs(pub BatchMaspTxRefs);
 
 impl EventAttributeEntry<'static> for MaspTxBatchRefs {
-    type Value = ValidMaspTxs;
+    type Value = BatchMaspTxRefs;
     type ValueOwned = Self::Value;
 
     const KEY: &'static str = "masp_tx_batch_refs";

--- a/crates/events/src/extend.rs
+++ b/crates/events/src/extend.rs
@@ -511,12 +511,20 @@ pub struct MaspTxRef {
 /// The collection of valid masp transactions
 #[derive(Default, Clone, Serialize, Deserialize)]
 //FIXME: move somewhere else?
-//FIXME: maybe rename
+//FIXME: maybe rename, yes
 pub struct ValidMaspTxs(pub Vec<MaspTxRef>);
 
 impl Display for ValidMaspTxs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
+}
+
+impl FromStr for ValidMaspTxs {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
     }
 }
 

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -363,7 +363,7 @@ where
                     ref masp_section_ref,
                 }) = action
                 {
-                    tx_data.get_section(masp_section_ref)?.masp_tx()
+                    tx_data.tx.get_section(masp_section_ref)?.masp_tx()
                 } else {
                     None
                 }

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -25,7 +25,6 @@ use namada_proof_of_stake::Epoch;
 use namada_sdk::masp::verify_shielded_tx;
 use namada_state::{ConversionState, OptionExt, ResultExt, StateRead};
 use namada_token::read_denom;
-use namada_tx::action::{Action, MaspAction, Read};
 use namada_tx::BatchedTxRef;
 use namada_vp_env::VpEnv;
 use ripemd::Digest as RipemdDigest;
@@ -364,8 +363,7 @@ where
         let shielded_tx = tx_data
             .tx
             .get_section(&masp_section_ref)
-            .map(|section| section.masp_tx())
-            .flatten()
+            .and_then(|section| section.masp_tx())
             .ok_or_else(|| {
                 native_vp::Error::new_const(
                     "Missing MASP section in transaction",

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -336,22 +336,9 @@ where
                 if is_accepted {
                     // If the transaction was a masp one append the
                     // transaction refs for the events
-                    //FIXME: should join this logic with the one used by the vp?
-                    if let Some(masp_section_ref) = state
-                        .read_actions()
-                        .map_err(|e| Error::StateError(e))?
-                        .into_iter()
-                        .find_map(|action| {
-                            // In case of multiple masp actions we get the first one
-                            if let Action::Masp(MaspAction {
-                                masp_section_ref,
-                            }) = action
-                            {
-                                Some(masp_section_ref)
-                            } else {
-                                None
-                            }
-                        })
+                    if let Some(masp_section_ref) =
+                        namada_tx::action::get_masp_section_ref(state)
+                            .map_err(|e| Error::StateError(e))?
                     {
                         extended_tx_result.masp_tx_refs.0.push(MaspTxRef {
                             cmt: cmt.get_hash(),

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -7,9 +7,10 @@ use borsh_ext::BorshSerializeExt;
 use eyre::{eyre, WrapErr};
 use namada_core::booleans::BoolResultUnitExt;
 use namada_core::hash::Hash;
+use namada_core::masp::MaspTxRef;
 use namada_core::storage::Key;
 use namada_events::extend::{
-    ComposeEvent, Height as HeightAttr, MaspTxRef, TxHash as TxHashAttr,
+    ComposeEvent, Height as HeightAttr, TxHash as TxHashAttr,
 };
 use namada_events::EventLevel;
 use namada_gas::TxGasMeter;
@@ -335,6 +336,7 @@ where
                 if is_accepted {
                     // If the transaction was a masp one append the
                     // transaction refs for the events
+                    //FIXME: should join this logic with the one used by the vp?
                     if let Some(masp_section_ref) = state
                         .read_actions()
                         .map_err(|e| Error::StateError(e))?

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -7,7 +7,6 @@ use borsh_ext::BorshSerializeExt;
 use eyre::{eyre, WrapErr};
 use namada_core::booleans::BoolResultUnitExt;
 use namada_core::hash::Hash;
-use namada_core::masp::MaspTxRef;
 use namada_core::storage::Key;
 use namada_events::extend::{
     ComposeEvent, Height as HeightAttr, TxHash as TxHashAttr,
@@ -15,9 +14,8 @@ use namada_events::extend::{
 use namada_events::EventLevel;
 use namada_gas::TxGasMeter;
 use namada_sdk::tx::TX_TRANSFER_WASM;
-use namada_state::{StateRead, StorageWrite};
+use namada_state::StorageWrite;
 use namada_token::event::{TokenEvent, TokenOperation, UserAccount};
-use namada_tx::action::{Action, MaspAction, Read};
 use namada_tx::data::protocol::ProtocolTxType;
 use namada_tx::data::{
     BatchResults, BatchedTxResult, ExtendedTxResult, TxResult, TxType,
@@ -338,12 +336,12 @@ where
                     // transaction refs for the events
                     if let Some(masp_section_ref) =
                         namada_tx::action::get_masp_section_ref(state)
-                            .map_err(|e| Error::StateError(e))?
+                            .map_err(Error::StateError)?
                     {
-                        extended_tx_result.masp_tx_refs.0.push(MaspTxRef {
-                            cmt: cmt.get_hash(),
-                            masp_section_ref,
-                        });
+                        extended_tx_result
+                            .masp_tx_refs
+                            .0
+                            .push(masp_section_ref);
                     }
                     state.write_log_mut().commit_tx_to_batch();
                 } else {

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -63,8 +63,6 @@ pub enum Error {
     TxRunnerError(vm::wasm::run::Error),
     #[error("{0:?}")]
     ProtocolTxError(#[from] eyre::Error),
-    #[error("Txs must either be encrypted or a decryption of an encrypted tx")]
-    TxTypeError,
     #[error("The atomic batch failed at inner transaction {0}")]
     FailingAtomicBatch(Hash),
     #[error("Gas error: {0}")]

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -27,9 +27,7 @@ use namada::core::masp::{
 use namada::core::storage::{BlockHeight, Epoch, Key, KeySeg, TxIndex};
 use namada::core::time::DateTimeUtc;
 use namada::core::token::{Amount, DenominatedAmount, Transfer};
-use namada::events::extend::{
-    ComposeEvent, MaspTxBatchRefs, MaspTxBlockIndex, MaspTxRef, ValidMaspTxs,
-};
+use namada::events::extend::{ComposeEvent, MaspTxBatchRefs, MaspTxBlockIndex};
 use namada::events::Event;
 use namada::governance::storage::proposal::ProposalType;
 use namada::governance::InitProposalData;
@@ -76,6 +74,7 @@ use namada::ledger::native_vp::ibc::get_dummy_header;
 use namada::ledger::queries::{
     Client, EncodedResponseQuery, RequestCtx, RequestQuery, Router, RPC,
 };
+use namada::masp::{BatchMaspTxRefs, MaspTxRef};
 use namada::state::StorageRead;
 use namada::tx::data::pos::Bond;
 use namada::tx::data::{
@@ -924,7 +923,7 @@ impl Client for BenchShell {
                             .with(MaspTxBlockIndex(TxIndex::must_from_usize(
                                 idx,
                             )))
-                            .with(MaspTxBatchRefs(ValidMaspTxs(vec![
+                            .with(MaspTxBatchRefs(BatchMaspTxRefs(vec![
                                 MaspTxRef {
                                     cmt: tx
                                         .first_commitments()

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -74,7 +74,7 @@ use namada::ledger::native_vp::ibc::get_dummy_header;
 use namada::ledger::queries::{
     Client, EncodedResponseQuery, RequestCtx, RequestQuery, Router, RPC,
 };
-use namada::masp::{BatchMaspTxRefs, MaspTxRef};
+use namada::masp::MaspTxRefs;
 use namada::state::StorageRead;
 use namada::tx::data::pos::Bond;
 use namada::tx::data::{
@@ -923,25 +923,17 @@ impl Client for BenchShell {
                             .with(MaspTxBlockIndex(TxIndex::must_from_usize(
                                 idx,
                             )))
-                            .with(MaspTxBatchRefs(BatchMaspTxRefs(vec![
-                                MaspTxRef {
-                                    cmt: tx
-                                        .first_commitments()
-                                        .unwrap()
-                                        .get_hash(),
-                                    masp_section_ref: tx
-                                        .sections
-                                        .iter()
-                                        .find_map(|section| {
-                                            if let Section::MaspTx(_) = section
-                                            {
-                                                Some(section.get_hash())
-                                            } else {
-                                                None
-                                            }
-                                        })
-                                        .unwrap(),
-                                },
+                            .with(MaspTxBatchRefs(MaspTxRefs(vec![
+                                tx.sections
+                                    .iter()
+                                    .find_map(|section| {
+                                        if let Section::MaspTx(_) = section {
+                                            Some(section.get_hash())
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .unwrap(),
                             ])))
                             .into();
                         namada::tendermint::abci::Event::from(event)

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -4,7 +4,6 @@ use data_encoding::HEXUPPER;
 use masp_primitives::merkle_tree::CommitmentTree;
 use masp_primitives::sapling::Node;
 use namada::core::storage::{BlockResults, Epoch, Header};
-use namada::events::extend::ValidMaspTxs;
 use namada::events::Event;
 use namada::gas::event::GasUsed;
 use namada::governance::pgf::inflation as pgf_inflation;
@@ -17,6 +16,7 @@ use namada::ledger::gas::GasMetering;
 use namada::ledger::ibc;
 use namada::ledger::pos::namada_proof_of_stake;
 use namada::ledger::protocol::DispatchError;
+use namada::masp::BatchMaspTxRefs;
 use namada::proof_of_stake;
 use namada::proof_of_stake::storage::{
     find_validator_by_raw_hash, write_last_block_proposer_address,
@@ -824,7 +824,7 @@ impl<'finalize> TempTxLogs {
     fn check_inner_results(
         &mut self,
         tx_result: &namada::tx::data::TxResult<protocol::Error>,
-        masp_tx_refs: ValidMaspTxs,
+        masp_tx_refs: BatchMaspTxRefs,
         tx_header: &namada::tx::Header,
         tx_index: usize,
         height: BlockHeight,

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -16,7 +16,7 @@ use namada::ledger::gas::GasMetering;
 use namada::ledger::ibc;
 use namada::ledger::pos::namada_proof_of_stake;
 use namada::ledger::protocol::DispatchError;
-use namada::masp::BatchMaspTxRefs;
+use namada::masp::MaspTxRefs;
 use namada::proof_of_stake;
 use namada::proof_of_stake::storage::{
     find_validator_by_raw_hash, write_last_block_proposer_address,
@@ -824,7 +824,7 @@ impl<'finalize> TempTxLogs {
     fn check_inner_results(
         &mut self,
         tx_result: &namada::tx::data::TxResult<protocol::Error>,
-        masp_tx_refs: BatchMaspTxRefs,
+        masp_tx_refs: MaspTxRefs,
         tx_header: &namada::tx::Header,
         tx_index: usize,
         height: BlockHeight,

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -2801,21 +2801,25 @@ mod test_finalize_block {
         assert_eq!(root_pre.0, root_post.0);
 
         // Check transaction's hash in storage
-        assert!(shell
-            .shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&wrapper_tx.raw_header_hash()));
+        assert!(
+            shell
+                .shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper_tx.raw_header_hash())
+        );
         // Check that the hash is not present in the merkle tree
         shell.state.commit_block().unwrap();
-        assert!(!shell
-            .shell
-            .state
-            .in_mem()
-            .block
-            .tree
-            .has_key(&wrapper_hash_key)
-            .unwrap());
+        assert!(
+            !shell
+                .shell
+                .state
+                .in_mem()
+                .block
+                .tree
+                .has_key(&wrapper_hash_key)
+                .unwrap()
+        );
 
         // test that a commitment to replay protection gets added.
         let reprot_key = replay_protection::commitment_key();
@@ -2862,22 +2866,26 @@ mod test_finalize_block {
         assert_eq!(root_pre.0, root_post.0);
         // Check that the hashes are present in the merkle tree
         shell.state.commit_block().unwrap();
-        assert!(shell
-            .shell
-            .state
-            .in_mem()
-            .block
-            .tree
-            .has_key(&convert_key)
-            .unwrap());
-        assert!(shell
-            .shell
-            .state
-            .in_mem()
-            .block
-            .tree
-            .has_key(&commitment_key)
-            .unwrap());
+        assert!(
+            shell
+                .shell
+                .state
+                .in_mem()
+                .block
+                .tree
+                .has_key(&convert_key)
+                .unwrap()
+        );
+        assert!(
+            shell
+                .shell
+                .state
+                .in_mem()
+                .block
+                .tree
+                .has_key(&commitment_key)
+                .unwrap()
+        );
     }
 
     /// Test that a tx that has already been applied in the same block
@@ -2955,26 +2963,34 @@ mod test_finalize_block {
         assert_eq!(code, ResultCode::WasmRuntimeError);
 
         for wrapper in [&wrapper, &new_wrapper] {
-            assert!(shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper.raw_header_hash()));
-            assert!(!shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper.header_hash()));
+            assert!(
+                shell
+                    .state
+                    .write_log()
+                    .has_replay_protection_entry(&wrapper.raw_header_hash())
+            );
+            assert!(
+                !shell
+                    .state
+                    .write_log()
+                    .has_replay_protection_entry(&wrapper.header_hash())
+            );
         }
         // Commit to check the hashes from storage
         shell.commit();
         for wrapper in [&wrapper, &new_wrapper] {
-            assert!(shell
-                .state
-                .has_replay_protection_entry(&wrapper.raw_header_hash())
-                .unwrap());
-            assert!(!shell
-                .state
-                .has_replay_protection_entry(&wrapper.header_hash())
-                .unwrap());
+            assert!(
+                shell
+                    .state
+                    .has_replay_protection_entry(&wrapper.raw_header_hash())
+                    .unwrap()
+            );
+            assert!(
+                !shell
+                    .state
+                    .has_replay_protection_entry(&wrapper.header_hash())
+                    .unwrap()
+            );
         }
     }
 
@@ -3257,23 +3273,29 @@ mod test_finalize_block {
             &unsigned_wrapper,
             &wrong_commitment_wrapper,
         ] {
-            assert!(!shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&valid_wrapper.raw_header_hash()));
-            assert!(shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&valid_wrapper.header_hash()));
+            assert!(
+                !shell.state.write_log().has_replay_protection_entry(
+                    &valid_wrapper.raw_header_hash()
+                )
+            );
+            assert!(
+                shell
+                    .state
+                    .write_log()
+                    .has_replay_protection_entry(&valid_wrapper.header_hash())
+            );
         }
-        assert!(shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&failing_wrapper.raw_header_hash()));
-        assert!(!shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&failing_wrapper.header_hash()));
+        assert!(
+            shell.state.write_log().has_replay_protection_entry(
+                &failing_wrapper.raw_header_hash()
+            )
+        );
+        assert!(
+            !shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&failing_wrapper.header_hash())
+        );
 
         // Commit to check the hashes from storage
         shell.commit();
@@ -3282,23 +3304,33 @@ mod test_finalize_block {
             unsigned_wrapper,
             wrong_commitment_wrapper,
         ] {
-            assert!(!shell
-                .state
-                .has_replay_protection_entry(&valid_wrapper.raw_header_hash())
-                .unwrap());
-            assert!(shell
-                .state
-                .has_replay_protection_entry(&valid_wrapper.header_hash())
-                .unwrap());
+            assert!(
+                !shell
+                    .state
+                    .has_replay_protection_entry(
+                        &valid_wrapper.raw_header_hash()
+                    )
+                    .unwrap()
+            );
+            assert!(
+                shell
+                    .state
+                    .has_replay_protection_entry(&valid_wrapper.header_hash())
+                    .unwrap()
+            );
         }
-        assert!(shell
-            .state
-            .has_replay_protection_entry(&failing_wrapper.raw_header_hash())
-            .unwrap());
-        assert!(!shell
-            .state
-            .has_replay_protection_entry(&failing_wrapper.header_hash())
-            .unwrap());
+        assert!(
+            shell
+                .state
+                .has_replay_protection_entry(&failing_wrapper.raw_header_hash())
+                .unwrap()
+        );
+        assert!(
+            !shell
+                .state
+                .has_replay_protection_entry(&failing_wrapper.header_hash())
+                .unwrap()
+        );
     }
 
     #[test]
@@ -3358,14 +3390,18 @@ mod test_finalize_block {
         let code = event[0].read_attribute::<CodeAttr>().expect("Test failed");
         assert_eq!(code, ResultCode::InvalidTx);
 
-        assert!(shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&wrapper_hash));
-        assert!(!shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&wrapper.raw_header_hash()));
+        assert!(
+            shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper_hash)
+        );
+        assert!(
+            !shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper.raw_header_hash())
+        );
     }
 
     // Test that the fees are paid even if the inner transaction fails and its
@@ -3763,9 +3799,11 @@ mod test_finalize_block {
                 .unwrap(),
             Some(ValidatorState::Consensus)
         );
-        assert!(enqueued_slashes_handle()
-            .at(&Epoch::default())
-            .is_empty(&shell.state)?);
+        assert!(
+            enqueued_slashes_handle()
+                .at(&Epoch::default())
+                .is_empty(&shell.state)?
+        );
         assert_eq!(
             get_num_consensus_validators(&shell.state, Epoch::default())
                 .unwrap(),
@@ -3784,17 +3822,21 @@ mod test_finalize_block {
                     .unwrap(),
                 Some(ValidatorState::Jailed)
             );
-            assert!(enqueued_slashes_handle()
-                .at(&epoch)
-                .is_empty(&shell.state)?);
+            assert!(
+                enqueued_slashes_handle()
+                    .at(&epoch)
+                    .is_empty(&shell.state)?
+            );
             assert_eq!(
                 get_num_consensus_validators(&shell.state, epoch).unwrap(),
                 5_u64
             );
         }
-        assert!(!enqueued_slashes_handle()
-            .at(&processing_epoch)
-            .is_empty(&shell.state)?);
+        assert!(
+            !enqueued_slashes_handle()
+                .at(&processing_epoch)
+                .is_empty(&shell.state)?
+        );
 
         // Advance to the processing epoch
         loop {
@@ -3817,9 +3859,11 @@ mod test_finalize_block {
                 // println!("Reached processing epoch");
                 break;
             } else {
-                assert!(enqueued_slashes_handle()
-                    .at(&shell.state.in_mem().block.epoch)
-                    .is_empty(&shell.state)?);
+                assert!(
+                    enqueued_slashes_handle()
+                        .at(&shell.state.in_mem().block.epoch)
+                        .is_empty(&shell.state)?
+                );
                 let stake1 = read_validator_stake(
                     &shell.state,
                     &params,
@@ -4303,11 +4347,13 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(misbehavior_epoch));
-        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
-            &val1.address
-        )
-        .is_empty(&shell.state)
-        .unwrap());
+        assert!(
+            namada_proof_of_stake::storage::validator_slashes_handle(
+                &val1.address
+            )
+            .is_empty(&shell.state)
+            .unwrap()
+        );
 
         tracing::debug!("Advancing to epoch 7");
 
@@ -4372,18 +4418,22 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(Epoch(4)));
-        assert!(namada_proof_of_stake::is_validator_frozen(
-            &shell.state,
-            &val1.address,
-            current_epoch,
-            &params
-        )
-        .unwrap());
-        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
-            &val1.address
-        )
-        .is_empty(&shell.state)
-        .unwrap());
+        assert!(
+            namada_proof_of_stake::is_validator_frozen(
+                &shell.state,
+                &val1.address,
+                current_epoch,
+                &params
+            )
+            .unwrap()
+        );
+        assert!(
+            namada_proof_of_stake::storage::validator_slashes_handle(
+                &val1.address
+            )
+            .is_empty(&shell.state)
+            .unwrap()
+        );
 
         let pre_stake_10 =
             namada_proof_of_stake::storage::read_validator_stake(
@@ -5261,9 +5311,11 @@ mod test_finalize_block {
             shell.vp_wasm_cache.clone(),
         );
         let parameters = ParametersVp { ctx };
-        assert!(parameters
-            .validate_tx(&batched_tx, &keys_changed, &verifiers)
-            .is_ok());
+        assert!(
+            parameters
+                .validate_tx(&batched_tx, &keys_changed, &verifiers)
+                .is_ok()
+        );
 
         // we advance forward to the next epoch
         let mut req = FinalizeBlock::default();
@@ -5336,11 +5388,13 @@ mod test_finalize_block {
         let inner_results = inner_tx_result.batch_results.0;
 
         for cmt in batch.commitments() {
-            assert!(inner_results
-                .get(&cmt.get_hash())
-                .unwrap()
-                .clone()
-                .is_ok_and(|res| res.is_accepted()));
+            assert!(
+                inner_results
+                    .get(&cmt.get_hash())
+                    .unwrap()
+                    .clone()
+                    .is_ok_and(|res| res.is_accepted())
+            );
         }
 
         // Check storage modifications
@@ -5378,18 +5432,24 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(inner_results
-            .get(&batch.commitments()[0].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
-        assert!(inner_results
-            .get(&batch.commitments()[1].get_hash())
-            .unwrap()
-            .clone()
-            .is_err());
+        assert!(
+            inner_results
+                .get(&batch.commitments()[0].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[1].get_hash())
+                .unwrap()
+                .clone()
+                .is_err()
+        );
         // Assert that the last tx didn't run
-        assert!(!inner_results.contains_key(&batch.commitments()[2].get_hash()));
+        assert!(
+            !inner_results.contains_key(&batch.commitments()[2].get_hash())
+        );
 
         // Check storage modifications are missing
         for key in ["random_key_1", "random_key_2", "random_key_3"] {
@@ -5420,21 +5480,27 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(inner_results
-            .get(&batch.commitments()[0].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
-        assert!(inner_results
-            .get(&batch.commitments()[1].get_hash())
-            .unwrap()
-            .clone()
-            .is_err());
-        assert!(inner_results
-            .get(&batch.commitments()[2].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
+        assert!(
+            inner_results
+                .get(&batch.commitments()[0].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[1].get_hash())
+                .unwrap()
+                .clone()
+                .is_err()
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[2].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
 
         // Check storage modifications
         assert_eq!(
@@ -5445,10 +5511,12 @@ mod test_finalize_block {
                 .unwrap(),
             STORAGE_VALUE
         );
-        assert!(!shell
-            .state
-            .has_key(&"random_key_2".parse().unwrap())
-            .unwrap());
+        assert!(
+            !shell
+                .state
+                .has_key(&"random_key_2".parse().unwrap())
+                .unwrap()
+        );
         assert_eq!(
             shell
                 .state
@@ -5480,18 +5548,24 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(inner_results
-            .get(&batch.commitments()[0].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
-        assert!(inner_results
-            .get(&batch.commitments()[1].get_hash())
-            .unwrap()
-            .clone()
-            .is_err());
+        assert!(
+            inner_results
+                .get(&batch.commitments()[0].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[1].get_hash())
+                .unwrap()
+                .clone()
+                .is_err()
+        );
         // Assert that the last tx didn't run
-        assert!(!inner_results.contains_key(&batch.commitments()[2].get_hash()));
+        assert!(
+            !inner_results.contains_key(&batch.commitments()[2].get_hash())
+        );
 
         // Check storage modifications are missing
         for key in ["random_key_1", "random_key_2", "random_key_3"] {
@@ -5521,18 +5595,24 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(inner_results
-            .get(&batch.commitments()[0].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
-        assert!(inner_results
-            .get(&batch.commitments()[1].get_hash())
-            .unwrap()
-            .clone()
-            .is_err());
+        assert!(
+            inner_results
+                .get(&batch.commitments()[0].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[1].get_hash())
+                .unwrap()
+                .clone()
+                .is_err()
+        );
         // Assert that the last tx didn't run
-        assert!(!inner_results.contains_key(&batch.commitments()[2].get_hash()));
+        assert!(
+            !inner_results.contains_key(&batch.commitments()[2].get_hash())
+        );
 
         // Check storage modifications
         assert_eq!(

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -612,7 +612,8 @@ where
             commit_batch_hash,
             is_any_tx_invalid,
         } = temp_log.check_inner_results(
-            &extended_tx_result,
+            &extended_tx_result.tx_result,
+            extended_tx_result.masp_tx_refs,
             tx_data.tx_header,
             tx_data.tx_index,
             tx_data.height,
@@ -675,7 +676,8 @@ where
             commit_batch_hash,
             is_any_tx_invalid: _,
         } = temp_log.check_inner_results(
-            &extended_tx_result,
+            &extended_tx_result.tx_result,
+            extended_tx_result.masp_tx_refs,
             tx_data.tx_header,
             tx_data.tx_index,
             tx_data.height,
@@ -821,10 +823,8 @@ impl<'finalize> TempTxLogs {
 
     fn check_inner_results(
         &mut self,
-        namada::tx::data::ExtendedTxResult {
-            tx_result,
-            masp_tx_refs,
-        }: &namada::tx::data::ExtendedTxResult<protocol::Error>,
+        tx_result: &namada::tx::data::TxResult<protocol::Error>,
+        masp_tx_refs: ValidMaspTxs,
         tx_header: &namada::tx::Header,
         tx_index: usize,
         height: BlockHeight,
@@ -900,9 +900,7 @@ impl<'finalize> TempTxLogs {
         if !masp_tx_refs.0.is_empty() {
             self.tx_event
                 .extend(MaspTxBlockIndex(TxIndex::must_from_usize(tx_index)));
-            //FIXME: avoid clone here if possible
-            self.tx_event
-                .extend(MaspTxBatchRefs(masp_tx_refs.to_owned()));
+            self.tx_event.extend(MaspTxBatchRefs(masp_tx_refs));
         }
 
         flags

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -4,6 +4,7 @@ use data_encoding::HEXUPPER;
 use masp_primitives::merkle_tree::CommitmentTree;
 use masp_primitives::sapling::Node;
 use namada::core::storage::{BlockResults, Epoch, Header};
+use namada::events::extend::ValidMaspTxs;
 use namada::events::Event;
 use namada::gas::event::GasUsed;
 use namada::governance::pgf::inflation as pgf_inflation;
@@ -22,7 +23,6 @@ use namada::proof_of_stake::storage::{
 };
 use namada::state::write_log::StorageModification;
 use namada::state::{ResultExt, StorageWrite, EPOCH_SWITCH_BLOCKS_DELAY};
-use namada::token::utils::is_masp_tx;
 use namada::tx::data::protocol::ProtocolTxType;
 use namada::tx::data::VpStatusFlags;
 use namada::tx::event::{Batch, Code};
@@ -529,17 +529,17 @@ where
     fn evaluate_tx_result(
         &mut self,
         response: &mut shim::response::FinalizeBlock,
-        dispatch_result: std::result::Result<
-            namada::tx::data::TxResult<protocol::Error>,
+        extended_dispatch_result: std::result::Result<
+            namada::tx::data::ExtendedTxResult<protocol::Error>,
             DispatchError,
         >,
         tx_data: TxData<'_>,
         mut tx_logs: TxLogs<'_>,
     ) {
-        match dispatch_result {
-            Ok(tx_result) => self.handle_inner_tx_results(
+        match extended_dispatch_result {
+            Ok(extended_tx_result) => self.handle_inner_tx_results(
                 response,
-                tx_result,
+                extended_tx_result,
                 tx_data,
                 &mut tx_logs,
             ),
@@ -602,7 +602,7 @@ where
     fn handle_inner_tx_results(
         &mut self,
         response: &mut shim::response::FinalizeBlock,
-        tx_result: namada::tx::data::TxResult<protocol::Error>,
+        extended_tx_result: namada::tx::data::ExtendedTxResult<protocol::Error>,
         tx_data: TxData<'_>,
         tx_logs: &mut TxLogs<'_>,
     ) {
@@ -612,7 +612,7 @@ where
             commit_batch_hash,
             is_any_tx_invalid,
         } = temp_log.check_inner_results(
-            &tx_result,
+            &extended_tx_result,
             tx_data.tx_header,
             tx_data.tx_index,
             tx_data.height,
@@ -624,8 +624,10 @@ where
             let unrun_txs = tx_data
                 .commitments_len
                 .checked_sub(
-                    u64::try_from(tx_result.batch_results.0.len())
-                        .expect("Should be able to convert to u64"),
+                    u64::try_from(
+                        extended_tx_result.tx_result.batch_results.0.len(),
+                    )
+                    .expect("Should be able to convert to u64"),
                 )
                 .expect("Shouldn't underflow");
             temp_log.stats.set_failing_atomic_batch(unrun_txs);
@@ -654,16 +656,16 @@ where
 
         tx_logs
             .tx_event
-            .extend(GasUsed(tx_result.gas_used))
+            .extend(GasUsed(extended_tx_result.tx_result.gas_used))
             .extend(Info("Check batch for result.".to_string()))
-            .extend(Batch(&tx_result.to_result_string()));
+            .extend(Batch(&extended_tx_result.tx_result.to_result_string()));
     }
 
     fn handle_batch_error(
         &mut self,
         response: &mut shim::response::FinalizeBlock,
         msg: &Error,
-        tx_result: namada::tx::data::TxResult<protocol::Error>,
+        extended_tx_result: namada::tx::data::ExtendedTxResult<protocol::Error>,
         tx_data: TxData<'_>,
         tx_logs: &mut TxLogs<'_>,
     ) {
@@ -673,7 +675,7 @@ where
             commit_batch_hash,
             is_any_tx_invalid: _,
         } = temp_log.check_inner_results(
-            &tx_result,
+            &extended_tx_result,
             tx_data.tx_header,
             tx_data.tx_index,
             tx_data.height,
@@ -682,8 +684,10 @@ where
         let unrun_txs = tx_data
             .commitments_len
             .checked_sub(
-                u64::try_from(tx_result.batch_results.0.len())
-                    .expect("Should be able to convert to u64"),
+                u64::try_from(
+                    extended_tx_result.tx_result.batch_results.0.len(),
+                )
+                .expect("Should be able to convert to u64"),
             )
             .expect("Shouldn't underflow");
 
@@ -714,7 +718,7 @@ where
 
         tx_logs
             .tx_event
-            .extend(Batch(&tx_result.to_result_string()));
+            .extend(Batch(&extended_tx_result.tx_result.to_result_string()));
     }
 
     fn handle_batch_error_reprot(&mut self, err: &Error, tx_data: TxData<'_>) {
@@ -817,21 +821,20 @@ impl<'finalize> TempTxLogs {
 
     fn check_inner_results(
         &mut self,
-        tx_result: &namada::tx::data::TxResult<protocol::Error>,
+        namada::tx::data::ExtendedTxResult {
+            tx_result,
+            masp_tx_refs,
+        }: &namada::tx::data::ExtendedTxResult<protocol::Error>,
         tx_header: &namada::tx::Header,
         tx_index: usize,
         height: BlockHeight,
     ) -> ValidityFlags {
         let mut flags = ValidityFlags::default();
-        let mut masp_cmts = vec![];
 
         for (cmt_hash, batched_result) in &tx_result.batch_results.0 {
             match batched_result {
                 Ok(result) => {
                     if result.is_accepted() {
-                        if is_masp_tx(&result.changed_keys) {
-                            masp_cmts.push(*cmt_hash);
-                        }
                         tracing::trace!(
                             "all VPs accepted inner tx {} storage \
                              modification {:#?}",
@@ -894,10 +897,12 @@ impl<'finalize> TempTxLogs {
 
         // If at least one of the inner transactions is a valid masp tx, update
         // the events
-        if !masp_cmts.is_empty() {
+        if !masp_tx_refs.0.is_empty() {
             self.tx_event
                 .extend(MaspTxBlockIndex(TxIndex::must_from_usize(tx_index)));
-            self.tx_event.extend(MaspTxBatchRefs(masp_cmts.into()));
+            //FIXME: avoid clone here if possible
+            self.tx_event
+                .extend(MaspTxBatchRefs(masp_tx_refs.to_owned()));
         }
 
         flags
@@ -2798,25 +2803,21 @@ mod test_finalize_block {
         assert_eq!(root_pre.0, root_post.0);
 
         // Check transaction's hash in storage
-        assert!(
-            shell
-                .shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper_tx.raw_header_hash())
-        );
+        assert!(shell
+            .shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&wrapper_tx.raw_header_hash()));
         // Check that the hash is not present in the merkle tree
         shell.state.commit_block().unwrap();
-        assert!(
-            !shell
-                .shell
-                .state
-                .in_mem()
-                .block
-                .tree
-                .has_key(&wrapper_hash_key)
-                .unwrap()
-        );
+        assert!(!shell
+            .shell
+            .state
+            .in_mem()
+            .block
+            .tree
+            .has_key(&wrapper_hash_key)
+            .unwrap());
 
         // test that a commitment to replay protection gets added.
         let reprot_key = replay_protection::commitment_key();
@@ -2863,26 +2864,22 @@ mod test_finalize_block {
         assert_eq!(root_pre.0, root_post.0);
         // Check that the hashes are present in the merkle tree
         shell.state.commit_block().unwrap();
-        assert!(
-            shell
-                .shell
-                .state
-                .in_mem()
-                .block
-                .tree
-                .has_key(&convert_key)
-                .unwrap()
-        );
-        assert!(
-            shell
-                .shell
-                .state
-                .in_mem()
-                .block
-                .tree
-                .has_key(&commitment_key)
-                .unwrap()
-        );
+        assert!(shell
+            .shell
+            .state
+            .in_mem()
+            .block
+            .tree
+            .has_key(&convert_key)
+            .unwrap());
+        assert!(shell
+            .shell
+            .state
+            .in_mem()
+            .block
+            .tree
+            .has_key(&commitment_key)
+            .unwrap());
     }
 
     /// Test that a tx that has already been applied in the same block
@@ -2960,34 +2957,26 @@ mod test_finalize_block {
         assert_eq!(code, ResultCode::WasmRuntimeError);
 
         for wrapper in [&wrapper, &new_wrapper] {
-            assert!(
-                shell
-                    .state
-                    .write_log()
-                    .has_replay_protection_entry(&wrapper.raw_header_hash())
-            );
-            assert!(
-                !shell
-                    .state
-                    .write_log()
-                    .has_replay_protection_entry(&wrapper.header_hash())
-            );
+            assert!(shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper.raw_header_hash()));
+            assert!(!shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper.header_hash()));
         }
         // Commit to check the hashes from storage
         shell.commit();
         for wrapper in [&wrapper, &new_wrapper] {
-            assert!(
-                shell
-                    .state
-                    .has_replay_protection_entry(&wrapper.raw_header_hash())
-                    .unwrap()
-            );
-            assert!(
-                !shell
-                    .state
-                    .has_replay_protection_entry(&wrapper.header_hash())
-                    .unwrap()
-            );
+            assert!(shell
+                .state
+                .has_replay_protection_entry(&wrapper.raw_header_hash())
+                .unwrap());
+            assert!(!shell
+                .state
+                .has_replay_protection_entry(&wrapper.header_hash())
+                .unwrap());
         }
     }
 
@@ -3270,29 +3259,23 @@ mod test_finalize_block {
             &unsigned_wrapper,
             &wrong_commitment_wrapper,
         ] {
-            assert!(
-                !shell.state.write_log().has_replay_protection_entry(
-                    &valid_wrapper.raw_header_hash()
-                )
-            );
-            assert!(
-                shell
-                    .state
-                    .write_log()
-                    .has_replay_protection_entry(&valid_wrapper.header_hash())
-            );
-        }
-        assert!(
-            shell.state.write_log().has_replay_protection_entry(
-                &failing_wrapper.raw_header_hash()
-            )
-        );
-        assert!(
-            !shell
+            assert!(!shell
                 .state
                 .write_log()
-                .has_replay_protection_entry(&failing_wrapper.header_hash())
-        );
+                .has_replay_protection_entry(&valid_wrapper.raw_header_hash()));
+            assert!(shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&valid_wrapper.header_hash()));
+        }
+        assert!(shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&failing_wrapper.raw_header_hash()));
+        assert!(!shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&failing_wrapper.header_hash()));
 
         // Commit to check the hashes from storage
         shell.commit();
@@ -3301,33 +3284,23 @@ mod test_finalize_block {
             unsigned_wrapper,
             wrong_commitment_wrapper,
         ] {
-            assert!(
-                !shell
-                    .state
-                    .has_replay_protection_entry(
-                        &valid_wrapper.raw_header_hash()
-                    )
-                    .unwrap()
-            );
-            assert!(
-                shell
-                    .state
-                    .has_replay_protection_entry(&valid_wrapper.header_hash())
-                    .unwrap()
-            );
+            assert!(!shell
+                .state
+                .has_replay_protection_entry(&valid_wrapper.raw_header_hash())
+                .unwrap());
+            assert!(shell
+                .state
+                .has_replay_protection_entry(&valid_wrapper.header_hash())
+                .unwrap());
         }
-        assert!(
-            shell
-                .state
-                .has_replay_protection_entry(&failing_wrapper.raw_header_hash())
-                .unwrap()
-        );
-        assert!(
-            !shell
-                .state
-                .has_replay_protection_entry(&failing_wrapper.header_hash())
-                .unwrap()
-        );
+        assert!(shell
+            .state
+            .has_replay_protection_entry(&failing_wrapper.raw_header_hash())
+            .unwrap());
+        assert!(!shell
+            .state
+            .has_replay_protection_entry(&failing_wrapper.header_hash())
+            .unwrap());
     }
 
     #[test]
@@ -3387,18 +3360,14 @@ mod test_finalize_block {
         let code = event[0].read_attribute::<CodeAttr>().expect("Test failed");
         assert_eq!(code, ResultCode::InvalidTx);
 
-        assert!(
-            shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper_hash)
-        );
-        assert!(
-            !shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper.raw_header_hash())
-        );
+        assert!(shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&wrapper_hash));
+        assert!(!shell
+            .state
+            .write_log()
+            .has_replay_protection_entry(&wrapper.raw_header_hash()));
     }
 
     // Test that the fees are paid even if the inner transaction fails and its
@@ -3796,11 +3765,9 @@ mod test_finalize_block {
                 .unwrap(),
             Some(ValidatorState::Consensus)
         );
-        assert!(
-            enqueued_slashes_handle()
-                .at(&Epoch::default())
-                .is_empty(&shell.state)?
-        );
+        assert!(enqueued_slashes_handle()
+            .at(&Epoch::default())
+            .is_empty(&shell.state)?);
         assert_eq!(
             get_num_consensus_validators(&shell.state, Epoch::default())
                 .unwrap(),
@@ -3819,21 +3786,17 @@ mod test_finalize_block {
                     .unwrap(),
                 Some(ValidatorState::Jailed)
             );
-            assert!(
-                enqueued_slashes_handle()
-                    .at(&epoch)
-                    .is_empty(&shell.state)?
-            );
+            assert!(enqueued_slashes_handle()
+                .at(&epoch)
+                .is_empty(&shell.state)?);
             assert_eq!(
                 get_num_consensus_validators(&shell.state, epoch).unwrap(),
                 5_u64
             );
         }
-        assert!(
-            !enqueued_slashes_handle()
-                .at(&processing_epoch)
-                .is_empty(&shell.state)?
-        );
+        assert!(!enqueued_slashes_handle()
+            .at(&processing_epoch)
+            .is_empty(&shell.state)?);
 
         // Advance to the processing epoch
         loop {
@@ -3856,11 +3819,9 @@ mod test_finalize_block {
                 // println!("Reached processing epoch");
                 break;
             } else {
-                assert!(
-                    enqueued_slashes_handle()
-                        .at(&shell.state.in_mem().block.epoch)
-                        .is_empty(&shell.state)?
-                );
+                assert!(enqueued_slashes_handle()
+                    .at(&shell.state.in_mem().block.epoch)
+                    .is_empty(&shell.state)?);
                 let stake1 = read_validator_stake(
                     &shell.state,
                     &params,
@@ -4344,13 +4305,11 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(misbehavior_epoch));
-        assert!(
-            namada_proof_of_stake::storage::validator_slashes_handle(
-                &val1.address
-            )
-            .is_empty(&shell.state)
-            .unwrap()
-        );
+        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
+            &val1.address
+        )
+        .is_empty(&shell.state)
+        .unwrap());
 
         tracing::debug!("Advancing to epoch 7");
 
@@ -4415,22 +4374,18 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(Epoch(4)));
-        assert!(
-            namada_proof_of_stake::is_validator_frozen(
-                &shell.state,
-                &val1.address,
-                current_epoch,
-                &params
-            )
-            .unwrap()
-        );
-        assert!(
-            namada_proof_of_stake::storage::validator_slashes_handle(
-                &val1.address
-            )
-            .is_empty(&shell.state)
-            .unwrap()
-        );
+        assert!(namada_proof_of_stake::is_validator_frozen(
+            &shell.state,
+            &val1.address,
+            current_epoch,
+            &params
+        )
+        .unwrap());
+        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
+            &val1.address
+        )
+        .is_empty(&shell.state)
+        .unwrap());
 
         let pre_stake_10 =
             namada_proof_of_stake::storage::read_validator_stake(
@@ -5308,11 +5263,9 @@ mod test_finalize_block {
             shell.vp_wasm_cache.clone(),
         );
         let parameters = ParametersVp { ctx };
-        assert!(
-            parameters
-                .validate_tx(&batched_tx, &keys_changed, &verifiers)
-                .is_ok()
-        );
+        assert!(parameters
+            .validate_tx(&batched_tx, &keys_changed, &verifiers)
+            .is_ok());
 
         // we advance forward to the next epoch
         let mut req = FinalizeBlock::default();
@@ -5385,13 +5338,11 @@ mod test_finalize_block {
         let inner_results = inner_tx_result.batch_results.0;
 
         for cmt in batch.commitments() {
-            assert!(
-                inner_results
-                    .get(&cmt.get_hash())
-                    .unwrap()
-                    .clone()
-                    .is_ok_and(|res| res.is_accepted())
-            );
+            assert!(inner_results
+                .get(&cmt.get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted()));
         }
 
         // Check storage modifications
@@ -5429,24 +5380,18 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(
-            inner_results
-                .get(&batch.commitments()[0].get_hash())
-                .unwrap()
-                .clone()
-                .is_ok_and(|res| res.is_accepted())
-        );
-        assert!(
-            inner_results
-                .get(&batch.commitments()[1].get_hash())
-                .unwrap()
-                .clone()
-                .is_err()
-        );
+        assert!(inner_results
+            .get(&batch.commitments()[0].get_hash())
+            .unwrap()
+            .clone()
+            .is_ok_and(|res| res.is_accepted()));
+        assert!(inner_results
+            .get(&batch.commitments()[1].get_hash())
+            .unwrap()
+            .clone()
+            .is_err());
         // Assert that the last tx didn't run
-        assert!(
-            !inner_results.contains_key(&batch.commitments()[2].get_hash())
-        );
+        assert!(!inner_results.contains_key(&batch.commitments()[2].get_hash()));
 
         // Check storage modifications are missing
         for key in ["random_key_1", "random_key_2", "random_key_3"] {
@@ -5477,27 +5422,21 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(
-            inner_results
-                .get(&batch.commitments()[0].get_hash())
-                .unwrap()
-                .clone()
-                .is_ok_and(|res| res.is_accepted())
-        );
-        assert!(
-            inner_results
-                .get(&batch.commitments()[1].get_hash())
-                .unwrap()
-                .clone()
-                .is_err()
-        );
-        assert!(
-            inner_results
-                .get(&batch.commitments()[2].get_hash())
-                .unwrap()
-                .clone()
-                .is_ok_and(|res| res.is_accepted())
-        );
+        assert!(inner_results
+            .get(&batch.commitments()[0].get_hash())
+            .unwrap()
+            .clone()
+            .is_ok_and(|res| res.is_accepted()));
+        assert!(inner_results
+            .get(&batch.commitments()[1].get_hash())
+            .unwrap()
+            .clone()
+            .is_err());
+        assert!(inner_results
+            .get(&batch.commitments()[2].get_hash())
+            .unwrap()
+            .clone()
+            .is_ok_and(|res| res.is_accepted()));
 
         // Check storage modifications
         assert_eq!(
@@ -5508,12 +5447,10 @@ mod test_finalize_block {
                 .unwrap(),
             STORAGE_VALUE
         );
-        assert!(
-            !shell
-                .state
-                .has_key(&"random_key_2".parse().unwrap())
-                .unwrap()
-        );
+        assert!(!shell
+            .state
+            .has_key(&"random_key_2".parse().unwrap())
+            .unwrap());
         assert_eq!(
             shell
                 .state
@@ -5545,24 +5482,18 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(
-            inner_results
-                .get(&batch.commitments()[0].get_hash())
-                .unwrap()
-                .clone()
-                .is_ok_and(|res| res.is_accepted())
-        );
-        assert!(
-            inner_results
-                .get(&batch.commitments()[1].get_hash())
-                .unwrap()
-                .clone()
-                .is_err()
-        );
+        assert!(inner_results
+            .get(&batch.commitments()[0].get_hash())
+            .unwrap()
+            .clone()
+            .is_ok_and(|res| res.is_accepted()));
+        assert!(inner_results
+            .get(&batch.commitments()[1].get_hash())
+            .unwrap()
+            .clone()
+            .is_err());
         // Assert that the last tx didn't run
-        assert!(
-            !inner_results.contains_key(&batch.commitments()[2].get_hash())
-        );
+        assert!(!inner_results.contains_key(&batch.commitments()[2].get_hash()));
 
         // Check storage modifications are missing
         for key in ["random_key_1", "random_key_2", "random_key_3"] {
@@ -5592,24 +5523,18 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(
-            inner_results
-                .get(&batch.commitments()[0].get_hash())
-                .unwrap()
-                .clone()
-                .is_ok_and(|res| res.is_accepted())
-        );
-        assert!(
-            inner_results
-                .get(&batch.commitments()[1].get_hash())
-                .unwrap()
-                .clone()
-                .is_err()
-        );
+        assert!(inner_results
+            .get(&batch.commitments()[0].get_hash())
+            .unwrap()
+            .clone()
+            .is_ok_and(|res| res.is_accepted()));
+        assert!(inner_results
+            .get(&batch.commitments()[1].get_hash())
+            .unwrap()
+            .clone()
+            .is_err());
         // Assert that the last tx didn't run
-        assert!(
-            !inner_results.contains_key(&batch.commitments()[2].get_hash())
-        );
+        assert!(!inner_results.contains_key(&batch.commitments()[2].get_hash()));
 
         // Check storage modifications
         assert_eq!(

--- a/crates/node/src/shell/governance.rs
+++ b/crates/node/src/shell/governance.rs
@@ -419,7 +419,12 @@ where
         .delete(&pending_execution_key)
         .expect("Should be able to delete the storage.");
     match dispatch_result {
-        Ok(tx_result) => match tx_result.batch_results.0.get(&cmt.get_hash()) {
+        Ok(extended_tx_result) => match extended_tx_result
+            .tx_result
+            .batch_results
+            .0
+            .get(&cmt.get_hash())
+        {
             Some(Ok(batched_result)) if batched_result.is_accepted() => {
                 shell.state.commit_tx();
                 Ok(true)

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -865,6 +865,8 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
         let mut txs = vec![];
 
         // Expect transaction
+        // FIXME: update this to rely on the masp section hash emitted in the
+        // event instead of deserializing to Transfer
         for cmt in tx.commitments() {
             let tx_data = tx.data(cmt).ok_or_else(|| {
                 Error::Other("Missing data section".to_string())

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -53,11 +53,11 @@ use masp_proofs::sapling::SaplingVerificationContext;
 use namada_core::address::Address;
 use namada_core::collections::{HashMap, HashSet};
 use namada_core::dec::Dec;
+use namada_core::masp::MaspTxRefs;
 pub use namada_core::masp::{
     encode_asset_type, AssetData, BalanceOwner, ExtendedViewingKey,
     PaymentAddress, TransferSource, TransferTarget,
 };
-use namada_core::masp::{BatchMaspTxRefs, MaspTxRef};
 use namada_core::storage::{BlockHeight, Epoch, TxIndex};
 use namada_core::time::{DateTimeUtc, DurationSecs};
 use namada_core::uint::Uint;
@@ -65,13 +65,12 @@ use namada_events::extend::{
     MaspTxBatchRefs as MaspTxBatchRefsAttr,
     MaspTxBlockIndex as MaspTxBlockIndexAttr, ReadFromEventAttributes,
 };
-use namada_ibc::IbcMessage;
 use namada_macros::BorshDeserializer;
 #[cfg(feature = "migrations")]
 use namada_migrations::*;
 use namada_state::StorageError;
-use namada_token::{self as token, Denomination, MaspDigitPos, Transfer};
-use namada_tx::{IndexedTx, Tx, TxCommitments};
+use namada_token::{self as token, Denomination, MaspDigitPos};
+use namada_tx::{IndexedTx, Tx};
 use rand_core::{CryptoRng, OsRng, RngCore};
 use ripemd::Digest as RipemdDigest;
 use sha2::Digest;
@@ -103,10 +102,10 @@ pub const OUTPUT_NAME: &str = "masp-output.params";
 pub const CONVERT_NAME: &str = "masp-convert.params";
 
 /// Type alias for convenience and profit
-pub type IndexedNoteData = BTreeMap<IndexedTx, Transaction>;
+pub type IndexedNoteData = BTreeMap<IndexedTx, Vec<Transaction>>;
 
 /// Type alias for the entries of [`IndexedNoteData`] iterators
-pub type IndexedNoteEntry = (IndexedTx, Transaction);
+pub type IndexedNoteEntry = (IndexedTx, Vec<Transaction>);
 
 /// Shielded transfer
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize, BorshDeserializer)]
@@ -143,9 +142,6 @@ pub enum TransferErr {
     #[error("{0}")]
     General(#[from] Error),
 }
-
-#[derive(Debug, Clone)]
-struct ExtractedMaspTxs(Vec<(TxCommitments, Transaction)>);
 
 /// MASP verifying keys
 pub struct PVKs {
@@ -668,35 +664,37 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
     }
 
     /// Update the merkle tree of witnesses the first time we
-    /// scan a new MASP transaction.
+    /// scan new MASP transactions.
     fn update_witness_map(
         &mut self,
         indexed_tx: IndexedTx,
-        shielded: &Transaction,
+        shielded: &[Transaction],
     ) -> Result<(), Error> {
         let mut note_pos = self.tree.size();
         self.tx_note_map.insert(indexed_tx, note_pos);
-        for so in shielded
-            .sapling_bundle()
-            .map_or(&vec![], |x| &x.shielded_outputs)
-        {
-            // Create merkle tree leaf node from note commitment
-            let node = Node::new(so.cmu.to_repr());
-            // Update each merkle tree in the witness map with the latest
-            // addition
-            for (_, witness) in self.witness_map.iter_mut() {
-                witness.append(node).map_err(|()| {
+
+        for tx in shielded {
+            for so in
+                tx.sapling_bundle().map_or(&vec![], |x| &x.shielded_outputs)
+            {
+                // Create merkle tree leaf node from note commitment
+                let node = Node::new(so.cmu.to_repr());
+                // Update each merkle tree in the witness map with the latest
+                // addition
+                for (_, witness) in self.witness_map.iter_mut() {
+                    witness.append(node).map_err(|()| {
+                        Error::Other("note commitment tree is full".to_string())
+                    })?;
+                }
+                self.tree.append(node).map_err(|()| {
                     Error::Other("note commitment tree is full".to_string())
                 })?;
+                // Finally, make it easier to construct merkle paths to this new
+                // note
+                let witness = IncrementalWitness::<Node>::from_tree(&self.tree);
+                self.witness_map.insert(note_pos, witness);
+                note_pos += 1;
             }
-            self.tree.append(node).map_err(|()| {
-                Error::Other("note commitment tree is full".to_string())
-            })?;
-            // Finally, make it easier to construct merkle paths to this new
-            // note
-            let witness = IncrementalWitness::<Node>::from_tree(&self.tree);
-            self.witness_map.insert(note_pos, witness);
-            note_pos += 1;
         }
         Ok(())
     }
@@ -841,16 +839,13 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
                 let extracted_masp_txs =
                     Self::extract_masp_tx(&tx, &masp_sections_refs).await?;
                 // Collect the current transactions
-                for (inner_tx, transaction) in extracted_masp_txs.0 {
-                    shielded_txs.insert(
-                        IndexedTx {
-                            height: height.into(),
-                            index: idx,
-                            inner_tx,
-                        },
-                        transaction,
-                    );
-                }
+                shielded_txs.insert(
+                    IndexedTx {
+                        height: height.into(),
+                        index: idx,
+                    },
+                    extracted_masp_txs,
+                );
             }
         }
 
@@ -860,44 +855,33 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
     /// Extract the relevant shield portions of a [`Tx`], if any.
     async fn extract_masp_tx(
         tx: &Tx,
-        masp_section_refs: &BatchMaspTxRefs,
-    ) -> Result<ExtractedMaspTxs, Error> {
+        masp_section_refs: &MaspTxRefs,
+    ) -> Result<Vec<Transaction>, Error> {
         // NOTE: simply looking for masp sections attached to the tx
         // is not safe. We don't validate the sections attached to a
         // transaction se we could end up with transactions carrying
         // an unnecessary masp section. We must instead look for the
         // required masp sections coming from the events
-        let mut txs = vec![];
 
-        for MaspTxRef {
-            cmt,
-            masp_section_ref,
-        } in &masp_section_refs.0
-        {
-            let transaction = tx
-                .get_section(masp_section_ref)
-                .map(|section| section.masp_tx())
-                .flatten()
-                .ok_or_else(|| {
-                    Error::Other(
-                        "Missing expected masp transaction".to_string(),
-                    )
-                })?;
-
-            let cmt = tx
-                .commitments()
-                .iter()
-                .find(|inner_tx| &inner_tx.get_hash() == cmt)
-                .ok_or_else(|| {
-                    Error::Other(
-                        "Missing expected inner transaction".to_string(),
-                    )
-                })?;
-
-            txs.push((cmt.to_owned(), transaction));
-        }
-
-        Ok(ExtractedMaspTxs(txs))
+        masp_section_refs
+            .0
+            .iter()
+            .try_fold(vec![], |mut acc, hash| {
+                match tx
+                    .get_section(hash)
+                    .and_then(|section| section.masp_tx())
+                    .ok_or_else(|| {
+                        Error::Other(
+                            "Missing expected masp transaction".to_string(),
+                        )
+                    }) {
+                    Ok(transaction) => {
+                        acc.push(transaction);
+                        Ok(acc)
+                    }
+                    Err(e) => Err(e),
+                }
+            })
     }
 
     /// Applies the given transaction to the supplied context. More precisely,
@@ -911,7 +895,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
     pub fn scan_tx(
         &mut self,
         indexed_tx: IndexedTx,
-        shielded: &Transaction,
+        shielded: &[Transaction],
         vk: &ViewingKey,
     ) -> Result<(), Error> {
         // For tracking the account changes caused by this Transaction
@@ -920,42 +904,78 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
             let mut note_pos = self.tx_note_map[&indexed_tx];
             // Listen for notes sent to our viewing keys, only if we are syncing
             // (i.e. in a confirmed status)
-            for so in shielded
-                .sapling_bundle()
-                .map_or(&vec![], |x| &x.shielded_outputs)
-            {
-                // Let's try to see if this viewing key can decrypt latest
-                // note
-                let notes = self.pos_map.entry(*vk).or_default();
-                let decres = try_sapling_note_decryption::<_, OutputDescription<<<Authorized as Authorization>::SaplingAuth as masp_primitives::transaction::components::sapling::Authorization>::Proof>>(
+            for tx in shielded {
+                for so in
+                    tx.sapling_bundle().map_or(&vec![], |x| &x.shielded_outputs)
+                {
+                    // Let's try to see if this viewing key can decrypt latest
+                    // note
+                    let notes = self.pos_map.entry(*vk).or_default();
+                    let decres = try_sapling_note_decryption::<_, OutputDescription<<<Authorized as Authorization>::SaplingAuth as masp_primitives::transaction::components::sapling::Authorization>::Proof>>(
                 &NETWORK,
                 1.into(),
                 &PreparedIncomingViewingKey::new(&vk.ivk()),
                 so,
             );
-                // So this current viewing key does decrypt this current note...
-                if let Some((note, pa, memo)) = decres {
-                    // Add this note to list of notes decrypted by this viewing
-                    // key
-                    notes.insert(note_pos);
-                    // Compute the nullifier now to quickly recognize when spent
-                    let nf = note.nf(
-                        &vk.nk,
-                        note_pos.try_into().map_err(|_| {
-                            Error::Other("Can not get nullifier".to_string())
-                        })?,
-                    );
-                    self.note_map.insert(note_pos, note);
-                    self.memo_map.insert(note_pos, memo);
-                    // The payment address' diversifier is required to spend
-                    // note
-                    self.div_map.insert(note_pos, *pa.diversifier());
-                    self.nf_map.insert(nf, note_pos);
+                    // So this current viewing key does decrypt this current
+                    // note...
+                    if let Some((note, pa, memo)) = decres {
+                        // Add this note to list of notes decrypted by this
+                        // viewing key
+                        notes.insert(note_pos);
+                        // Compute the nullifier now to quickly recognize when
+                        // spent
+                        let nf = note.nf(
+                            &vk.nk,
+                            note_pos.try_into().map_err(|_| {
+                                Error::Other(
+                                    "Can not get nullifier".to_string(),
+                                )
+                            })?,
+                        );
+                        self.note_map.insert(note_pos, note);
+                        self.memo_map.insert(note_pos, memo);
+                        // The payment address' diversifier is required to spend
+                        // note
+                        self.div_map.insert(note_pos, *pa.diversifier());
+                        self.nf_map.insert(nf, note_pos);
+                        // Note the account changes
+                        let balance = transaction_delta
+                            .entry(*vk)
+                            .or_insert_with(I128Sum::zero);
+                        *balance += I128Sum::from_nonnegative(
+                            note.asset_type,
+                            note.value as i128,
+                        )
+                        .map_err(|()| {
+                            Error::Other(
+                                "found note with invalid value or asset type"
+                                    .to_string(),
+                            )
+                        })?;
+                        self.vk_map.insert(note_pos, *vk);
+                    }
+                    note_pos += 1;
+                }
+            }
+        }
+
+        // Cancel out those of our notes that have been spent
+        for tx in shielded {
+            for ss in
+                tx.sapling_bundle().map_or(&vec![], |x| &x.shielded_spends)
+            {
+                // If the shielded spend's nullifier is in our map, then target
+                // note is rendered unusable
+                if let Some(note_pos) = self.nf_map.get(&ss.nullifier) {
+                    self.spents.insert(*note_pos);
                     // Note the account changes
                     let balance = transaction_delta
-                        .entry(*vk)
+                        .entry(self.vk_map[note_pos])
                         .or_insert_with(I128Sum::zero);
-                    *balance += I128Sum::from_nonnegative(
+                    let note = self.note_map[note_pos];
+
+                    *balance -= I128Sum::from_nonnegative(
                         note.asset_type,
                         note.value as i128,
                     )
@@ -965,37 +985,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
                                 .to_string(),
                         )
                     })?;
-                    self.vk_map.insert(note_pos, *vk);
                 }
-                note_pos += 1;
-            }
-        }
-
-        // Cancel out those of our notes that have been spent
-        for ss in shielded
-            .sapling_bundle()
-            .map_or(&vec![], |x| &x.shielded_spends)
-        {
-            // If the shielded spend's nullifier is in our map, then target note
-            // is rendered unusable
-            if let Some(note_pos) = self.nf_map.get(&ss.nullifier) {
-                self.spents.insert(*note_pos);
-                // Note the account changes
-                let balance = transaction_delta
-                    .entry(self.vk_map[note_pos])
-                    .or_insert_with(I128Sum::zero);
-                let note = self.note_map[note_pos];
-
-                *balance -= I128Sum::from_nonnegative(
-                    note.asset_type,
-                    note.value as i128,
-                )
-                .map_err(|()| {
-                    Error::Other(
-                        "found note with invalid value or asset type"
-                            .to_string(),
-                    )
-                })?;
             }
         }
 
@@ -1899,7 +1889,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
             // Cache the generated transfer
             let mut shielded_ctx = context.shielded_mut().await;
             shielded_ctx
-                .pre_cache_transaction(context, &masp_tx)
+                .pre_cache_transaction(context, &[masp_tx.clone()])
                 .await?;
         }
 
@@ -1918,7 +1908,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
     async fn pre_cache_transaction(
         &mut self,
         context: &impl Namada,
-        masp_tx: &Transaction,
+        masp_tx: &[Transaction],
     ) -> Result<(), Error> {
         let vks: Vec<_> = context
             .wallet()
@@ -1938,7 +1928,6 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
                         .index
                         .checked_add(1)
                         .expect("Tx index shouldn't overflow"),
-                    inner_tx: TxCommitments::default(),
                 }
             });
         self.sync_status = ContextSyncStatus::Speculative;
@@ -2020,7 +2009,7 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
     client: &C,
     height: BlockHeight,
     first_idx_to_query: Option<TxIndex>,
-) -> Result<Option<Vec<(TxIndex, BatchMaspTxRefs)>>, Error> {
+) -> Result<Option<Vec<(TxIndex, MaspTxRefs)>>, Error> {
     let first_idx_to_query = first_idx_to_query.unwrap_or_default();
 
     Ok(client
@@ -2053,45 +2042,6 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
                 })
                 .collect::<Vec<_>>()
         }))
-}
-
-// Extract the Transaction hash from a masp over ibc message
-async fn extract_payload_from_shielded_action(
-    tx_data: &[u8],
-) -> Result<Transfer, Error> {
-    let message = namada_ibc::decode_message(tx_data)
-        .map_err(|e| Error::Other(e.to_string()))?;
-
-    let result = match message {
-        IbcMessage::Transfer(msg) => msg.transfer.ok_or_else(|| {
-            Error::Other("Missing masp tx in the ibc message".to_string())
-        })?,
-        IbcMessage::NftTransfer(msg) => msg.transfer.ok_or_else(|| {
-            Error::Other("Missing masp tx in the ibc message".to_string())
-        })?,
-        IbcMessage::RecvPacket(msg) => msg.transfer.ok_or_else(|| {
-            Error::Other("Missing masp tx in the ibc message".to_string())
-        })?,
-        IbcMessage::AckPacket(msg) => {
-            // Refund tokens by the ack message
-            msg.transfer.ok_or_else(|| {
-                Error::Other("Missing masp tx in the ibc message".to_string())
-            })?
-        }
-        IbcMessage::Timeout(msg) => {
-            // Refund tokens by the timeout message
-            msg.transfer.ok_or_else(|| {
-                Error::Other("Missing masp tx in the ibc message".to_string())
-            })?
-        }
-        IbcMessage::Envelope(_) => {
-            return Err(Error::Other(
-                "Unexpected ibc message for masp".to_string(),
-            ));
-        }
-    };
-
-    Ok(result)
 }
 
 mod tests {

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -57,13 +57,13 @@ pub use namada_core::masp::{
     encode_asset_type, AssetData, BalanceOwner, ExtendedViewingKey,
     PaymentAddress, TransferSource, TransferTarget,
 };
+use namada_core::masp::{BatchMaspTxRefs, MaspTxRef};
 use namada_core::storage::{BlockHeight, Epoch, TxIndex};
 use namada_core::time::{DateTimeUtc, DurationSecs};
 use namada_core::uint::Uint;
 use namada_events::extend::{
     MaspTxBatchRefs as MaspTxBatchRefsAttr,
-    MaspTxBlockIndex as MaspTxBlockIndexAttr, MaspTxRef,
-    ReadFromEventAttributes, ValidMaspTxs,
+    MaspTxBlockIndex as MaspTxBlockIndexAttr, ReadFromEventAttributes,
 };
 use namada_ibc::IbcMessage;
 use namada_macros::BorshDeserializer;
@@ -860,7 +860,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
     /// Extract the relevant shield portions of a [`Tx`], if any.
     async fn extract_masp_tx(
         tx: &Tx,
-        masp_section_refs: &ValidMaspTxs,
+        masp_section_refs: &BatchMaspTxRefs,
     ) -> Result<ExtractedMaspTxs, Error> {
         // NOTE: simply looking for masp sections attached to the tx
         // is not safe. We don't validate the sections attached to a
@@ -2020,7 +2020,7 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
     client: &C,
     height: BlockHeight,
     first_idx_to_query: Option<TxIndex>,
-) -> Result<Option<Vec<(TxIndex, ValidMaspTxs)>>, Error> {
+) -> Result<Option<Vec<(TxIndex, BatchMaspTxRefs)>>, Error> {
     let first_idx_to_query = first_idx_to_query.unwrap_or_default();
 
     Ok(client

--- a/crates/shielded_token/src/utils.rs
+++ b/crates/shielded_token/src/utils.rs
@@ -9,7 +9,8 @@ use namada_core::storage;
 use namada_storage::{Error, Result, StorageRead, StorageWrite};
 
 use crate::storage_key::{
-    is_masp_key, masp_commitment_tree_key, masp_nullifier_key,
+    is_masp_key, is_masp_transfer_key, masp_commitment_tree_key,
+    masp_nullifier_key,
 };
 
 // Writes the nullifiers of the provided masp transaction to storage
@@ -71,12 +72,4 @@ pub fn handle_masp_tx(
     reveal_nullifiers(ctx, shielded)?;
 
     Ok(())
-}
-
-/// Check if a transaction was a MASP transaction. This means
-/// that at least one key owned by MASP was changed. We cannot
-/// simply check that the MASP VP was triggered, as this can
-/// be manually requested to be triggered by users.
-pub fn is_masp_tx(changed_keys: &BTreeSet<storage::Key>) -> bool {
-    changed_keys.iter().any(is_masp_key)
 }

--- a/crates/shielded_token/src/utils.rs
+++ b/crates/shielded_token/src/utils.rs
@@ -1,17 +1,11 @@
 //! MASP utilities
 
-use std::collections::BTreeSet;
-
 use masp_primitives::merkle_tree::CommitmentTree;
 use masp_primitives::sapling::Node;
 use masp_primitives::transaction::Transaction;
-use namada_core::storage;
 use namada_storage::{Error, Result, StorageRead, StorageWrite};
 
-use crate::storage_key::{
-    is_masp_key, is_masp_transfer_key, masp_commitment_tree_key,
-    masp_nullifier_key,
-};
+use crate::storage_key::{masp_commitment_tree_key, masp_nullifier_key};
 
 // Writes the nullifiers of the provided masp transaction to storage
 fn reveal_nullifiers(

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -1345,7 +1345,6 @@ where
     }
 }
 
-//FIXME: can join this with FullAccessState?
 impl<D, H> namada_tx::action::Read for WlState<D, H>
 where
     D: 'static + DB + for<'iter> DBIter<'iter>,

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -1344,3 +1344,28 @@ where
         Ok(())
     }
 }
+
+//FIXME: can join this with FullAccessState?
+impl<D, H> namada_tx::action::Read for WlState<D, H>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter>,
+    H: 'static + StorageHasher,
+{
+    type Err = Error;
+
+    fn read_temp<T: namada_core::borsh::BorshDeserialize>(
+        &self,
+        key: &storage::Key,
+    ) -> Result<Option<T>> {
+        let (log_val, _) = self.write_log().read_temp(key).unwrap();
+        match log_val {
+            Some(value) => {
+                let value =
+                    namada_core::borsh::BorshDeserialize::try_from_slice(value)
+                        .map_err(Error::BorshCodingError)?;
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
+}

--- a/crates/tx/src/action.rs
+++ b/crates/tx/src/action.rs
@@ -66,7 +66,7 @@ pub enum PgfAction {
 /// MASP tx action.
 #[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
 pub struct MaspAction {
-    /// The hash of the masp [`Section`]
+    /// The hash of the masp [`crate::types::Section`]
     pub masp_section_ref: Hash,
 }
 

--- a/crates/tx/src/action.rs
+++ b/crates/tx/src/action.rs
@@ -8,6 +8,7 @@ use std::fmt;
 
 use namada_core::address::Address;
 use namada_core::borsh::{BorshDeserialize, BorshSerialize};
+use namada_core::hash::Hash;
 use namada_core::storage::KeySeg;
 use namada_core::{address, storage};
 
@@ -25,6 +26,7 @@ pub enum Action {
     Pos(PosAction),
     Gov(GovAction),
     Pgf(PgfAction),
+    Masp(MaspAction),
 }
 
 /// PoS tx actions.
@@ -59,6 +61,12 @@ pub enum GovAction {
 pub enum PgfAction {
     ResignSteward(Address),
     UpdateStewardCommission(Address),
+}
+
+/// MASP tx action.
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub struct MaspAction {
+    pub masp_section_ref: Hash,
 }
 
 /// Read actions from temporary storage

--- a/crates/tx/src/action.rs
+++ b/crates/tx/src/action.rs
@@ -66,6 +66,7 @@ pub enum PgfAction {
 /// MASP tx action.
 #[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
 pub struct MaspAction {
+    /// The hash of the masp [`Section`]
     pub masp_section_ref: Hash,
 }
 
@@ -117,7 +118,9 @@ fn storage_key() -> storage::Key {
         .expect("Cannot obtain a storage key")
 }
 
-/// Helper function to get the optional masp section reference from the [`Actions`]. If more than one [`MaspAction`] has been found we return the first one
+/// Helper function to get the optional masp section reference from the
+/// [`Actions`]. If more than one [`MaspAction`] has been found we return the
+/// first one
 pub fn get_masp_section_ref<T: Read>(
     reader: &T,
 ) -> Result<Option<Hash>, <T as Read>::Err> {

--- a/crates/tx/src/action.rs
+++ b/crates/tx/src/action.rs
@@ -116,3 +116,17 @@ fn storage_key() -> storage::Key {
         .push(&TX_ACTIONS_KEY.to_owned())
         .expect("Cannot obtain a storage key")
 }
+
+/// Helper function to get the optional masp section reference from the [`Actions`]. If more than one [`MaspAction`] has been found we return the first one
+pub fn get_masp_section_ref<T: Read>(
+    reader: &T,
+) -> Result<Option<Hash>, <T as Read>::Err> {
+    Ok(reader.read_actions()?.into_iter().find_map(|action| {
+        // In case of multiple masp actions we get the first one
+        if let Action::Masp(MaspAction { masp_section_ref }) = action {
+            Some(masp_section_ref)
+        } else {
+            None
+        }
+    }))
+}

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -22,6 +22,7 @@ use namada_core::borsh::{
 };
 use namada_core::hash::Hash;
 use namada_core::storage;
+use namada_events::extend::{MaspTxRef, ValidMaspTxs};
 use namada_events::Event;
 use namada_gas::{Gas, VpsGas};
 use namada_macros::BorshDeserializer;
@@ -238,6 +239,21 @@ impl<'de, T: Deserialize<'de>> serde::Deserialize<'de> for BatchResults<T> {
     }
 }
 
+/// The extended transaction result, containing the optional references to masp sections
+pub struct ExtendedTxResult<T> {
+    pub tx_result: TxResult<T>,
+    pub masp_tx_refs: ValidMaspTxs,
+}
+
+impl<T> Default for ExtendedTxResult<T> {
+    fn default() -> Self {
+        Self {
+            tx_result: Default::default(),
+            masp_tx_refs: Default::default(),
+        }
+    }
+}
+
 /// Transaction application result
 // TODO derive BorshSchema after <https://github.com/near/borsh-rs/issues/82>
 #[derive(
@@ -277,6 +293,17 @@ impl<T: Display> TxResult<T> {
         TxResult {
             gas_used: self.gas_used,
             batch_results: BatchResults(batch_results),
+        }
+    }
+
+    /// Converts this result to [`ExtendedTxResult`]
+    pub fn to_extended_result(
+        self,
+        masp_tx_refs: Option<ValidMaspTxs>,
+    ) -> ExtendedTxResult<T> {
+        ExtendedTxResult {
+            tx_result: self,
+            masp_tx_refs: masp_tx_refs.unwrap_or_default(),
         }
     }
 }

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -21,7 +21,7 @@ use namada_core::borsh::{
     BorshDeserialize, BorshSchema, BorshSerialize, BorshSerializeExt,
 };
 use namada_core::hash::Hash;
-use namada_core::masp::BatchMaspTxRefs;
+use namada_core::masp::MaspTxRefs;
 use namada_core::storage;
 use namada_events::Event;
 use namada_gas::{Gas, VpsGas};
@@ -242,8 +242,10 @@ impl<'de, T: Deserialize<'de>> serde::Deserialize<'de> for BatchResults<T> {
 /// The extended transaction result, containing the references to masp
 /// sections (if any)
 pub struct ExtendedTxResult<T> {
+    /// The transaction result
     pub tx_result: TxResult<T>,
-    pub masp_tx_refs: BatchMaspTxRefs,
+    /// The optional references to masp sections
+    pub masp_tx_refs: MaspTxRefs,
 }
 
 impl<T> Default for ExtendedTxResult<T> {
@@ -300,7 +302,7 @@ impl<T: Display> TxResult<T> {
     /// Converts this result to [`ExtendedTxResult`]
     pub fn to_extended_result(
         self,
-        masp_tx_refs: Option<BatchMaspTxRefs>,
+        masp_tx_refs: Option<MaspTxRefs>,
     ) -> ExtendedTxResult<T> {
         ExtendedTxResult {
             tx_result: self,

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -21,8 +21,8 @@ use namada_core::borsh::{
     BorshDeserialize, BorshSchema, BorshSerialize, BorshSerializeExt,
 };
 use namada_core::hash::Hash;
+use namada_core::masp::BatchMaspTxRefs;
 use namada_core::storage;
-use namada_events::extend::{MaspTxRef, ValidMaspTxs};
 use namada_events::Event;
 use namada_gas::{Gas, VpsGas};
 use namada_macros::BorshDeserializer;
@@ -239,10 +239,11 @@ impl<'de, T: Deserialize<'de>> serde::Deserialize<'de> for BatchResults<T> {
     }
 }
 
-/// The extended transaction result, containing the optional references to masp sections
+/// The extended transaction result, containing the references to masp
+/// sections (if any)
 pub struct ExtendedTxResult<T> {
     pub tx_result: TxResult<T>,
-    pub masp_tx_refs: ValidMaspTxs,
+    pub masp_tx_refs: BatchMaspTxRefs,
 }
 
 impl<T> Default for ExtendedTxResult<T> {
@@ -299,7 +300,7 @@ impl<T: Display> TxResult<T> {
     /// Converts this result to [`ExtendedTxResult`]
     pub fn to_extended_result(
         self,
-        masp_tx_refs: Option<ValidMaspTxs>,
+        masp_tx_refs: Option<BatchMaspTxRefs>,
     ) -> ExtendedTxResult<T> {
         ExtendedTxResult {
             tx_result: self,

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -1731,8 +1731,7 @@ impl<'tx> Tx {
 }
 
 /// Represents the pointers of an indexed tx, which are the block height, the
-/// index inside that block and the commitment inside the tx bundle (if inner
-/// tx)
+/// index inside that block and the commitment inside the tx bundle
 #[derive(
     Debug,
     Clone,
@@ -1751,6 +1750,7 @@ pub struct IndexedTx {
     /// The index in the block of the tx
     pub index: TxIndex,
     /// This is a pointer to the inner tx inside the batch
+    //FIXME: do we really need this? Probably not for the masp
     pub inner_tx: TxCommitments,
 }
 

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -1730,8 +1730,8 @@ impl<'tx> Tx {
     }
 }
 
-/// Represents the pointers of an indexed tx, which are the block height, the
-/// index inside that block and the commitment inside the tx bundle
+/// Represents the pointers to a indexed tx, which are the block height and the
+/// index inside that block
 #[derive(
     Debug,
     Clone,
@@ -1749,9 +1749,6 @@ pub struct IndexedTx {
     pub height: BlockHeight,
     /// The index in the block of the tx
     pub index: TxIndex,
-    /// This is a pointer to the inner tx inside the batch
-    //FIXME: do we really need this? Probably not for the masp
-    pub inner_tx: TxCommitments,
 }
 
 impl Default for IndexedTx {
@@ -1759,7 +1756,6 @@ impl Default for IndexedTx {
         Self {
             height: BlockHeight::first(),
             index: TxIndex(0),
-            inner_tx: TxCommitments::default(),
         }
     }
 }

--- a/crates/vp_env/src/lib.rs
+++ b/crates/vp_env/src/lib.rs
@@ -20,15 +20,13 @@
 
 pub mod collection_validation;
 
-use masp_primitives::transaction::Transaction;
 use namada_core::address::Address;
 use namada_core::borsh::BorshDeserialize;
 use namada_core::hash::Hash;
 use namada_core::storage::{BlockHeight, Epoch, Epochs, Header, Key, TxIndex};
 use namada_core::token::Transfer;
 use namada_events::{Event, EventType};
-use namada_ibc::{decode_message, IbcMessage};
-use namada_storage::{OptionExt, StorageRead};
+use namada_storage::StorageRead;
 use namada_tx::BatchedTxRef;
 
 /// Validity predicate's environment is available for native VPs and WASM VPs
@@ -121,43 +119,6 @@ where
 
     /// Get a tx hash
     fn get_tx_code_hash(&self) -> Result<Option<Hash>, namada_storage::Error>;
-
-    /// Get the masp tx part of the shielded action
-    fn get_shielded_action(
-        &self,
-        batched_tx: &BatchedTxRef<'_>,
-    ) -> Result<Transaction, namada_storage::Error> {
-        let data = batched_tx
-            .tx
-            .data(batched_tx.cmt)
-            .ok_or_err_msg("No transaction data")?;
-        let transfer = match Transfer::try_from_slice(&data) {
-            Ok(transfer) => Some(transfer),
-            Err(_) => {
-                match decode_message(&data).map_err(|_| {
-                    namada_storage::Error::new_const("Unknown IBC message")
-                })? {
-                    IbcMessage::Transfer(msg) => msg.transfer,
-                    IbcMessage::NftTransfer(msg) => msg.transfer,
-                    IbcMessage::RecvPacket(msg) => msg.transfer,
-                    IbcMessage::AckPacket(msg) => msg.transfer,
-                    IbcMessage::Timeout(msg) => msg.transfer,
-                    IbcMessage::Envelope(_) => None,
-                }
-            }
-        };
-
-        let shielded_hash = transfer
-            .ok_or_err_msg("Missing transfer")?
-            .shielded
-            .ok_or_err_msg("unable to find shielded hash")?;
-        let masp_tx = batched_tx
-            .tx
-            .get_section(&shielded_hash)
-            .and_then(|x| x.as_ref().masp_tx())
-            .ok_or_err_msg("unable to find shielded section")?;
-        Ok(masp_tx)
-    }
 
     /// Charge the provided gas for the current vp
     fn charge_gas(&self, used_gas: u64) -> Result<(), namada_storage::Error>;

--- a/crates/vp_env/src/lib.rs
+++ b/crates/vp_env/src/lib.rs
@@ -24,7 +24,6 @@ use namada_core::address::Address;
 use namada_core::borsh::BorshDeserialize;
 use namada_core::hash::Hash;
 use namada_core::storage::{BlockHeight, Epoch, Epochs, Header, Key, TxIndex};
-use namada_core::token::Transfer;
 use namada_events::{Event, EventType};
 use namada_storage::StorageRead;
 use namada_tx::BatchedTxRef;

--- a/wasm/tx_ibc/src/lib.rs
+++ b/wasm/tx_ibc/src/lib.rs
@@ -3,6 +3,7 @@
 //! tx_data. This tx uses an IBC message wrapped inside
 //! `key::ed25519::SignedTxData` as its input as declared in `ibc` crate.
 
+use namada_tx_prelude::action::{Action, MaspAction, Write};
 use namada_tx_prelude::*;
 
 #[transaction]
@@ -12,24 +13,26 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
         ibc::ibc_actions(ctx).execute(&data).into_storage_result()?;
 
     if let Some(transfer) = transfer {
-        let shielded = transfer
-            .shielded
-            .as_ref()
-            .map(|hash| {
-                tx_data
-                    .tx
-                    .get_section(hash)
-                    .and_then(|x| x.as_ref().masp_tx())
-                    .ok_or_err_msg("unable to find shielded section")
-                    .map_err(|err| {
-                        ctx.set_commitment_sentinel();
-                        err
-                    })
-            })
-            .transpose()?;
-        if let Some(shielded) = shielded {
-            token::utils::handle_masp_tx(ctx, &shielded)?;
-            update_masp_note_commitment_tree(&shielded)?;
+        if let Some(masp_section_ref) = transfer.shielded {
+            let shielded = signed
+                .get_section(&masp_section_ref)
+                .and_then(|x| x.as_ref().masp_tx())
+                .ok_or_err_msg(
+                    "Unable to find required shielded section in tx data",
+                )
+                .map_err(|err| {
+                    ctx.set_commitment_sentinel();
+                    err
+                })?;
+            token::utils::handle_masp_tx(
+                ctx,
+                &shielded,
+                transfer.key.as_deref(),
+            )
+            .wrap_err("Encountered error while handling MASP transaction")?;
+            update_masp_note_commitment_tree(&shielded)
+                .wrap_err("Failed to update the MASP commitment tree")?;
+            ctx.push_action(Action::Masp(MaspAction { masp_section_ref }))?;
         }
     }
 

--- a/wasm/tx_ibc/src/lib.rs
+++ b/wasm/tx_ibc/src/lib.rs
@@ -12,28 +12,25 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
     let transfer =
         ibc::ibc_actions(ctx).execute(&data).into_storage_result()?;
 
-    if let Some(transfer) = transfer {
-        if let Some(masp_section_ref) = transfer.shielded {
-            let shielded = signed
-                .get_section(&masp_section_ref)
-                .and_then(|x| x.as_ref().masp_tx())
-                .ok_or_err_msg(
-                    "Unable to find required shielded section in tx data",
-                )
-                .map_err(|err| {
-                    ctx.set_commitment_sentinel();
-                    err
-                })?;
-            token::utils::handle_masp_tx(
-                ctx,
-                &shielded,
-                transfer.key.as_deref(),
+    if let Some(masp_section_ref) =
+        transfer.and_then(|transfer| transfer.shielded)
+    {
+        let shielded = tx_data
+            .tx
+            .get_section(&masp_section_ref)
+            .and_then(|x| x.as_ref().masp_tx())
+            .ok_or_err_msg(
+                "Unable to find required shielded section in tx data",
             )
+            .map_err(|err| {
+                ctx.set_commitment_sentinel();
+                err
+            })?;
+        token::utils::handle_masp_tx(ctx, &shielded)
             .wrap_err("Encountered error while handling MASP transaction")?;
-            update_masp_note_commitment_tree(&shielded)
-                .wrap_err("Failed to update the MASP commitment tree")?;
-            ctx.push_action(Action::Masp(MaspAction { masp_section_ref }))?;
-        }
+        update_masp_note_commitment_tree(&shielded)
+            .wrap_err("Failed to update the MASP commitment tree")?;
+        ctx.push_action(Action::Masp(MaspAction { masp_section_ref }))?;
     }
 
     Ok(())

--- a/wasm/tx_transfer/src/lib.rs
+++ b/wasm/tx_transfer/src/lib.rs
@@ -22,7 +22,8 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
     .wrap_err("Token transfer failed")?;
 
     if let Some(masp_section_ref) = transfer.shielded {
-        let shielded = signed
+        let shielded = tx_data
+            .tx
             .get_section(&masp_section_ref)
             .and_then(|x| x.as_ref().masp_tx())
             .ok_or_err_msg(
@@ -32,7 +33,7 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
                 ctx.set_commitment_sentinel();
                 err
             })?;
-        token::utils::handle_masp_tx(ctx, &shielded, transfer.key.as_deref())
+        token::utils::handle_masp_tx(ctx, &shielded)
             .wrap_err("Encountered error while handling MASP transaction")?;
         update_masp_note_commitment_tree(&shielded)
             .wrap_err("Failed to update the MASP commitment tree")?;

--- a/wasm/tx_transfer/src/lib.rs
+++ b/wasm/tx_transfer/src/lib.rs
@@ -2,6 +2,7 @@
 //! This tx uses `token::Transfer` wrapped inside `SignedTxData`
 //! as its input as declared in `namada` crate.
 
+use namada_tx_prelude::action::{Action, MaspAction, Write};
 use namada_tx_prelude::*;
 
 #[transaction]
@@ -20,28 +21,22 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
     )
     .wrap_err("Token transfer failed")?;
 
-    let shielded = transfer
-        .shielded
-        .as_ref()
-        .map(|hash| {
-            tx_data
-                .tx
-                .get_section(hash)
-                .and_then(|x| x.as_ref().masp_tx())
-                .ok_or_err_msg(
-                    "Unable to find required shielded section in tx data",
-                )
-                .map_err(|err| {
-                    ctx.set_commitment_sentinel();
-                    err
-                })
-        })
-        .transpose()?;
-    if let Some(shielded) = shielded {
-        token::utils::handle_masp_tx(ctx, &shielded)
+    if let Some(masp_section_ref) = transfer.shielded {
+        let shielded = signed
+            .get_section(&masp_section_ref)
+            .and_then(|x| x.as_ref().masp_tx())
+            .ok_or_err_msg(
+                "Unable to find required shielded section in tx data",
+            )
+            .map_err(|err| {
+                ctx.set_commitment_sentinel();
+                err
+            })?;
+        token::utils::handle_masp_tx(ctx, &shielded, transfer.key.as_deref())
             .wrap_err("Encountered error while handling MASP transaction")?;
         update_masp_note_commitment_tree(&shielded)
             .wrap_err("Failed to update the MASP commitment tree")?;
+        ctx.push_action(Action::Masp(MaspAction { masp_section_ref }))?;
     }
     Ok(())
 }

--- a/wasm/vp_implicit/src/lib.rs
+++ b/wasm/vp_implicit/src/lib.rs
@@ -101,6 +101,7 @@ fn validate_tx(
                 &tx,
                 &addr,
             )?,
+            Action::Masp(_) => (),
         }
     }
 

--- a/wasm/vp_user/src/lib.rs
+++ b/wasm/vp_user/src/lib.rs
@@ -101,6 +101,7 @@ fn validate_tx(
                 &tx,
                 &addr,
             )?,
+            Action::Masp(_) => (),
         }
     }
 


### PR DESCRIPTION
## Describe your changes

Closes #3148.
Partially addresses #2597.

Removes the last dependency on `Transfer` from the masp vp by using a new masp `Action`. Creates a new event for this and updated the sdk to fetch data relying on this event. 

## Indicate on which release or other PRs this topic is based on

v0.37.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
