### PR TITLE
ci: update rust stable to 1.78 and nightly 2024-05-15

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,7 +103,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         wasm_cache_version: ["v2"]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         mold_version: [2.4.0]
 
     steps:
@@ -166,7 +166,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         wasm_cache_version: ["v2"]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         mold_version: [2.4.0]
 
     steps:
@@ -197,7 +197,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         mold_version: [2.4.0]
         make:
           - name: ABCI
@@ -300,7 +300,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         mold_version: [2.4.0]
         make:
           - name: ABCI
@@ -392,7 +392,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         mold_version: [2.4.0]
         make:
           - name: ABCI
@@ -586,7 +586,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         mold_version: [2.4.0]
         comet_bft: [0.37.2]
         make:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         make:
           - name: Clippy
             command: clippy

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         make:
           - name: Audit
             command: audit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         mdbook_version: [rust-lang/mdbook@v0.4.18]
         mdbook_mermaid: [badboy/mdbook-mermaid@v0.11.1]
         mdbook_linkcheck: [Michael-F-Bryan/mdbook-linkcheck@v0.7.6]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         mold_version: [2.4.0]
         make:
           - name: ABCI

--- a/.github/workflows/triggerable_sync.yml
+++ b/.github/workflows/triggerable_sync.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        nightly_version: [nightly-2024-02-10]
+        nightly_version: [nightly-2024-05-15]
         mold_version: [2.4.0]
         comet_bft: [0.37.2]
         name: ["Run chain sync test"]

--- a/docker/namada-wasm/Dockerfile
+++ b/docker/namada-wasm/Dockerfile
@@ -1,7 +1,7 @@
 # This docker is used for deterministic wasm builds
 
 # The version should be matching the version set in wasm/rust-toolchain.toml
-FROM rust:1.76.0-bullseye
+FROM rust:1.78.0-bookworm
 
 WORKDIR /__w/namada/namada
 

--- a/docker/namada/Dockerfile
+++ b/docker/namada/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.76.0-bullseye AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.78.0-bookwork AS chef
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
## Describe your changes

In preparation for #3254 updating versions in CI and docker files

## Indicate on which release or other PRs this topic is based on

0.35.1

## Checklist before merging to `draft`
- ~~[ ] I have added a changelog~~
- [x] Git history is in acceptable state
