### PR TITLE
[feature] Allow balance querying at specified block height

### DIFF
--- a/.changelog/unreleased/improvements/3530-balance-query-at-height.md
+++ b/.changelog/unreleased/improvements/3530-balance-query-at-height.md
@@ -1,0 +1,2 @@
+- Add optional height parameter to get_token_balance
+  ([\#3530](https://github.com/anoma/namada/pull/3530))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -6208,6 +6208,7 @@ pub mod args {
                 owner: chain_ctx.get_cached(&self.owner),
                 token: chain_ctx.get(&self.token),
                 no_conversions: self.no_conversions,
+                height: self.height,
             })
         }
     }
@@ -6218,11 +6219,13 @@ pub mod args {
             let owner = BALANCE_OWNER.parse(matches);
             let token = TOKEN.parse(matches);
             let no_conversions = NO_CONVERSIONS.parse(matches);
+            let height = BLOCK_HEIGHT_OPT.parse(matches);
             Self {
                 query,
                 owner,
                 token,
                 no_conversions,
+                height,
             }
         }
 
@@ -6240,6 +6243,10 @@ pub mod args {
                 )
                 .arg(NO_CONVERSIONS.def().help(wrap!(
                     "Whether not to automatically perform conversions."
+                )))
+                .arg(BLOCK_HEIGHT_OPT.def().help(wrap!(
+                    "The block height at which to query the balance. \
+                     (Optional)"
                 )))
         }
     }
@@ -7218,6 +7225,7 @@ pub mod args {
         type AddrOrNativeToken = WalletAddrOrNativeToken;
         type Address = WalletAddress;
         type BalanceOwner = WalletBalanceOwner;
+        type BlockHeight = BlockHeight;
         type BpConversionTable = PathBuf;
         type ConfigRpcTendermintAddress = ConfigRpcAddress;
         type Data = PathBuf;

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -206,6 +206,8 @@ async fn query_transparent_balance(
         owner,
         // The token to query
         token,
+        // Optional block height
+        height,
         ..
     } = args;
 
@@ -214,9 +216,13 @@ async fn query_transparent_balance(
         .expect("Balance owner should have been a transparent address");
 
     let token_alias = lookup_token_alias(context, &token, &owner).await;
-    let token_balance_result =
-        namada_sdk::rpc::get_token_balance(context.client(), &token, &owner)
-            .await;
+    let token_balance_result = namada_sdk::rpc::get_token_balance(
+        context.client(),
+        &token,
+        &owner,
+        height,
+    )
+    .await;
 
     match token_balance_result {
         Ok(balance) => {

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -969,6 +969,7 @@ where
             namada.client(),
             &namada.native_token(),
             &proposal.proposal.author,
+            None,
         )
         .await
         .unwrap();
@@ -999,6 +1000,7 @@ where
             namada.client(),
             &namada.native_token(),
             &proposal.proposal.author,
+            None,
         )
         .await
         .unwrap();

--- a/crates/light_sdk/src/reading/asynchronous/account.rs
+++ b/crates/light_sdk/src/reading/asynchronous/account.rs
@@ -1,5 +1,6 @@
 use namada_sdk::account::Account;
 use namada_sdk::key::common;
+use namada_sdk::storage::BlockHeight;
 
 use super::*;
 
@@ -8,13 +9,14 @@ pub async fn get_token_balance(
     tendermint_addr: &str,
     token: &Address,
     owner: &Address,
+    height: Option<BlockHeight>, // Specify block height or None for latest
 ) -> Result<token::Amount, Error> {
     let client = HttpClient::new(
         TendermintAddress::from_str(tendermint_addr)
             .map_err(|e| Error::Other(e.to_string()))?,
     )
     .map_err(|e| Error::Other(e.to_string()))?;
-    rpc::get_token_balance(&client, token, owner).await
+    rpc::get_token_balance(&client, token, owner, height).await
 }
 
 /// Check if the address exists on chain. Established address exists if it

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -110,7 +110,7 @@ impl NamadaTypes for SdkTypes {
     type AddrOrNativeToken = Address;
     type Address = Address;
     type BalanceOwner = namada_core::masp::BalanceOwner;
-    type BlockHeight = namada_core::storage::BlockHeight;
+    type BlockHeight = namada_core::chain::BlockHeight;
     type BpConversionTable = HashMap<Address, BpConversionTableEntry>;
     type ConfigRpcTendermintAddress = tendermint_rpc::Url;
     type Data = Vec<u8>;

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -87,6 +87,8 @@ pub trait NamadaTypes: Clone + std::fmt::Debug {
     type BpConversionTable: Clone + std::fmt::Debug;
     /// Address of a `namada-masp-indexer` live instance
     type MaspIndexerAddress: Clone + std::fmt::Debug;
+    /// Represents a block height
+    type BlockHeight: Clone + std::fmt::Debug;
 }
 
 /// The concrete types being used in Namada SDK
@@ -108,6 +110,7 @@ impl NamadaTypes for SdkTypes {
     type AddrOrNativeToken = Address;
     type Address = Address;
     type BalanceOwner = namada_core::masp::BalanceOwner;
+    type BlockHeight = namada_core::storage::BlockHeight;
     type BpConversionTable = HashMap<Address, BpConversionTableEntry>;
     type ConfigRpcTendermintAddress = tendermint_rpc::Url;
     type Data = Vec<u8>;
@@ -718,6 +721,7 @@ impl InitProposal {
                 context.client(),
                 &nam_address,
                 &proposal.proposal.author,
+                None,
             )
             .await?;
             let proposal = proposal
@@ -746,6 +750,7 @@ impl InitProposal {
                 context.client(),
                 &nam_address,
                 &proposal.proposal.author,
+                None,
             )
             .await?;
             let proposal = proposal
@@ -1604,6 +1609,8 @@ pub struct QueryBalance<C: NamadaTypes = SdkTypes> {
     pub token: C::Address,
     /// Whether not to convert balances
     pub no_conversions: bool,
+    /// Optional height to query balances at
+    pub height: Option<C::BlockHeight>,
 }
 
 /// Query historical transfer(s)

--- a/crates/sdk/src/queries/vp/token.rs
+++ b/crates/sdk/src/queries/vp/token.rs
@@ -54,7 +54,7 @@ where
 pub mod client_only_methods {
     use borsh::BorshDeserialize;
     use namada_core::address::Address;
-    use namada_core::storage::BlockHeight;
+    use namada_core::chain::BlockHeight;
     use namada_core::token;
     use namada_io::Client;
     use namada_token::storage_key::{balance_key, masp_total_rewards};

--- a/crates/sdk/src/queries/vp/token.rs
+++ b/crates/sdk/src/queries/vp/token.rs
@@ -54,6 +54,7 @@ where
 pub mod client_only_methods {
     use borsh::BorshDeserialize;
     use namada_core::address::Address;
+    use namada_core::storage::BlockHeight;
     use namada_core::token;
     use namada_io::Client;
     use namada_token::storage_key::{balance_key, masp_total_rewards};
@@ -62,12 +63,14 @@ pub mod client_only_methods {
     use crate::queries::RPC;
 
     impl Token {
-        /// Get the balance of the given `token` belonging to the given `owner`.
+        /// Get the balance of the given `token` belonging to the given `owner`,
+        /// optionally at the given `height`.
         pub async fn balance<CLIENT>(
             &self,
             client: &CLIENT,
             token: &Address,
             owner: &Address,
+            height: Option<BlockHeight>,
         ) -> Result<token::Amount, <CLIENT as Client>::Error>
         where
             CLIENT: Client + Sync,
@@ -75,7 +78,7 @@ pub mod client_only_methods {
             let balance_key = balance_key(token, owner);
             let response = RPC
                 .shell()
-                .storage_value(client, None, None, false, &balance_key)
+                .storage_value(client, None, height, false, &balance_key)
                 .await?;
 
             let balance = if response.data.is_empty() {

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -211,9 +211,10 @@ pub async fn get_token_balance<C: namada_io::Client + Sync>(
     client: &C,
     token: &Address,
     owner: &Address,
+    height: Option<namada_storage::BlockHeight>,
 ) -> Result<token::Amount, error::Error> {
     convert_response::<C, _>(
-        RPC.vp().token().balance(client, token, owner).await,
+        RPC.vp().token().balance(client, token, owner, height).await,
     )
 }
 


### PR DESCRIPTION
## Describe your changes

This adds an `Option` argument to `get_token_balance` which permits querying for balances at specific block heights. Additionally, this feature is implemented for the `namadac` CLI via the `--height` argument.

This is needed for accounting / auditing purposes and for some upcoming enhancements I will be contributing to `namada-indexer`.

This is a breaking change to the client SDK only. (The node RPC already supports this option)

Example:
```
# Query balance with unspecified height (same as existing behavior)
$ ./target/debug/namadac balance \
        --node https://rpc.namada.tududes.com:443 \
        --chain-id tududes-test.81efb06d86523ae4f \
        --token tnam1q87wtaqqtlwkw927gaff34hgda36huk0kgry692a \
        --owner tnam1qrcqrpj8r8lv6632wcwv9j0r6pp4n3xsug9hkxzx
nam: 9588921.2

# Query balance with specific height where a transaction occurred
$ ./target/debug/namadac balance \
        --node https://rpc.namada.tududes.com:443 \
        --chain-id tududes-test.81efb06d86523ae4f \
        --token tnam1q87wtaqqtlwkw927gaff34hgda36huk0kgry692a \
        --owner tnam1qrcqrpj8r8lv6632wcwv9j0r6pp4n3xsug9hkxzx \
        --height 59780
nam: 9590921.25

# Query balance with specific height just before the above transaction
$ ./target/debug/namadac balance \
        --node https://rpc.namada.tududes.com:443 \
        --chain-id tududes-test.81efb06d86523ae4f \
        --token tnam1q87wtaqqtlwkw927gaff34hgda36huk0kgry692a \
        --owner tnam1qrcqrpj8r8lv6632wcwv9j0r6pp4n3xsug9hkxzx \
        --height 59781
nam: 9589921.225
```

## Indicate on which release or other PRs this topic is based on

This is based on the current `main` branch.

## Checklist before merging to `draft`
- [x] I have added a changelog
- [ ] Git history is in acceptable state
