### PR TITLE
Streamline validation

### DIFF
--- a/.changelog/unreleased/improvements/3192-opt-recomm.md
+++ b/.changelog/unreleased/improvements/3192-opt-recomm.md
@@ -1,0 +1,2 @@
+- Miscellaneous code optimizations.
+  ([\#3192](https://github.com/anoma/namada/issues/3192))

--- a/.changelog/unreleased/improvements/3448-streamline-validation.md
+++ b/.changelog/unreleased/improvements/3448-streamline-validation.md
@@ -1,0 +1,3 @@
+- Introduced a local configuration parameter to allow nodes to
+  rerun the process proposal checks before block finalization.
+  ([\#3448](https://github.com/anoma/namada/pull/3448))

--- a/crates/apps/src/bin/namada-node/cli.rs
+++ b/crates/apps/src/bin/namada-node/cli.rs
@@ -5,7 +5,9 @@ use namada::core::time::{DateTimeUtc, Utc};
 use namada::sdk::migrations::ScheduledMigration;
 use namada_apps_lib::cli::cmds::TestGenesis;
 use namada_apps_lib::cli::{self, cmds};
-use namada_apps_lib::config::{Action, ActionAtHeight, ValidatorLocalConfig};
+use namada_apps_lib::config::{
+    Action, ActionAtHeight, NodeLocalConfig, ValidatorLocalConfig,
+};
 use namada_node as node;
 #[cfg(not(feature = "migrations"))]
 use namada_sdk::display_line;
@@ -127,7 +129,9 @@ pub fn main() -> Result<()> {
                     );
                 }
             }
-            cmds::Config::UpdateLocalConfig(cmds::LocalConfig(args)) => {
+            cmds::Config::UpdateValidatorLocalConfig(
+                cmds::ValidatorLocalConfig(args),
+            ) => {
                 // Validate the new config
                 let updated_config = std::fs::read(args.config_path).unwrap();
                 let _validator_local_config: ValidatorLocalConfig =
@@ -142,6 +146,23 @@ pub fn main() -> Result<()> {
                         ctx.chain.unwrap().config.ledger.chain_id
                     ))
                     .join("validator_local_config.toml");
+                std::fs::write(config_path, updated_config).unwrap();
+            }
+            cmds::Config::UpdateLocalConfig(cmds::LocalConfig(args)) => {
+                // Validate the new config
+                let updated_config = std::fs::read(args.config_path).unwrap();
+                let _local_config: NodeLocalConfig =
+                    toml::from_slice(&updated_config).unwrap();
+
+                // Update the configuration file with the new one
+                let config_path = ctx
+                    .global_args
+                    .base_dir
+                    .join(format!(
+                        "{}",
+                        ctx.chain.unwrap().config.ledger.chain_id
+                    ))
+                    .join("local_config.toml");
                 std::fs::write(config_path, updated_config).unwrap();
             }
         },

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -1065,6 +1065,7 @@ pub mod cmds {
     #[derive(Clone, Debug)]
     pub enum Config {
         Gen(ConfigGen),
+        UpdateValidatorLocalConfig(ValidatorLocalConfig),
         UpdateLocalConfig(LocalConfig),
     }
 
@@ -1074,9 +1075,11 @@ pub mod cmds {
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).and_then(|matches| {
                 let gen = SubCmd::parse(matches).map(Self::Gen);
-                let gas_tokens =
+                let validator_cfg = SubCmd::parse(matches)
+                    .map(Self::UpdateValidatorLocalConfig);
+                let local_cfg =
                     SubCmd::parse(matches).map(Self::UpdateLocalConfig);
-                gen.or(gas_tokens)
+                gen.or(validator_cfg).or(local_cfg)
             })
         }
 
@@ -1086,6 +1089,7 @@ pub mod cmds {
                 .arg_required_else_help(true)
                 .about(wrap!("Configuration sub-commands."))
                 .subcommand(ConfigGen::def())
+                .subcommand(ValidatorLocalConfig::def())
                 .subcommand(LocalConfig::def())
         }
     }
@@ -1107,6 +1111,25 @@ pub mod cmds {
     }
 
     #[derive(Clone, Debug)]
+    pub struct ValidatorLocalConfig(pub args::UpdateValidatorLocalConfig);
+
+    impl SubCmd for ValidatorLocalConfig {
+        const CMD: &'static str = "update-validator-local-config";
+
+        fn parse(matches: &ArgMatches) -> Option<Self> {
+            matches.subcommand_matches(Self::CMD).map(|matches| {
+                Self(args::UpdateValidatorLocalConfig::parse(matches))
+            })
+        }
+
+        fn def() -> App {
+            App::new(Self::CMD)
+                .about(wrap!("Update the validator's local configuration."))
+                .add_args::<args::UpdateValidatorLocalConfig>()
+        }
+    }
+
+    #[derive(Clone, Debug)]
     pub struct LocalConfig(pub args::UpdateLocalConfig);
 
     impl SubCmd for LocalConfig {
@@ -1120,7 +1143,7 @@ pub mod cmds {
 
         fn def() -> App {
             App::new(Self::CMD)
-                .about(wrap!("Update the validator's local configuration."))
+                .about(wrap!("Update the node's local configuration."))
                 .add_args::<args::UpdateLocalConfig>()
         }
     }
@@ -3671,6 +3694,25 @@ pub mod args {
     }
 
     #[derive(Clone, Debug)]
+    pub struct UpdateValidatorLocalConfig {
+        pub config_path: PathBuf,
+    }
+
+    impl Args for UpdateValidatorLocalConfig {
+        fn parse(matches: &ArgMatches) -> Self {
+            let config_path = DATA_PATH.parse(matches);
+            Self { config_path }
+        }
+
+        fn def(app: App) -> App {
+            app.arg(DATA_PATH.def().help(wrap!(
+                "The path to the toml file containing the updated validator's \
+                 local configuration."
+            )))
+        }
+    }
+
+    #[derive(Clone, Debug)]
     pub struct UpdateLocalConfig {
         pub config_path: PathBuf,
     }
@@ -3683,8 +3725,8 @@ pub mod args {
 
         fn def(app: App) -> App {
             app.arg(DATA_PATH.def().help(wrap!(
-                "The path to the toml file containing the updated local \
-                 configuration."
+                "The path to the toml file containing the updated node's \
+                 local configuration."
             )))
         }
     }

--- a/crates/apps_lib/src/config/mod.rs
+++ b/crates/apps_lib/src/config/mod.rs
@@ -48,6 +48,11 @@ pub struct ValidatorLocalConfig {
         HashMap<namada::core::address::Address, namada::core::token::Amount>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NodeLocalConfig {
+    pub recheck_process_proposal: bool,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TendermintMode {
     Full,

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -152,10 +152,6 @@ impl Shell {
                     shell::ShellMode::Seed => false,
                 };
 
-                // FIXME: also optiomize if
-                // process_proposal has already run Run process
-                // proposal validation once more if the node runner
-                // requested it
                 if recheck_process_proposal {
                     let tm_raw_hash_string =
                         tm_raw_hash_to_string(&finalize.proposer_address);
@@ -168,11 +164,6 @@ impl Shell {
                         "Unable to find native validator address of block \
                          proposer from tendermint raw hash",
                     );
-
-                    // FIXME: would be slightly more safe to call
-                    // process_proposal instead so that if the logic changes we
-                    // don't diverge. But we need to cache the process_proposal
-                    // request in that case
 
                     let check_result = self.process_txs(
                         &finalize

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -43,22 +43,7 @@ where
     /// of epoch changes and applies associated updates to validator sets,
     /// etc. as necessary.
     ///
-    /// Validate and apply decrypted transactions unless
-    /// [`Shell::process_proposal`] detected that they were not submitted in
-    /// correct order or more decrypted txs arrived than expected. In that
-    /// case, all decrypted transactions are not applied and must be
-    /// included in the next `Shell::prepare_proposal` call.
-    ///
-    /// Incoming wrapper txs need no further validation. They
-    /// are added to the block.
-    ///
-    /// Error codes:
-    ///   0: Ok
-    ///   1: Invalid tx
-    ///   2: Tx is invalidly signed
-    ///   3: Wasm runtime error
-    ///   4: Invalid order of decrypted txs
-    ///   5. More decrypted txs than expected
+    /// Apply the transactions included in the block.
     pub fn finalize_block(
         &mut self,
         req: shim::request::FinalizeBlock,

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -624,13 +624,6 @@ where
                 continue;
             }
 
-            if tx.validate_tx().is_err() {
-                tracing::error!(
-                    "Internal logic error: FinalizeBlock received tx that \
-                     could not be deserialized to a valid TxType"
-                );
-                continue;
-            };
             let tx_header = tx.header();
             // If [`process_proposal`] rejected a Tx, emit an event here and
             // move on to next tx

--- a/crates/node/src/shell/governance.rs
+++ b/crates/node/src/shell/governance.rs
@@ -82,6 +82,7 @@ where
     H: StorageHasher + Sync + 'static,
 {
     let mut proposals_result = ProposalsResult::default();
+    let params = read_pos_params(&shell.state)?;
 
     for id in proposal_ids {
         let proposal_funds_key = gov_storage::get_funds_key(id);
@@ -100,7 +101,6 @@ where
 
         let is_steward = pgf::is_steward(&shell.state, &proposal_author)?;
 
-        let params = read_pos_params(&shell.state)?;
         let total_active_voting_power =
             read_total_active_stake(&shell.state, &params, proposal_end_epoch)?;
 

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -1129,22 +1129,6 @@ where
                     return response;
                 }
 
-                // TODO(namada#2597): validate masp fee payment if normal fee
-                // payment fails Validate wrapper fees
-                if let Err(e) = mempool_fee_check(
-                    &wrapper,
-                    &mut ShellParams::new(
-                        &RefCell::new(gas_meter),
-                        &mut self.state.with_temp_write_log(),
-                        &mut self.vp_wasm_cache.clone(),
-                        &mut self.tx_wasm_cache.clone(),
-                    ),
-                ) {
-                    response.code = ResultCode::FeeError.into();
-                    response.log = format!("{INVALID_MSG}: {e}");
-                    return response;
-                }
-
                 // Validate the inner txs after. Even if the batch is non-atomic
                 // we still reject it if just one of the inner txs is
                 // invalid
@@ -1161,6 +1145,22 @@ where
                         );
                         return response;
                     }
+                }
+
+                // TODO(namada#2597): validate masp fee payment if normal fee
+                // payment fails Validate wrapper fees
+                if let Err(e) = mempool_fee_check(
+                    &wrapper,
+                    &mut ShellParams::new(
+                        &RefCell::new(gas_meter),
+                        &mut self.state.with_temp_write_log(),
+                        &mut self.vp_wasm_cache.clone(),
+                        &mut self.tx_wasm_cache.clone(),
+                    ),
+                ) {
+                    response.code = ResultCode::FeeError.into();
+                    response.log = format!("{INVALID_MSG}: {e}");
+                    return response;
                 }
             }
             TxType::Raw => {

--- a/crates/node/src/shell/prepare_proposal.rs
+++ b/crates/node/src/shell/prepare_proposal.rs
@@ -46,7 +46,8 @@ where
         mut req: RequestPrepareProposal,
     ) -> response::PrepareProposal {
         let txs = if let ShellMode::Validator {
-            ref local_config, ..
+            ref validator_local_config,
+            ..
         } = self.mode
         {
             // start counting allotted space for txs
@@ -70,7 +71,7 @@ where
                 &req.txs,
                 req.time,
                 &block_proposer,
-                local_config.as_ref(),
+                validator_local_config.as_ref(),
             );
             txs.append(&mut normal_txs);
             let mut remaining_txs =
@@ -1036,9 +1037,13 @@ mod test_prepare_proposal {
     fn test_fee_non_accepted_token() {
         let (mut shell, _recv, _, _) = test_utils::setup();
         // Update local validator configuration for gas tokens
-        if let ShellMode::Validator { local_config, .. } = &mut shell.mode {
+        if let ShellMode::Validator {
+            validator_local_config,
+            ..
+        } = &mut shell.mode
+        {
             // Remove the allowed btc
-            *local_config = Some(ValidatorLocalConfig {
+            *validator_local_config = Some(ValidatorLocalConfig {
                 accepted_gas_tokens: namada::core::collections::HashMap::from(
                     [(namada::core::address::testing::nam(), Amount::from(1))],
                 ),
@@ -1137,9 +1142,13 @@ mod test_prepare_proposal {
     fn test_fee_wrong_minimum_accepted_amount() {
         let (mut shell, _recv, _, _) = test_utils::setup();
         // Update local validator configuration for gas tokens
-        if let ShellMode::Validator { local_config, .. } = &mut shell.mode {
+        if let ShellMode::Validator {
+            validator_local_config,
+            ..
+        } = &mut shell.mode
+        {
             // Remove btc and increase minimum for nam
-            *local_config = Some(ValidatorLocalConfig {
+            *validator_local_config = Some(ValidatorLocalConfig {
                 accepted_gas_tokens: namada::core::collections::HashMap::from(
                     [(
                         namada::core::address::testing::nam(),

--- a/crates/node/src/shell/prepare_proposal.rs
+++ b/crates/node/src/shell/prepare_proposal.rs
@@ -10,7 +10,7 @@ use namada::ledger::protocol::{self, ShellParams};
 use namada::proof_of_stake::storage::find_validator_by_raw_hash;
 use namada::state::{DBIter, StorageHasher, TempWlState, DB};
 use namada::token::{Amount, DenominatedAmount};
-use namada::tx::data::{TxType, WrapperTx};
+use namada::tx::data::WrapperTx;
 use namada::tx::Tx;
 use namada::vm::wasm::{TxCache, VpCache};
 use namada::vm::WasmCacheAccess;
@@ -273,6 +273,7 @@ where
     CA: 'static + WasmCacheAccess + Sync,
 {
     let tx = Tx::try_from(tx_bytes).map_err(|_| ())?;
+    let wrapper = tx.header.wrapper().ok_or(())?;
 
     // If tx doesn't have an expiration it is valid. If time cannot be
     // retrieved from block default to last block datetime which has
@@ -286,33 +287,29 @@ where
     }
 
     tx.validate_tx().map_err(|_| ())?;
-    if let TxType::Wrapper(wrapper) = tx.header().tx_type {
-        // Check tx gas limit for tx size
-        let gas_limit = Gas::try_from(wrapper.gas_limit).map_err(|_| ())?;
-        let mut tx_gas_meter = TxGasMeter::new(gas_limit);
-        tx_gas_meter.add_wrapper_gas(tx_bytes).map_err(|_| ())?;
+    // Check tx gas limit for tx size
+    let gas_limit = Gas::try_from(wrapper.gas_limit).map_err(|_| ())?;
+    let mut tx_gas_meter = TxGasMeter::new(gas_limit);
+    tx_gas_meter.add_wrapper_gas(tx_bytes).map_err(|_| ())?;
 
-        super::replay_protection_checks(&tx, temp_state).map_err(|_| ())?;
+    super::replay_protection_checks(&tx, temp_state).map_err(|_| ())?;
 
-        // Check fees and extract the gas limit of this transaction
-        // TODO(namada#2597): check if masp fee payment is required
-        match prepare_proposal_fee_check(
-            &wrapper,
-            tx.header_hash(),
-            block_proposer,
-            proposer_local_config,
-            &mut ShellParams::new(
-                &RefCell::new(tx_gas_meter),
-                temp_state,
-                vp_wasm_cache,
-                tx_wasm_cache,
-            ),
-        ) {
-            Ok(()) => Ok(u64::from(wrapper.gas_limit)),
-            Err(_) => Err(()),
-        }
-    } else {
-        Err(())
+    // Check fees and extract the gas limit of this transaction
+    // TODO(namada#2597): check if masp fee payment is required
+    match prepare_proposal_fee_check(
+        &wrapper,
+        tx.header_hash(),
+        block_proposer,
+        proposer_local_config,
+        &mut ShellParams::new(
+            &RefCell::new(tx_gas_meter),
+            temp_state,
+            vp_wasm_cache,
+            tx_wasm_cache,
+        ),
+    ) {
+        Ok(()) => Ok(u64::from(wrapper.gas_limit)),
+        Err(_) => Err(()),
     }
 }
 
@@ -419,7 +416,7 @@ mod test_prepare_proposal {
     use namada::proof_of_stake::Epoch;
     use namada::state::collections::lazy_map::{NestedSubKey, SubKey};
     use namada::token::read_denom;
-    use namada::tx::data::Fee;
+    use namada::tx::data::{Fee, TxType};
     use namada::tx::{Authorization, Code, Data, Section, Signed};
     use namada::vote_ext::{ethereum_events, ethereum_tx_data_variants};
     use namada::{replay_protection, token};

--- a/crates/node/src/shell/prepare_proposal.rs
+++ b/crates/node/src/shell/prepare_proposal.rs
@@ -286,7 +286,6 @@ where
         }
     }
 
-    tx.validate_tx().map_err(|_| ())?;
     // Check tx gas limit for tx size
     let gas_limit = Gas::try_from(wrapper.gas_limit).map_err(|_| ())?;
     let mut tx_gas_meter = TxGasMeter::new(gas_limit);

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -108,7 +108,6 @@ where
             );
         }
         (
-            // FIXME: match this on the other side
             if invalid_txs {
                 ProcessProposal::Reject
             } else {

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -247,15 +247,15 @@ where
             |tx| {
                 let tx_chain_id = tx.header.chain_id.clone();
                 let tx_expiration = tx.header.expiration;
-                if let Err(err) = tx.validate_tx() {
+                match tx.validate_tx() {
+                    Ok(_) => Ok((tx_chain_id, tx_expiration, tx)),
                     // This occurs if the wrapper / protocol tx signature is
                     // invalid
-                    return Err(TxResult {
+                    Err(err) => Err(TxResult {
                         code: ResultCode::InvalidSig.into(),
                         info: err.to_string(),
-                    });
+                    }),
                 }
-                Ok((tx_chain_id, tx_expiration, tx))
             },
         );
         let (tx_chain_id, tx_expiration, tx) = match maybe_tx {
@@ -263,12 +263,6 @@ where
             Err(tx_result) => return tx_result,
         };
 
-        if let Err(err) = tx.validate_tx() {
-            return TxResult {
-                code: ResultCode::InvalidSig.into(),
-                info: err.to_string(),
-            };
-        }
         match tx.header().tx_type {
             // If it is a raw transaction, we do no further validation
             TxType::Raw => TxResult {

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -108,6 +108,7 @@ where
             );
         }
         (
+            // FIXME: match this on the other side
             if invalid_txs {
                 ProcessProposal::Reject
             } else {
@@ -174,19 +175,21 @@ where
     ///
     /// Error codes:
     ///   0: Ok
-    ///   1: Invalid tx
-    ///   2: Tx is invalidly signed
-    ///   3: Wasm runtime error
-    ///   4: Invalid order of decrypted txs
-    ///   5. More decrypted txs than expected
-    ///   6. A transaction could not be decrypted
-    ///   7. An error in the vote extensions included in the proposal
-    ///   8. Not enough block space was available for some tx
-    ///   9. Replay attack
+    ///   1: Wasm runtime error
+    ///   2: Invalid tx
+    ///   3: Tx is invalidly signed
+    ///   4: Block is full
+    ///   5: Replay attempt
+    ///   6. Tx targets a different chain id
+    ///   7. Tx is expired
+    ///   8. Tx exceeds the gas limit
+    ///   9. Tx failed to pay fees
+    ///   10. An error in the vote extensions included in the proposal
+    ///   11. Not enough block space was available for some tx
+    ///   12. Tx wasm code is not allowlisted
     ///
-    /// INVARIANT: Any changes applied in this method must be reverted if the
-    /// proposal is rejected (unless we can simply overwrite them in the
-    /// next block).
+    /// INVARIANT: This function should not, under any circumstances, modify the
+    /// state since the proposal could be rejected.
     #[allow(clippy::too_many_arguments)]
     pub fn check_proposal_tx<CA>(
         &self,


### PR DESCRIPTION
## Describe your changes

Closes #3190.
Closes #3193.

This PR fixes some wrong documentation for the `finalize_block` and `check_proposal_tx_function`.

It also introduces a new local configuration parameter to allows a node to rerun the `process_proposal` checks before finalize block in case they don't want to blindly trust the majority of validators. This is implemented for both full nodes and validators since the latter could also skip the `process_proposal` call in some cases.

## Indicate on which release or other PRs this topic is based on

#3192 (diffs for review: https://github.com/anoma/namada/pull/3448/files/176754fbd523ec7d17a1dbbd10f59900b846aeb1..1a704b679b122656aa4ff6d0baa947054c326271)

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
