### PR TITLE
Test batch tx events

### DIFF
--- a/.changelog/unreleased/testing/3401-test-batch-tx-events.md
+++ b/.changelog/unreleased/testing/3401-test-batch-tx-events.md
@@ -1,0 +1,3 @@
+- Adds additional test coverage to batch tx events emission, to make
+  sure we correctly build a batch of inner tx events from a batched tx.
+  ([\#3401](https://github.com/anoma/namada/pull/3401))

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -258,7 +258,6 @@ impl<T> Default for ExtendedTxResult<T> {
 }
 
 /// Transaction application result
-// TODO derive BorshSchema after <https://github.com/near/borsh-rs/issues/82>
 #[derive(
     Clone, Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
 )]


### PR DESCRIPTION
## Describe your changes

Closes #3397

Adds additional test coverage to batch tx events emission, to make sure we correctly build a batch of inner tx events from a batched tx.

## Indicate on which release or other PRs this topic is based on

`v0.39.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
