### PR TITLE
Scheduled migrations

### DIFF
--- a/.changelog/unreleased/improvements/3310-scheduled-migrations.md
+++ b/.changelog/unreleased/improvements/3310-scheduled-migrations.md
@@ -1,0 +1,3 @@
+- Allow nodes to schedule a migrations json to be read and run to facilitate hard-forking. This is done by 
+  taking a migrations json and passing the path, a hash of the contents, and a block height to the node when 
+  starting the ledger. ([\#3310](https://github.com/anoma/namada/pull/3310))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -3388,7 +3388,7 @@ pub mod args {
                     .requires(PATH_OPT.name)
                     .requires(BLOCK_HEIGHT_OPT.name)
                     .help(wrap!(
-                        "Hash to verify contents of optinally provided \
+                        "Hash to verify contents of optionally provided \
                          migrations file."
                     )),
             )

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -180,6 +180,7 @@ impl Default for BenchShell {
             sender,
             None,
             None,
+            None,
             50 * 1024 * 1024, // 50 kiB
             50 * 1024 * 1024, // 50 kiB
         );

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -666,10 +666,10 @@ where
             .commit_block()
             .expect("Encountered a storage error while committing a block");
         let committed_height = self.state.in_mem().get_last_block_height();
-        self.scheduled_migration = migrations::commit(
+        migrations::commit(
             self.state.db(),
             committed_height,
-            self.scheduled_migration.take(),
+            &mut self.scheduled_migration,
         );
         let merkle_root = self.state.in_mem().merkle_root();
 

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -353,7 +353,8 @@ where
     storage_read_past_height_limit: Option<u64>,
     /// Log of events emitted by `FinalizeBlock` ABCI calls.
     event_log: EventLog,
-    scheduled_migration: Option<ScheduledMigration<D::Migrator>>,
+    /// A migration that can be scheduled at a given block height
+    pub scheduled_migration: Option<ScheduledMigration<D::Migrator>>,
 }
 
 /// Storage key filter to store the diffs into the storage. Return `false` for

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -64,6 +64,8 @@ use namada::vm::{WasmCacheAccess, WasmCacheRwAccess};
 use namada::vote_ext::EthereumTxData;
 use namada_apps_lib::wallet::{self, ValidatorData, ValidatorKeys};
 use namada_sdk::eth_bridge::{EthBridgeQueries, EthereumOracleConfig};
+use namada_sdk::migrations;
+use namada_sdk::migrations::ScheduledMigration;
 use namada_sdk::tendermint::AppHash;
 use thiserror::Error;
 use tokio::sync::mpsc::{Receiver, UnboundedSender};
@@ -351,6 +353,7 @@ where
     storage_read_past_height_limit: Option<u64>,
     /// Log of events emitted by `FinalizeBlock` ABCI calls.
     event_log: EventLog,
+    scheduled_migration: Option<ScheduledMigration<D::Migrator>>,
 }
 
 /// Storage key filter to store the diffs into the storage. Return `false` for
@@ -401,6 +404,7 @@ where
         broadcast_sender: UnboundedSender<Vec<u8>>,
         eth_oracle: Option<EthereumOracleChannels>,
         db_cache: Option<&D::Cache>,
+        scheduled_migration: Option<ScheduledMigration<D::Migrator>>,
         vp_wasm_compilation_cache: u64,
         tx_wasm_compilation_cache: u64,
     ) -> Self {
@@ -510,6 +514,17 @@ where
             TendermintMode::Seed => ShellMode::Seed,
         };
 
+        if let Some(schedule_migration) = scheduled_migration.as_ref() {
+            let current = state.get_block_height().unwrap_or_default();
+            if schedule_migration.height < current {
+                panic!(
+                    "Cannot schedule a migration earlier than the latest \
+                     block height({})",
+                    current
+                );
+            }
+        }
+
         let mut shell = Self {
             chain_id,
             state,
@@ -531,6 +546,7 @@ where
             storage_read_past_height_limit,
             // TODO(namada#3237): config event log params
             event_log: EventLog::default(),
+            scheduled_migration,
         };
         shell.update_eth_oracle(&Default::default());
         shell
@@ -648,9 +664,14 @@ where
         self.state
             .commit_block()
             .expect("Encountered a storage error while committing a block");
-
-        let merkle_root = self.state.in_mem().merkle_root();
         let committed_height = self.state.in_mem().get_last_block_height();
+        self.scheduled_migration = migrations::commit(
+            self.state.db(),
+            committed_height,
+            self.scheduled_migration.take(),
+        );
+        let merkle_root = self.state.in_mem().merkle_root();
+
         tracing::info!(
             "Committed block hash: {merkle_root}, height: {committed_height}",
         );
@@ -1512,6 +1533,7 @@ mod test_utils {
                 top_level_directory().join("wasm"),
                 sender,
                 Some(eth_oracle),
+                None,
                 None,
                 vp_wasm_compilation_cache,
                 tx_wasm_compilation_cache,

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -333,6 +333,15 @@ impl MockNode {
         self.genesis_dir().join("wallet.toml")
     }
 
+    pub fn block_height(&self) -> BlockHeight {
+        self.shell
+            .lock()
+            .unwrap()
+            .state
+            .get_block_height()
+            .unwrap_or_default()
+    }
+
     pub fn current_epoch(&self) -> Epoch {
         self.shell.lock().unwrap().state.in_mem().last_epoch
     }

--- a/crates/node/src/shims/abcipp_shim.rs
+++ b/crates/node/src/shims/abcipp_shim.rs
@@ -10,6 +10,7 @@ use namada::core::storage::BlockHeight;
 use namada::proof_of_stake::storage::find_validator_by_raw_hash;
 use namada::time::{DateTimeUtc, Utc};
 use namada::tx::data::hash_tx;
+use namada_sdk::migrations::ScheduledMigration;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::UnboundedSender;
 use tower::Service;
@@ -48,6 +49,7 @@ impl AbcippShim {
         broadcast_sender: UnboundedSender<Vec<u8>>,
         eth_oracle: Option<EthereumOracleChannels>,
         db_cache: &rocksdb::Cache,
+        scheduled_migration: Option<ScheduledMigration>,
         vp_wasm_compilation_cache: u64,
         tx_wasm_compilation_cache: u64,
     ) -> (Self, AbciService, broadcast::Sender<()>) {
@@ -65,6 +67,7 @@ impl AbcippShim {
                     broadcast_sender,
                     eth_oracle,
                     Some(db_cache),
+                    scheduled_migration,
                     vp_wasm_compilation_cache,
                     tx_wasm_compilation_cache,
                 ),

--- a/crates/sdk/src/migrations.rs
+++ b/crates/sdk/src/migrations.rs
@@ -511,12 +511,12 @@ impl Display for UpdateStatus {
 pub fn commit<D: DB>(
     db: &D,
     height: BlockHeight,
-    mut migration: Option<ScheduledMigration<D::Migrator>>,
+    migration: Option<ScheduledMigration<D::Migrator>>,
 ) -> Option<ScheduledMigration<D::Migrator>>
 where
     D::Migrator: DeserializeOwned,
 {
-    let maybe_migration = migration.take();
+    let maybe_migration = migration;
     if let Some(migration) = maybe_migration.as_ref() {
         if height != migration.height {
             return maybe_migration;

--- a/crates/sdk/src/migrations.rs
+++ b/crates/sdk/src/migrations.rs
@@ -401,13 +401,9 @@ where
     }
 
     fn validate(&self) -> eyre::Result<String> {
-        let mut update_json = String::new();
-        let mut file = std::fs::File::open(&self.path).map_err(|_| {
-            eyre!("Could not fine updates file at the specified path.")
+        let update_json = std::fs::read_to_string(&self.path).map_err(|_| {
+            eyre!("Could not find or read updates file at the specified path.")
         })?;
-        _ = file
-            .read_to_string(&mut update_json)
-            .map_err(|e| eyre!("{}", e))?;
         // validate contents against provided hash
         if Hash::sha256(update_json.as_bytes()) != self.hash {
             Err(eyre!(

--- a/crates/sdk/src/migrations.rs
+++ b/crates/sdk/src/migrations.rs
@@ -6,11 +6,16 @@ use core::fmt::Formatter;
 use core::fmt::{Display, Formatter};
 #[cfg(feature = "migrations")]
 use core::str::FromStr;
+use std::io::Read;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use data_encoding::HEXUPPER;
-use namada_core::storage::Key;
+use eyre::eyre;
+use namada_core::hash::Hash;
+use namada_core::storage::{BlockHeight, Key};
 #[cfg(feature = "migrations")]
 use namada_macros::derive_borshdeserializer;
 #[cfg(feature = "migrations")]
@@ -19,9 +24,9 @@ use namada_macros::typehash;
 use namada_migrations::TypeHash;
 #[cfg(feature = "migrations")]
 use namada_migrations::*;
-use namada_storage::DbColFam;
+use namada_storage::{DbColFam, DbMigration, DB};
 use regex::Regex;
-use serde::de::{Error, Visitor};
+use serde::de::{DeserializeOwned, Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "migrations")]
@@ -35,7 +40,7 @@ pub trait DBUpdateVisitor {
     fn get_pattern(&self, pattern: Regex) -> Vec<(String, Vec<u8>)>;
 }
 
-#[derive(Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 enum UpdateBytes {
     Raw {
         to_write: Vec<u8>,
@@ -46,7 +51,7 @@ enum UpdateBytes {
     },
 }
 
-#[derive(Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 /// A value to be added to the database that can be
 /// validated.
 pub struct UpdateValue {
@@ -171,7 +176,7 @@ impl<'de> Deserialize<'de> for UpdateValue {
         deserializer.deserialize_any(UpdateValueVisitor)
     }
 }
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// An update to the database
 pub enum DbUpdateType {
     Add {
@@ -189,6 +194,8 @@ pub enum DbUpdateType {
     },
     RepeatDelete(String, DbColFam),
 }
+
+impl DbMigration for DbUpdateType {}
 
 #[cfg(feature = "migrations")]
 impl DbUpdateType {
@@ -280,7 +287,6 @@ impl DbUpdateType {
 
     /// Validate a DB change and persist it if so. The debug representation of
     /// the new value is returned for logging purposes.
-    #[allow(dead_code)]
     pub fn update<DB: DBUpdateVisitor>(
         &self,
         db: &mut DB,
@@ -352,11 +358,81 @@ impl DbUpdateType {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct DbChanges {
-    pub changes: Vec<DbUpdateType>,
+/// A set of key-value changes to be applied to
+/// the db at a specified height.
+#[derive(Debug, Clone)]
+pub struct ScheduledMigration<D: DbMigration = DbUpdateType> {
+    /// The height at which to perform the changes
+    pub height: BlockHeight,
+    /// The actual set of changes
+    pub path: PathBuf,
+    /// A hash of the expected contents in the file
+    pub hash: Hash,
+    /// For keeping track of what data type we deserialize the
+    /// contents of the file to.
+    phantom: PhantomData<D>,
 }
 
+impl<D> ScheduledMigration<D>
+where
+    D: DbMigration + DeserializeOwned,
+{
+    /// Read in a migrations json and a hash to verify the contents
+    /// against. Also needs a height for which the changes are scheduled.
+    pub fn from_path(
+        path: impl AsRef<Path>,
+        hash: Hash,
+        height: BlockHeight,
+    ) -> eyre::Result<Self> {
+        let scheduled_migration = Self {
+            height,
+            path: path.as_ref().to_path_buf(),
+            hash,
+            phantom: Default::default(),
+        };
+        scheduled_migration.validate()?;
+        Ok(scheduled_migration)
+    }
+
+    fn load(&self) -> eyre::Result<DbChanges<D>> {
+        let update_json = self.validate()?;
+        serde_json::from_str(&update_json)
+            .map_err(|_| eyre!("Could not parse the updates file as json"))
+    }
+
+    fn validate(&self) -> eyre::Result<String> {
+        let mut update_json = String::new();
+        let mut file = std::fs::File::open(&self.path).map_err(|_| {
+            eyre!("Could not fine updates file at the specified path.")
+        })?;
+        _ = file
+            .read_to_string(&mut update_json)
+            .map_err(|e| eyre!("{}", e))?;
+        // validate contents against provided hash
+        if Hash::sha256(update_json.as_bytes()) != self.hash {
+            Err(eyre!(
+                "Provided hash did not match the contents at the specified \
+                 path."
+            ))
+        } else {
+            Ok(update_json)
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DbChanges<D: DbMigration = DbUpdateType> {
+    pub changes: Vec<D>,
+}
+
+impl<D: DbMigration> IntoIterator for DbChanges<D> {
+    type IntoIter = std::vec::IntoIter<D>;
+    type Item = D;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.changes.into_iter()
+    }
+}
 #[cfg(feature = "migrations")]
 impl Display for DbUpdateType {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
@@ -429,6 +505,46 @@ impl Display for UpdateStatus {
         }
         Ok(())
     }
+}
+
+/// Check if a scheduled migration should take place at this block height.
+/// If so, apply it to the DB.
+pub fn commit<D: DB>(
+    db: &D,
+    height: BlockHeight,
+    mut migration: Option<ScheduledMigration<D::Migrator>>,
+) -> Option<ScheduledMigration<D::Migrator>>
+where
+    D::Migrator: DeserializeOwned,
+{
+    let maybe_migration = migration.take();
+    if let Some(migration) = maybe_migration.as_ref() {
+        if height != migration.height {
+            return maybe_migration;
+        }
+    } else {
+        return None;
+    }
+    tracing::info!(
+        "A migration is scheduled to take place at this block height. \
+         Starting..."
+    );
+    let migration = maybe_migration.unwrap().load().unwrap();
+
+    match db.apply_migration_to_batch(migration) {
+        Ok(batch) => {
+            tracing::info!("Persisting DB changes...");
+            db.exec_batch(batch).expect("Failed to execute write batch");
+        }
+        Err(e) => {
+            panic!(
+                "Failed to execute migration, no changes persisted. \
+                 Encountered error: {}",
+                e
+            );
+        }
+    }
+    None
 }
 
 #[cfg(feature = "migrations")]

--- a/crates/sdk/src/migrations.rs
+++ b/crates/sdk/src/migrations.rs
@@ -6,7 +6,6 @@ use core::fmt::Formatter;
 use core::fmt::{Display, Formatter};
 #[cfg(feature = "migrations")]
 use core::str::FromStr;
-use std::io::Read;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
@@ -401,9 +400,13 @@ where
     }
 
     fn validate(&self) -> eyre::Result<String> {
-        let update_json = std::fs::read_to_string(&self.path).map_err(|_| {
-            eyre!("Could not find or read updates file at the specified path.")
-        })?;
+        let update_json =
+            std::fs::read_to_string(&self.path).map_err(|_| {
+                eyre!(
+                    "Could not find or read updates file at the specified \
+                     path."
+                )
+            })?;
         // validate contents against provided hash
         if Hash::sha256(update_json.as_bytes()) != self.hash {
             Err(eyre!(

--- a/crates/storage/src/db.rs
+++ b/crates/storage/src/db.rs
@@ -153,7 +153,7 @@ pub trait DB: Debug {
     fn read_block_header(&self, height: BlockHeight) -> Result<Option<Header>>;
 
     /// Read the merkle tree stores with the given epoch. If a store_type is
-    /// given, it reads only the the specified tree. Otherwise, it reads all
+    /// given, it reads only the specified tree. Otherwise, it reads all
     /// trees.
     fn read_merkle_tree_stores(
         &self,

--- a/crates/storage/src/mockdb.rs
+++ b/crates/storage/src/mockdb.rs
@@ -91,6 +91,7 @@ impl MockDB {
 impl DB for MockDB {
     /// There is no cache for MockDB
     type Cache = ();
+    type Migrator = ();
     type WriteBatch = MockDBWriteBatch;
 
     fn open(_db_path: impl AsRef<Path>, _cache: Option<&Self::Cache>) -> Self {

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::str::FromStr;
 
 use assert_matches::assert_matches;
+use borsh::BorshDeserialize;
 use borsh_ext::BorshSerializeExt;
 use color_eyre::eyre::Result;
 use data_encoding::HEXLOWER;
@@ -9,10 +10,13 @@ use namada::core::collections::HashMap;
 use namada::token;
 use namada_apps_lib::wallet::defaults;
 use namada_core::dec::Dec;
-use namada_core::storage::Epoch;
-use namada_core::token::NATIVE_MAX_DECIMAL_PLACES;
+use namada_core::hash::Hash;
+use namada_core::storage::{DbColFam, Epoch, Key};
+use namada_core::token::{Amount, NATIVE_MAX_DECIMAL_PLACES};
 use namada_node::shell::testing::client::run;
 use namada_node::shell::testing::utils::{Bin, CapturedOutput};
+use namada_sdk::migrations;
+use namada_sdk::queries::RPC;
 use namada_sdk::tx::{TX_TRANSFER_WASM, VP_USER_WASM};
 use namada_test_utils::TestWasms;
 use test_log::test;
@@ -1577,4 +1581,81 @@ fn change_validator_metadata() -> Result<()> {
     assert!(captured.contains("max change per epoch:"));
 
     Ok(())
+}
+
+/// Test that a scheduled migration actually makes changes
+/// to storage at the scheduled height.
+#[test]
+fn scheduled_migration() -> Result<()> {
+    let (node, _services) = setup::setup()?;
+
+    // schedule a migration
+    let (hash, migrations_file) = make_migration_json();
+    let scheduled_migration = migrations::ScheduledMigration::from_path(
+        migrations_file.path(),
+        hash,
+        5.into(),
+    )
+    .expect("Test failed");
+    {
+        let mut locked = node.shell.lock().unwrap();
+        locked.scheduled_migration = Some(scheduled_migration);
+    }
+
+    while node.block_height().0 != 4 {
+        node.finalize_and_commit()
+    }
+    // check that the key doesn't exist before the scheduled block
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let bytes = rt
+        .block_on(RPC.shell().storage_value(
+            &&node,
+            None,
+            None,
+            false,
+            &Key::parse("bing/fucking/bong").expect("Test failed"),
+        ))
+        .expect("Test failed")
+        .data;
+    assert!(bytes.is_empty());
+
+    // check that the key now exists and has the expected value
+    node.finalize_and_commit();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let bytes = rt
+        .block_on(RPC.shell().storage_value(
+            &&node,
+            None,
+            None,
+            false,
+            &Key::parse("bing/fucking/bong").expect("Test failed"),
+        ))
+        .expect("Test failed")
+        .data;
+    let amount = Amount::try_from_slice(&bytes).expect("Test failed");
+    assert_eq!(amount, Amount::native_whole(1337));
+
+    // check that no migration is scheduled
+    {
+        let locked = node.shell.lock().unwrap();
+        assert!(locked.scheduled_migration.is_none());
+    }
+    Ok(())
+}
+
+fn make_migration_json() -> (Hash, tempfile::NamedTempFile) {
+    let file = tempfile::Builder::new().tempfile().expect("Test failed");
+    let updates = [migrations::DbUpdateType::Add {
+        key: Key::parse("bing/fucking/bong").expect("Test failed"),
+        cf: DbColFam::SUBSPACE,
+        value: Amount::native_whole(1337).into(),
+        force: false,
+    }];
+    let changes = migrations::DbChanges {
+        changes: updates.into_iter().collect(),
+    };
+    let json = serde_json::to_string(&changes).expect("Test failed");
+    let hash = Hash::sha256(json.as_bytes());
+    std::fs::write(file.path(), json).expect("Test failed");
+    (hash, file)
 }

--- a/crates/tests/src/integration/setup.rs
+++ b/crates/tests/src/integration/setup.rs
@@ -211,6 +211,7 @@ fn create_node(
             shell_handlers.tx_broadcaster,
             shell_handlers.eth_oracle_channels,
             None,
+            None,
             50 * 1024 * 1024, // 50 kiB
             50 * 1024 * 1024, // 50 kiB
         ))),


### PR DESCRIPTION
Allow nodes to schedule a migrations json to be read and run to facilitate hard-forking. This is done by taking a migrations json and passing the path, a hash of the contents, and a block height to the node when starting the ledger.

## Describe your changes

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
