### PR TITLE
Increase disposable key lifetime

### DIFF
--- a/.changelog/unreleased/bug-fixes/3378-increase-disposable-key-lifetime.md
+++ b/.changelog/unreleased/bug-fixes/3378-increase-disposable-key-lifetime.md
@@ -1,0 +1,2 @@
+- Increase the lifetime of disposable signing keys from 5 minutes to 1 week.
+  ([\#3378](https://github.com/anoma/namada/pull/3378))

--- a/crates/sdk/src/wallet/mod.rs
+++ b/crates/sdk/src/wallet/mod.rs
@@ -35,7 +35,7 @@ pub use self::keys::{DecryptionError, StoredKeypair};
 pub use self::store::{ConfirmationResponse, ValidatorData, ValidatorKeys};
 use crate::wallet::store::{derive_hd_secret_key, derive_hd_spending_key};
 
-const DISPOSABLE_KEY_LIFETIME_IN_SECONDS: i64 = 5 * 60; // 5 minutes
+const DISPOSABLE_KEY_LIFETIME_IN_SECONDS: i64 = 7 * 24 * 60 * 60; // 1 week
 
 /// Captures the interactive parts of the wallet's functioning
 pub trait WalletIo: Sized + Clone {


### PR DESCRIPTION
## Describe your changes

Increase the lifetime of disposable signing keys from 5 minutes to 1 week.

## Indicate on which release or other PRs this topic is based on

`v0.39.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
