### PR TITLE
update cargo-about used for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         run: sccache --start-server
       - name: Install cargo-about
         if: "!startsWith(runner.os, 'Windows')"
-        run: curl -k https://installer.heliax.click/EmbarkStudios/cargo-about@0.5.7! | bash
+        run: curl -k https://installer.heliax.click/EmbarkStudios/cargo-about@0.6.1! | bash
       - name: Install cargo-about (only windows)
         if: startsWith(runner.os, 'Windows')
         run: cargo install --locked cargo-about


### PR DESCRIPTION
this should fix the release job (see https://github.com/anoma/namada/actions/runs/9179421750/job/25241527344) by updating to later transitive dep `krates` that fixes the cause