### PR TITLE
Remove unused WASM memory export

### DIFF
--- a/.changelog/unreleased/improvements/3258-dont-export-wasm-mem.md
+++ b/.changelog/unreleased/improvements/3258-dont-export-wasm-mem.md
@@ -1,0 +1,2 @@
+- Remove unused WASM memory export.
+  ([\#3258](https://github.com/anoma/namada/pull/3258))

--- a/crates/namada/src/vm/wasm/host_env.rs
+++ b/crates/namada/src/vm/wasm/host_env.rs
@@ -5,8 +5,7 @@
 
 use namada_state::{DBIter, StorageHasher, DB};
 use wasmer::{
-    Function, HostEnvInitError, ImportObject, Instance, Memory, Store,
-    WasmerEnv,
+    Function, HostEnvInitError, ImportObject, Instance, Store, WasmerEnv,
 };
 
 use crate::vm::host_env::{TxVmEnv, VpEvaluator, VpVmEnv};
@@ -47,7 +46,6 @@ where
 #[allow(clippy::too_many_arguments)]
 pub fn tx_imports<D, H, CA>(
     wasm_store: &Store,
-    initial_memory: Memory,
     env: TxVmEnv<'static, WasmMemory, D, H, CA>,
 ) -> ImportObject
 where
@@ -58,7 +56,6 @@ where
     wasmer::imports! {
         // default namespace
         "env" => {
-            "memory" => initial_memory,
             // Wasm middleware gas injection hook
             "gas" => Function::new_native_with_env(wasm_store, env.clone(), host_env::tx_charge_gas),
             "namada_tx_read" => Function::new_native_with_env(wasm_store, env.clone(), host_env::tx_read),
@@ -96,7 +93,6 @@ where
 /// validity predicate code
 pub fn vp_imports<D, H, EVAL, CA>(
     wasm_store: &Store,
-    initial_memory: Memory,
     env: VpVmEnv<'static, WasmMemory, D, H, EVAL, CA>,
 ) -> ImportObject
 where
@@ -108,7 +104,6 @@ where
     wasmer::imports! {
         // default namespace
         "env" => {
-            "memory" => initial_memory,
             // Wasm middleware gas injection hook
             "gas" => Function::new_native_with_env(wasm_store, env.clone(), host_env::vp_charge_gas),
             "namada_vp_read_pre" => Function::new_native_with_env(wasm_store, env.clone(), host_env::vp_read_pre),

--- a/crates/namada/src/vm/wasm/run.rs
+++ b/crates/namada/src/vm/wasm/run.rs
@@ -210,9 +210,7 @@ where
         tx_wasm_cache,
     );
 
-    let initial_memory =
-        memory::prepare_tx_memory(&store).map_err(Error::MemoryError)?;
-    let imports = tx_imports(&store, initial_memory, env);
+    let imports = tx_imports(&store, env);
 
     // Instantiate the wasm module
     let instance = wasmer::Instance::new(&module, &imports)
@@ -328,10 +326,8 @@ where
         &mut vp_wasm_cache,
     );
 
-    let initial_memory =
-        memory::prepare_vp_memory(&store).map_err(Error::MemoryError)?;
     let yielded_value_borrow = env.ctx.yielded_value.clone();
-    let imports = vp_imports(&store, initial_memory, env);
+    let imports = vp_imports(&store, env);
 
     run_vp(
         module,
@@ -520,15 +516,12 @@ where
             gas_meter,
         )?;
 
-        let initial_memory =
-            memory::prepare_vp_memory(&store).map_err(Error::MemoryError)?;
-
         let env = VpVmEnv {
             memory: WasmMemory::default(),
             ctx,
         };
         let yielded_value_borrow = env.ctx.yielded_value.clone();
-        let imports = vp_imports(&store, initial_memory, env);
+        let imports = vp_imports(&store, env);
 
         run_vp(
             module,


### PR DESCRIPTION
## Describe your changes

The wasm execution environment instantiated a block of memory that went unused by txs/vps. In this PR, we remove the code that instantiated that memory block.

## Indicate on which release or other PRs this topic is based on

`v0.35.1`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
