### PR TITLE
Outsource masp signature verification

### DIFF
--- a/.changelog/unreleased/improvements/3312-outsource-masp-sig-verification.md
+++ b/.changelog/unreleased/improvements/3312-outsource-masp-sig-verification.md
@@ -1,0 +1,2 @@
+- Moved the signature verifications out of the masp vp and into the affected
+  addresses' vps. ([\#3312](https://github.com/anoma/namada/issues/3312))

--- a/.changelog/unreleased/improvements/3516-reduce-masp-vp-signatures.md
+++ b/.changelog/unreleased/improvements/3516-reduce-masp-vp-signatures.md
@@ -1,0 +1,2 @@
+- Eliminates the MASP VPs requirement for all debited accounts to sign a Tx.
+  ([\#3516](https://github.com/anoma/namada/pull/3516))

--- a/crates/namada/src/ledger/native_vp/masp.rs
+++ b/crates/namada/src/ledger/native_vp/masp.rs
@@ -908,10 +908,23 @@ where
             } else if let Some(TAddrData::Addr(signer)) =
                 changed_bals_minus_txn.decoder.get(&signer)
             {
-                // Otherwise the owner's vp must have been triggered
+                // Otherwise the owner's vp must have been triggered and the
+                // relative action must have been written
                 if !verifiers.contains(signer) {
                     let error = native_vp::Error::new_alloc(format!(
                         "The required vp of address {signer} was not triggered"
+                    ))
+                    .into();
+                    tracing::debug!("{error}");
+                    return Err(error);
+                }
+
+                if !namada_tx::action::is_required_masp_signer(
+                    &self.ctx, signer,
+                )? {
+                    let error = native_vp::Error::new_alloc(format!(
+                        "The required masp signer action for address {signer} \
+                         is missing"
                     ))
                     .into();
                     tracing::debug!("{error}");

--- a/crates/namada/src/ledger/protocol/mod.rs
+++ b/crates/namada/src/ledger/protocol/mod.rs
@@ -415,9 +415,10 @@ where
                 if is_accepted {
                     // If the transaction was a masp one append the
                     // transaction refs for the events
+                    let actions =
+                        state.read_actions().map_err(Error::StateError)?;
                     if let Some(masp_section_ref) =
-                        namada_tx::action::get_masp_section_ref(state)
-                            .map_err(Error::StateError)?
+                        namada_tx::action::get_masp_section_ref(&actions)
                     {
                         extended_tx_result
                             .masp_tx_refs
@@ -740,8 +741,10 @@ where
                     );
                 }
 
-                let masp_ref = namada_tx::action::get_masp_section_ref(*state)
-                    .map_err(Error::StateError)?;
+                let actions =
+                    state.read_actions().map_err(Error::StateError)?;
+                let masp_ref =
+                    namada_tx::action::get_masp_section_ref(&actions);
                 // Ensure that the transaction is actually a masp one, otherwise
                 // reject
                 (is_masp_transfer(&result.changed_keys) && result.is_accepted())

--- a/crates/tx/src/action.rs
+++ b/crates/tx/src/action.rs
@@ -64,11 +64,13 @@ pub enum PgfAction {
     UpdateStewardCommission(Address),
 }
 
-/// MASP tx action.
+/// MASP tx actions.
 #[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
-pub struct MaspAction {
+pub enum MaspAction {
     /// The hash of the masp [`crate::types::Section`]
-    pub masp_section_ref: TxId,
+    MaspSectionRef(TxId),
+    /// A required signer for the transaction
+    MaspSigner(Address),
 }
 
 /// Read actions from temporary storage
@@ -127,7 +129,9 @@ pub fn get_masp_section_ref<T: Read>(
 ) -> Result<Option<TxId>, <T as Read>::Err> {
     Ok(reader.read_actions()?.into_iter().find_map(|action| {
         // In case of multiple masp actions we get the first one
-        if let Action::Masp(MaspAction { masp_section_ref }) = action {
+        if let Action::Masp(MaspAction::MaspSectionRef(masp_section_ref)) =
+            action
+        {
             Some(masp_section_ref)
         } else {
             None

--- a/crates/tx/src/action.rs
+++ b/crates/tx/src/action.rs
@@ -148,3 +148,19 @@ pub fn is_ibc_shielding_transfer<T: Read>(
         .iter()
         .any(|action| matches!(action, Action::IbcShielding)))
 }
+
+// FIXME: remove if used only in one place
+/// Helper function to check if the provided address is mentioned as a  masp
+/// signer in the [`Actions`].
+pub fn is_required_masp_signer<T: Read>(
+    reader: &T,
+    address: &Address,
+) -> Result<bool, <T as Read>::Err> {
+    Ok(reader.read_actions()?.iter().any(|action| {
+        if let Action::Masp(MaspAction::MaspSigner(addr)) = action {
+            addr == address
+        } else {
+            false
+        }
+    }))
+}

--- a/crates/tx/src/action.rs
+++ b/crates/tx/src/action.rs
@@ -69,8 +69,8 @@ pub enum PgfAction {
 pub enum MaspAction {
     /// The hash of the masp [`crate::types::Section`]
     MaspSectionRef(TxId),
-    /// A required signer for the transaction
-    MaspSigner(Address),
+    /// A required authorizer for the transaction
+    MaspAuthorizer(Address),
 }
 
 /// Read actions from temporary storage

--- a/crates/tx_prelude/src/token.rs
+++ b/crates/tx_prelude/src/token.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 
 use namada_core::address::Address;
+use namada_core::collections::HashSet;
 use namada_events::extend::UserAccount;
 use namada_events::{EmitEvents, EventLevel};
 use namada_token::event::{TokenEvent, TokenOperation};
@@ -50,13 +51,14 @@ pub fn transfer(
     Ok(())
 }
 
-/// A transparent token transfer that can be used in a transaction.
+/// A transparent token transfer that can be used in a transaction. Returns the
+/// set of debited accounts.
 pub fn multi_transfer(
     ctx: &mut Ctx,
     sources: &BTreeMap<(Address, Address), Amount>,
     dests: &BTreeMap<(Address, Address), Amount>,
-) -> TxResult {
-    namada_token::multi_transfer(ctx, sources, dests)?;
+) -> crate::EnvResult<HashSet<Address>> {
+    let debited_accounts = namada_token::multi_transfer(ctx, sources, dests)?;
 
     let mut evt_sources = BTreeMap::new();
     let mut evt_targets = BTreeMap::new();
@@ -108,5 +110,5 @@ pub fn multi_transfer(
         },
     });
 
-    Ok(())
+    Ok(debited_accounts)
 }

--- a/wasm/tx_ibc/src/lib.rs
+++ b/wasm/tx_ibc/src/lib.rs
@@ -65,7 +65,9 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
         update_masp_note_commitment_tree(&shielded)
             .wrap_err("Failed to update the MASP commitment tree")?;
         if let Some(masp_section_ref) = masp_section_ref {
-            ctx.push_action(Action::Masp(MaspAction { masp_section_ref }))?;
+            ctx.push_action(Action::Masp(MaspAction::MaspSectionRef(
+                masp_section_ref,
+            )))?;
         } else {
             ctx.push_action(Action::IbcShielding)?;
         }

--- a/wasm/tx_transfer/src/lib.rs
+++ b/wasm/tx_transfer/src/lib.rs
@@ -53,7 +53,9 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
             .wrap_err("Encountered error while handling MASP transaction")?;
         update_masp_note_commitment_tree(&shielded)
             .wrap_err("Failed to update the MASP commitment tree")?;
-        ctx.push_action(Action::Masp(MaspAction { masp_section_ref }))?;
+        ctx.push_action(Action::Masp(MaspAction::MaspSectionRef(
+            masp_section_ref,
+        )))?;
     }
 
     Ok(())

--- a/wasm/vp_implicit/src/lib.rs
+++ b/wasm/vp_implicit/src/lib.rs
@@ -101,7 +101,9 @@ fn validate_tx(
                 &tx,
                 &addr,
             )?,
-            Action::Masp(_) => (),
+            Action::Masp(MaspAction::MaspSigner(source)) => gadget
+                .verify_signatures_when(|| source == addr, ctx, &tx, &addr)?,
+            Action::Masp(MaspAction::MaspSectionRef(_)) => (),
             Action::IbcShielding => (),
         }
     }

--- a/wasm/vp_implicit/src/lib.rs
+++ b/wasm/vp_implicit/src/lib.rs
@@ -101,7 +101,7 @@ fn validate_tx(
                 &tx,
                 &addr,
             )?,
-            Action::Masp(MaspAction::MaspSigner(source)) => gadget
+            Action::Masp(MaspAction::MaspAuthorizer(source)) => gadget
                 .verify_signatures_when(|| source == addr, ctx, &tx, &addr)?,
             Action::Masp(MaspAction::MaspSectionRef(_)) => (),
             Action::IbcShielding => (),

--- a/wasm/vp_user/src/lib.rs
+++ b/wasm/vp_user/src/lib.rs
@@ -101,7 +101,9 @@ fn validate_tx(
                 &tx,
                 &addr,
             )?,
-            Action::Masp(_) => (),
+            Action::Masp(MaspAction::MaspSigner(source)) => gadget
+                .verify_signatures_when(|| source == addr, ctx, &tx, &addr)?,
+            Action::Masp(MaspAction::MaspSectionRef(_)) => (),
             Action::IbcShielding => (),
         }
     }

--- a/wasm/vp_user/src/lib.rs
+++ b/wasm/vp_user/src/lib.rs
@@ -101,7 +101,7 @@ fn validate_tx(
                 &tx,
                 &addr,
             )?,
-            Action::Masp(MaspAction::MaspSigner(source)) => gadget
+            Action::Masp(MaspAction::MaspAuthorizer(source)) => gadget
                 .verify_signatures_when(|| source == addr, ctx, &tx, &addr)?,
             Action::Masp(MaspAction::MaspSectionRef(_)) => (),
             Action::IbcShielding => (),


### PR DESCRIPTION
## Describe your changes

Closes #3312.

Swaps the signature verification call in the masp vp with a check on the triggered vps. Introduces a new masp `Action` to support signature verification in the affected vps since we expect them to not be triggered by the transaction itself (no changed keys).

## Indicate on which release or other PRs this topic is based on

#3516 (diffs for review: https://github.com/anoma/namada/pull/3372/files/17b9fcfa9c85f5a115646120f6595e8cf28c38a7..fc63450e3dfc2882c467d96a2600d761fb40853b)

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
