### PR TITLE
Avoid multiple calls to `process_proposal`

### DIFF
--- a/.changelog/unreleased/improvements/3473-opt-validation-calls.md
+++ b/.changelog/unreleased/improvements/3473-opt-validation-calls.md
@@ -1,0 +1,4 @@
+- Modified rechecks of process proposal to actually use `process_proposal`
+  instead of `process_txs`. Added a caching mechanism to avoid
+  running the check for a given proposed block more than once.
+  ([\#3473](https://github.com/anoma/namada/pull/3473))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5339,6 +5339,7 @@ dependencies = [
  "assert_matches",
  "borsh 1.2.1",
  "chrono",
+ "clru",
  "itertools 0.12.1",
  "linkme",
  "namada_core",

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -29,6 +29,8 @@ pub enum Error {
     ConversionFailed(std::array::TryFromSliceError),
     #[error("Failed to convert string into a hash: {0}")]
     FromStringError(data_encoding::DecodeError),
+    #[error("Cannot convert an empty CometBFT hash")]
+    FromCometError,
 }
 
 /// Result for functions that may fail
@@ -175,6 +177,17 @@ impl Hash {
 impl From<Hash> for crate::tendermint::Hash {
     fn from(hash: Hash) -> Self {
         Self::Sha256(hash.0)
+    }
+}
+
+impl TryFrom<crate::tendermint::Hash> for Hash {
+    type Error = self::Error;
+
+    fn try_from(value: crate::tendermint::Hash) -> Result<Self, Self::Error> {
+        match value {
+            crate::tendermint::Hash::Sha256(hash) => Ok(Self(hash)),
+            crate::tendermint::Hash::None => Err(Error::FromCometError),
+        }
     }
 }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -192,9 +192,10 @@ impl Shell {
         };
 
         if recheck_process_proposal {
-            let process_req = crate::shims::abcipp_shim_types::shim::request::finalize_block_to_process_proposal_req(
-                            finalize.clone(),
-                        ).map_err(|_| Error::InvalidBlockProposal)?;
+            let process_req = finalize
+                .clone()
+                .cast_to_process_proposal_req()
+                .map_err(|_| Error::InvalidBlockProposal)?;
             // FIXME: should instead mock a call to call? Probably yes
             // FIXME: need the processing results? Maybe for caching
             // even though caching here is useless

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -151,7 +151,7 @@ impl Shell {
                     self.state
                         .in_mem_mut()
                         .process_proposal_cache
-                        .insert(block_hash, result);
+                        .put(block_hash, result);
                 }
                 Ok(Response::ProcessProposal(response))
             }
@@ -218,7 +218,7 @@ impl Shell {
         if recheck_process_proposal {
             let process_proposal_result = match self
                 .state
-                .in_mem()
+                .in_mem_mut()
                 .process_proposal_cache
                 .get(&finalize_req.block_hash)
             {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -131,11 +131,12 @@ impl Shell {
                 // checks if (when) needed. Every check living outside that
                 // function will not be correctly replicated in the other
                 // locations
+                let block_hash = block.hash.try_into();
                 let (response, tx_results) =
-                    self.process_proposal(block.clone().into());
+                    self.process_proposal(block.into());
                 // Cache the response in case of future calls from Namada. If
                 // hash conversion fails avoid caching
-                if let Ok(block_hash) = block.hash.try_into() {
+                if let Ok(block_hash) = block_hash {
                     self.state.in_mem_mut().process_proposal_cache.insert(
                         block_hash,
                         (

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -150,7 +150,7 @@ impl Shell {
 
                     self.state
                         .in_mem_mut()
-                        .process_proposal_cache
+                        .block_proposals_cache
                         .put(block_hash, result);
                 }
                 Ok(Response::ProcessProposal(response))
@@ -219,7 +219,7 @@ impl Shell {
             let process_proposal_result = match self
                 .state
                 .in_mem_mut()
-                .process_proposal_cache
+                .block_proposals_cache
                 .get(&finalize_req.block_hash)
             {
                 // We already have the result of process proposal for this block
@@ -250,7 +250,7 @@ impl Shell {
         }
 
         // Clear the cache of proposed blocks' results
-        self.state.in_mem_mut().process_proposal_cache.clear();
+        self.state.in_mem_mut().block_proposals_cache.clear();
 
         Ok(())
     }

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -83,7 +83,8 @@ where
 
         let emit_events = &mut response.events;
         // Get the actual votes from cometBFT in the preferred format
-        let votes = pos_votes_from_abci(&self.state, &req.votes);
+        let votes =
+            pos_votes_from_abci(&self.state, &req.decided_last_commit.votes);
         let validator_set_update_epoch =
             self.get_validator_set_update_epoch(current_epoch);
 
@@ -1893,7 +1894,10 @@ mod test_finalize_block {
             let req = FinalizeBlock {
                 txs,
                 proposer_address: proposer_address.clone(),
-                votes: votes.clone(),
+                decided_last_commit: tendermint::abci::types::CommitInfo {
+                    round: 0u8.into(),
+                    votes: votes.clone(),
+                },
                 ..Default::default()
             };
             // merkle tree root before finalize_block

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -126,6 +126,11 @@ pub enum Error {
     ReplayAttempt(String),
     #[error("Error with snapshots: {0}")]
     Snapshot(std::io::Error),
+    #[error(
+        "Received a finalize request for a block that was previously rejected \
+         by process proposal"
+    )]
+    RejectedBlockProposal,
     #[error("Received an invalid block proposal")]
     InvalidBlockProposal,
 }

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -1902,6 +1902,7 @@ mod test_utils {
                     time: DateTimeUtc::now(),
                     next_validators_hash: Hash([0; 32]),
                 },
+                block_hash: Hash([0; 32]),
                 byzantine_validators: vec![],
                 txs: vec![],
                 proposer_address: HEXUPPER

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -1912,7 +1912,6 @@ mod test_utils {
                             .as_bytes(),
                     )
                     .unwrap(),
-                votes: vec![],
                 height: 0u8.into(),
                 decided_last_commit: tendermint::abci::types::CommitInfo {
                     round: 0u8.into(),
@@ -1964,7 +1963,10 @@ mod test_utils {
         let mut req = FinalizeBlock {
             header,
             proposer_address,
-            votes,
+            decided_last_commit: tendermint::abci::types::CommitInfo {
+                round: 0u8.into(),
+                votes,
+            },
             ..Default::default()
         };
         if let Some(byz_vals) = byzantine_validators {

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -1913,6 +1913,11 @@ mod test_utils {
                     )
                     .unwrap(),
                 votes: vec![],
+                height: 0u8.into(),
+                decided_last_commit: tendermint::abci::types::CommitInfo {
+                    round: 0u8.into(),
+                    votes: vec![],
+                },
             }
         }
     }

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -127,8 +127,8 @@ pub enum Error {
     #[error("Error with snapshots: {0}")]
     Snapshot(std::io::Error),
     #[error(
-        "Received a finalize request for a block that was previously rejected \
-         by process proposal"
+        "Received a finalize request for a block that was rejected by process \
+         proposal"
     )]
     RejectedBlockProposal,
     #[error("Received an invalid block proposal")]

--- a/crates/node/src/shell/prepare_proposal.rs
+++ b/crates/node/src/shell/prepare_proposal.rs
@@ -687,7 +687,10 @@ mod test_prepare_proposal {
         ];
         let req = FinalizeBlock {
             proposer_address: pkh1.to_vec(),
-            votes,
+            decided_last_commit: namada::tendermint::abci::types::CommitInfo {
+                round: 0u8.into(),
+                votes,
+            },
             ..Default::default()
         };
         shell.start_new_epoch(Some(req));

--- a/crates/node/src/shell/queries.rs
+++ b/crates/node/src/shell/queries.rs
@@ -163,7 +163,10 @@ mod test_queries {
                     }];
                     let req = FinalizeBlock {
                         proposer_address: pkh1.to_vec(),
-                        votes,
+                        decided_last_commit: namada::tendermint::abci::types::CommitInfo{
+                            round: 0u8.into(),
+                            votes
+                        },
                         ..Default::default()
                     };
                     shell.finalize_and_commit(Some(req));

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -478,7 +478,6 @@ impl MockNode {
             byzantine_validators: vec![],
             txs: txs.clone(),
             proposer_address,
-            votes: votes.clone(),
             height: height.try_into().unwrap(),
             decided_last_commit: tendermint::abci::types::CommitInfo {
                 round: 0u8.into(),
@@ -605,7 +604,6 @@ impl MockNode {
                 })
                 .collect(),
             proposer_address,
-            votes: votes.clone(),
             height: height.try_into().unwrap(),
             decided_last_commit: tendermint::abci::types::CommitInfo {
                 round: 0u8.into(),

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -475,6 +475,7 @@ impl MockNode {
                 time: DateTimeUtc::now(),
                 next_validators_hash: Hash([0; 32]),
             },
+            block_hash: Hash([0; 32]),
             byzantine_validators: vec![],
             txs: txs.clone(),
             proposer_address,
@@ -593,6 +594,7 @@ impl MockNode {
                 time: DateTimeUtc::now(),
                 next_validators_hash: Hash([0; 32]),
             },
+            block_hash: Hash([0; 32]),
             byzantine_validators: vec![],
             txs: txs
                 .clone()

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -478,7 +478,12 @@ impl MockNode {
             byzantine_validators: vec![],
             txs: txs.clone(),
             proposer_address,
-            votes,
+            votes: votes.clone(),
+            height: height.try_into().unwrap(),
+            decided_last_commit: tendermint::abci::types::CommitInfo {
+                round: 0u8.into(),
+                votes,
+            },
         };
 
         let resp = locked.finalize_block(req).expect("Test failed");
@@ -600,7 +605,12 @@ impl MockNode {
                 })
                 .collect(),
             proposer_address,
-            votes,
+            votes: votes.clone(),
+            height: height.try_into().unwrap(),
+            decided_last_commit: tendermint::abci::types::CommitInfo {
+                round: 0u8.into(),
+                votes,
+            },
         };
 
         // process the results

--- a/crates/node/src/shell/vote_extensions/bridge_pool_vext.rs
+++ b/crates/node/src/shell/vote_extensions/bridge_pool_vext.rs
@@ -145,7 +145,10 @@ mod test_bp_vote_extensions {
         }];
         let req = FinalizeBlock {
             proposer_address: pkh1.to_vec(),
-            votes,
+            decided_last_commit: namada::tendermint::abci::types::CommitInfo {
+                round: 0u8.into(),
+                votes,
+            },
             ..Default::default()
         };
         assert_eq!(shell.start_new_epoch(Some(req)).0, 1);

--- a/crates/node/src/shell/vote_extensions/eth_events.rs
+++ b/crates/node/src/shell/vote_extensions/eth_events.rs
@@ -471,7 +471,10 @@ mod test_vote_extensions {
         }];
         let req = FinalizeBlock {
             proposer_address: pkh1.to_vec(),
-            votes,
+            decided_last_commit: namada::tendermint::abci::types::CommitInfo {
+                round: 0u8.into(),
+                votes,
+            },
             ..Default::default()
         };
         assert_eq!(shell.start_new_epoch(Some(req)).0, 1);

--- a/crates/node/src/shell/vote_extensions/val_set_update.rs
+++ b/crates/node/src/shell/vote_extensions/val_set_update.rs
@@ -323,7 +323,10 @@ mod test_vote_extensions {
         }];
         let req = FinalizeBlock {
             proposer_address: pkh1.to_vec(),
-            votes,
+            decided_last_commit: namada::tendermint::abci::types::CommitInfo {
+                round: 0u8.into(),
+                votes,
+            },
             ..Default::default()
         };
         assert_eq!(shell.start_new_epoch(Some(req)).0, 1);

--- a/crates/node/src/shims/abcipp_shim.rs
+++ b/crates/node/src/shims/abcipp_shim.rs
@@ -125,8 +125,7 @@ impl AbcippShim {
                     let begin_block_request =
                         self.begin_block_request.take().unwrap();
 
-                    let mut process_req = super::abcipp_shim_types::shim::request::begin_block_to_process_proposal_req(begin_block_request.clone());
-                    process_req.txs.clone_from(&self.delivered_txs);
+                    let process_req = super::abcipp_shim_types::shim::request::CheckProcessProposal::from(begin_block_request.clone()).cast_to_tendermint_req(self.delivered_txs.clone());
                     // FIXME: should instead mock a call to call? Probably yes
                     // FIXME: if cached avoid this call
                     // Need to run process proposal to extract the data we need

--- a/crates/node/src/shims/abcipp_shim.rs
+++ b/crates/node/src/shims/abcipp_shim.rs
@@ -6,8 +6,7 @@ use std::task::{Context, Poll};
 use futures::future::FutureExt;
 use namada::core::hash::Hash;
 use namada::core::storage::BlockHeight;
-use namada::state::ProcessProposalCachedResult;
-use namada::state::DB;
+use namada::state::{ProcessProposalCachedResult, DB};
 use namada::tendermint::abci::response::ProcessProposal;
 use namada::time::{DateTimeUtc, Utc};
 use namada::tx::data::hash_tx;
@@ -254,7 +253,7 @@ impl AbcippShim {
                     .service
                     .state
                     .in_mem_mut()
-                    .process_proposal_cache
+                    .block_proposals_cache
                     .get(&block_hash)
                 {
                     // We already have the result of process proposal for
@@ -285,7 +284,7 @@ impl AbcippShim {
                         self.service
                             .state
                             .in_mem_mut()
-                            .process_proposal_cache
+                            .block_proposals_cache
                             .put(block_hash.to_owned(), result.clone());
 
                         result

--- a/crates/node/src/shims/abcipp_shim.rs
+++ b/crates/node/src/shims/abcipp_shim.rs
@@ -253,7 +253,7 @@ impl AbcippShim {
                 match self
                     .service
                     .state
-                    .in_mem()
+                    .in_mem_mut()
                     .process_proposal_cache
                     .get(&block_hash)
                 {
@@ -286,7 +286,7 @@ impl AbcippShim {
                             .state
                             .in_mem_mut()
                             .process_proposal_cache
-                            .insert(block_hash.to_owned(), result.clone());
+                            .put(block_hash.to_owned(), result.clone());
 
                         result
                     }

--- a/crates/node/src/shims/abcipp_shim_types.rs
+++ b/crates/node/src/shims/abcipp_shim_types.rs
@@ -194,6 +194,7 @@ pub mod shim {
         #[derive(Debug, Clone)]
         pub struct FinalizeBlock {
             pub header: Header,
+            pub block_hash: Hash,
             pub byzantine_validators: Vec<Misbehavior>,
             pub txs: Vec<ProcessedTx>,
             pub proposer_address: Vec<u8>,
@@ -220,11 +221,12 @@ pub mod shim {
                         hash: Hash::try_from(header.app_hash.as_bytes())
                             .unwrap_or_default(),
                         time: DateTimeUtc::try_from(header.time).unwrap(),
-                        next_validators_hash: Hash::try_from(
-                            header.next_validators_hash.as_bytes(),
-                        )
-                        .unwrap(),
+                        next_validators_hash: header
+                            .next_validators_hash
+                            .try_into()
+                            .unwrap(),
                     },
+                    block_hash: req.hash.try_into().unwrap(),
                     byzantine_validators: req.byzantine_validators,
                     txs: vec![],
                     proposer_address: header.proposer_address.into(),
@@ -286,7 +288,7 @@ pub mod shim {
                     txs: self.txs.into_iter().map(|tx| tx.tx).collect(),
                     proposed_last_commit: Some(self.decided_last_commit),
                     misbehavior: self.byzantine_validators,
-                    hash: header.hash.into(),
+                    hash: self.block_hash.into(),
                     height: self.height,
                     time: header.time.try_into().map_err(|_| {
                         super::Error::Shell(

--- a/crates/node/src/shims/abcipp_shim_types.rs
+++ b/crates/node/src/shims/abcipp_shim_types.rs
@@ -353,5 +353,20 @@ pub mod shim {
                 }
             }
         }
+
+        impl From<(u32, String)> for TxResult {
+            fn from(value: (u32, String)) -> Self {
+                Self {
+                    code: value.0,
+                    info: value.1,
+                }
+            }
+        }
+
+        impl From<TxResult> for (u32, String) {
+            fn from(value: TxResult) -> Self {
+                (value.code, value.info)
+            }
+        }
     }
 }

--- a/crates/node/src/shims/abcipp_shim_types.rs
+++ b/crates/node/src/shims/abcipp_shim_types.rs
@@ -7,7 +7,6 @@ pub mod shim {
     use thiserror::Error;
 
     use super::{Request as Req, Response as Resp};
-    use crate::facade::tendermint::abci::types::VoteInfo;
     use crate::facade::tendermint::v0_37::abci::{
         request as tm_request, response as tm_response,
     };
@@ -175,7 +174,6 @@ pub mod shim {
         use namada::tendermint::abci::types::CommitInfo;
         use namada::tendermint::block::Height;
 
-        use super::VoteInfo;
         use crate::facade::tendermint::abci::types::Misbehavior;
         use crate::facade::tendermint::v0_37::abci::request as tm_request;
 
@@ -196,9 +194,6 @@ pub mod shim {
             pub byzantine_validators: Vec<Misbehavior>,
             pub txs: Vec<ProcessedTx>,
             pub proposer_address: Vec<u8>,
-            // FIXME: remove votes caus it's already contained in
-            // decided_last_commit
-            pub votes: Vec<VoteInfo>,
             pub height: Height,
             pub decided_last_commit: CommitInfo,
         }
@@ -219,7 +214,6 @@ pub mod shim {
                     byzantine_validators: req.byzantine_validators,
                     txs: vec![],
                     proposer_address: header.proposer_address.into(),
-                    votes: req.last_commit_info.votes.clone(),
                     height: header.height,
                     decided_last_commit: req.last_commit_info,
                 }

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -40,6 +40,7 @@ namada_storage = { path = "../storage" }
 namada_tx = { path = "../tx" }
 
 borsh.workspace = true
+clru.workspace = true
 itertools.workspace = true
 linkme = {workspace = true, optional = true}
 smooth-operator.workspace = true

--- a/crates/state/src/in_memory.rs
+++ b/crates/state/src/in_memory.rs
@@ -73,12 +73,18 @@ where
     pub storage_read_past_height_limit: Option<u64>,
     /// Data that needs to be committed to the merkle tree
     pub commit_only_data: CommitOnlyData,
-    //FIXME: change this to cache the actual process proposal request? No the result!
-    //FIXME: important to set and clear this in the correct way
-    //FIXME: maybe if I use the block height here it's a bit safer? Not sure, what happens if multiple rounds in the same height?
-    //FIXME: actually what if I get multiple rounds I believe the boolean doesn't work because I don't clear it in between the calls? Maybe there's a way to clean it? I don't think so
-    //FIXME: rename
-    pub process_proposal_ran: bool,
+    /// Cache of the results of process proposal for the next height to decide.
+    /// The different proposed blocks are indexed by their hash. This is used
+    /// to avoid running process proposal more than once internally (comet only
+    /// calls it at most once for a given height/round) because of the shim or
+    /// the recheck option
+    pub process_proposal_cache: namada_core::collections::HashMap<
+        Hash,
+        (
+            namada_core::tendermint::abci::response::ProcessProposal,
+            Vec<(u32, String)>,
+        ),
+    >,
 }
 
 /// Last committed block
@@ -149,7 +155,7 @@ where
             eth_events_queue: EthEventsQueue::default(),
             storage_read_past_height_limit,
             commit_only_data: CommitOnlyData::default(),
-            process_proposal_ran: false,
+            process_proposal_cache: Default::default(),
         }
     }
 

--- a/crates/state/src/in_memory.rs
+++ b/crates/state/src/in_memory.rs
@@ -80,10 +80,8 @@ where
     /// for a given height/round)
     pub process_proposal_cache: namada_core::collections::HashMap<
         Hash,
-        (
-            namada_core::tendermint::abci::response::ProcessProposal,
-            Vec<(u32, String)>,
-        ),
+        // FIXME: myabe better with an enum instead of result?
+        std::result::Result<Vec<(u32, String)>, ()>,
     >,
 }
 

--- a/crates/state/src/in_memory.rs
+++ b/crates/state/src/in_memory.rs
@@ -73,6 +73,12 @@ where
     pub storage_read_past_height_limit: Option<u64>,
     /// Data that needs to be committed to the merkle tree
     pub commit_only_data: CommitOnlyData,
+    //FIXME: change this to cache the actual process proposal request? No the result!
+    //FIXME: important to set and clear this in the correct way
+    //FIXME: maybe if I use the block height here it's a bit safer? Not sure, what happens if multiple rounds in the same height?
+    //FIXME: actually what if I get multiple rounds I believe the boolean doesn't work because I don't clear it in between the calls? Maybe there's a way to clean it? I don't think so
+    //FIXME: rename
+    pub process_proposal_ran: bool,
 }
 
 /// Last committed block
@@ -143,6 +149,7 @@ where
             eth_events_queue: EthEventsQueue::default(),
             storage_read_past_height_limit,
             commit_only_data: CommitOnlyData::default(),
+            process_proposal_ran: false,
         }
     }
 

--- a/crates/state/src/in_memory.rs
+++ b/crates/state/src/in_memory.rs
@@ -75,9 +75,9 @@ where
     pub commit_only_data: CommitOnlyData,
     /// Cache of the results of process proposal for the next height to decide.
     /// The different proposed blocks are indexed by their hash. This is used
-    /// to avoid running process proposal more than once internally (comet only
-    /// calls it at most once for a given height/round) because of the shim or
-    /// the recheck option
+    /// to avoid running process proposal more than once internally because of
+    /// the shim or the recheck option (comet only calls it at most once
+    /// for a given height/round)
     pub process_proposal_cache: namada_core::collections::HashMap<
         Hash,
         (

--- a/crates/state/src/in_memory.rs
+++ b/crates/state/src/in_memory.rs
@@ -78,11 +78,9 @@ where
     /// to avoid running process proposal more than once internally because of
     /// the shim or the recheck option (comet only calls it at most once
     /// for a given height/round)
-    pub process_proposal_cache: namada_core::collections::HashMap<
-        Hash,
-        // FIXME: myabe better with an enum instead of result?
-        std::result::Result<Vec<(u32, String)>, ()>,
-    >,
+    // FIXME: would be better to limit the size of this cache. CLruCache?
+    pub process_proposal_cache:
+        namada_core::collections::HashMap<Hash, ProcessProposalCachedResult>,
 }
 
 /// Last committed block
@@ -92,6 +90,17 @@ pub struct LastBlock {
     pub height: BlockHeight,
     /// Block time
     pub time: DateTimeUtc,
+}
+
+/// The result of process proposal that can be cached for future lookup
+#[must_use]
+#[derive(Debug, Clone)]
+pub enum ProcessProposalCachedResult {
+    /// The proposed block was accepted by this node with the attached results
+    /// for every included tx
+    Accepted(Vec<(u32, String)>),
+    /// The proposed block was rejected by this node
+    Rejected,
 }
 
 /// The block storage data

--- a/crates/state/src/in_memory.rs
+++ b/crates/state/src/in_memory.rs
@@ -83,7 +83,7 @@ where
     /// to avoid running process proposal more than once internally because of
     /// the shim or the recheck option (comet only calls it at most once
     /// for a given height/round)
-    pub process_proposal_cache: CLruCache<Hash, ProcessProposalCachedResult>,
+    pub block_proposals_cache: CLruCache<Hash, ProcessProposalCachedResult>,
 }
 
 /// Last committed block
@@ -165,7 +165,7 @@ where
             eth_events_queue: EthEventsQueue::default(),
             storage_read_past_height_limit,
             commit_only_data: CommitOnlyData::default(),
-            process_proposal_cache: CLruCache::new(
+            block_proposals_cache: CLruCache::new(
                 NonZeroUsize::new(10).unwrap(),
             ),
         }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -604,6 +604,9 @@ where
 #[cfg(any(test, feature = "testing"))]
 pub mod testing {
 
+    use std::num::NonZeroUsize;
+
+    use clru::CLruCache;
     use namada_core::address;
     use namada_core::address::EstablishedAddressGen;
     use namada_core::chain::ChainId;
@@ -667,7 +670,9 @@ pub mod testing {
                 eth_events_queue: EthEventsQueue::default(),
                 storage_read_past_height_limit: Some(1000),
                 commit_only_data: CommitOnlyData::default(),
-                process_proposal_cache: Default::default(),
+                process_proposal_cache: CLruCache::new(
+                    NonZeroUsize::new(10).unwrap(),
+                ),
             }
         }
     }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -670,7 +670,7 @@ pub mod testing {
                 eth_events_queue: EthEventsQueue::default(),
                 storage_read_past_height_limit: Some(1000),
                 commit_only_data: CommitOnlyData::default(),
-                process_proposal_cache: CLruCache::new(
+                block_proposals_cache: CLruCache::new(
                     NonZeroUsize::new(10).unwrap(),
                 ),
             }

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -26,7 +26,9 @@ use std::fmt::Debug;
 use std::iter::Peekable;
 
 pub use host_env::{TxHostEnvState, VpHostEnvState};
-pub use in_memory::{BlockStorage, InMemory, LastBlock};
+pub use in_memory::{
+    BlockStorage, InMemory, LastBlock, ProcessProposalCachedResult,
+};
 use namada_core::address::Address;
 use namada_core::arith::{self, checked};
 use namada_core::eth_bridge_pool::is_pending_transfer_key;

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -665,6 +665,7 @@ pub mod testing {
                 eth_events_queue: EthEventsQueue::default(),
                 storage_read_past_height_limit: Some(1000),
                 commit_only_data: CommitOnlyData::default(),
+                process_proposal_cache: Default::default(),
             }
         }
     }

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -4101,6 +4101,7 @@ name = "namada_state"
 version = "0.40.0"
 dependencies = [
  "borsh 1.4.0",
+ "clru",
  "itertools 0.12.1",
  "linkme",
  "namada_core",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -4124,6 +4124,7 @@ name = "namada_state"
 version = "0.40.0"
 dependencies = [
  "borsh 1.2.1",
+ "clru",
  "itertools 0.12.1",
  "namada_core",
  "namada_events",


### PR DESCRIPTION
## Describe your changes

This PR tries to improve the extra calls to process proposal requested by Namada (nothing changes for the requests coming from Comet). More specifically:

- The more complete `process_proposal` is now called instead of `process_txs`
- The `InMemory` struct has been expanded with an extra field that caches the requests to `process_proposal` for a given block so that future calls can be avoided. This cache is cleared when handling a `FinalizeBlock` request

## Indicate on which release or other PRs this topic is based on

`v0.40.0`

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
