### PR TITLE
Vectorize transfers

### DIFF
--- a/.changelog/unreleased/features/3356-vectorize-transfers.md
+++ b/.changelog/unreleased/features/3356-vectorize-transfers.md
@@ -1,0 +1,2 @@
+- Reworked transparent and masp transfers to allow for multiple sources, targets,
+  tokens and amounts. ([\#3356](https://github.com/anoma/namada/pull/3356))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -4366,13 +4366,13 @@ pub mod args {
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let tx_code_path = PathBuf::from(TX_TRANSPARENT_TRANSFER_WASM);
-
             let data = vec![TxTransparentTransferData {
                 source,
                 target,
                 token,
                 amount,
             }];
+
             Self {
                 tx,
                 data,
@@ -4404,14 +4404,21 @@ pub mod args {
             ctx: &mut Context,
         ) -> Result<TxShieldedTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
+            let mut data = vec![];
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
+
+            for transfer_data in self.data {
+                data.push(TxShieldedTransferData {
+                    source: chain_ctx.get_cached(&transfer_data.source),
+                    target: chain_ctx.get(&transfer_data.target),
+                    token: chain_ctx.get(&transfer_data.token),
+                    amount: transfer_data.amount,
+                });
+            }
 
             Ok(TxShieldedTransfer::<SdkTypes> {
                 tx,
-                source: chain_ctx.get_cached(&self.source),
-                target: chain_ctx.get(&self.target),
-                token: chain_ctx.get(&self.token),
-                amount: self.amount,
+                data,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
         }
@@ -4425,12 +4432,16 @@ pub mod args {
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let tx_code_path = PathBuf::from(TX_SHIELDED_TRANSFER_WASM);
-            Self {
-                tx,
+            let data = vec![TxShieldedTransferData {
                 source,
                 target,
                 token,
                 amount,
+            }];
+
+            Self {
+                tx,
+                data,
                 tx_code_path,
             }
         }
@@ -4464,14 +4475,21 @@ pub mod args {
             ctx: &mut Context,
         ) -> Result<TxShieldingTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
+            let mut data = vec![];
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
+
+            for transfer_data in self.data {
+                data.push(TxShieldingTransferData {
+                    source: chain_ctx.get(&transfer_data.source),
+                    token: chain_ctx.get(&transfer_data.token),
+                    amount: transfer_data.amount,
+                });
+            }
 
             Ok(TxShieldingTransfer::<SdkTypes> {
                 tx,
-                source: chain_ctx.get(&self.source),
+                data,
                 target: chain_ctx.get(&self.target),
-                token: chain_ctx.get(&self.token),
-                amount: self.amount,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
         }
@@ -4485,12 +4503,16 @@ pub mod args {
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let tx_code_path = PathBuf::from(TX_SHIELDING_TRANSFER_WASM);
-            Self {
-                tx,
+            let data = vec![TxShieldingTransferData {
                 source,
-                target,
                 token,
                 amount,
+            }];
+
+            Self {
+                tx,
+                data,
+                target,
                 tx_code_path,
             }
         }
@@ -4525,14 +4547,21 @@ pub mod args {
             ctx: &mut Context,
         ) -> Result<TxUnshieldingTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
+            let mut data = vec![];
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
+
+            for transfer_data in self.data {
+                data.push(TxUnshieldingTransferData {
+                    target: chain_ctx.get(&transfer_data.target),
+                    token: chain_ctx.get(&transfer_data.token),
+                    amount: transfer_data.amount,
+                });
+            }
 
             Ok(TxUnshieldingTransfer::<SdkTypes> {
                 tx,
+                data,
                 source: chain_ctx.get_cached(&self.source),
-                target: chain_ctx.get(&self.target),
-                token: chain_ctx.get(&self.token),
-                amount: self.amount,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
         }
@@ -4546,12 +4575,16 @@ pub mod args {
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let tx_code_path = PathBuf::from(TX_UNSHIELDING_TRANSFER_WASM);
-            Self {
-                tx,
-                source,
+            let data = vec![TxUnshieldingTransferData {
                 target,
                 token,
                 amount,
+            }];
+
+            Self {
+                tx,
+                source,
+                data,
                 tx_code_path,
             }
         }

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -743,7 +743,18 @@ pub async fn submit_transparent_transfer(
     namada: &impl Namada,
     args: args::TxTransparentTransfer,
 ) -> Result<(), error::Error> {
-    submit_reveal_aux(namada, args.tx.clone(), &args.source).await?;
+    submit_reveal_aux(
+        namada,
+        args.tx.clone(),
+        &args
+            .data
+            .first()
+            .ok_or_else(|| {
+                error::Error::Other("Missing transfer data".to_string())
+            })?
+            .source,
+    )
+    .await?;
 
     let (mut tx, signing_data) = args.clone().build(namada).await?;
 

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -743,6 +743,14 @@ pub async fn submit_transparent_transfer(
     namada: &impl Namada,
     args: args::TxTransparentTransfer,
 ) -> Result<(), error::Error> {
+    if args.data.len() > 1 {
+        // TODO(namada#3379): Vectorized transfers are not yet supported in the
+        // CLI
+        return Err(error::Error::Other(
+            "Unexpected vectorized transparent transfer".to_string(),
+        ));
+    }
+
     submit_reveal_aux(
         namada,
         args.tx.clone(),

--- a/crates/benches/host_env.rs
+++ b/crates/benches/host_env.rs
@@ -3,7 +3,7 @@ use namada::core::account::AccountPublicKeysMap;
 use namada::core::address;
 use namada::core::collections::{HashMap, HashSet};
 use namada::ledger::storage::DB;
-use namada::token::{Amount, TransparentTransfer};
+use namada::token::{Amount, TransparentTransfer, TransparentTransferData};
 use namada::tx::Authorization;
 use namada::vm::wasm::TxCache;
 use namada_apps_lib::wallet::defaults;
@@ -18,12 +18,12 @@ use namada_node::bench_utils::{
 // transaction
 fn tx_section_signature_validation(c: &mut Criterion) {
     let shell = BenchShell::default();
-    let transfer_data = TransparentTransfer {
+    let transfer_data = TransparentTransfer(vec![TransparentTransferData {
         source: defaults::albert_address(),
         target: defaults::bertha_address(),
         token: address::testing::nam(),
         amount: Amount::native_whole(500).native_denominated(),
-    };
+    }]);
     let tx = shell.generate_tx(
         TX_TRANSPARENT_TRANSFER_WASM,
         transfer_data,

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -55,7 +55,7 @@ use namada::sdk::masp_primitives::merkle_tree::CommitmentTree;
 use namada::sdk::masp_primitives::transaction::Transaction;
 use namada::sdk::masp_proofs::sapling::SaplingVerificationContextInner;
 use namada::state::{Epoch, StorageRead, StorageWrite, TxIndex};
-use namada::token::{Amount, TransparentTransfer};
+use namada::token::{Amount, TransparentTransfer, TransparentTransferData};
 use namada::tx::{BatchedTx, Code, Section, Tx};
 use namada_apps_lib::wallet::defaults;
 use namada_node::bench_utils::{
@@ -476,12 +476,12 @@ fn vp_multitoken(c: &mut Criterion) {
 
     let transfer = shell.generate_tx(
         TX_TRANSPARENT_TRANSFER_WASM,
-        TransparentTransfer {
+        TransparentTransfer(vec![TransparentTransferData {
             source: defaults::albert_address(),
             target: defaults::bertha_address(),
             token: address::testing::nam(),
             amount: Amount::native_whole(1000).native_denominated(),
-        },
+        }]),
         None,
         None,
         vec![&defaults::albert_keypair()],

--- a/crates/benches/process_wrapper.rs
+++ b/crates/benches/process_wrapper.rs
@@ -3,7 +3,9 @@ use namada::core::address;
 use namada::core::key::RefTo;
 use namada::core::storage::BlockHeight;
 use namada::core::time::DateTimeUtc;
-use namada::token::{Amount, DenominatedAmount, TransparentTransfer};
+use namada::token::{
+    Amount, DenominatedAmount, TransparentTransfer, TransparentTransferData,
+};
 use namada::tx::data::{Fee, WrapperTx};
 use namada::tx::Authorization;
 use namada_apps_lib::wallet::defaults;
@@ -19,12 +21,12 @@ fn process_tx(c: &mut Criterion) {
 
     let mut batched_tx = shell.generate_tx(
         TX_TRANSPARENT_TRANSFER_WASM,
-        TransparentTransfer {
+        TransparentTransfer(vec![TransparentTransferData {
             source: defaults::albert_address(),
             target: defaults::bertha_address(),
             token: address::testing::nam(),
             amount: Amount::native_whole(1).native_denominated(),
-        },
+        }]),
         None,
         None,
         vec![&defaults::albert_keypair()],

--- a/crates/light_sdk/src/transaction/transfer.rs
+++ b/crates/light_sdk/src/transaction/transfer.rs
@@ -25,7 +25,7 @@ impl Transfer {
         amount: DenominatedAmount,
         args: GlobalArgs,
     ) -> Self {
-        let data = namada_sdk::token::TransparentTransfer {
+        let data = namada_sdk::token::TransparentTransferData {
             source,
             target,
             token,

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -76,8 +76,9 @@ use namada::ledger::queries::{
 use namada::masp::MaspTxRefs;
 use namada::state::StorageRead;
 use namada::token::{
-    Amount, DenominatedAmount, ShieldedTransfer, ShieldingTransfer,
-    ShieldingTransferData, UnshieldingTransfer, UnshieldingTransferData,
+    Amount, DenominatedAmount, ShieldedTransfer, ShieldingMultiTransfer,
+    ShieldingTransfer, ShieldingTransferData, UnshieldingMultiTransfer,
+    UnshieldingTransferData,
 };
 use namada::tx::data::pos::Bond;
 use namada::tx::data::{
@@ -1127,12 +1128,12 @@ impl BenchShieldedCtx {
         } else if target.effective_address() == MASP {
             namada.client().generate_tx(
                 TX_SHIELDING_TRANSFER_WASM,
-                ShieldingTransfer {
-                    data: ShieldingTransferData {
+                ShieldingMultiTransfer {
+                    data: vec![ShieldingTransferData {
                         source: source.effective_address(),
                         token: address::testing::nam(),
                         amount: DenominatedAmount::native(amount),
-                    },
+                    }],
                     shielded_section_hash,
                 },
                 Some(shielded),
@@ -1142,12 +1143,12 @@ impl BenchShieldedCtx {
         } else {
             namada.client().generate_tx(
                 TX_UNSHIELDING_TRANSFER_WASM,
-                UnshieldingTransfer {
-                    data: UnshieldingTransferData {
+                UnshieldingMultiTransfer {
+                    data: vec![UnshieldingTransferData {
                         target: target.effective_address(),
                         token: address::testing::nam(),
                         amount: DenominatedAmount::native(amount),
-                    },
+                    }],
                     shielded_section_hash,
                 },
                 Some(shielded),
@@ -1213,10 +1214,14 @@ impl BenchShieldedCtx {
             timeout_timestamp_on_b: timeout_timestamp,
         };
 
-        let transfer = ShieldingTransfer::deserialize(
+        let vectorized_transfer = ShieldingMultiTransfer::deserialize(
             &mut tx.tx.data(&tx.cmt).unwrap().as_slice(),
         )
         .unwrap();
+        let transfer = ShieldingTransfer {
+            data: vectorized_transfer.data.first().unwrap().to_owned(),
+            shielded_section_hash: vectorized_transfer.shielded_section_hash,
+        };
         let masp_tx = tx
             .tx
             .get_section(&transfer.shielded_section_hash)

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -229,11 +229,9 @@ impl From<token::DenominatedAmount> for InputAmount {
     }
 }
 
-/// Transparent transfer transaction arguments
+/// Transparent transfer-specific arguments
 #[derive(Clone, Debug)]
-pub struct TxTransparentTransfer<C: NamadaTypes = SdkTypes> {
-    /// Common tx arguments
-    pub tx: Tx<C>,
+pub struct TxTransparentTransferData<C: NamadaTypes = SdkTypes> {
     /// Transfer source address
     pub source: C::Address,
     /// Transfer target address
@@ -242,6 +240,15 @@ pub struct TxTransparentTransfer<C: NamadaTypes = SdkTypes> {
     pub token: C::Address,
     /// Transferred token amount
     pub amount: InputAmount,
+}
+
+/// Transparent transfer transaction arguments
+#[derive(Clone, Debug)]
+pub struct TxTransparentTransfer<C: NamadaTypes = SdkTypes> {
+    /// Common tx arguments
+    pub tx: Tx<C>,
+    /// The transfer specific data
+    pub data: Vec<TxTransparentTransferData<C>>,
     /// Path to the TX WASM code file
     pub tx_code_path: PathBuf,
 }
@@ -258,7 +265,7 @@ impl<C: NamadaTypes> TxBuilder<C> for TxTransparentTransfer<C> {
     }
 }
 
-impl<C: NamadaTypes> TxTransparentTransfer<C> {
+impl<C: NamadaTypes> TxTransparentTransferData<C> {
     /// Transfer source address
     pub fn source(self, source: C::Address) -> Self {
         Self { source, ..self }
@@ -278,7 +285,9 @@ impl<C: NamadaTypes> TxTransparentTransfer<C> {
     pub fn amount(self, amount: InputAmount) -> Self {
         Self { amount, ..self }
     }
+}
 
+impl<C: NamadaTypes> TxTransparentTransfer<C> {
     /// Path to the TX WASM code file
     pub fn tx_code_path(self, tx_code_path: PathBuf) -> Self {
         Self {

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -307,11 +307,9 @@ impl TxTransparentTransfer {
     }
 }
 
-/// Shielded transfer transaction arguments
+/// Shielded transfer-specific arguments
 #[derive(Clone, Debug)]
-pub struct TxShieldedTransfer<C: NamadaTypes = SdkTypes> {
-    /// Common tx arguments
-    pub tx: Tx<C>,
+pub struct TxShieldedTransferData<C: NamadaTypes = SdkTypes> {
     /// Transfer source spending key
     pub source: C::SpendingKey,
     /// Transfer target address
@@ -320,6 +318,15 @@ pub struct TxShieldedTransfer<C: NamadaTypes = SdkTypes> {
     pub token: C::Address,
     /// Transferred token amount
     pub amount: InputAmount,
+}
+
+/// Shielded transfer transaction arguments
+#[derive(Clone, Debug)]
+pub struct TxShieldedTransfer<C: NamadaTypes = SdkTypes> {
+    /// Common tx arguments
+    pub tx: Tx<C>,
+    /// Transfer-specific data
+    pub data: Vec<TxShieldedTransferData<C>>,
     /// Path to the TX WASM code file
     pub tx_code_path: PathBuf,
 }
@@ -334,19 +341,26 @@ impl TxShieldedTransfer {
     }
 }
 
+/// Shielded transfer-specific arguments
+#[derive(Clone, Debug)]
+pub struct TxShieldingTransferData<C: NamadaTypes = SdkTypes> {
+    /// Transfer source spending key
+    pub source: C::Address,
+    /// Transferred token address
+    pub token: C::Address,
+    /// Transferred token amount
+    pub amount: InputAmount,
+}
+
 /// Shielding transfer transaction arguments
 #[derive(Clone, Debug)]
 pub struct TxShieldingTransfer<C: NamadaTypes = SdkTypes> {
     /// Common tx arguments
     pub tx: Tx<C>,
-    /// Transfer source address
-    pub source: C::Address,
     /// Transfer target address
     pub target: C::PaymentAddress,
-    /// Transferred token address
-    pub token: C::Address,
-    /// Transferred token amount
-    pub amount: InputAmount,
+    /// Transfer-specific data
+    pub data: Vec<TxShieldingTransferData<C>>,
     /// Path to the TX WASM code file
     pub tx_code_path: PathBuf,
 }
@@ -361,6 +375,17 @@ impl TxShieldingTransfer {
     }
 }
 
+/// Unshielding transfer-specific arguments
+#[derive(Clone, Debug)]
+pub struct TxUnshieldingTransferData<C: NamadaTypes = SdkTypes> {
+    /// Transfer target address
+    pub target: C::Address,
+    /// Transferred token address
+    pub token: C::Address,
+    /// Transferred token amount
+    pub amount: InputAmount,
+}
+
 /// Unshielding transfer transaction arguments
 #[derive(Clone, Debug)]
 pub struct TxUnshieldingTransfer<C: NamadaTypes = SdkTypes> {
@@ -368,12 +393,8 @@ pub struct TxUnshieldingTransfer<C: NamadaTypes = SdkTypes> {
     pub tx: Tx<C>,
     /// Transfer source spending key
     pub source: C::SpendingKey,
-    /// Transfer target address
-    pub target: C::Address,
-    /// Transferred token address
-    pub token: C::Address,
-    /// Transferred token amount
-    pub amount: InputAmount,
+    /// Transfer-specific data
+    pub data: Vec<TxUnshieldingTransferData<C>>,
     /// Path to the TX WASM code file
     pub tx_code_path: PathBuf,
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -613,8 +613,8 @@ pub trait Namada: Sized + MaybeSync + MaybeSend {
         args: &args::Tx,
         signing_data: SigningTxData,
         with: impl Fn(Tx, common::PublicKey, HashSet<signing::Signable>, D) -> F
-            + MaybeSend
-            + MaybeSync,
+        + MaybeSend
+        + MaybeSync,
         user_data: D,
     ) -> crate::error::Result<()>
     where

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -175,16 +175,10 @@ pub trait Namada: Sized + MaybeSync + MaybeSend {
     /// arguments
     fn new_transparent_transfer(
         &self,
-        source: Address,
-        target: Address,
-        token: Address,
-        amount: InputAmount,
+        data: Vec<args::TxTransparentTransferData>,
     ) -> args::TxTransparentTransfer {
         args::TxTransparentTransfer {
-            source,
-            target,
-            token,
-            amount,
+            data,
             tx_code_path: PathBuf::from(TX_TRANSPARENT_TRANSFER_WASM),
             tx: self.tx_builder(),
         }
@@ -872,9 +866,7 @@ pub mod testing {
     };
     use namada_governance::{InitProposalData, VoteProposalData};
     use namada_ibc::testing::arb_ibc_any;
-    use namada_token::testing::{
-        arb_denominated_amount, arb_transparent_transfer,
-    };
+    use namada_token::testing::arb_denominated_amount;
     use namada_token::{
         ShieldedTransfer, ShieldingTransfer, TransparentTransfer,
         UnshieldingTransfer,
@@ -890,6 +882,9 @@ pub mod testing {
     use prost::Message;
     use ripemd::Digest as RipemdDigest;
     use sha2::Digest;
+    use token::testing::{
+        arb_transparent_transfer, arb_vectorized_transparent_transfer,
+    };
 
     use super::*;
     use crate::account::tests::{arb_init_account, arb_update_account};
@@ -1093,7 +1088,7 @@ pub mod testing {
         pub fn arb_transparent_transfer_tx()(
             mut header in arb_header(),
             wrapper in arb_wrapper_tx(),
-            transfer in arb_transparent_transfer(),
+            transfer in arb_vectorized_transparent_transfer(10),
             code_hash in arb_hash(),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -188,16 +188,10 @@ pub trait Namada: Sized + MaybeSync + MaybeSend {
     /// arguments
     fn new_shielded_transfer(
         &self,
-        source: ExtendedSpendingKey,
-        target: PaymentAddress,
-        token: Address,
-        amount: InputAmount,
+        data: Vec<args::TxShieldedTransferData>,
     ) -> args::TxShieldedTransfer {
         args::TxShieldedTransfer {
-            source,
-            target,
-            token,
-            amount,
+            data,
             tx_code_path: PathBuf::from(TX_SHIELDED_TRANSFER_WASM),
             tx: self.tx_builder(),
         }
@@ -207,16 +201,12 @@ pub trait Namada: Sized + MaybeSync + MaybeSend {
     /// arguments
     fn new_shielding_transfer(
         &self,
-        source: Address,
         target: PaymentAddress,
-        token: Address,
-        amount: InputAmount,
+        data: Vec<args::TxShieldingTransferData>,
     ) -> args::TxShieldingTransfer {
         args::TxShieldingTransfer {
-            source,
+            data,
             target,
-            token,
-            amount,
             tx_code_path: PathBuf::from(TX_SHIELDING_TRANSFER_WASM),
             tx: self.tx_builder(),
         }
@@ -227,15 +217,11 @@ pub trait Namada: Sized + MaybeSync + MaybeSend {
     fn new_unshielding_transfer(
         &self,
         source: ExtendedSpendingKey,
-        target: Address,
-        token: Address,
-        amount: InputAmount,
+        data: Vec<args::TxUnshieldingTransferData>,
     ) -> args::TxUnshieldingTransfer {
         args::TxUnshieldingTransfer {
             source,
-            target,
-            token,
-            amount,
+            data,
             tx_code_path: PathBuf::from(TX_UNSHIELDING_TRANSFER_WASM),
             tx: self.tx_builder(),
         }
@@ -627,8 +613,8 @@ pub trait Namada: Sized + MaybeSync + MaybeSend {
         args: &args::Tx,
         signing_data: SigningTxData,
         with: impl Fn(Tx, common::PublicKey, HashSet<signing::Signable>, D) -> F
-        + MaybeSend
-        + MaybeSync,
+            + MaybeSend
+            + MaybeSync,
         user_data: D,
     ) -> crate::error::Result<()>
     where
@@ -867,10 +853,7 @@ pub mod testing {
     use namada_governance::{InitProposalData, VoteProposalData};
     use namada_ibc::testing::arb_ibc_any;
     use namada_token::testing::arb_denominated_amount;
-    use namada_token::{
-        ShieldedTransfer, ShieldingTransfer, TransparentTransfer,
-        UnshieldingTransfer,
-    };
+    use namada_token::{ShieldedTransfer, TransparentTransfer};
     use namada_tx::data::pgf::UpdateStewardCommission;
     use namada_tx::data::pos::{
         BecomeValidator, Bond, CommissionChange, ConsensusKeyChange,
@@ -882,8 +865,10 @@ pub mod testing {
     use prost::Message;
     use ripemd::Digest as RipemdDigest;
     use sha2::Digest;
-    use token::testing::{
-        arb_transparent_transfer, arb_vectorized_transparent_transfer,
+    use token::testing::arb_vectorized_transparent_transfer;
+    use token::{
+        ShieldingMultiTransfer, ShieldingTransferData,
+        UnshieldingMultiTransfer, UnshieldingTransferData,
     };
 
     use super::*;
@@ -928,8 +913,11 @@ pub mod testing {
         Withdraw(Withdraw),
         TransparentTransfer(TransparentTransfer),
         ShieldedTransfer(ShieldedTransfer, (StoredBuildParams, String)),
-        ShieldingTransfer(ShieldingTransfer, (StoredBuildParams, String)),
-        UnshieldingTransfer(UnshieldingTransfer, (StoredBuildParams, String)),
+        ShieldingTransfer(ShieldingMultiTransfer, (StoredBuildParams, String)),
+        UnshieldingTransfer(
+            UnshieldingMultiTransfer,
+            (StoredBuildParams, String),
+        ),
         Bond(Bond),
         Redelegation(Redelegation),
         UpdateStewardCommission(UpdateStewardCommission),
@@ -1122,17 +1110,17 @@ pub mod testing {
     }
 
     prop_compose! {
-        /// Generate an arbitrary transfer transaction
-        pub fn arb_masp_transfer_tx()(transfer in arb_transparent_transfer())(
+        /// Generate an arbitrary masp transfer transaction
+        pub fn arb_masp_transfer_tx()(transfers in arb_vectorized_transparent_transfer(5))(
             mut header in arb_header(),
             wrapper in arb_wrapper_tx(),
             code_hash in arb_hash(),
             (masp_tx_type, (shielded_transfer, asset_types, build_params)) in prop_oneof![
                 (Just(MaspTxType::Shielded), arb_shielded_transfer(0..MAX_ASSETS)),
-                (Just(MaspTxType::Shielding), arb_shielding_transfer(encode_address(&transfer.source), 1)),
-                (Just(MaspTxType::Unshielding), arb_deshielding_transfer(encode_address(&transfer.target), 1)),
+                (Just(MaspTxType::Shielding), arb_shielding_transfer(encode_address(&transfers.0.first().unwrap().source), 1)),
+                (Just(MaspTxType::Unshielding), arb_deshielding_transfer(encode_address(&transfers.0.first().unwrap().target), 1)),
             ],
-            transfer in Just(transfer),
+            transfers in Just(transfers),
         ) -> (Tx, TxData) {
             header.tx_type = TxType::Wrapper(Box::new(wrapper));
             let mut tx = Tx { header, sections: vec![] };
@@ -1155,7 +1143,14 @@ pub mod testing {
                         decoded.denom,
                     );
                     tx.add_code_from_hash(code_hash, Some(TX_SHIELDING_TRANSFER_WASM.to_owned()));
-                    let data = ShieldingTransfer {source: transfer.source, token, amount, shielded_section_hash };
+                    let data = transfers.0.into_iter().map(|transfer|
+                    ShieldingTransferData{
+                        source: transfer.source,
+                            token: token.clone(),
+                            amount
+                    }
+                    ).collect();
+                    let data = ShieldingMultiTransfer{data, shielded_section_hash };
                     tx.add_data(data.clone());
                     TxData::ShieldingTransfer(data, (build_params, build_param_bytes))
                 },
@@ -1168,7 +1163,14 @@ pub mod testing {
                         decoded.denom,
                     );
                     tx.add_code_from_hash(code_hash, Some(TX_UNSHIELDING_TRANSFER_WASM.to_owned()));
-                    let data = UnshieldingTransfer {target: transfer.target, token, amount, shielded_section_hash };
+                    let data = transfers.0.into_iter().map(|transfer|
+                    UnshieldingTransferData{
+                        target: transfer.target,
+                            token: token.clone(),
+                            amount
+                    }
+                    ).collect();
+                    let data = UnshieldingMultiTransfer{data, shielded_section_hash };
                     tx.add_data(data.clone());
                     TxData::UnshieldingTransfer(data, (build_params, build_param_bytes))
                 },

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -759,27 +759,28 @@ impl TokenTransfer<'_> {
                 let mut map: HashMap<&Address, DenominatedAmount> =
                     HashMap::new();
 
-                for transfer in &transfers.0 {
-                    match address {
-                        TransferSide::Source(source)
-                            if source == &transfer.source =>
-                        {
-                            Self::update_token_amount_map(
-                                &mut map,
-                                &transfer.token,
-                                transfer.amount,
-                            )?;
+                match address {
+                    TransferSide::Source(source) => {
+                        for transfer in &transfers.0 {
+                            if source == &transfer.source {
+                                Self::update_token_amount_map(
+                                    &mut map,
+                                    &transfer.token,
+                                    transfer.amount,
+                                )?;
+                            }
                         }
-                        TransferSide::Target(target)
-                            if target == &transfer.target =>
-                        {
-                            Self::update_token_amount_map(
-                                &mut map,
-                                &transfer.token,
-                                transfer.amount,
-                            )?;
+                    }
+                    TransferSide::Target(target) => {
+                        for transfer in &transfers.0 {
+                            if target == &transfer.target {
+                                Self::update_token_amount_map(
+                                    &mut map,
+                                    &transfer.token,
+                                    transfer.amount,
+                                )?;
+                            }
                         }
-                        _ => (),
                     }
                 }
 
@@ -832,10 +833,7 @@ impl TokenTransfer<'_> {
     ) -> Result<(), Error> {
         match map.get_mut(token) {
             Some(prev_amount) => {
-                *prev_amount =
-                    prev_amount.checked_add(amount).ok_or_else(|| {
-                        Error::Other("Overflow in amount".to_string())
-                    })?;
+                *prev_amount = checked!(prev_amount + amount)?;
             }
             None => {
                 map.insert(token, amount);

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -65,13 +65,17 @@ use namada_tx::data::{pos, BatchedTxResult, ResultCode, TxResult};
 pub use namada_tx::{Authorization, *};
 use num_traits::Zero;
 use rand_core::{OsRng, RngCore};
+use token::ShieldingTransferData;
 
-use crate::args::TxTransparentTransferData;
+use crate::args::{
+    TxShieldedTransferData, TxShieldingTransferData, TxTransparentTransferData,
+    TxUnshieldingTransferData,
+};
 use crate::control_flow::time;
 use crate::error::{EncodingError, Error, QueryError, Result, TxSubmitError};
 use crate::io::Io;
 use crate::masp::TransferErr::Build;
-use crate::masp::{ShieldedContext, ShieldedTransfer};
+use crate::masp::{MaspTransferData, ShieldedContext, ShieldedTransfer};
 use crate::queries::Client;
 use crate::rpc::{
     self, get_validator_stake, query_wasm_code_hash, validate_amount,
@@ -2514,15 +2518,19 @@ pub async fn build_ibc_transfer(
         query_wasm_code_hash(context, args.tx_code_path.to_str().unwrap())
             .await
             .map_err(|e| Error::from(QueryError::Wasm(e.to_string())))?;
+    let masp_transfer_data = MaspTransferData {
+        source: args.source.clone(),
+        target: TransferTarget::Address(Address::Internal(
+            InternalAddress::Ibc,
+        )),
+        token: args.token.clone(),
+        amount: validated_amount,
+    };
 
     // For transfer from a spending key
     let shielded_parts = construct_shielded_parts(
         context,
-        &args.source,
-        // The token will be escrowed to IBC address
-        &TransferTarget::Address(Address::Internal(InternalAddress::Ibc)),
-        &args.token,
-        validated_amount,
+        vec![masp_transfer_data],
         !(args.tx.dry_run || args.tx.dry_run_wrapper),
     )
     .await?;
@@ -2569,10 +2577,12 @@ pub async fn build_ibc_transfer(
         let masp_tx_hash =
             tx.add_masp_tx_section(shielded_transfer.masp_tx.clone()).1;
         let transfer = token::ShieldingTransfer {
-            // The token will be escrowed to IBC address
-            source: source.clone(),
-            token: args.token.clone(),
-            amount: validated_amount,
+            data: ShieldingTransferData {
+                // The token will be escrowed to IBC address
+                source: source.clone(),
+                token: args.token.clone(),
+                amount: validated_amount,
+            },
             // Link the Transfer to the MASP Transaction by hash code
             shielded_section_hash: masp_tx_hash,
         };
@@ -2931,31 +2941,39 @@ pub async fn build_shielded_transfer<N: Namada>(
     context: &N,
     args: &mut args::TxShieldedTransfer,
 ) -> Result<(Tx, SigningTxData)> {
-    let default_signer = Some(MASP);
-    let signing_data = signing::aux_signing_data(
-        context,
-        &args.tx,
-        Some(MASP),
-        default_signer,
-    )
-    .await?;
+    let signing_data =
+        signing::aux_signing_data(context, &args.tx, Some(MASP), Some(MASP))
+            .await?;
 
     // Shielded fee payment
     let fee_amount = validate_fee(context, &args.tx).await?;
 
-    // Validate the amount given
-    let validated_amount =
-        validate_amount(context, args.amount, &args.token, args.tx.force)
-            .await?;
+    let mut transfer_data = vec![];
+    for TxShieldedTransferData {
+        source,
+        target,
+        token,
+        amount,
+    } in &args.data
+    {
+        // Validate the amount given
+        let validated_amount =
+            validate_amount(context, amount.to_owned(), token, args.tx.force)
+                .await?;
+
+        transfer_data.push(MaspTransferData {
+            source: TransferSource::ExtendedSpendingKey(source.to_owned()),
+            target: TransferTarget::PaymentAddress(target.to_owned()),
+            token: token.to_owned(),
+            amount: validated_amount,
+        });
+    }
 
     // TODO(namada#2597): this function should also take another arg as the fees
     // token and amount
     let shielded_parts = construct_shielded_parts(
         context,
-        &TransferSource::ExtendedSpendingKey(args.source),
-        &TransferTarget::PaymentAddress(args.target),
-        &args.token,
-        validated_amount,
+        transfer_data,
         !(args.tx.dry_run || args.tx.dry_run_wrapper),
     )
     .await?
@@ -3013,13 +3031,13 @@ pub async fn build_shielding_transfer<N: Namada>(
     context: &N,
     args: &mut args::TxShieldingTransfer,
 ) -> Result<(Tx, SigningTxData, MaspEpoch)> {
-    let source = &args.source;
-    let default_signer = Some(source.clone());
     let signing_data = signing::aux_signing_data(
         context,
         &args.tx,
-        Some(source.clone()),
-        default_signer,
+        None,
+        args.data
+            .first()
+            .map(|transfer_data| transfer_data.source.clone()),
     )
     .await?;
 
@@ -3031,38 +3049,57 @@ pub async fn build_shielding_transfer<N: Namada>(
                 (fee_amount, Some(updated_balance))
             })?;
 
-    // Validate the amount given
-    let validated_amount =
-        validate_amount(context, args.amount, &args.token, args.tx.force)
+    let mut transfer_data = vec![];
+    let mut data = vec![];
+    for TxShieldingTransferData {
+        source,
+        token,
+        amount,
+    } in &args.data
+    {
+        // Validate the amount given
+        let validated_amount =
+            validate_amount(context, amount.to_owned(), token, args.tx.force)
+                .await?;
+
+        // Check the balance of the source
+        if let Some(updated_balance) = &updated_balance {
+            let check_balance = if &updated_balance.source == source
+                && &updated_balance.token == token
+            {
+                CheckBalance::Balance(updated_balance.post_balance)
+            } else {
+                CheckBalance::Query(balance_key(token, source))
+            };
+
+            check_balance_too_low_err(
+                token,
+                source,
+                validated_amount.amount(),
+                check_balance,
+                args.tx.force,
+                context,
+            )
             .await?;
+        }
 
-    // Check the balance of the source
-    if let Some(updated_balance) = updated_balance {
-        let check_balance = if &updated_balance.source == source
-            && updated_balance.token == args.token
-        {
-            CheckBalance::Balance(updated_balance.post_balance)
-        } else {
-            CheckBalance::Query(balance_key(&args.token, source))
-        };
+        transfer_data.push(MaspTransferData {
+            source: TransferSource::Address(source.to_owned()),
+            target: TransferTarget::PaymentAddress(args.target),
+            token: token.to_owned(),
+            amount: validated_amount,
+        });
 
-        check_balance_too_low_err(
-            &args.token,
-            source,
-            validated_amount.amount(),
-            check_balance,
-            args.tx.force,
-            context,
-        )
-        .await?;
+        data.push(token::ShieldingTransferData {
+            source: source.to_owned(),
+            token: token.to_owned(),
+            amount: validated_amount,
+        });
     }
 
     let shielded_parts = construct_shielded_parts(
         context,
-        &TransferSource::Address(source.clone()),
-        &TransferTarget::PaymentAddress(args.target),
-        &args.token,
-        validated_amount,
+        transfer_data,
         !(args.tx.dry_run || args.tx.dry_run_wrapper),
     )
     .await?
@@ -3070,7 +3107,7 @@ pub async fn build_shielding_transfer<N: Namada>(
     let shielded_tx_epoch = shielded_parts.0.epoch;
 
     let add_shielded_parts =
-        |tx: &mut Tx, data: &mut token::ShieldingTransfer| {
+        |tx: &mut Tx, data: &mut token::ShieldingMultiTransfer| {
             // Add the MASP Transaction and its Builder to facilitate validation
             let (
                 ShieldedTransfer {
@@ -3100,10 +3137,8 @@ pub async fn build_shielding_transfer<N: Namada>(
         };
 
     // Construct the tx data with a placeholder shielded section hash
-    let data = token::ShieldingTransfer {
-        source: source.clone(),
-        token: args.token.clone(),
-        amount: validated_amount,
+    let data = token::ShieldingMultiTransfer {
+        data,
         shielded_section_hash: Hash::zero(),
     };
 
@@ -3125,38 +3160,52 @@ pub async fn build_unshielding_transfer<N: Namada>(
     context: &N,
     args: &mut args::TxUnshieldingTransfer,
 ) -> Result<(Tx, SigningTxData)> {
-    let default_signer = Some(MASP);
-    let signing_data = signing::aux_signing_data(
-        context,
-        &args.tx,
-        Some(MASP),
-        default_signer,
-    )
-    .await?;
+    let signing_data =
+        signing::aux_signing_data(context, &args.tx, Some(MASP), Some(MASP))
+            .await?;
 
     // Shielded fee payment
     let fee_amount = validate_fee(context, &args.tx).await?;
 
-    // Validate the amount given
-    let validated_amount =
-        validate_amount(context, args.amount, &args.token, args.tx.force)
-            .await?;
+    let mut transfer_data = vec![];
+    let mut data = vec![];
+    for TxUnshieldingTransferData {
+        target,
+        token,
+        amount,
+    } in &args.data
+    {
+        // Validate the amount given
+        let validated_amount =
+            validate_amount(context, amount.to_owned(), token, args.tx.force)
+                .await?;
+
+        transfer_data.push(MaspTransferData {
+            source: TransferSource::ExtendedSpendingKey(args.source),
+            target: TransferTarget::Address(target.to_owned()),
+            token: token.to_owned(),
+            amount: validated_amount,
+        });
+
+        data.push(token::UnshieldingTransferData {
+            target: target.to_owned(),
+            token: token.to_owned(),
+            amount: validated_amount,
+        });
+    }
 
     // TODO(namada#2597): this function should also take another arg as the fees
     // token and amount
     let shielded_parts = construct_shielded_parts(
         context,
-        &TransferSource::ExtendedSpendingKey(args.source),
-        &TransferTarget::Address(args.target.clone()),
-        &args.token,
-        validated_amount,
+        transfer_data,
         !(args.tx.dry_run || args.tx.dry_run_wrapper),
     )
     .await?
     .expect("Shielding transfer must have shielded parts");
 
     let add_shielded_parts =
-        |tx: &mut Tx, data: &mut token::UnshieldingTransfer| {
+        |tx: &mut Tx, data: &mut token::UnshieldingMultiTransfer| {
             // Add the MASP Transaction and its Builder to facilitate validation
             let (
                 ShieldedTransfer {
@@ -3186,12 +3235,11 @@ pub async fn build_unshielding_transfer<N: Namada>(
         };
 
     // Construct the tx data with a placeholder shielded section hash
-    let data = token::UnshieldingTransfer {
-        target: args.target.clone(),
-        token: args.token.clone(),
-        amount: validated_amount,
+    let data = token::UnshieldingMultiTransfer {
+        data,
         shielded_section_hash: Hash::zero(),
     };
+
     let tx = build_pow_flag(
         context,
         &args.tx,
@@ -3208,10 +3256,7 @@ pub async fn build_unshielding_transfer<N: Namada>(
 // Construct the shielded part of the transaction, if any
 async fn construct_shielded_parts<N: Namada>(
     context: &N,
-    source: &TransferSource,
-    target: &TransferTarget,
-    token: &Address,
-    amount: token::DenominatedAmount,
+    data: Vec<MaspTransferData>,
     update_ctx: bool,
 ) -> Result<Option<(ShieldedTransfer, HashSet<AssetData>)>> {
     // Precompute asset types to increase chances of success in decoding
@@ -3224,14 +3269,23 @@ async fn construct_shielded_parts<N: Namada>(
         .await;
     let stx_result =
         ShieldedContext::<N::ShieldedUtils>::gen_shielded_transfer(
-            context, source, target, token, amount, update_ctx,
+            context, data, update_ctx,
         )
         .await;
 
     let shielded_parts = match stx_result {
         Ok(Some(stx)) => stx,
         Ok(None) => return Ok(None),
-        Err(Build(builder::Error::InsufficientFunds(_))) => {
+        Err(Build {
+            error: builder::Error::InsufficientFunds(_),
+            data,
+        }) => {
+            let MaspTransferData {
+                source,
+                token,
+                amount,
+                ..
+            } = data.unwrap();
             return Err(TxSubmitError::NegativeBalanceAfterTransfer(
                 Box::new(source.effective_address()),
                 amount.to_string(),
@@ -3549,13 +3603,16 @@ pub async fn gen_ibc_shielding_transfer<N: Namada>(
         .precompute_asset_types(context.client(), tokens)
         .await;
 
+    let masp_transfer_data = MaspTransferData {
+        source: TransferSource::Address(source.clone()),
+        target: args.target,
+        token: token.clone(),
+        amount: validated_amount,
+    };
     let shielded_transfer =
         ShieldedContext::<N::ShieldedUtils>::gen_shielded_transfer(
             context,
-            &TransferSource::Address(source.clone()),
-            &args.target,
-            &token,
-            validated_amount,
+            vec![masp_transfer_data],
             true,
         )
         .await
@@ -3565,9 +3622,11 @@ pub async fn gen_ibc_shielding_transfer<N: Namada>(
         let masp_tx_hash =
             Section::MaspTx(shielded_transfer.masp_tx.clone()).get_hash();
         let transfer = token::ShieldingTransfer {
-            source: source.clone(),
-            token: token.clone(),
-            amount: validated_amount,
+            data: ShieldingTransferData {
+                source: source.clone(),
+                token: token.clone(),
+                amount: validated_amount,
+            },
             shielded_section_hash: masp_tx_hash,
         };
         Ok(Some((transfer, shielded_transfer.masp_tx)))

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -59,16 +59,17 @@ fn ledger_txs_and_queries() -> Result<()> {
     let validator_one_rpc = "http://127.0.0.1:26567";
 
     let (node, _services) = setup::setup()?;
-    let transfer = token::TransparentTransfer {
-        source: defaults::bertha_address(),
-        target: defaults::albert_address(),
-        token: node.native_token(),
-        amount: token::DenominatedAmount::new(
-            token::Amount::native_whole(10),
-            token::NATIVE_MAX_DECIMAL_PLACES.into(),
-        ),
-    }
-    .serialize_to_vec();
+    let transfer =
+        token::TransparentTransfer(vec![token::TransparentTransferData {
+            source: defaults::bertha_address(),
+            target: defaults::albert_address(),
+            token: node.native_token(),
+            amount: token::DenominatedAmount::new(
+                token::Amount::native_whole(10),
+                token::NATIVE_MAX_DECIMAL_PLACES.into(),
+            ),
+        }])
+        .serialize_to_vec();
     let tx_data_path = node.test_dir.path().join("tx.data");
     std::fs::write(&tx_data_path, transfer).unwrap();
     let tx_data_path = tx_data_path.to_string_lossy();

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -67,6 +67,23 @@ where
     Ok(())
 }
 
+/// Arguments for a multi-party transparent token transfer
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshDeserializer,
+    BorshSchema,
+    Hash,
+    Eq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+)]
+pub struct TransparentTransfer(pub Vec<TransparentTransferData>);
+
 /// Arguments for a transparent token transfer
 #[derive(
     Debug,
@@ -82,7 +99,7 @@ where
     Serialize,
     Deserialize,
 )]
-pub struct TransparentTransfer {
+pub struct TransparentTransferData {
     /// Source address will spend the tokens
     pub source: Address,
     /// Target address will receive the tokens
@@ -178,7 +195,7 @@ pub mod testing {
     pub use namada_trans_token::testing::*;
     use proptest::prelude::*;
 
-    use super::TransparentTransfer;
+    use super::{TransparentTransfer, TransparentTransferData};
 
     prop_compose! {
         /// Generate a transparent transfer
@@ -187,13 +204,21 @@ pub mod testing {
             target in arb_non_internal_address(),
             token in arb_established_address().prop_map(Address::Established),
             amount in arb_denominated_amount(),
-        ) -> TransparentTransfer {
-            TransparentTransfer {
+        ) -> TransparentTransferData{
+            TransparentTransferData {
                 source,
                 target,
                 token,
                 amount,
             }
         }
+    }
+
+    /// Generate a vectorized transparent transfer
+    pub fn arb_vectorized_transparent_transfer(
+        number_of_txs: usize,
+    ) -> impl Strategy<Value = TransparentTransfer> {
+        proptest::collection::vec(arb_transparent_transfer(), 0..number_of_txs)
+            .prop_map(TransparentTransfer)
     }
 }

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -146,13 +146,57 @@ pub struct ShieldedTransfer {
     Serialize,
     Deserialize,
 )]
-pub struct ShieldingTransfer {
+pub struct ShieldingTransferData {
     /// Source address will spend the tokens
     pub source: Address,
     /// Token's address
     pub token: Address,
     /// The amount of tokens
     pub amount: DenominatedAmount,
+}
+
+/// Arguments for a shielding transfer (from a transparent token to a shielded
+/// token)
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshDeserializer,
+    BorshSchema,
+    Hash,
+    Eq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+)]
+pub struct ShieldingTransfer {
+    /// Transfer-specific data
+    pub data: ShieldingTransferData,
+    /// Hash of tx section that contains the MASP transaction
+    pub shielded_section_hash: Hash,
+}
+
+/// Arguments for a shielding transfer (from a transparent token to a shielded
+/// token)
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshDeserializer,
+    BorshSchema,
+    Hash,
+    Eq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+)]
+pub struct ShieldingMultiTransfer {
+    /// Transfer-specific data
+    pub data: Vec<ShieldingTransferData>,
     /// Hash of tx section that contains the MASP transaction
     pub shielded_section_hash: Hash,
 }
@@ -173,13 +217,57 @@ pub struct ShieldingTransfer {
     Serialize,
     Deserialize,
 )]
-pub struct UnshieldingTransfer {
+pub struct UnshieldingTransferData {
     /// Target address will receive the tokens
     pub target: Address,
     /// Token's address
     pub token: Address,
     /// The amount of tokens
     pub amount: DenominatedAmount,
+}
+
+/// Arguments for an unshielding transfer (from a shielded token to a
+/// transparent token)
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshDeserializer,
+    BorshSchema,
+    Hash,
+    Eq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+)]
+pub struct UnshieldingTransfer {
+    /// Transfer-specific data
+    pub data: UnshieldingTransferData,
+    /// Hash of tx section that contains the MASP transaction
+    pub shielded_section_hash: Hash,
+}
+
+/// Arguments for a multi-source unshielding transfer (from a shielded token to
+/// a transparent token)
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshDeserializer,
+    BorshSchema,
+    Hash,
+    Eq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+)]
+pub struct UnshieldingMultiTransfer {
+    /// Transfer-specific data
+    pub data: Vec<UnshieldingTransferData>,
     /// Hash of tx section that contains the MASP transaction
     pub shielded_section_hash: Hash,
 }
@@ -199,7 +287,7 @@ pub mod testing {
 
     prop_compose! {
         /// Generate a transparent transfer
-        pub fn arb_transparent_transfer()(
+        fn arb_transparent_transfer()(
             source in arb_non_internal_address(),
             target in arb_non_internal_address(),
             token in arb_established_address().prop_map(Address::Established),

--- a/crates/tx_prelude/src/token.rs
+++ b/crates/tx_prelude/src/token.rs
@@ -6,7 +6,8 @@ use namada_events::{EmitEvents, EventLevel};
 pub use namada_token::testing;
 pub use namada_token::{
     storage_key, utils, Amount, DenominatedAmount, ShieldedTransfer,
-    ShieldingTransfer, TransparentTransfer, UnshieldingTransfer,
+    ShieldingMultiTransfer, ShieldingTransfer, TransparentTransfer,
+    UnshieldingMultiTransfer, UnshieldingTransfer,
 };
 use namada_tx_env::TxEnv;
 

--- a/wasm/tx_shielding_transfer/src/lib.rs
+++ b/wasm/tx_shielding_transfer/src/lib.rs
@@ -6,20 +6,22 @@ use namada_tx_prelude::*;
 #[transaction]
 fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
     let data = ctx.get_tx_data(&tx_data)?;
-    let transfer = token::ShieldingTransfer::try_from_slice(&data[..])
+    let transfers = token::ShieldingMultiTransfer::try_from_slice(&data[..])
         .wrap_err("Failed to decode token::ShieldingTransfer tx data")?;
-    debug_log!("apply_tx called with transfer: {:#?}", transfer);
+    debug_log!("apply_tx called with transfer: {:#?}", transfers);
 
-    token::transfer(
-        ctx,
-        &transfer.source,
-        &address::MASP,
-        &transfer.token,
-        transfer.amount.amount(),
-    )
-    .wrap_err("Token transfer failed")?;
+    for transfer in transfers.data {
+        token::transfer(
+            ctx,
+            &transfer.source,
+            &address::MASP,
+            &transfer.token,
+            transfer.amount.amount(),
+        )
+        .wrap_err("Token transfer failed")?;
+    }
 
-    let masp_section_ref = transfer.shielded_section_hash;
+    let masp_section_ref = transfers.shielded_section_hash;
     let shielded = tx_data
         .tx
         .get_section(&masp_section_ref)

--- a/wasm/tx_transparent_transfer/src/lib.rs
+++ b/wasm/tx_transparent_transfer/src/lib.rs
@@ -7,16 +7,20 @@ use namada_tx_prelude::*;
 #[transaction]
 fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
     let data = ctx.get_tx_data(&tx_data)?;
-    let transfer = token::TransparentTransfer::try_from_slice(&data[..])
+    let transfers = token::TransparentTransfer::try_from_slice(&data[..])
         .wrap_err("Failed to decode token::TransparentTransfer tx data")?;
-    debug_log!("apply_tx called with transfer: {:#?}", transfer);
+    debug_log!("apply_tx called with transfer: {:#?}", transfers);
 
-    token::transfer(
-        ctx,
-        &transfer.source,
-        &transfer.target,
-        &transfer.token,
-        transfer.amount.amount(),
-    )
-    .wrap_err("Token transfer failed")
+    for transfer in transfers.0 {
+        token::transfer(
+            ctx,
+            &transfer.source,
+            &transfer.target,
+            &transfer.token,
+            transfer.amount.amount(),
+        )
+        .wrap_err("Token transfer failed")?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Describe your changes

Closes #2596.
Required modification to enable #2597.

Modifies transparent and masp transactions to allow for multi-party transfers. Transparent transfers allow for multiple sources, targets token and amounts.

Shielding and unshielding masp transfers are instead vectorized in a slightly different way: shieldings are vectorized in a fan-in fashion: multiple sources, amounts and tokens but the target is a single `PaymentAddress`. Unshieldings are fan-out: multiple targets, tokens and amount but the source is a single `SpendingKey`.

Ibc shielded actions remain unchanged as I believe we can't vectorize them because of the way packets are designed. 

This PR does NOT update the client to support vectorized transfers as at the moment it's unclear to me how to achieve that maintaining a decent UX: for now we only support these transactions via the SDK.

## Indicate on which release or other PRs this topic is based on

`v0.39.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
