### PR TITLE
Fallible trait bound for queries' height param

### DIFF
--- a/.changelog/unreleased/improvements/2891-sdk-query-height.md
+++ b/.changelog/unreleased/improvements/2891-sdk-query-height.md
@@ -1,0 +1,2 @@
+- Queries methods now requests `TryInto` trait bound for block heights to reduce
+  the conversion error. ([\#2891](https://github.com/anoma/namada/issues/2891))

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -831,11 +831,20 @@ impl Client for BenchShell {
         height: H,
     ) -> Result<tendermint_rpc::endpoint::block::Response, tendermint_rpc::Error>
     where
-        H: Into<tendermint::block::Height> + Send,
+        H: TryInto<tendermint::block::Height> + Send,
     {
         // NOTE: atm this is only needed to query blocks at a specific height
         // for masp transactions
-        let height = BlockHeight(height.into().into());
+        let height = BlockHeight(
+            height
+                .try_into()
+                .map_err(|_| {
+                    tendermint_rpc::Error::parse(
+                        "Failed to cast block height".to_string(),
+                    )
+                })?
+                .into(),
+        );
 
         // Given the way we setup and run benchmarks, the masp transactions can
         // only present in the last block, we can mock the previous
@@ -895,11 +904,15 @@ impl Client for BenchShell {
         tendermint_rpc::Error,
     >
     where
-        H: Into<namada::tendermint::block::Height> + Send,
+        H: TryInto<namada::tendermint::block::Height> + Send,
     {
         // NOTE: atm this is only needed to query block results at a specific
         // height for masp transactions
-        let height = height.into();
+        let height = height.try_into().map_err(|_| {
+            tendermint_rpc::Error::parse(
+                "Failed to cast block height".to_string(),
+            )
+        })?;
 
         // We can expect all the masp tranfers to have happened only in the last
         // block

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -811,7 +811,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedContext<U> {
             // minimal improvement and it's even hard to tell how many times
             // we'd need a single masp tx to make this worth it
             let block = client
-                .block(height as u32)
+                .block(height)
                 .await
                 .map_err(|e| Error::from(QueryError::General(e.to_string())))?
                 .block
@@ -1994,7 +1994,7 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
     let first_idx_to_query = first_idx_to_query.unwrap_or_default();
 
     Ok(client
-        .block_results(height.0 as u32)
+        .block_results(height.0)
         .await
         .map_err(|e| Error::from(QueryError::General(e.to_string())))?
         .end_block_events


### PR DESCRIPTION
## Describe your changes

Closes #2891.

Changes the `Into` trait bound for the height param of queries to `TryInto` to minimize the cast error.

## Indicate on which release or other PRs this topic is based on

`v0.39.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
