### PR TITLE
accept BSL-1.0 license

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -15,4 +15,5 @@ accepted = [
     "Apache-2.0",
     "NOASSERTION",
     "Zlib",
+    "BSL-1.0",
 ]


### PR DESCRIPTION
to fix https://github.com/anoma/namada/actions/runs/9312054507/job/25632231677 used in `xxhash-rust` (transitive dep of wasmer)