### PR TITLE
Limit number of pgf stewards

### DIFF
--- a/.changelog/unreleased/improvements/3442-limit-pgf-stewards.md
+++ b/.changelog/unreleased/improvements/3442-limit-pgf-stewards.md
@@ -1,0 +1,2 @@
+- Enforce an upper limit on the number of PGF stewards allowed to exist at a
+  given time. ([\#3442](https://github.com/anoma/namada/pull/3442))

--- a/crates/apps_lib/src/config/genesis/chain.rs
+++ b/crates/apps_lib/src/config/genesis/chain.rs
@@ -759,6 +759,7 @@ impl FinalizedParameters {
             stewards: pgf_params.stewards,
             pgf_inflation_rate: pgf_params.pgf_inflation_rate,
             stewards_inflation_rate: pgf_params.stewards_inflation_rate,
+            maximum_number_of_stewards: pgf_params.maximum_number_of_stewards,
         };
         Self {
             parameters,

--- a/crates/apps_lib/src/config/genesis/templates.rs
+++ b/crates/apps_lib/src/config/genesis/templates.rs
@@ -474,6 +474,8 @@ pub struct PgfParams<T: TemplateValidation> {
     pub pgf_inflation_rate: Dec,
     /// The pgf stewards inflation rate
     pub stewards_inflation_rate: Dec,
+    /// The pgf stewards inflation rate
+    pub maximum_number_of_stewards: u64,
     #[serde(default)]
     #[serde(skip_serializing)]
     #[cfg(test)]
@@ -913,6 +915,8 @@ pub fn validate_parameters(
                 stewards: pgf_params.stewards,
                 pgf_inflation_rate: pgf_params.pgf_inflation_rate,
                 stewards_inflation_rate: pgf_params.stewards_inflation_rate,
+                maximum_number_of_stewards: pgf_params
+                    .maximum_number_of_stewards,
                 valid: Default::default(),
             },
             eth_bridge_params,

--- a/crates/apps_lib/src/config/genesis/templates.rs
+++ b/crates/apps_lib/src/config/genesis/templates.rs
@@ -474,7 +474,7 @@ pub struct PgfParams<T: TemplateValidation> {
     pub pgf_inflation_rate: Dec,
     /// The pgf stewards inflation rate
     pub stewards_inflation_rate: Dec,
-    /// The pgf stewards inflation rate
+    /// The maximum allowed number of PGF stewards at any time
     pub maximum_number_of_stewards: u64,
     #[serde(default)]
     #[serde(skip_serializing)]

--- a/crates/governance/src/pgf/parameters.rs
+++ b/crates/governance/src/pgf/parameters.rs
@@ -34,6 +34,8 @@ pub struct PgfParameters {
     pub pgf_inflation_rate: Dec,
     /// The pgf stewards inflation rate
     pub stewards_inflation_rate: Dec,
+    /// The maximum number of pgf stewards at once
+    pub maximum_number_of_stewards: u64,
 }
 
 impl Default for PgfParameters {
@@ -42,6 +44,7 @@ impl Default for PgfParameters {
             stewards: BTreeSet::default(),
             pgf_inflation_rate: Dec::new(10, 2).unwrap(),
             stewards_inflation_rate: Dec::new(1, 2).unwrap(),
+            maximum_number_of_stewards: 5,
         }
     }
 }
@@ -56,6 +59,7 @@ impl PgfParameters {
             stewards,
             pgf_inflation_rate,
             stewards_inflation_rate,
+            maximum_number_of_stewards,
         } = self;
 
         for steward in stewards {
@@ -71,6 +75,11 @@ impl PgfParameters {
 
         let steward_inflation_rate_key =
             pgf_storage::get_steward_inflation_rate_key();
-        storage.write(&steward_inflation_rate_key, stewards_inflation_rate)
+        storage.write(&steward_inflation_rate_key, stewards_inflation_rate)?;
+
+        let maximum_number_of_stewards_key =
+            pgf_storage::get_pgf_inflation_rate_key();
+        storage
+            .write(&maximum_number_of_stewards_key, maximum_number_of_stewards)
     }
 }

--- a/crates/governance/src/pgf/parameters.rs
+++ b/crates/governance/src/pgf/parameters.rs
@@ -78,7 +78,7 @@ impl PgfParameters {
         storage.write(&steward_inflation_rate_key, stewards_inflation_rate)?;
 
         let maximum_number_of_stewards_key =
-            pgf_storage::get_pgf_inflation_rate_key();
+            pgf_storage::get_maximum_number_of_pgf_steward_key();
         storage
             .write(&maximum_number_of_stewards_key, maximum_number_of_stewards)
     }

--- a/crates/governance/src/pgf/storage/keys.rs
+++ b/crates/governance/src/pgf/storage/keys.rs
@@ -14,6 +14,7 @@ struct Keys {
     fundings: &'static str,
     pgf_inflation_rate: &'static str,
     steward_inflation_rate: &'static str,
+    maximum_number_of_stewards: &'static str,
 }
 
 /// Obtain a storage key for stewards key
@@ -91,6 +92,13 @@ pub fn is_steward_inflation_rate_key(key: &Key) -> bool {
 pub fn get_pgf_inflation_rate_key() -> Key {
     Key::from(ADDRESS.to_db_key())
         .push(&Keys::VALUES.pgf_inflation_rate.to_owned())
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get key for maximum number of pgf stewards
+pub fn get_maximum_number_of_pgf_steward_key() -> Key {
+    Key::from(ADDRESS.to_db_key())
+        .push(&Keys::VALUES.maximum_number_of_stewards.to_owned())
         .expect("Cannot obtain a storage key")
 }
 

--- a/crates/node/src/shell/governance.rs
+++ b/crates/node/src/shell/governance.rs
@@ -158,14 +158,19 @@ where
                         GovernanceEvent::passed_proposal(id, true, result)
                     }
                     ProposalType::PGFSteward(stewards) => {
-                        let _result = execute_pgf_steward_proposal(
+                        let result = execute_pgf_steward_proposal(
                             &mut shell.state,
                             stewards,
                         )?;
                         tracing::info!(
                             "Governance proposal (pgf stewards){} has been \
-                             executed and passed.",
-                            id
+                             executed and {}.",
+                            id,
+                            if result {
+                                "applied the state changes successfully"
+                            } else {
+                                "didn't applied the state changes successfully"
+                            }
                         );
 
                         GovernanceEvent::passed_proposal(id, false, false)

--- a/crates/node/src/shell/governance.rs
+++ b/crates/node/src/shell/governance.rs
@@ -163,13 +163,14 @@ where
                             stewards,
                         )?;
                         tracing::info!(
-                            "Governance proposal (pgf stewards){} has been \
-                             executed and {}.",
+                            "Governance proposal #{} for PGF stewards has \
+                             been executed. {}.",
                             id,
                             if result {
-                                "applied the state changes successfully"
+                                "State changes have been applied successfully"
                             } else {
-                                "didn't applied the state changes successfully"
+                                "FAILURE trying to apply the state changes - \
+                                 no state change occurred"
                             }
                         );
 
@@ -473,14 +474,16 @@ where
         .expect(
             "Pgf parameter maximum_number_of_pgf_steward must be in storage",
         );
-    // first we remove
+
+    // First, remove the appropriate addresses
     for address in stewards.iter().filter_map(|action| match action {
         AddRemove::Add(_) => None,
         AddRemove::Remove(address) => Some(address),
     }) {
         pgf_storage::stewards_handle().remove(storage, address)?;
     }
-    // then we add
+
+    // Then add new addresses
     let mut steward_count = pgf_storage::stewards_handle().len(storage)?;
     for address in stewards.iter().filter_map(|action| match action {
         AddRemove::Add(address) => Some(address),

--- a/genesis/localnet/parameters.toml
+++ b/genesis/localnet/parameters.toml
@@ -104,6 +104,8 @@ stewards = [
 pgf_inflation_rate = "0.1"
 # The pgf stewards inflation rate
 stewards_inflation_rate = "0.01"
+# The maximum number of pgf stewards
+maximum_number_of_stewards = 5
 
 # IBC parameters
 [ibc_params]

--- a/genesis/starter/parameters.toml
+++ b/genesis/starter/parameters.toml
@@ -99,6 +99,8 @@ stewards = []
 pgf_inflation_rate = "0.1"
 # The pgf stewards inflation rate
 stewards_inflation_rate = "0.01"
+# The maximum number of pgf stewards
+maximum_number_of_stewards = 5
 
 # IBC parameters
 [ibc_params]


### PR DESCRIPTION
## Describe your changes
Introduced a new genesis parameter to limit the number of pgf stewards.

## Indicate on which release or other PRs this topic is based on
0.39.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
