### PR TITLE
store MASP total rewards

### DIFF
--- a/.changelog/unreleased/bug-fixes/3375-masp-total-rewards.md
+++ b/.changelog/unreleased/bug-fixes/3375-masp-total-rewards.md
@@ -1,0 +1,2 @@
+- Update native token total supply with MASP rewards.
+  ([\#3375](https://github.com/anoma/namada/pull/3375))

--- a/.changelog/unreleased/improvements/3375-masp-total-rewards.md
+++ b/.changelog/unreleased/improvements/3375-masp-total-rewards.md
@@ -1,0 +1,2 @@
+- Store total MASP rewards and print them in the conversions query.
+  ([\#3375](https://github.com/anoma/namada/pull/3375))

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -1707,6 +1707,19 @@ pub async fn query_conversions(
 ) {
     // The chosen token type of the conversions
     let target_token = args.token;
+
+    if target_token.as_ref().is_none() {
+        // Query and print the total rewards first
+        let total_rewards = rpc::query_masp_total_rewards(context.client())
+            .await
+            .expect("MASP total rewards should be present");
+        display!(
+            context.io(),
+            "Total rewards of native token minted for shielded pool: {}",
+            total_rewards.to_string_native()
+        );
+    }
+
     // To facilitate human readable token addresses
     let tokens = context
         .wallet()

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -347,6 +347,13 @@ pub async fn query_conversions<C: crate::queries::Client + Sync>(
     convert_response::<C, _>(RPC.shell().read_conversions(client).await)
 }
 
+/// Query the total rewards minted by MASP
+pub async fn query_masp_total_rewards<C: crate::queries::Client + Sync>(
+    client: &C,
+) -> Result<token::Amount, error::Error> {
+    convert_response::<C, _>(RPC.vp().token().masp_total_rewards(client).await)
+}
+
 /// Query to read the tokens that earn masp rewards.
 pub async fn query_masp_reward_tokens<C: crate::queries::Client + Sync>(
     client: &C,

--- a/crates/shielded_token/src/storage_key.rs
+++ b/crates/shielded_token/src/storage_key.rs
@@ -32,6 +32,8 @@ pub const MASP_KD_GAIN_KEY: &str = "derivative_gain";
 pub const MASP_LOCKED_AMOUNT_TARGET_KEY: &str = "locked_amount_target";
 /// The key for the max reward rate for a given asset
 pub const MASP_MAX_REWARD_RATE_KEY: &str = "max_reward_rate";
+/// The key for the total inflation rewards minted by MASP
+pub const MASP_TOTAL_REWARDS: &str = "max_total_rewards";
 
 /// Obtain the nominal proportional key for the given token
 pub fn masp_kp_gain_key(token_addr: &Address) -> storage::Key {
@@ -161,5 +163,12 @@ pub fn masp_token_map_key() -> storage::Key {
 pub fn masp_assets_hash_key() -> storage::Key {
     storage::Key::from(address::MASP.to_db_key())
         .push(&MASP_ASSETS_HASH_KEY.to_owned())
+        .expect("Cannot obtain a storage key")
+}
+
+/// The max reward rate key for the given token
+pub fn masp_total_rewards() -> storage::Key {
+    storage::Key::from(address::MASP.to_db_key())
+        .push(&MASP_TOTAL_REWARDS.to_owned())
         .expect("Cannot obtain a storage key")
 }


### PR DESCRIPTION
## Describe your changes

closes #1730

Additionally, the original impl didn't increment the token total supply with the minted reward. This is fixed by using the `fn credit_tokens` that takes care of it.

## Indicate on which release or other PRs this topic is based on

v0.39.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
