### PR TITLE
Murisi/decode asset types

### DIFF
--- a/.changelog/unreleased/improvements/3507-decode-asset-types.md
+++ b/.changelog/unreleased/improvements/3507-decode-asset-types.md
@@ -1,0 +1,2 @@
+- Decode asset types to addresses when generating test vectors if possible.
+  ([\#3507](https://github.com/anoma/namada/pull/3507))

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -1302,7 +1302,6 @@ pub async fn to_ledger_vector(
                         "Receiver : {}",
                         transfer.message.packet_data.receiver
                     ),
-                    format!("Memo : {}", transfer.message.packet_data.memo),
                     format!(
                         "Timeout height : {}",
                         transfer.message.timeout_height_on_b
@@ -1427,9 +1426,6 @@ pub async fn to_ledger_vector(
                         transfer.message.packet_data.receiver
                     ),
                 ]);
-                if let Some(memo) = &transfer.message.packet_data.memo {
-                    tv.output.push(format!("Memo: {}", memo));
-                }
                 tv.output.extend(vec![
                     format!(
                         "Timeout height : {}",

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -1020,9 +1020,9 @@ pub async fn to_ledger_vector(
                 Error::from(EncodingError::Conversion(err.to_string()))
             })?;
 
-            tv.name = "Init_Validator_0".to_string();
+            tv.name = "Become_Validator_0".to_string();
 
-            tv.output.extend(vec!["Type : Init Validator".to_string()]);
+            tv.output.extend(vec!["Type : Become Validator".to_string()]);
             tv.output.extend(vec![
                 format!("Address : {}", init_validator.address),
                 format!("Consensus key : {}", init_validator.consensus_key),
@@ -1036,6 +1036,9 @@ pub async fn to_ledger_vector(
                 ),
                 format!("Email : {}", init_validator.email),
             ]);
+            if let Some(name) = &init_validator.name {
+                tv.output.push(format!("Name : {}", name));
+            }
             if let Some(description) = &init_validator.description {
                 tv.output.push(format!("Description : {}", description));
             }
@@ -1045,6 +1048,10 @@ pub async fn to_ledger_vector(
             if let Some(discord_handle) = &init_validator.discord_handle {
                 tv.output
                     .push(format!("Discord handle : {}", discord_handle));
+            }
+            if let Some(avatar) = &init_validator.avatar {
+                tv.output
+                    .push(format!("Avatar : {}", avatar));
             }
 
             tv.output_expert.extend(vec![
@@ -1060,6 +1067,9 @@ pub async fn to_ledger_vector(
                 ),
                 format!("Email : {}", init_validator.email),
             ]);
+            if let Some(name) = &init_validator.name {
+                tv.output_expert.push(format!("Name : {}", name));
+            }
             if let Some(description) = &init_validator.description {
                 tv.output_expert
                     .push(format!("Description : {}", description));
@@ -1070,6 +1080,10 @@ pub async fn to_ledger_vector(
             if let Some(discord_handle) = &init_validator.discord_handle {
                 tv.output_expert
                     .push(format!("Discord handle : {}", discord_handle));
+            }
+            if let Some(avatar) = &init_validator.avatar {
+                tv.output_expert
+                    .push(format!("Avatar : {}", avatar));
             }
         } else if code_sec.tag == Some(TX_INIT_PROPOSAL.to_string()) {
             let init_proposal_data = InitProposalData::try_from_slice(
@@ -1689,6 +1703,9 @@ pub async fn to_ledger_vector(
             let mut other_items = vec![];
             other_items
                 .push(format!("Validator : {}", metadata_change.validator));
+            if let Some(name) = metadata_change.name {
+                other_items.push(format!("Name : {}", name));
+            }
             if let Some(email) = metadata_change.email {
                 other_items.push(format!("Email : {}", email));
             }

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -1022,7 +1022,8 @@ pub async fn to_ledger_vector(
 
             tv.name = "Become_Validator_0".to_string();
 
-            tv.output.extend(vec!["Type : Become Validator".to_string()]);
+            tv.output
+                .extend(vec!["Type : Become Validator".to_string()]);
             tv.output.extend(vec![
                 format!("Address : {}", init_validator.address),
                 format!("Consensus key : {}", init_validator.consensus_key),
@@ -1050,8 +1051,7 @@ pub async fn to_ledger_vector(
                     .push(format!("Discord handle : {}", discord_handle));
             }
             if let Some(avatar) = &init_validator.avatar {
-                tv.output
-                    .push(format!("Avatar : {}", avatar));
+                tv.output.push(format!("Avatar : {}", avatar));
             }
 
             tv.output_expert.extend(vec![
@@ -1082,8 +1082,7 @@ pub async fn to_ledger_vector(
                     .push(format!("Discord handle : {}", discord_handle));
             }
             if let Some(avatar) = &init_validator.avatar {
-                tv.output_expert
-                    .push(format!("Avatar : {}", avatar));
+                tv.output_expert.push(format!("Avatar : {}", avatar));
             }
         } else if code_sec.tag == Some(TX_INIT_PROPOSAL.to_string()) {
             let init_proposal_data = InitProposalData::try_from_slice(
@@ -1342,7 +1341,14 @@ pub async fn to_ledger_vector(
                         "Receiver : {}",
                         transfer.message.packet_data.receiver
                     ),
-                    format!("Memo : {}", transfer.message.packet_data.memo),
+                ]);
+                if !transfer.message.packet_data.memo.to_string().is_empty() {
+                    tv.output_expert.push(format!(
+                        "Memo : {}",
+                        transfer.message.packet_data.memo
+                    ));
+                }
+                tv.output_expert.extend(vec![
                     format!(
                         "Timeout height : {}",
                         transfer.message.timeout_height_on_b
@@ -1509,7 +1515,9 @@ pub async fn to_ledger_vector(
                     ),
                 ]);
                 if let Some(memo) = &transfer.message.packet_data.memo {
-                    tv.output_expert.push(format!("Memo: {}", memo));
+                    if !memo.to_string().is_empty() {
+                        tv.output_expert.push(format!("Memo: {}", memo));
+                    }
                 }
                 tv.output_expert.extend(vec![
                     format!(

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -586,7 +586,7 @@ async fn make_ledger_amount_asset(
             ));
         } else {
             output.extend(vec![
-                format!("{}Token : {}", prefix, token),
+                format!("{}Token : {}", prefix, decoded.token),
                 format!(
                     "{}Amount : {}",
                     prefix,

--- a/crates/tx/src/data/pgf.rs
+++ b/crates/tx/src/data/pgf.rs
@@ -47,7 +47,7 @@ pub mod tests {
         /// Generate an arbitraary steward commission update
         pub fn arb_update_steward_commission()(
             steward in arb_non_internal_address(),
-            commission in collection::hash_map(arb_non_internal_address(), arb_dec(), 0..10),
+            commission in collection::btree_map(arb_non_internal_address(), arb_dec(), 0..10),
         ) -> UpdateStewardCommission {
             UpdateStewardCommission {
                 steward,

--- a/examples/generate_txs.rs
+++ b/examples/generate_txs.rs
@@ -10,7 +10,7 @@ use proptest::test_runner::{Reason, TestRunner};
 
 #[tokio::main]
 async fn main() -> Result<(), Reason> {
-    let mut runner = TestRunner::default();
+    let mut runner = TestRunner::deterministic();
     let wallet = FsWalletUtils::new(PathBuf::from("wallet.toml"));
     let mut debug_vectors = vec![];
     let mut test_vectors = vec![];


### PR DESCRIPTION
## Describe your changes
This PR makes miscellaneous improvements to the test vector generator:
* A token being transferred in a shielded `Transaction` test vector is rendered as an `AssetType` even when it can and should be decoded into an `Address`. This PR fixes that.
* This PR disables the printing of IBC memos in normal mode since its contents are usually unintelligible.
* Finally, this PR makes the generation of test vectors almost deterministic in order to allow minor changes to be easily made to the formatting of an existing test vector file.

The corresponding changes to the Ledger app are at https://github.com/Zondax/ledger-namada/pull/58 .
## Indicate on which release or other PRs this topic is based on
Namada 0.41.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
