### PR TITLE
Updated get_cometbft.sh script

### DIFF
--- a/scripts/get_cometbft.sh
+++ b/scripts/get_cometbft.sh
@@ -6,7 +6,7 @@ set -Eo pipefail
 # https://github.com/tendermint/tendermint/releases/download/v0.34.13/tendermint_0.34.13_linux_amd64.tar.gz
 # https://github.com/heliaxdev/tendermint/releases/download/v0.1.1-abcipp/tendermint_0.1.0-abcipp_darwin_amd64.tar.gz
 CMT_MAJORMINOR="0.37"
-CMT_PATCH="2"
+CMT_PATCH="9"
 
 CMT_REPO="https://github.com/cometbft/cometbft"
 


### PR DESCRIPTION
## Describe your changes
Updated `get_cometbft.sh` script to v0.37.9. Very silly PR, but it prevents v0.37.2 to get installed when the `make install` command gets run. 

## Indicate on which release or other PRs this topic is based on

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [ ] Git history is in acceptable state
