### PR TITLE
test/e2e/masp: wait for first block instead of epoch

### DIFF
--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -2358,7 +2358,7 @@ fn masp_txs_and_queries() -> Result<()> {
             .background();
 
     let rpc_address = get_actor_rpc(&test, who);
-    let _ep1 = epoch_sleep(&test, &rpc_address, 720)?;
+    wait_for_block_height(&test, &rpc_address, 1, 30)?;
 
     // add necessary viewing keys to shielded context
     let mut sync = run_as!(


### PR DESCRIPTION
## Describe your changes

Sometimes the `epoch-sleep` command runs when the first epoch has already started and then fails. Instead just wait for a first block before running the tested cmds

## Indicate on which release or other PRs this topic is based on

0.41.0

## Checklist before merging to `draft`
- ~~[ ] I have added a changelog~~ - testing only
- [x] Git history is in acceptable state
