### PR TITLE
Eliminates MASP VP's requirement for all debited accounts to sign Tx

### DIFF
--- a/.changelog/unreleased/improvements/3516-reduce-masp-vp-signatures.md
+++ b/.changelog/unreleased/improvements/3516-reduce-masp-vp-signatures.md
@@ -1,0 +1,2 @@
+- Eliminates the MASP VPs requirement for all debited accounts to sign a Tx.
+  ([\#3516](https://github.com/anoma/namada/pull/3516))


### PR DESCRIPTION
## Describe your changes
This PR attempts to eliminate the MASP VP's requirement (mentioned in https://github.com/anoma/namada/pull/3372#issuecomment-2225421559) for all debited accounts to sign a `Tx`. This is done by requiring only those accounts whose balances are modified by the inner `Transaction` and whose balances decrease to sign the transaction. The justification for this change is that in the case of accounts not modified by the inner `Transaction`, other VPs already validate all changes pertaining to the given address.

## Indicate on which release or other PRs this topic is based on
Namada 0.40.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
