### PR TITLE
fix possible panic in sig verification

### DIFF
--- a/.changelog/unreleased/bug-fixes/3543-fix-verify-sig-panic.md
+++ b/.changelog/unreleased/bug-fixes/3543-fix-verify-sig-panic.md
@@ -1,0 +1,2 @@
+- Fixed a possible panic in transaction signatures verification missing expected
+  signature(s). ([\#3543](https://github.com/anoma/namada/pull/3543))


### PR DESCRIPTION
## Describe your changes

The index op used to look-up signatures may fail if there isn't matching number of signatures.

## Indicate on which release or other PRs this topic is based on

v0.40.0

## Checklist before merging to `draft`
- [x] I have added a changelog
- [x] Git history is in acceptable state
