### PR TITLE
sdk/queries/vp/pos: sanitize the input of `validator_by_tm_addr`

### DIFF
--- a/.changelog/unreleased/bug-fixes/3340-validator--by-tm-addr.md
+++ b/.changelog/unreleased/bug-fixes/3340-validator--by-tm-addr.md
@@ -1,0 +1,3 @@
+- Fixes an issue with unsanitized input to a PoS query to find
+  a validator by TM address which may cause a node to panic.
+  ([\#3340](https://github.com/anoma/namada/pull/3340))


### PR DESCRIPTION
## Describe your changes

Fixes an issue where an invalid input to `validator_by_tm_addr` may cause a node crash. The problem is that the parameter is used as an unsanitized string in input to `namada_proof_of_stake::storage_key::validator_address_raw_hash_key` which only expects valid inputs and panics otherwise.

## Indicate on which release or other PRs this topic is based on

0.38.1

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
