### PR TITLE
apps: switch off "mainnet" by default

### DIFF
--- a/.changelog/unreleased/bug-fixes/3287-no-default-mainnet.md
+++ b/.changelog/unreleased/bug-fixes/3287-no-default-mainnet.md
@@ -1,0 +1,2 @@
+- Switch off the "mainnet" feature by default for now.
+  ([\#3287](https://github.com/anoma/namada/pull/3287))

--- a/crates/apps/Cargo.toml
+++ b/crates/apps/Cargo.toml
@@ -44,7 +44,7 @@ name = "namadar"
 path = "src/bin/namada-relayer/main.rs"
 
 [features]
-default = ["namada/mainnet", "migrations"]
+default = ["migrations"]
 mainnet = ["namada_apps_lib/mainnet"]
 jemalloc = ["namada_node/jemalloc"]
 migrations = ["namada/migrations", "namada_apps_lib/migrations"]


### PR DESCRIPTION
## Describe your changes

Undoes accidentally switched on "mainnet' by default in #3259

## Indicate on which release or other PRs this topic is based on

0.36.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
