### PR TITLE
cli: use the default configured node addr for shielded sync

### DIFF
--- a/.changelog/unreleased/improvements/3333-sync-default-node-addr.md
+++ b/.changelog/unreleased/improvements/3333-sync-default-node-addr.md
@@ -1,0 +1,3 @@
+- Default to the address from local config when the `--node`
+  argument is not specified for `shielded-sync` command
+  ([\#3333](https://github.com/anoma/namada/pull/3333))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -6078,7 +6078,7 @@ pub mod args {
 
     impl Args for ShieldedSync<CliTypes> {
         fn parse(matches: &ArgMatches) -> Self {
-            let ledger_address = LEDGER_ADDRESS.parse(matches);
+            let ledger_address = CONFIG_RPC_LEDGER_ADDRESS.parse(matches);
             let batch_size = BATCH_SIZE_OPT.parse(matches);
             let start_query_height = BLOCK_HEIGHT_FROM_OPT.parse(matches);
             let last_query_height = BLOCK_HEIGHT_TO_OPT.parse(matches);
@@ -6095,7 +6095,7 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.arg(LEDGER_ADDRESS.def().help(LEDGER_ADDRESS_ABOUT))
+            app.arg(CONFIG_RPC_LEDGER_ADDRESS.def().help(LEDGER_ADDRESS_ABOUT))
                 .arg(BATCH_SIZE_OPT.def().help(wrap!(
                     "Optional batch size which determines how many txs to \
                      fetch before caching locally. Default is 1."
@@ -6129,7 +6129,7 @@ pub mod args {
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
             Ok(ShieldedSync {
-                ledger_address: self.ledger_address,
+                ledger_address: chain_ctx.get(&self.ledger_address),
                 batch_size: self.batch_size,
                 start_query_height: self.start_query_height,
                 last_query_height: self.last_query_height,

--- a/crates/apps_lib/src/cli/client.rs
+++ b/crates/apps_lib/src/cli/client.rs
@@ -301,12 +301,12 @@ impl CliApi {
                             .await?;
                     }
                     Sub::ShieldedSync(ShieldedSync(args)) => {
+                        let args = args.to_sdk(&mut ctx)?;
+                        let chain_ctx = ctx.take_chain_or_exit();
                         let client = client.unwrap_or_else(|| {
                             C::from_tendermint_address(&args.ledger_address)
                         });
                         client.wait_until_node_is_synced(&io).await?;
-                        let args = args.to_sdk(&mut ctx)?;
-                        let chain_ctx = ctx.take_chain_or_exit();
                         let vks = chain_ctx
                             .wallet
                             .get_viewing_keys()

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -1878,7 +1878,7 @@ pub struct SignTx<C: NamadaTypes = SdkTypes> {
 /// block height.
 pub struct ShieldedSync<C: NamadaTypes = SdkTypes> {
     /// The ledger address
-    pub ledger_address: C::TendermintAddress,
+    pub ledger_address: C::ConfigRpcTendermintAddress,
     /// The number of txs to fetch before caching
     pub batch_size: u64,
     /// Height to start syncing from. Defaults to the correct one.


### PR DESCRIPTION
## Describe your changes

A tiny change - when the `--node` is not specified for `shielded-sync` cmd it should default to the address from local config

## Indicate on which release or other PRs this topic is based on

v0.38.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
