### PR TITLE
Enforce fee payment

### DIFF
--- a/.changelog/unreleased/bug-fixes/3075-force-fee-payment.md
+++ b/.changelog/unreleased/bug-fixes/3075-force-fee-payment.md
@@ -1,0 +1,2 @@
+- Fixed the fee collection logic in `finalize_block` to match that of
+  `process_proposal`. ([\#3075](https://github.com/anoma/namada/issues/3075))

--- a/crates/namada/src/ledger/mod.rs
+++ b/crates/namada/src/ledger/mod.rs
@@ -61,7 +61,7 @@ mod dry_run_tx {
                     Gas::try_from(wrapper.gas_limit).into_storage_result()?;
                 let tx_gas_meter = RefCell::new(TxGasMeter::new(gas_limit));
                 let tx_result = protocol::apply_wrapper_tx(
-                    tx.clone(),
+                    &tx,
                     &wrapper,
                     &request.data,
                     &tx_gas_meter,
@@ -252,8 +252,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_shell_queries_router_with_client(
-    ) -> namada_state::StorageResult<()> {
+    async fn test_shell_queries_router_with_client()
+    -> namada_state::StorageResult<()> {
         // Initialize the `TestClient`
         let mut client = TestClient::new(RPC);
         // store the wasm code
@@ -287,15 +287,17 @@ mod test {
             .dry_run_tx(&client, Some(tx_bytes), None, false)
             .await
             .unwrap();
-        assert!(result
-            .data
-            .batch_results
-            .0
-            .get(&cmt.get_hash())
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .is_accepted());
+        assert!(
+            result
+                .data
+                .batch_results
+                .0
+                .get(&cmt.get_hash())
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .is_accepted()
+        );
 
         // Request storage value for a balance key ...
         let token_addr = address::testing::established_address_1();

--- a/crates/namada/src/ledger/mod.rs
+++ b/crates/namada/src/ledger/mod.rs
@@ -64,12 +64,8 @@ mod dry_run_tx {
                     tx.clone(),
                     &wrapper,
                     &request.data,
-                    ShellParams::new(
-                        &tx_gas_meter,
-                        &mut temp_state,
-                        &mut ctx.vp_wasm_cache,
-                        &mut ctx.tx_wasm_cache,
-                    ),
+                    &tx_gas_meter,
+                    &mut temp_state,
                     None,
                 )
                 .into_storage_result()?;
@@ -256,8 +252,8 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_shell_queries_router_with_client()
-    -> namada_state::StorageResult<()> {
+    async fn test_shell_queries_router_with_client(
+    ) -> namada_state::StorageResult<()> {
         // Initialize the `TestClient`
         let mut client = TestClient::new(RPC);
         // store the wasm code
@@ -291,17 +287,15 @@ mod test {
             .dry_run_tx(&client, Some(tx_bytes), None, false)
             .await
             .unwrap();
-        assert!(
-            result
-                .data
-                .batch_results
-                .0
-                .get(&cmt.get_hash())
-                .unwrap()
-                .as_ref()
-                .unwrap()
-                .is_accepted()
-        );
+        assert!(result
+            .data
+            .batch_results
+            .0
+            .get(&cmt.get_hash())
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .is_accepted());
 
         // Request storage value for a balance key ...
         let token_addr = address::testing::established_address_1();

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -180,7 +180,7 @@ impl From<Error> for DispatchError {
 
 /// Arguments for transactions' execution
 pub enum DispatchArgs<'a, CA: 'static + WasmCacheAccess + Sync> {
-    /// Protocoli tx data
+    /// Protocol tx data
     Protocol(&'a ProtocolTx),
     /// Raw tx data
     Raw {

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -183,7 +183,7 @@ impl From<Error> for DispatchError {
 /// environment, in which case validity predicates will be bypassed.
 #[allow(clippy::too_many_arguments)]
 pub fn dispatch_tx<'a, D, H, CA>(
-    tx: Tx,
+    tx: &Tx,
     //FIXME: some params are only needed for some tx types, should also pass the txtype with the associated data here? Maybe yes
     tx_bytes: &'a [u8],
     tx_index: TxIndex,
@@ -311,7 +311,7 @@ where
             })
         }
         TxType::Wrapper(ref wrapper) => {
-            let mut tx_result = apply_wrapper_tx(
+            let tx_result = apply_wrapper_tx(
                 tx.clone(),
                 wrapper,
                 tx_bytes,

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -210,7 +210,7 @@ pub enum DispatchArgs<'a, CA: 'static + WasmCacheAccess + Sync> {
 /// environment, in which case validity predicates will be bypassed.
 pub fn dispatch_tx<'a, D, H, CA>(
     tx: &Tx,
-    dispatch_args: DispatchArgs<CA>,
+    dispatch_args: DispatchArgs<'a, CA>,
     tx_gas_meter: &'a RefCell<TxGasMeter>,
     state: &'a mut WlState<D, H>,
 ) -> std::result::Result<TxResult<Error>, DispatchError>

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -660,7 +660,10 @@ where
             }
 
             //FIXME: rename?
-            let (dispatch_args, tx_gas_meter) = match &tx_header.tx_type {
+            let (dispatch_args, tx_gas_meter): (
+                DispatchArgs<'_, WasmCacheRwAccess>,
+                TxGasMeter,
+            ) = match &tx_header.tx_type {
                 TxType::Wrapper(wrapper) => {
                     stats.increment_wrapper_txs();
                     let tx_gas_meter = TxGasMeter::new(wrapper.gas_limit);
@@ -679,8 +682,6 @@ where
                             wrapper,
                             tx_bytes: processed_tx.tx.as_ref(),
                             block_proposer: native_block_proposer_address,
-                            vp_wasm_cache: &mut self.vp_wasm_cache,
-                            tx_wasm_cache: &mut self.tx_wasm_cache,
                         },
                         tx_gas_meter,
                     )

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -142,7 +142,9 @@ where
                      proposer from tendermint raw hash",
                 )
         };
-        //FIXME: need uni test on fee pyament when inner txs touch balance of fee payer (also run this test on the old version with the bug to check that the bug was indeed there)
+        // FIXME: need uni test on fee pyament when inner txs touch balance of
+        // fee payer (also run this test on the old version with the bug to
+        // check that the bug was indeed there)
 
         // Tracks the accepted transactions
         self.state.in_mem_mut().block.results = BlockResults::default();
@@ -341,7 +343,9 @@ where
     }
 
     // Evaluate the result of a transaction. Commit or drop the storage changes,
-    // update stats and event, manage replay protection. For successful wrapper transactions return the relevant data and delay the evaluation after the batch execution
+    // update stats and event, manage replay protection. For successful wrapper
+    // transactions return the relevant data and delay the evaluation after the
+    // batch execution
     fn evaluate_tx_result(
         &mut self,
         response: &mut shim::response::FinalizeBlock,
@@ -578,7 +582,9 @@ where
         }
     }
 
-    // Get the transactions from the consensus engine, preprocess and execute them. Return the cache of successful wrapper transactions later used when executing the inner txs.
+    // Get the transactions from the consensus engine, preprocess and execute
+    // them. Return the cache of successful wrapper transactions later used when
+    // executing the inner txs.
     fn retrieve_and_execute_transactions(
         &mut self,
         native_block_proposer_address: &Address,
@@ -659,7 +665,6 @@ where
                 continue;
             }
 
-            //FIXME: rename?
             let (dispatch_args, tx_gas_meter): (
                 DispatchArgs<'_, WasmCacheRwAccess>,
                 TxGasMeter,
@@ -865,7 +870,8 @@ struct ExecutionArgs<'finalize> {
     height: BlockHeight,
 }
 
-// Caches the execution of a wrapper transaction to be used when later executing the inner batch
+// Caches the execution of a wrapper transaction to be used when later executing
+// the inner batch
 struct WrapperCache {
     tx: Tx,
     tx_index: usize,

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -1351,11 +1351,7 @@ mod test_finalize_block {
                 .enumerate()
                 .find_map(
                     |(idx, tx_hash)| {
-                        if tx_hash == &hash {
-                            Some(idx)
-                        } else {
-                            None
-                        }
+                        if tx_hash == &hash { Some(idx) } else { None }
                     },
                 )
                 .unwrap();
@@ -2949,21 +2945,25 @@ mod test_finalize_block {
         assert_eq!(root_pre.0, root_post.0);
 
         // Check transaction's hash in storage
-        assert!(shell
-            .shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&wrapper_tx.raw_header_hash()));
+        assert!(
+            shell
+                .shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper_tx.raw_header_hash())
+        );
         // Check that the hash is not present in the merkle tree
         shell.state.commit_block().unwrap();
-        assert!(!shell
-            .shell
-            .state
-            .in_mem()
-            .block
-            .tree
-            .has_key(&wrapper_hash_key)
-            .unwrap());
+        assert!(
+            !shell
+                .shell
+                .state
+                .in_mem()
+                .block
+                .tree
+                .has_key(&wrapper_hash_key)
+                .unwrap()
+        );
 
         // test that a commitment to replay protection gets added.
         let reprot_key = replay_protection::commitment_key();
@@ -3010,22 +3010,26 @@ mod test_finalize_block {
         assert_eq!(root_pre.0, root_post.0);
         // Check that the hashes are present in the merkle tree
         shell.state.commit_block().unwrap();
-        assert!(shell
-            .shell
-            .state
-            .in_mem()
-            .block
-            .tree
-            .has_key(&convert_key)
-            .unwrap());
-        assert!(shell
-            .shell
-            .state
-            .in_mem()
-            .block
-            .tree
-            .has_key(&commitment_key)
-            .unwrap());
+        assert!(
+            shell
+                .shell
+                .state
+                .in_mem()
+                .block
+                .tree
+                .has_key(&convert_key)
+                .unwrap()
+        );
+        assert!(
+            shell
+                .shell
+                .state
+                .in_mem()
+                .block
+                .tree
+                .has_key(&commitment_key)
+                .unwrap()
+        );
     }
 
     /// Test that a tx that has already been applied in the same block
@@ -3103,26 +3107,34 @@ mod test_finalize_block {
         assert_eq!(code, ResultCode::WasmRuntimeError);
 
         for wrapper in [&wrapper, &new_wrapper] {
-            assert!(shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper.raw_header_hash()));
-            assert!(!shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&wrapper.header_hash()));
+            assert!(
+                shell
+                    .state
+                    .write_log()
+                    .has_replay_protection_entry(&wrapper.raw_header_hash())
+            );
+            assert!(
+                !shell
+                    .state
+                    .write_log()
+                    .has_replay_protection_entry(&wrapper.header_hash())
+            );
         }
         // Commit to check the hashes from storage
         shell.commit();
         for wrapper in [&wrapper, &new_wrapper] {
-            assert!(shell
-                .state
-                .has_replay_protection_entry(&wrapper.raw_header_hash())
-                .unwrap());
-            assert!(!shell
-                .state
-                .has_replay_protection_entry(&wrapper.header_hash())
-                .unwrap());
+            assert!(
+                shell
+                    .state
+                    .has_replay_protection_entry(&wrapper.raw_header_hash())
+                    .unwrap()
+            );
+            assert!(
+                !shell
+                    .state
+                    .has_replay_protection_entry(&wrapper.header_hash())
+                    .unwrap()
+            );
         }
     }
 
@@ -3405,23 +3417,29 @@ mod test_finalize_block {
             &unsigned_wrapper,
             &wrong_commitment_wrapper,
         ] {
-            assert!(!shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&valid_wrapper.raw_header_hash()));
-            assert!(shell
-                .state
-                .write_log()
-                .has_replay_protection_entry(&valid_wrapper.header_hash()));
+            assert!(
+                !shell.state.write_log().has_replay_protection_entry(
+                    &valid_wrapper.raw_header_hash()
+                )
+            );
+            assert!(
+                shell
+                    .state
+                    .write_log()
+                    .has_replay_protection_entry(&valid_wrapper.header_hash())
+            );
         }
-        assert!(shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&failing_wrapper.raw_header_hash()));
-        assert!(!shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&failing_wrapper.header_hash()));
+        assert!(
+            shell.state.write_log().has_replay_protection_entry(
+                &failing_wrapper.raw_header_hash()
+            )
+        );
+        assert!(
+            !shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&failing_wrapper.header_hash())
+        );
 
         // Commit to check the hashes from storage
         shell.commit();
@@ -3430,23 +3448,33 @@ mod test_finalize_block {
             unsigned_wrapper,
             wrong_commitment_wrapper,
         ] {
-            assert!(!shell
-                .state
-                .has_replay_protection_entry(&valid_wrapper.raw_header_hash())
-                .unwrap());
-            assert!(shell
-                .state
-                .has_replay_protection_entry(&valid_wrapper.header_hash())
-                .unwrap());
+            assert!(
+                !shell
+                    .state
+                    .has_replay_protection_entry(
+                        &valid_wrapper.raw_header_hash()
+                    )
+                    .unwrap()
+            );
+            assert!(
+                shell
+                    .state
+                    .has_replay_protection_entry(&valid_wrapper.header_hash())
+                    .unwrap()
+            );
         }
-        assert!(shell
-            .state
-            .has_replay_protection_entry(&failing_wrapper.raw_header_hash())
-            .unwrap());
-        assert!(!shell
-            .state
-            .has_replay_protection_entry(&failing_wrapper.header_hash())
-            .unwrap());
+        assert!(
+            shell
+                .state
+                .has_replay_protection_entry(&failing_wrapper.raw_header_hash())
+                .unwrap()
+        );
+        assert!(
+            !shell
+                .state
+                .has_replay_protection_entry(&failing_wrapper.header_hash())
+                .unwrap()
+        );
     }
 
     #[test]
@@ -3506,14 +3534,18 @@ mod test_finalize_block {
         let code = event[0].read_attribute::<CodeAttr>().expect("Test failed");
         assert_eq!(code, ResultCode::InvalidTx);
 
-        assert!(shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&wrapper_hash));
-        assert!(!shell
-            .state
-            .write_log()
-            .has_replay_protection_entry(&wrapper.raw_header_hash()));
+        assert!(
+            shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper_hash)
+        );
+        assert!(
+            !shell
+                .state
+                .write_log()
+                .has_replay_protection_entry(&wrapper.raw_header_hash())
+        );
     }
 
     // Test that the fees are paid even if the inner transaction fails and its
@@ -3911,9 +3943,11 @@ mod test_finalize_block {
                 .unwrap(),
             Some(ValidatorState::Consensus)
         );
-        assert!(enqueued_slashes_handle()
-            .at(&Epoch::default())
-            .is_empty(&shell.state)?);
+        assert!(
+            enqueued_slashes_handle()
+                .at(&Epoch::default())
+                .is_empty(&shell.state)?
+        );
         assert_eq!(
             get_num_consensus_validators(&shell.state, Epoch::default())
                 .unwrap(),
@@ -3932,17 +3966,21 @@ mod test_finalize_block {
                     .unwrap(),
                 Some(ValidatorState::Jailed)
             );
-            assert!(enqueued_slashes_handle()
-                .at(&epoch)
-                .is_empty(&shell.state)?);
+            assert!(
+                enqueued_slashes_handle()
+                    .at(&epoch)
+                    .is_empty(&shell.state)?
+            );
             assert_eq!(
                 get_num_consensus_validators(&shell.state, epoch).unwrap(),
                 5_u64
             );
         }
-        assert!(!enqueued_slashes_handle()
-            .at(&processing_epoch)
-            .is_empty(&shell.state)?);
+        assert!(
+            !enqueued_slashes_handle()
+                .at(&processing_epoch)
+                .is_empty(&shell.state)?
+        );
 
         // Advance to the processing epoch
         loop {
@@ -3965,9 +4003,11 @@ mod test_finalize_block {
                 // println!("Reached processing epoch");
                 break;
             } else {
-                assert!(enqueued_slashes_handle()
-                    .at(&shell.state.in_mem().block.epoch)
-                    .is_empty(&shell.state)?);
+                assert!(
+                    enqueued_slashes_handle()
+                        .at(&shell.state.in_mem().block.epoch)
+                        .is_empty(&shell.state)?
+                );
                 let stake1 = read_validator_stake(
                     &shell.state,
                     &params,
@@ -4451,11 +4491,13 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(misbehavior_epoch));
-        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
-            &val1.address
-        )
-        .is_empty(&shell.state)
-        .unwrap());
+        assert!(
+            namada_proof_of_stake::storage::validator_slashes_handle(
+                &val1.address
+            )
+            .is_empty(&shell.state)
+            .unwrap()
+        );
 
         tracing::debug!("Advancing to epoch 7");
 
@@ -4520,18 +4562,22 @@ mod test_finalize_block {
             )
             .unwrap();
         assert_eq!(last_slash, Some(Epoch(4)));
-        assert!(namada_proof_of_stake::is_validator_frozen(
-            &shell.state,
-            &val1.address,
-            current_epoch,
-            &params
-        )
-        .unwrap());
-        assert!(namada_proof_of_stake::storage::validator_slashes_handle(
-            &val1.address
-        )
-        .is_empty(&shell.state)
-        .unwrap());
+        assert!(
+            namada_proof_of_stake::is_validator_frozen(
+                &shell.state,
+                &val1.address,
+                current_epoch,
+                &params
+            )
+            .unwrap()
+        );
+        assert!(
+            namada_proof_of_stake::storage::validator_slashes_handle(
+                &val1.address
+            )
+            .is_empty(&shell.state)
+            .unwrap()
+        );
 
         let pre_stake_10 =
             namada_proof_of_stake::storage::read_validator_stake(
@@ -5409,9 +5455,11 @@ mod test_finalize_block {
             shell.vp_wasm_cache.clone(),
         );
         let parameters = ParametersVp { ctx };
-        assert!(parameters
-            .validate_tx(&batched_tx, &keys_changed, &verifiers)
-            .is_ok());
+        assert!(
+            parameters
+                .validate_tx(&batched_tx, &keys_changed, &verifiers)
+                .is_ok()
+        );
 
         // we advance forward to the next epoch
         let mut req = FinalizeBlock::default();
@@ -5484,11 +5532,13 @@ mod test_finalize_block {
         let inner_results = inner_tx_result.batch_results.0;
 
         for cmt in batch.commitments() {
-            assert!(inner_results
-                .get(&cmt.get_hash())
-                .unwrap()
-                .clone()
-                .is_ok_and(|res| res.is_accepted()));
+            assert!(
+                inner_results
+                    .get(&cmt.get_hash())
+                    .unwrap()
+                    .clone()
+                    .is_ok_and(|res| res.is_accepted())
+            );
         }
 
         // Check storage modifications
@@ -5526,18 +5576,24 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(inner_results
-            .get(&batch.commitments()[0].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
-        assert!(inner_results
-            .get(&batch.commitments()[1].get_hash())
-            .unwrap()
-            .clone()
-            .is_err());
+        assert!(
+            inner_results
+                .get(&batch.commitments()[0].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[1].get_hash())
+                .unwrap()
+                .clone()
+                .is_err()
+        );
         // Assert that the last tx didn't run
-        assert!(!inner_results.contains_key(&batch.commitments()[2].get_hash()));
+        assert!(
+            !inner_results.contains_key(&batch.commitments()[2].get_hash())
+        );
 
         // Check storage modifications are missing
         for key in ["random_key_1", "random_key_2", "random_key_3"] {
@@ -5568,21 +5624,27 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(inner_results
-            .get(&batch.commitments()[0].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
-        assert!(inner_results
-            .get(&batch.commitments()[1].get_hash())
-            .unwrap()
-            .clone()
-            .is_err());
-        assert!(inner_results
-            .get(&batch.commitments()[2].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
+        assert!(
+            inner_results
+                .get(&batch.commitments()[0].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[1].get_hash())
+                .unwrap()
+                .clone()
+                .is_err()
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[2].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
 
         // Check storage modifications
         assert_eq!(
@@ -5593,10 +5655,12 @@ mod test_finalize_block {
                 .unwrap(),
             STORAGE_VALUE
         );
-        assert!(!shell
-            .state
-            .has_key(&"random_key_2".parse().unwrap())
-            .unwrap());
+        assert!(
+            !shell
+                .state
+                .has_key(&"random_key_2".parse().unwrap())
+                .unwrap()
+        );
         assert_eq!(
             shell
                 .state
@@ -5628,18 +5692,24 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(inner_results
-            .get(&batch.commitments()[0].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
-        assert!(inner_results
-            .get(&batch.commitments()[1].get_hash())
-            .unwrap()
-            .clone()
-            .is_err());
+        assert!(
+            inner_results
+                .get(&batch.commitments()[0].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[1].get_hash())
+                .unwrap()
+                .clone()
+                .is_err()
+        );
         // Assert that the last tx didn't run
-        assert!(!inner_results.contains_key(&batch.commitments()[2].get_hash()));
+        assert!(
+            !inner_results.contains_key(&batch.commitments()[2].get_hash())
+        );
 
         // Check storage modifications are missing
         for key in ["random_key_1", "random_key_2", "random_key_3"] {
@@ -5669,18 +5739,24 @@ mod test_finalize_block {
         let inner_tx_result = event[0].read_attribute::<Batch<'_>>().unwrap();
         let inner_results = inner_tx_result.batch_results.0;
 
-        assert!(inner_results
-            .get(&batch.commitments()[0].get_hash())
-            .unwrap()
-            .clone()
-            .is_ok_and(|res| res.is_accepted()));
-        assert!(inner_results
-            .get(&batch.commitments()[1].get_hash())
-            .unwrap()
-            .clone()
-            .is_err());
+        assert!(
+            inner_results
+                .get(&batch.commitments()[0].get_hash())
+                .unwrap()
+                .clone()
+                .is_ok_and(|res| res.is_accepted())
+        );
+        assert!(
+            inner_results
+                .get(&batch.commitments()[1].get_hash())
+                .unwrap()
+                .clone()
+                .is_err()
+        );
         // Assert that the last tx didn't run
-        assert!(!inner_results.contains_key(&batch.commitments()[2].get_hash()));
+        assert!(
+            !inner_results.contains_key(&batch.commitments()[2].get_hash())
+        );
 
         // Check storage modifications
         assert_eq!(

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -142,9 +142,6 @@ where
                      proposer from tendermint raw hash",
                 )
         };
-        // FIXME: need uni test on fee pyament when inner txs touch balance of
-        // fee payer (also run this test on the old version with the bug to
-        // check that the bug was indeed there)
 
         // Tracks the accepted transactions
         self.state.in_mem_mut().block.results = BlockResults::default();

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -359,16 +359,6 @@ where
         match dispatch_result {
             Ok(tx_result) => match tx_data.tx.header.tx_type {
                 TxType::Wrapper(_) => {
-                    // FIXME: review this, really need to do all this stuff?
-                    // Wait if the inenr transaction is empty (no cmts?)
-                    self.state.write_log_mut().commit_tx();
-                    self.state
-                        .in_mem_mut()
-                        .block
-                        .results
-                        .accept(tx_data.tx_index);
-                    tx_logs.tx_event.extend(Code(ResultCode::Ok));
-
                     // Return withouth emitting any events
                     return Some(WrapperCache {
                         tx: tx_data.tx.to_owned(),
@@ -458,7 +448,6 @@ where
             is_any_tx_invalid,
         } = temp_log.check_inner_results(
             &tx_result,
-            &tx_data.tx.header,
             tx_data.tx_index,
             tx_data.height,
         );
@@ -519,7 +508,6 @@ where
             is_any_tx_invalid: _,
         } = temp_log.check_inner_results(
             &tx_result,
-            &tx_data.tx.header,
             tx_data.tx_index,
             tx_data.height,
         );
@@ -956,7 +944,6 @@ impl<'finalize> TempTxLogs {
     fn check_inner_results(
         &mut self,
         tx_result: &namada::tx::data::TxResult<protocol::Error>,
-        tx_header: &namada::tx::Header,
         tx_index: usize,
         height: BlockHeight,
     ) -> ValidityFlags {

--- a/crates/node/src/shell/governance.rs
+++ b/crates/node/src/shell/governance.rs
@@ -403,7 +403,7 @@ where
     let cmt = tx.first_commitments().unwrap().to_owned();
 
     let dispatch_result = protocol::dispatch_tx(
-        tx,
+        &tx,
         &[], /*  this is used to compute the fee
               * based on the code size. We dont
               * need it here. */

--- a/crates/node/src/shell/governance.rs
+++ b/crates/node/src/shell/governance.rs
@@ -413,6 +413,7 @@ where
         &mut shell.vp_wasm_cache,
         &mut shell.tx_wasm_cache,
         None,
+        None,
     );
     shell
         .state

--- a/crates/node/src/shell/governance.rs
+++ b/crates/node/src/shell/governance.rs
@@ -404,16 +404,15 @@ where
 
     let dispatch_result = protocol::dispatch_tx(
         &tx,
-        &[], /*  this is used to compute the fee
-              * based on the code size. We dont
-              * need it here. */
-        TxIndex::default(),
-        &RefCell::new(TxGasMeter::new_from_sub_limit(u64::MAX.into())), /* No gas limit for governance proposal */
+        protocol::DispatchArgs::Raw {
+            tx_index: TxIndex::default(),
+            wrapper_tx_result: None,
+            vp_wasm_cache: &mut shell.vp_wasm_cache,
+            tx_wasm_cache: &mut shell.tx_wasm_cache,
+        },
+        // No gas limit for governance proposal
+        &RefCell::new(TxGasMeter::new_from_sub_limit(u64::MAX.into())),
         &mut shell.state,
-        &mut shell.vp_wasm_cache,
-        &mut shell.tx_wasm_cache,
-        None,
-        None,
     );
     shell
         .state

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -1626,7 +1626,7 @@ fn enforce_fee_payment() -> Result<()> {
             "--amount",
             // We want this transaction to consume all the remaining available
             // balance. If we executed the inner txs right after the
-            // corresponding wrapper's fee paymwent this would succeed (but
+            // corresponding wrapper's fee payment this would succeed (but
             // this is not the case)
             "1900000",
             "--output-folder-path",

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -1328,8 +1328,10 @@ fn pgf_steward_change_commission() -> Result<()> {
     assert!(
         captured.contains(&format!("- 0.7 to {}", defaults::bertha_address()))
     );
-    assert!(captured
-        .contains(&format!("- 0.05 to {}", defaults::christel_address())));
+    assert!(
+        captured
+            .contains(&format!("- 0.05 to {}", defaults::christel_address()))
+    );
     assert!(captured.contains("Pgf fundings: no fundings are currently set."));
 
     Ok(())
@@ -1696,7 +1698,7 @@ fn enforce_fee_payment() -> Result<()> {
     for bytes in txs_bytes {
         let mut tx = namada::tx::Tx::deserialize(&bytes).unwrap();
         tx.add_wrapper(
-            namada::tx::data::wrapper_tx::Fee {
+            namada::tx::data::wrapper::Fee {
                 amount_per_gas_unit: DenominatedAmount::native(
                     Amount::native_whole(1),
                 ),

--- a/crates/tx/src/data/protocol.rs
+++ b/crates/tx/src/data/protocol.rs
@@ -56,6 +56,7 @@ impl ProtocolTx {
 }
 
 #[derive(
+    Copy,
     Clone,
     Debug,
     BorshSerialize,

--- a/crates/tx/src/data/protocol.rs
+++ b/crates/tx/src/data/protocol.rs
@@ -67,7 +67,6 @@ impl ProtocolTx {
     Deserialize,
     PartialEq,
 )]
-#[allow(clippy::large_enum_variant)]
 /// Types of protocol messages to be sent
 pub enum ProtocolTxType {
     /// Ethereum events contained in vote extensions that


### PR DESCRIPTION
## Describe your changes

Closes #3075.

Restructures `finalize_block` to collect the fees from all the transactions before executing the inner txs, putting this back in line with the validation logic of `process_proposal` and removing an attack vector.

## Indicate on which release or other PRs this topic is based on

v0.37.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
