### PR TITLE
Replay protection contributes to App Hash

### DIFF
--- a/.changelog/unreleased/improvements/3284-reprot-merklized-commitment.md
+++ b/.changelog/unreleased/improvements/3284-reprot-merklized-commitment.md
@@ -1,0 +1,3 @@
+- Replay protection entries need to be verifiable and thus should contribute to the app hash. This PR makes
+  a cryptographic commitment to all replay protection entries (the root of some implicit merkle tree) which is itself
+  merklized. ([\#3284](https://github.com/anoma/namada/pull/3284))

--- a/crates/core/src/address.rs
+++ b/crates/core/src/address.rs
@@ -143,7 +143,7 @@ impl From<raw::Address<'_, raw::Validated>> for Address {
             raw::Discriminant::TempStorage => {
                 Address::Internal(InternalAddress::TempStorage)
             }
-            Discriminant::ReplayProtection => {
+            raw::Discriminant::ReplayProtection => {
                 Address::Internal(InternalAddress::ReplayProtection)
             }
         }

--- a/crates/core/src/address.rs
+++ b/crates/core/src/address.rs
@@ -15,6 +15,7 @@ use namada_migrations::*;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::address::raw::Discriminant;
 use crate::ethereum_events::EthAddress;
 use crate::ibc::primitives::Signer;
 use crate::ibc::IbcTokenHash;
@@ -143,6 +144,9 @@ impl From<raw::Address<'_, raw::Validated>> for Address {
             raw::Discriminant::TempStorage => {
                 Address::Internal(InternalAddress::TempStorage)
             }
+            Discriminant::ReplayProtection => {
+                Address::Internal(InternalAddress::ReplayProtection)
+            }
         }
     }
 }
@@ -241,6 +245,13 @@ impl<'addr> From<&'addr Address> for raw::Address<'addr, raw::Validated> {
                 raw::Address::from_discriminant(raw::Discriminant::TempStorage)
                     .validate()
                     .expect("This raw address is valid")
+            }
+            Address::Internal(InternalAddress::ReplayProtection) => {
+                raw::Address::from_discriminant(
+                    raw::Discriminant::ReplayProtection,
+                )
+                .validate()
+                .expect("This raw address is valid")
             }
         }
     }
@@ -575,6 +586,8 @@ pub enum InternalAddress {
     Pgf,
     /// Masp
     Masp,
+    /// Replay protection
+    ReplayProtection,
     /// Address with temporary storage is used to pass data from txs to VPs
     /// which is never committed to DB
     TempStorage,
@@ -599,6 +612,7 @@ impl Display for InternalAddress {
                 Self::Multitoken => "Multitoken".to_string(),
                 Self::Pgf => "PublicGoodFundings".to_string(),
                 Self::Masp => "MASP".to_string(),
+                Self::ReplayProtection => "ReplayProtection".to_string(),
                 Self::TempStorage => "TempStorage".to_string(),
             }
         )
@@ -615,6 +629,7 @@ impl InternalAddress {
             "bridgepool" => Some(InternalAddress::EthBridgePool),
             "governance" => Some(InternalAddress::Governance),
             "masp" => Some(InternalAddress::Masp),
+            "replayprotection" => Some(InternalAddress::ReplayProtection),
             _ => None,
         }
     }
@@ -821,6 +836,7 @@ pub mod testing {
             InternalAddress::Pgf => {}
             InternalAddress::Masp => {}
             InternalAddress::Multitoken => {}
+            InternalAddress::ReplayProtection => {}
             InternalAddress::TempStorage => {} /* Add new addresses in the
                                                 * `prop_oneof` below. */
         };
@@ -838,6 +854,7 @@ pub mod testing {
             Just(InternalAddress::Multitoken),
             Just(InternalAddress::Pgf),
             Just(InternalAddress::Masp),
+            Just(InternalAddress::ReplayProtection),
             Just(InternalAddress::TempStorage),
         ]
     }

--- a/crates/core/src/address.rs
+++ b/crates/core/src/address.rs
@@ -15,7 +15,6 @@ use namada_migrations::*;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::address::raw::Discriminant;
 use crate::ethereum_events::EthAddress;
 use crate::ibc::primitives::Signer;
 use crate::ibc::IbcTokenHash;

--- a/crates/core/src/address/raw.rs
+++ b/crates/core/src/address/raw.rs
@@ -65,10 +65,10 @@ pub enum Discriminant {
     IbcToken = 13,
     /// MASP raw address.
     Masp = 14,
-    /// Replay protection
-    ReplayProtection = 15,
     /// Temporary storage address.
-    TempStorage = 16,
+    TempStorage = 15,
+    /// Replay protection
+    ReplayProtection = 16,
 }
 
 /// Raw address representation.

--- a/crates/core/src/address/raw.rs
+++ b/crates/core/src/address/raw.rs
@@ -65,8 +65,10 @@ pub enum Discriminant {
     IbcToken = 13,
     /// MASP raw address.
     Masp = 14,
+    /// Replay protection
+    ReplayProtection = 15,
     /// Temporary storage address.
-    TempStorage = 15,
+    TempStorage = 16,
 }
 
 /// Raw address representation.

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -1,6 +1,7 @@
 //! Types for working with 32 bytes hashes.
 
 use std::fmt::{self, Display};
+use std::ops::Add;
 use std::str::FromStr;
 
 use arse_merkle_tree::traits::Hasher;
@@ -153,6 +154,23 @@ impl Hash {
     /// Return the inner pointer to the hash data.
     pub const fn as_ptr(&self) -> *const u8 {
         self.0.as_ptr()
+    }
+}
+
+impl<'a> Add<&'a Hash> for Hash {
+    type Output = Self;
+
+    fn add(self, rhs: &'a Hash) -> Self::Output {
+        let mut hasher = Sha256::default();
+        if self.is_zero() {
+            *rhs
+        } else if rhs.is_zero() {
+            self
+        } else {
+            hasher.update(self.as_ref());
+            hasher.update(rhs.as_ref());
+            Self(hasher.finalize().into())
+        }
     }
 }
 

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -159,12 +159,12 @@ impl Hash {
     /// but if one value is the zero hash, the other
     /// value is returned.
     pub fn concat(self, rhs: &Hash) -> Self {
-        let mut hasher = Sha256::default();
         if self.is_zero() {
             *rhs
         } else if rhs.is_zero() {
             self
         } else {
+            let mut hasher = Sha256::default();
             hasher.update(self.as_ref());
             hasher.update(rhs.as_ref());
             Self(hasher.finalize().into())

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -1,7 +1,6 @@
 //! Types for working with 32 bytes hashes.
 
 use std::fmt::{self, Display};
-use std::ops::Add;
 use std::str::FromStr;
 
 use arse_merkle_tree::traits::Hasher;
@@ -155,12 +154,11 @@ impl Hash {
     pub const fn as_ptr(&self) -> *const u8 {
         self.0.as_ptr()
     }
-}
 
-impl<'a> Add<&'a Hash> for Hash {
-    type Output = Self;
-
-    fn add(self, rhs: &'a Hash) -> Self::Output {
+    /// Given hashes A and B, compute Sha256(A||B),
+    /// but if one value is the zero hash, the other
+    /// value is returned.
+    pub fn concat(self, rhs: &Hash) -> Self {
         let mut hasher = Sha256::default();
         if self.is_zero() {
             *rhs

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -1021,6 +1021,12 @@ where
                             // Temp storage changes must never be committed
                             Error::AccessForbidden((*internal_addr).clone()),
                         ),
+                        InternalAddress::ReplayProtection => Err(
+                            // Replay protection entries should never be
+                            // written to
+                            // via transactions
+                            Error::AccessForbidden((*internal_addr).clone()),
+                        ),
                     }
                 }
             };

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -2817,6 +2817,15 @@ mod test_finalize_block {
                 .has_key(&wrapper_hash_key)
                 .unwrap()
         );
+
+        // test that a commitment to replay protection gets added.
+        let reprot_key = replay_protection::commitment_key();
+        let reprot_commitment: Hash = shell
+            .state
+            .read(&reprot_key)
+            .expect("Test failed")
+            .expect("Test failed");
+        assert_eq!(wrapper_tx.raw_header_hash(), reprot_commitment);
     }
 
     /// Test that masp anchor keys are added to the merkle tree

--- a/crates/replay_protection/src/lib.rs
+++ b/crates/replay_protection/src/lib.rs
@@ -17,10 +17,21 @@
     clippy::print_stderr
 )]
 
+use namada_core::address::{Address, InternalAddress};
 use namada_core::hash::Hash;
-use namada_core::storage::Key;
+use namada_core::storage::{DbKeySeg, Key};
 
 const ERROR_MSG: &str = "Cannot obtain a valid db key";
+
+/// Get the key under which we store a hash which is commitment
+/// to all replay protection entries.
+pub fn commitment_key() -> Key {
+    Key::from(DbKeySeg::AddressSeg(Address::Internal(
+        InternalAddress::ReplayProtection,
+    )))
+    .push(&"commitment".to_string())
+    .expect("Should be able to form this key")
+}
 
 /// Get the transaction hash key
 pub fn key(hash: &Hash) -> Key {

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -11,7 +11,10 @@ use namada_events::{EmitEvents, EventToEmit};
 use namada_parameters::EpochDuration;
 use namada_replay_protection as replay_protection;
 use namada_storage::conversion_state::{ConversionState, WithConversionState};
-use namada_storage::{BlockHeight, BlockStateRead, BlockStateWrite, ResultExt};
+use namada_storage::{
+    BlockHeight, BlockStateRead, BlockStateWrite, ResultExt, StorageRead,
+    StorageWrite,
+};
 
 use crate::in_memory::InMemory;
 use crate::write_log::{StorageModification, WriteLog};
@@ -227,14 +230,24 @@ where
         // hashes from the previous block to the general bucket
         self.move_current_replay_protection_entries(batch)?;
 
-        for hash in
-            std::mem::take(&mut self.0.write_log.replay_protection).iter()
-        {
-            self.write_replay_protection_entry(
-                batch,
-                &replay_protection::current_key(hash),
-            )?;
-        }
+        let replay_prot_key = replay_protection::commitment_key();
+        let commitment: Hash = self
+            .read(&replay_prot_key)
+            .expect("Could not read db")
+            .unwrap_or_default();
+        let new_commitment =
+            std::mem::take(&mut self.0.write_log.replay_protection)
+                .iter()
+                .try_fold(commitment, |mut acc, hash| {
+                    self.write_replay_protection_entry(
+                        batch,
+                        &replay_protection::current_key(hash),
+                    )?;
+                    acc = acc + hash;
+                    Ok::<_, Error>(acc)
+                })?;
+        self.write(&replay_prot_key, new_commitment)?;
+
         debug_assert!(self.0.write_log.replay_protection.is_empty());
 
         if let Some(address_gen) = self.0.write_log.block_address_gen.take() {

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -243,7 +243,7 @@ where
                         batch,
                         &replay_protection::current_key(hash),
                     )?;
-                    acc = acc + hash;
+                    acc = acc.concat(hash);
                     Ok::<_, Error>(acc)
                 })?;
         self.write(&replay_prot_key, new_commitment)?;

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -13,7 +13,6 @@ use namada_replay_protection as replay_protection;
 use namada_storage::conversion_state::{ConversionState, WithConversionState};
 use namada_storage::{
     BlockHeight, BlockStateRead, BlockStateWrite, ResultExt, StorageRead,
-    StorageWrite,
 };
 
 use crate::in_memory::InMemory;
@@ -246,7 +245,7 @@ where
                     acc = acc.concat(hash);
                     Ok::<_, Error>(acc)
                 })?;
-        self.write(&replay_prot_key, new_commitment)?;
+        self.batch_write_subspace_val(batch, &replay_prot_key, new_commitment)?;
 
         debug_assert!(self.0.write_log.replay_protection.is_empty());
 


### PR DESCRIPTION
## Describe your changes
Replay protection entries need to be verifiable and thus should contribute to the app hash. This PR makes a cryptographic commitment to all replay protection entries (the root of some implicit merkle tree) which is itself merklized.
## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
