### PR TITLE
parameters/max_block_time: fallback to parameters only when no blocks

### DIFF
--- a/crates/parameters/src/lib.rs
+++ b/crates/parameters/src/lib.rs
@@ -622,18 +622,9 @@ where
         last_block_height,
         num_blocks_to_read,
     )?;
-    let max_block_time_estimate =
-        estimate_max_block_time_from_parameters(storage)?;
 
-    Ok(maybe_max_block_time.map_or(
-        max_block_time_estimate,
-        |max_block_time_over_num_blocks_to_read| {
-            std::cmp::max(
-                max_block_time_over_num_blocks_to_read,
-                max_block_time_estimate,
-            )
-        },
-    ))
+    maybe_max_block_time
+        .map_or_else(|| estimate_max_block_time_from_parameters(storage), Ok)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Describe your changes

The value estimated from parameters might be very off when the configured epoch duration is proportionally much longer than the min number of blocks in epoch in respect to block duration from configured by `timeout_commit` (comet consensus config)

## Indicate on which release or other PRs this topic is based on

0.41.0

## Checklist before merging to `draft`
- [ ] I have added a changelog
- [x] Git history is in acceptable state
