### PR TITLE
Use total active voting power in `query_proposal_result`

### DIFF
--- a/.changelog/unreleased/bug-fixes/3540-fix-query-proposal-result-vp.md
+++ b/.changelog/unreleased/bug-fixes/3540-fix-query-proposal-result-vp.md
@@ -1,0 +1,3 @@
+- Client fixes that include using the correct total voting power to compute a
+  proposal result and also the correct voting threshold for steward proposals.
+  ([\#3540](https://github.com/anoma/namada/pull/3540))

--- a/crates/governance/src/utils.rs
+++ b/crates/governance/src/utils.rs
@@ -63,24 +63,25 @@ impl Vote {
     }
 }
 
-/// Represent a tally type
+/// Represents a tally type that describes the voting requirements for a
+/// proposal to pass.
 #[derive(
     Copy, Debug, Clone, BorshSerialize, BorshDeserialize, BorshDeserializer,
 )]
 pub enum TallyType {
-    /// Represent a tally type for proposal requiring 2/3 of the total voting
-    /// power to be yay
+    /// The `yay` votes are at least 2/3 of the non-abstain votes, and 2/3 of
+    /// the total voting power has voted
     TwoThirds,
-    /// Represent a tally type for proposal requiring 1/2 of yay votes over at
-    /// least 1/3 of the voting power
+    /// There are more `yay` votes than `nay` votes, and at least 1/3 of the
+    /// total voting power has voted
     OneHalfOverOneThird,
-    /// Represent a tally type for proposal requiring less than 1/2 of nay
-    /// votes over at least 1/3 of the voting power
+    /// Either less than 1/3 of the total voting power voted, or there are more
+    /// `yay` votes than `nay` votes
     LessOneHalfOverOneThirdNay,
 }
 
 impl TallyType {
-    /// Compute the type of tally for a proposal
+    /// The type of tally used for each proposal type
     pub fn from(proposal_type: ProposalType, is_steward: bool) -> Self {
         match (proposal_type, is_steward) {
             (ProposalType::Default, _) => TallyType::TwoThirds,
@@ -149,9 +150,9 @@ impl TallyResult {
                 )? >= total_voting_power
                     .mul_ceil(Dec::two_thirds())?;
 
+                // yay >= 2/3 * (yay + nay) ---> yay >= 2 * nay
                 let at_least_two_third_voted_yay = yay_voting_power
-                    >= checked!(nay_voting_power + yay_voting_power)?
-                        .mul_ceil(Dec::two_thirds())?;
+                    >= checked!(nay_voting_power + nay_voting_power)?;
 
                 at_least_two_third_voted && at_least_two_third_voted_yay
             }
@@ -230,9 +231,9 @@ impl ProposalResult {
                     >= two_thirds_power
             )?;
 
+            // nay >= 2/3 * (yay + nay) ---> nay >= 2 * yay
             let at_least_two_thirds_voted_nay = self.total_nay_power
-                >= checked!(self.total_yay_power + self.total_nay_power)?
-                    .mul_ceil(Dec::two_thirds())?;
+                >= checked!(self.total_yay_power + self.total_yay_power)?;
 
             Ok::<bool, arith::Error>(
                 at_least_two_third_voted && at_least_two_thirds_voted_nay,

--- a/crates/governance/src/utils.rs
+++ b/crates/governance/src/utils.rs
@@ -248,6 +248,7 @@ impl Display for ProposalResult {
             TallyType::TwoThirds => {
                 self.total_voting_power.mul_ceil(Dec::two_thirds())
             }
+            TallyType::LessOneHalfOverOneThirdNay => Ok(token::Amount::zero()),
             _ => self.total_voting_power.mul_ceil(Dec::one_third()),
         }
         .unwrap();

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -744,6 +744,19 @@ pub async fn get_total_staked_tokens<C: crate::queries::Client + Sync>(
     )
 }
 
+/// Get the total active voting power in the given epoch
+pub async fn get_total_active_voting_power<C: crate::queries::Client + Sync>(
+    client: &C,
+    epoch: Epoch,
+) -> Result<token::Amount, error::Error> {
+    convert_response::<C, _>(
+        RPC.vp()
+            .pos()
+            .total_active_voting_power(client, &Some(epoch))
+            .await,
+    )
+}
+
 /// Get the given validator's stake at the given epoch
 pub async fn get_validator_stake<C: crate::queries::Client + Sync>(
     client: &C,
@@ -947,8 +960,8 @@ pub async fn query_proposal_result<C: crate::queries::Client + Sync>(
                 .await
                 .unwrap_or_default();
             let tally_type = proposal.get_tally_type(is_author_pgf_steward);
-            let total_staked_token =
-                get_total_staked_tokens(client, tally_epoch)
+            let total_active_voting_power =
+                get_total_active_voting_power(client, tally_epoch)
                     .await
                     .unwrap_or_default();
 
@@ -992,7 +1005,7 @@ pub async fn query_proposal_result<C: crate::queries::Client + Sync>(
             }
             compute_proposal_result(
                 proposal_votes,
-                total_staked_token,
+                total_active_voting_power,
                 tally_type,
             )?
         }


### PR DESCRIPTION
## Describe your changes
Need to use the total active voting power instead of total deltas inside `fn query_proposal_result`.

Closes #3532.

## Indicate on which release or other PRs this topic is based on
v0.40.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
