### PR TITLE
Merklized but not diffed

### DIFF
--- a/.changelog/unreleased/features/3293-merklized-not-diffed.md
+++ b/.changelog/unreleased/features/3293-merklized-not-diffed.md
@@ -1,0 +1,2 @@
+- Enable to write data to be updated in the subspace and Merkle tree, but not to
+  be updated in diffs ([\#3293](https://github.com/anoma/namada/issues/3293))

--- a/crates/merkle_tree/Cargo.toml
+++ b/crates/merkle_tree/Cargo.toml
@@ -17,6 +17,7 @@ migrations = [
     "namada_migrations",
     "linkme",
 ]
+testing = ["namada_core/testing"]
 
 [dependencies]
 namada_core = { path = "../core" }

--- a/crates/merkle_tree/src/lib.rs
+++ b/crates/merkle_tree/src/lib.rs
@@ -48,6 +48,7 @@ use namada_macros::BorshDeserializer;
 use namada_migrations::*;
 use thiserror::Error;
 
+/// Key prefix for the data not stored to diffs
 pub const NO_DIFF_KEY_PREFIX: &str = "no_diff";
 
 /// Trait for reading from a merkle tree that is a sub-tree

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -353,13 +353,6 @@ where
     event_log: EventLog,
 }
 
-/// Merkle tree storage key filter. Return `false` for keys that shouldn't be
-/// merklized.
-pub fn is_merklized_storage_key(_key: &namada_sdk::storage::Key) -> bool {
-    // We need to merklize all keys for now
-    true
-}
-
 /// Storage key filter to store the diffs into the storage. Return `false` for
 /// keys whose diffs shouldn't be stored.
 pub fn is_key_diff_storable(key: &namada_sdk::storage::Key) -> bool {
@@ -448,7 +441,6 @@ where
             chain_id.clone(),
             native_token,
             config.shell.storage_read_past_height_limit,
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
         let vp_wasm_cache_dir =

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -355,7 +355,14 @@ where
 
 /// Merkle tree storage key filter. Return `false` for keys that shouldn't be
 /// merklized.
-pub fn is_merklized_storage_key(key: &namada_sdk::storage::Key) -> bool {
+pub fn is_merklized_storage_key(_key: &namada_sdk::storage::Key) -> bool {
+    // We need to merklize all keys for now
+    true
+}
+
+/// Storage key filter to store the diffs into the storage. Return `false` for
+/// keys whose diffs shouldn't be stored.
+pub fn is_key_diff_storable(key: &namada_sdk::storage::Key) -> bool {
     !(token::storage_key::is_masp_key(key)
         && *key != token::storage_key::masp_convert_anchor_key()
         && *key != token::storage_key::masp_token_map_key()
@@ -442,6 +449,7 @@ where
             native_token,
             config.shell.storage_read_past_height_limit,
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
         let vp_wasm_cache_dir =
             base_dir.join(chain_id.as_str()).join("vp_wasm_cache");

--- a/crates/node/src/storage/mod.rs
+++ b/crates/node/src/storage/mod.rs
@@ -79,7 +79,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::shell::is_merklized_storage_key;
+    use crate::shell::{is_key_diff_storable, is_merklized_storage_key};
 
     #[test]
     fn test_crud_value() {
@@ -92,6 +92,7 @@ mod tests {
             address::testing::nam(),
             None,
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
         let key = Key::parse("key").expect("cannot parse the key string");
         let value: u64 = 1;
@@ -144,6 +145,7 @@ mod tests {
             address::testing::nam(),
             None,
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
         state
             .in_mem_mut()
@@ -206,6 +208,7 @@ mod tests {
             address::testing::nam(),
             None,
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
         let (loaded_root, height) =
             state.in_mem().get_state().expect("no block exists");
@@ -227,6 +230,7 @@ mod tests {
             address::testing::nam(),
             None,
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
 
         let mut expected = Vec::new();
@@ -271,6 +275,7 @@ mod tests {
             address::testing::nam(),
             None,
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
         state
             .in_mem_mut()
@@ -343,6 +348,7 @@ mod tests {
             address::testing::nam(),
             None,
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
 
         // 1. For each `blocks_write_value`, write the current block height if
@@ -437,6 +443,7 @@ mod tests {
             address::testing::nam(),
             None,
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
 
         let num_keys = 5;
@@ -559,6 +566,7 @@ mod tests {
             address::testing::nam(),
             Some(5),
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
         let new_epoch_start = BlockHeight(1);
         let signed_root_key = bridge_pool::get_signed_root_key();
@@ -681,6 +689,7 @@ mod tests {
             address::testing::nam(),
             None,
             is_merklized_storage_key,
+            is_key_diff_storable,
         );
 
         let prefix = storage::Key::parse("prefix").unwrap();
@@ -788,6 +797,7 @@ mod tests {
             address::testing::nam(),
             None,
             // Only merkelize and persist diffs for `test_key_1`
+            |key: &Key| -> bool { key == &test_key_1() },
             |key: &Key| -> bool { key == &test_key_1() },
         );
         // Start the first block

--- a/crates/node/src/storage/mod.rs
+++ b/crates/node/src/storage/mod.rs
@@ -81,7 +81,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::shell::{is_key_diff_storable, is_merklized_storage_key};
+    use crate::shell::is_key_diff_storable;
 
     #[test]
     fn test_crud_value() {
@@ -93,7 +93,6 @@ mod tests {
             ChainId::default(),
             address::testing::nam(),
             None,
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
         let key = Key::parse("key").expect("cannot parse the key string");
@@ -146,7 +145,6 @@ mod tests {
             ChainId::default(),
             address::testing::nam(),
             None,
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
         state
@@ -209,7 +207,6 @@ mod tests {
             ChainId::default(),
             address::testing::nam(),
             None,
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
         let (loaded_root, height) =
@@ -231,7 +228,6 @@ mod tests {
             ChainId::default(),
             address::testing::nam(),
             None,
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
 
@@ -276,7 +272,6 @@ mod tests {
             ChainId::default(),
             address::testing::nam(),
             None,
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
         state
@@ -349,7 +344,6 @@ mod tests {
             ChainId::default(),
             address::testing::nam(),
             None,
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
 
@@ -444,9 +438,10 @@ mod tests {
             ChainId::default(),
             address::testing::nam(),
             None,
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
+        // Prepare written keys for non-probable data, probable data (IBC), and
+        // no diffed data
         let make_key = |suffix: u64| {
             match suffix % 3u64 {
                 0 => Key::parse(format!("key{suffix}")).unwrap(),
@@ -529,6 +524,7 @@ mod tests {
                 }
             }
         }
+        // save the last root
         roots.insert(state.in_mem().block.height, state.in_mem().merkle_root());
         state.commit_block_from_batch(batch)?;
 
@@ -543,6 +539,7 @@ mod tests {
                 continue;
             }
             let tree = state.get_merkle_tree(height, Some(StoreType::Ibc))?;
+            // Check if the rebuilt tree's root is the same as the saved one
             assert_eq!(tree.root().0, roots.get(&height).unwrap().0);
             match write_type {
                 0 => {
@@ -578,6 +575,7 @@ mod tests {
                     .join(&key);
             let tree =
                 state.get_merkle_tree(height, Some(StoreType::NoDiff))?;
+            // Check if the rebuilt tree's root is the same as the saved one
             assert_eq!(tree.root().0, roots.get(&height).unwrap().0);
             match write_type {
                 0 => {
@@ -612,7 +610,6 @@ mod tests {
             ChainId::default(),
             address::testing::nam(),
             Some(5),
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
         let new_epoch_start = BlockHeight(1);
@@ -735,7 +732,6 @@ mod tests {
             ChainId::default(),
             address::testing::nam(),
             None,
-            is_merklized_storage_key,
             is_key_diff_storable,
         );
 
@@ -844,7 +840,6 @@ mod tests {
             address::testing::nam(),
             None,
             // Only merkelize and persist diffs for `test_key_1`
-            |key: &Key| -> bool { key == &test_key_1() },
             |key: &Key| -> bool { key == &test_key_1() },
         );
         // Start the first block

--- a/crates/node/src/storage/mod.rs
+++ b/crates/node/src/storage/mod.rs
@@ -443,8 +443,11 @@ mod tests {
         // Prepare written keys for non-probable data, probable data (IBC), and
         // no diffed data
         let make_key = |suffix: u64| {
+            // For three type keys
             match suffix % 3u64 {
+                // for non-probable data
                 0 => Key::parse(format!("key{suffix}")).unwrap(),
+                // for probable data
                 1 => ibc_key(format!("key{suffix}")).unwrap(),
                 // for no diff
                 _ => client_counter_key(),
@@ -543,6 +546,7 @@ mod tests {
             assert_eq!(tree.root().0, roots.get(&height).unwrap().0);
             match write_type {
                 0 => {
+                    // data was not updated
                     if *current_state.get(&key).unwrap() {
                         assert!(tree.has_key(&key)?);
                     } else {
@@ -550,10 +554,12 @@ mod tests {
                     }
                 }
                 1 | 3 => {
+                    // data was deleted
                     assert!(!tree.has_key(&key)?);
                     current_state.insert(key, false);
                 }
                 _ => {
+                    // data was updated
                     assert!(tree.has_key(&key)?);
                     current_state.insert(key, true);
                 }
@@ -579,6 +585,7 @@ mod tests {
             assert_eq!(tree.root().0, roots.get(&height).unwrap().0);
             match write_type {
                 0 => {
+                    // data was not updated
                     if *current_state.get(&key).unwrap() {
                         assert!(tree.has_key(&merkle_key)?);
                     } else {
@@ -586,10 +593,12 @@ mod tests {
                     }
                 }
                 1 | 3 => {
+                    // data was deleted
                     assert!(!tree.has_key(&merkle_key)?);
                     current_state.insert(key, false);
                 }
                 _ => {
+                    // data was updated
                     assert!(tree.has_key(&merkle_key)?);
                     current_state.insert(key, true);
                 }

--- a/crates/node/src/storage/mod.rs
+++ b/crates/node/src/storage/mod.rs
@@ -61,17 +61,19 @@ mod tests {
     use namada::core::ethereum_events::Uint;
     use namada::core::hash::Hash;
     use namada::core::keccak::KeccakHash;
-    use namada::core::storage::{BlockHeight, Key};
+    use namada::core::storage::{BlockHeight, Key, KeySeg};
     use namada::core::time::DurationSecs;
     use namada::core::{address, storage};
     use namada::eth_bridge::storage::proof::BridgePoolRootProof;
+    use namada::ibc::storage::is_ibc_key;
     use namada::ledger::eth_bridge::storage::bridge_pool;
     use namada::ledger::gas::STORAGE_ACCESS_GAS_PER_BYTE;
-    use namada::ledger::ibc::storage::ibc_key;
+    use namada::ledger::ibc::storage::{client_counter_key, ibc_key};
     use namada::ledger::parameters::{EpochDuration, Parameters};
     use namada::state::{self, StorageRead, StorageWrite, StoreType, DB};
     use namada::token::conversion::update_allowed_conversions;
     use namada::{decode, encode, parameters};
+    use namada_sdk::state::merkle_tree::NO_DIFF_KEY_PREFIX;
     use namada_sdk::state::StateRead;
     use proptest::collection::vec;
     use proptest::prelude::*;
@@ -445,14 +447,21 @@ mod tests {
             is_merklized_storage_key,
             is_key_diff_storable,
         );
+        let make_key = |suffix: u64| {
+            match suffix % 3u64 {
+                0 => Key::parse(format!("key{suffix}")).unwrap(),
+                1 => ibc_key(format!("key{suffix}")).unwrap(),
+                // for no diff
+                _ => client_counter_key(),
+            }
+        };
 
         let num_keys = 5;
         let blocks_write_type = blocks_write_type.into_iter().enumerate().map(
             |(index, write_type)| {
                 // try to update some keys at each height
                 let height = BlockHeight::from(index as u64 / num_keys + 1);
-                let key =
-                    ibc_key(format!("key{}", index as u64 % num_keys)).unwrap();
+                let key = make_key(index as u64 % num_keys);
                 (height, key, write_type)
             },
         );
@@ -461,7 +470,7 @@ mod tests {
 
         // write values at Height 0 like init_storage
         for i in 0..num_keys {
-            let key = ibc_key(format!("key{}", i)).unwrap();
+            let key = make_key(i);
             let value_bytes = encode(&state.in_mem().block.height);
             state.db_write(&key, value_bytes)?;
         }
@@ -525,11 +534,14 @@ mod tests {
 
         let mut current_state = HashMap::new();
         for i in 0..num_keys {
-            let key = ibc_key(format!("key{}", i)).unwrap();
+            let key = make_key(i);
             current_state.insert(key, true);
         }
-        // Check a Merkle tree
-        for (height, key, write_type) in blocks_write_type {
+        // Check IBC subtree
+        for (height, key, write_type) in blocks_write_type.clone() {
+            if !is_ibc_key(&key) || key == client_counter_key() {
+                continue;
+            }
             let tree = state.get_merkle_tree(height, Some(StoreType::Ibc))?;
             assert_eq!(tree.root().0, roots.get(&height).unwrap().0);
             match write_type {
@@ -546,6 +558,41 @@ mod tests {
                 }
                 _ => {
                     assert!(tree.has_key(&key)?);
+                    current_state.insert(key, true);
+                }
+            }
+        }
+
+        // Check NoDiff subtree
+        let mut current_state = HashMap::new();
+        for i in 0..num_keys {
+            let key = make_key(i);
+            current_state.insert(key, true);
+        }
+        for (height, key, write_type) in blocks_write_type {
+            if key != client_counter_key() {
+                continue;
+            }
+            let merkle_key =
+                Key::from(NO_DIFF_KEY_PREFIX.to_string().to_db_key())
+                    .join(&key);
+            let tree =
+                state.get_merkle_tree(height, Some(StoreType::NoDiff))?;
+            assert_eq!(tree.root().0, roots.get(&height).unwrap().0);
+            match write_type {
+                0 => {
+                    if *current_state.get(&key).unwrap() {
+                        assert!(tree.has_key(&merkle_key)?);
+                    } else {
+                        assert!(!tree.has_key(&merkle_key)?);
+                    }
+                }
+                1 | 3 => {
+                    assert!(!tree.has_key(&merkle_key)?);
+                    current_state.insert(key, false);
+                }
+                _ => {
+                    assert!(tree.has_key(&merkle_key)?);
                     current_state.insert(key, true);
                 }
             }

--- a/crates/node/src/storage/mod.rs
+++ b/crates/node/src/storage/mod.rs
@@ -440,14 +440,14 @@ mod tests {
             None,
             is_key_diff_storable,
         );
-        // Prepare written keys for non-probable data, probable data (IBC), and
+        // Prepare written keys for non-provable data, provable data (IBC), and
         // no diffed data
         let make_key = |suffix: u64| {
             // For three type keys
             match suffix % 3u64 {
-                // for non-probable data
+                // for non-provable data
                 0 => Key::parse(format!("key{suffix}")).unwrap(),
-                // for probable data
+                // for provable data
                 1 => ibc_key(format!("key{suffix}")).unwrap(),
                 // for no diff
                 _ => client_counter_key(),

--- a/crates/node/src/storage/rocksdb.rs
+++ b/crates/node/src/storage/rocksdb.rs
@@ -903,15 +903,11 @@ impl DB for RocksDB {
 
         // Merkle tree
         for st in StoreType::iter() {
-            if *st == StoreType::Base
-                || *st == StoreType::CommitData
-                || is_full_commit
-            {
-                let key_prefix = match st {
-                    StoreType::Base | StoreType::CommitData => {
-                        tree_key_prefix_with_height(st, height)
-                    }
-                    _ => tree_key_prefix_with_epoch(st, epoch),
+            if st.is_stored_every_block() || is_full_commit {
+                let key_prefix = if st.is_stored_every_block() {
+                    tree_key_prefix_with_height(st, height)
+                } else {
+                    tree_key_prefix_with_epoch(st, epoch)
                 };
                 let root_key =
                     format!("{key_prefix}/{MERKLE_TREE_ROOT_KEY_SEGMENT}");
@@ -979,11 +975,10 @@ impl DB for RocksDB {
             .map(|st| Either::Left(std::iter::once(st)))
             .unwrap_or_else(|| Either::Right(StoreType::iter()));
         for st in store_types {
-            let key_prefix = match st {
-                StoreType::Base | StoreType::CommitData => {
-                    tree_key_prefix_with_height(st, base_height)
-                }
-                _ => tree_key_prefix_with_epoch(st, epoch),
+            let key_prefix = if st.is_stored_every_block() {
+                tree_key_prefix_with_height(st, base_height)
+            } else {
+                tree_key_prefix_with_epoch(st, epoch)
             };
             let root_key =
                 format!("{key_prefix}/{MERKLE_TREE_ROOT_KEY_SEGMENT}");

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -50,6 +50,7 @@ proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
 namada_core = { path = "../core", features = ["testing"] }
+namada_merkle_tree = { path = "../merkle_tree", features = ["testing"] }
 
 assert_matches.workspace = true
 chrono.workspace = true

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -16,7 +16,11 @@ version.workspace = true
 default = []
 
 # for integration tests and test utilities
-testing = ["proptest", "namada_core/testing"]
+testing = [
+    "proptest",
+    "namada_core/testing",
+    "namada_merkle_tree/testing"
+]
 migrations = [
     "namada_migrations",
     "linkme",

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -613,11 +613,16 @@ pub mod testing {
                 db: MockDB::default(),
                 in_mem: Default::default(),
                 merkle_tree_key_filter: merklize_all_keys,
+                diff_key_filter: diff_all_keys,
             })
         }
     }
 
     fn merklize_all_keys(_key: &storage::Key) -> bool {
+        true
+    }
+
+    fn diff_all_keys(_key: &storage::Key) -> bool {
         true
     }
 
@@ -895,7 +900,15 @@ mod tests {
         Key::parse("testing2").unwrap()
     }
 
+    fn test_key_3() -> Key {
+        Key::parse("testing3").unwrap()
+    }
+
     fn merkle_tree_key_filter(key: &Key) -> bool {
+        key == &test_key_1() || key == &test_key_2()
+    }
+
+    fn diff_key_filter(key: &Key) -> bool {
         key == &test_key_1()
     }
 
@@ -905,11 +918,14 @@ mod tests {
         assert_eq!(state.in_mem().block.height.0, 0);
 
         (state.0.merkle_tree_key_filter) = merkle_tree_key_filter;
+        (state.0.diff_key_filter) = diff_key_filter;
 
         let key1 = test_key_1();
         let val1 = 1u64;
         let key2 = test_key_2();
         let val2 = 2u64;
+        let key3 = test_key_3();
+        let val3 = 3u64;
 
         // Standard write of key-val-1
         state.write(&key1, val1).unwrap();
@@ -929,6 +945,13 @@ mod tests {
         // Read from state should return val2
         let res = state.read::<u64>(&key2).unwrap().unwrap();
         assert_eq!(res, val2);
+
+        // Write key-val-3 without merklizing or diffs
+        state.write(&key3, val3).unwrap();
+
+        // Read from state should return val3
+        let res = state.read::<u64>(&key3).unwrap().unwrap();
+        assert_eq!(res, val3);
 
         // Commit block and storage changes
         state.commit_block().unwrap();
@@ -952,9 +975,21 @@ mod tests {
         let res2 = u64::try_from_slice(&res2).unwrap();
         assert_eq!(res2, val2);
 
-        // Check explicitly that key-val-2 is not in merkle tree
+        // Check merkle tree inclusion of key-val-2 explicitly
         let is_merklized2 = state.in_mem().block.tree.has_key(&key2).unwrap();
-        assert!(!is_merklized2);
+        assert!(is_merklized2);
+
+        // Key3 should be in storage. Confirm by reading from
+        // state and also by reading DB subspace directly
+        let res3 = state.read::<u64>(&key3).unwrap().unwrap();
+        assert_eq!(res3, val3);
+        let res3 = state.db().read_subspace_val(&key3).unwrap().unwrap();
+        let res3 = u64::try_from_slice(&res3).unwrap();
+        assert_eq!(res3, val3);
+
+        // Check explicitly that key-val-3 is not in merkle tree
+        let is_merklized3 = state.in_mem().block.tree.has_key(&key3).unwrap();
+        assert!(!is_merklized3);
 
         // Check that the proper diffs exist for key-val-1
         let res1 = state
@@ -986,9 +1021,25 @@ mod tests {
         let res2 = u64::try_from_slice(&res2).unwrap();
         assert_eq!(res2, val2);
 
+        // Check that there are diffs for key-val-3 in block 0, since all keys
+        // need to have diffs for at least 1 block for rollback purposes
+        let res3 = state
+            .db()
+            .read_diffs_val(&key3, BlockHeight(0), true)
+            .unwrap();
+        assert!(res3.is_none());
+        let res3 = state
+            .db()
+            .read_diffs_val(&key3, BlockHeight(0), false)
+            .unwrap()
+            .unwrap();
+        let res3 = u64::try_from_slice(&res3).unwrap();
+        assert_eq!(res3, val3);
+
         // Now delete the keys properly
         state.delete(&key1).unwrap();
         state.delete(&key2).unwrap();
+        state.delete(&key3).unwrap();
 
         // Commit the block again
         state.commit_block().unwrap();
@@ -998,15 +1049,18 @@ mod tests {
         // Check the key-vals are removed from the storage subspace
         let res1 = state.read::<u64>(&key1).unwrap();
         let res2 = state.read::<u64>(&key2).unwrap();
-        assert!(res1.is_none() && res2.is_none());
+        let res3 = state.read::<u64>(&key3).unwrap();
+        assert!(res1.is_none() && res2.is_none() && res3.is_none());
         let res1 = state.db().read_subspace_val(&key1).unwrap();
         let res2 = state.db().read_subspace_val(&key2).unwrap();
-        assert!(res1.is_none() && res2.is_none());
+        let res3 = state.db().read_subspace_val(&key3).unwrap();
+        assert!(res1.is_none() && res2.is_none() && res3.is_none());
 
         // Check that the key-vals don't exist in the merkle tree anymore
         let is_merklized1 = state.in_mem().block.tree.has_key(&key1).unwrap();
         let is_merklized2 = state.in_mem().block.tree.has_key(&key2).unwrap();
-        assert!(!is_merklized1 && !is_merklized2);
+        let is_merklized3 = state.in_mem().block.tree.has_key(&key3).unwrap();
+        assert!(!is_merklized1 && !is_merklized2 && !is_merklized3);
 
         // Check that key-val-1 diffs are properly updated for blocks 0 and 1
         let res1 = state
@@ -1049,6 +1103,18 @@ mod tests {
             .unwrap();
         assert!(res2.is_none());
 
+        // Check that key-val-3 diffs don't exist for block 0 anymore
+        let res3 = state
+            .db()
+            .read_diffs_val(&key3, BlockHeight(0), true)
+            .unwrap();
+        assert!(res3.is_none());
+        let res3 = state
+            .db()
+            .read_diffs_val(&key3, BlockHeight(0), false)
+            .unwrap();
+        assert!(res3.is_none());
+
         // Check that the block 1 diffs for key-val-2 include an "old" value of
         // val2 and no "new" value
         let res2 = state
@@ -1063,6 +1129,21 @@ mod tests {
             .read_diffs_val(&key2, BlockHeight(1), false)
             .unwrap();
         assert!(res2.is_none());
+
+        // Check that the block 1 diffs for key-val-2 include an "old" value of
+        // val2 and no "new" value
+        let res3 = state
+            .db()
+            .read_diffs_val(&key3, BlockHeight(1), true)
+            .unwrap()
+            .unwrap();
+        let res3 = u64::try_from_slice(&res3).unwrap();
+        assert_eq!(res3, val3);
+        let res3 = state
+            .db()
+            .read_diffs_val(&key3, BlockHeight(1), false)
+            .unwrap();
+        assert!(res3.is_none());
     }
 
     proptest! {

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -676,6 +676,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use chrono::{TimeZone, Utc};
+    use merkle_tree::NO_DIFF_KEY_PREFIX;
     use namada_core::address::InternalAddress;
     use namada_core::borsh::{BorshDeserialize, BorshSerializeExt};
     use namada_core::storage::DbKeySeg;
@@ -977,6 +978,11 @@ mod tests {
 
         // Check merkle tree inclusion of key-val-2 explicitly
         let is_merklized2 = state.in_mem().block.tree.has_key(&key2).unwrap();
+        assert!(!is_merklized2);
+        let no_diff_key2 =
+            Key::from(NO_DIFF_KEY_PREFIX.to_string().to_db_key()).join(&key2);
+        let is_merklized2 =
+            state.in_mem().block.tree.has_key(&no_diff_key2).unwrap();
         assert!(is_merklized2);
 
         // Key3 should be in storage. Confirm by reading from
@@ -989,6 +995,11 @@ mod tests {
 
         // Check explicitly that key-val-3 is not in merkle tree
         let is_merklized3 = state.in_mem().block.tree.has_key(&key3).unwrap();
+        assert!(!is_merklized3);
+        let no_diff_key3 =
+            Key::from(NO_DIFF_KEY_PREFIX.to_string().to_db_key()).join(&key3);
+        let is_merklized3 =
+            state.in_mem().block.tree.has_key(&no_diff_key3).unwrap();
         assert!(!is_merklized3);
 
         // Check that the proper diffs exist for key-val-1
@@ -1058,8 +1069,10 @@ mod tests {
 
         // Check that the key-vals don't exist in the merkle tree anymore
         let is_merklized1 = state.in_mem().block.tree.has_key(&key1).unwrap();
-        let is_merklized2 = state.in_mem().block.tree.has_key(&key2).unwrap();
-        let is_merklized3 = state.in_mem().block.tree.has_key(&key3).unwrap();
+        let is_merklized2 =
+            state.in_mem().block.tree.has_key(&no_diff_key2).unwrap();
+        let is_merklized3 =
+            state.in_mem().block.tree.has_key(&no_diff_key3).unwrap();
         assert!(!is_merklized1 && !is_merklized2 && !is_merklized3);
 
         // Check that key-val-1 diffs are properly updated for blocks 0 and 1

--- a/crates/storage/src/mockdb.rs
+++ b/crates/storage/src/mockdb.rs
@@ -238,15 +238,11 @@ impl DB for MockDB {
 
         // Merkle tree
         for st in StoreType::iter() {
-            if *st == StoreType::Base
-                || *st == StoreType::CommitData
-                || is_full_commit
-            {
-                let key_prefix = match st {
-                    StoreType::Base | StoreType::CommitData => {
-                        tree_key_prefix_with_height(st, height)
-                    }
-                    _ => tree_key_prefix_with_epoch(st, epoch),
+            if st.is_stored_every_block() || is_full_commit {
+                let key_prefix = if st.is_stored_every_block() {
+                    tree_key_prefix_with_height(st, height)
+                } else {
+                    tree_key_prefix_with_epoch(st, epoch)
                 };
                 let root_key =
                     format!("{key_prefix}/{MERKLE_TREE_ROOT_KEY_SEGMENT}");
@@ -302,11 +298,10 @@ impl DB for MockDB {
             .map(|st| Either::Left(std::iter::once(st)))
             .unwrap_or_else(|| Either::Right(StoreType::iter()));
         for st in store_types {
-            let key_prefix = match st {
-                StoreType::Base | StoreType::CommitData => {
-                    tree_key_prefix_with_height(st, base_height)
-                }
-                _ => tree_key_prefix_with_epoch(st, epoch),
+            let key_prefix = if st.is_stored_every_block() {
+                tree_key_prefix_with_height(st, base_height)
+            } else {
+                tree_key_prefix_with_epoch(st, epoch)
             };
             let root_key =
                 format!("{key_prefix}/{MERKLE_TREE_ROOT_KEY_SEGMENT}");

--- a/crates/storage/src/types.rs
+++ b/crates/storage/src/types.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use borsh::{BorshDeserialize, BorshSerialize};
 use namada_core::borsh::BorshSerializeExt;
 use namada_core::hash::Hash;
+use namada_core::storage::Key;
 use regex::Regex;
 
 /// A key-value pair as raw bytes
@@ -69,11 +70,23 @@ impl<I> std::fmt::Debug for PatternIterator<I> {
 pub struct CommitOnlyData {
     /// Map from tx hashes to their gas cost
     pub tx_gas: BTreeMap<Hash, u64>,
+    pub no_diff_data: BTreeMap<Hash, Hash>,
 }
 
 impl CommitOnlyData {
     /// Serialize to bytes
     pub fn serialize(&self) -> Vec<u8> {
         self.serialize_to_vec()
+    }
+
+    pub fn add_no_diff_data(&mut self, key: &Key, value: impl AsRef<[u8]>) {
+        let key_hash = Hash::sha256(key.to_string());
+        let val_hash = Hash::sha256(value);
+        self.no_diff_data.insert(key_hash, val_hash);
+    }
+
+    pub fn delete_no_diff_data(&mut self, key: &Key) {
+        let key_hash = Hash::sha256(key.to_string());
+        self.no_diff_data.remove(&key_hash);
     }
 }

--- a/crates/storage/src/types.rs
+++ b/crates/storage/src/types.rs
@@ -5,7 +5,6 @@ use std::collections::BTreeMap;
 use borsh::{BorshDeserialize, BorshSerialize};
 use namada_core::borsh::BorshSerializeExt;
 use namada_core::hash::Hash;
-use namada_core::storage::Key;
 use regex::Regex;
 
 /// A key-value pair as raw bytes
@@ -70,23 +69,11 @@ impl<I> std::fmt::Debug for PatternIterator<I> {
 pub struct CommitOnlyData {
     /// Map from tx hashes to their gas cost
     pub tx_gas: BTreeMap<Hash, u64>,
-    pub no_diff_data: BTreeMap<Hash, Hash>,
 }
 
 impl CommitOnlyData {
     /// Serialize to bytes
     pub fn serialize(&self) -> Vec<u8> {
         self.serialize_to_vec()
-    }
-
-    pub fn add_no_diff_data(&mut self, key: &Key, value: impl AsRef<[u8]>) {
-        let key_hash = Hash::sha256(key.to_string());
-        let val_hash = Hash::sha256(value);
-        self.no_diff_data.insert(key_hash, val_hash);
-    }
-
-    pub fn delete_no_diff_data(&mut self, key: &Key) {
-        let key_hash = Hash::sha256(key.to_string());
-        self.no_diff_data.remove(&key_hash);
     }
 }


### PR DESCRIPTION
## Describe your changes
- Update some data in the subspace and the merkle tree, but not update the diffs
    - Add `diff_key_filter` to check if the data should be stored to diffs even if `merkle_tree_key_filter` is true
- Add `NoDiff` subtree in Merkle tree
    - Need it because we can't rebuild each subtree when some data aren't in diffs

## Indicate on which release or other PRs this topic is based on
`v0.36.1`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
