### PR TITLE
test/e2e: make slashing test more reliable

### DIFF
--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -115,7 +115,7 @@ fn run_ledger_ibc() -> Result<()> {
                 .parameters
                 .ibc_params
                 .default_per_epoch_throughput_limit = Amount::max_signed();
-            setup::set_validators(1, genesis, base_dir, |_| 0)
+            setup::set_validators(1, genesis, base_dir, |_| 0, vec![])
         };
     let (ledger_a, ledger_b, test_a, test_b) = run_two_nets(update_genesis)?;
     let _bg_ledger_a = ledger_a.background();
@@ -206,7 +206,7 @@ fn run_ledger_ibc_with_hermes() -> Result<()> {
                 .parameters
                 .ibc_params
                 .default_per_epoch_throughput_limit = Amount::max_signed();
-            setup::set_validators(1, genesis, base_dir, |_| 0)
+            setup::set_validators(1, genesis, base_dir, |_| 0, vec![])
         };
     let (ledger_a, ledger_b, test_a, test_b) = run_two_nets(update_genesis)?;
     let _bg_ledger_a = ledger_a.background();
@@ -393,7 +393,7 @@ fn ibc_namada_gaia() -> Result<()> {
                 .parameters
                 .ibc_params
                 .default_per_epoch_throughput_limit = Amount::max_signed();
-            setup::set_validators(1, genesis, base_dir, |_| 0)
+            setup::set_validators(1, genesis, base_dir, |_| 0, vec![])
         };
     let (ledger, mut ledger_b, test, _test_b) = run_two_nets(update_genesis)?;
     let _bg_ledger = ledger.background();
@@ -575,7 +575,7 @@ fn pgf_over_ibc_with_hermes() -> Result<()> {
             .parameters
             .ibc_params
             .default_per_epoch_throughput_limit = Amount::max_signed();
-        setup::set_validators(1, genesis, base_dir, |_| 0)
+        setup::set_validators(1, genesis, base_dir, |_| 0, vec![])
     };
     let (ledger_a, ledger_b, test_a, test_b) = run_two_nets(update_genesis)?;
     let _bg_ledger_a = ledger_a.background();
@@ -652,7 +652,7 @@ fn proposal_ibc_token_inflation() -> Result<()> {
                 .parameters
                 .ibc_params
                 .default_per_epoch_throughput_limit = Amount::max_signed();
-            setup::set_validators(1, genesis, base_dir, |_| 0)
+            setup::set_validators(1, genesis, base_dir, |_| 0, vec![])
         };
     let (ledger_a, ledger_b, test_a, test_b) = run_two_nets(update_genesis)?;
     let _bg_ledger_a = ledger_a.background();
@@ -744,7 +744,7 @@ fn ibc_rate_limit() -> Result<()> {
                 .ibc_params
                 .default_per_epoch_throughput_limit =
                 Amount::from_u64(1_000_000);
-            setup::set_validators(1, genesis, base_dir, |_| 0)
+            setup::set_validators(1, genesis, base_dir, |_| 0, vec![])
         };
     let (ledger_a, ledger_b, test_a, test_b) = run_two_nets(update_genesis)?;
     let _bg_ledger_a = ledger_a.background();

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -26,3 +26,34 @@ pub mod log {
 }
 
 pub use namada_sdk::*;
+
+/// A type corresponding to cometbft `FilePVLastSignState` in `privval/file.go`
+/// stored in `cometbft/data/priv_validator_state.json`
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct LastSignState {
+    // i64 encoded as a string
+    pub height: String,
+    pub round: i32,
+    pub step: i8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signbytes: Option<String>,
+}
+
+#[test]
+fn test_last_sign_state_encoding() {
+    // An example taken from `cometbft/data/priv_validate_state.json`
+    let example_state = serde_json::json!({
+      "height": "36",
+      "round": 0,
+      "step": 3,
+      "signature": "pBNefaWQtXBKXGCmiwdz3SVifEoytgoRD/Ui0JiA7giZYTwInKcLITyZLVHnZ/nbKq8CULoMrLhasAHPsS6HAw==",
+      "signbytes": "8301080211240000000000000022480A202B35C46A53F9E93AC38BDF7CAC71CAEBEC3889308BBB6012D848A67FE1756923122408011220530C5626D32F9D0D95E8494396BD510560357439BBC7B2F2F689E1246281A9C72A0C08DCE5EDB50610D2AAABCC03321E6532652D746573742E336636616131326538323736346261613631376637"
+    });
+
+    let state: LastSignState = serde_json::from_value(example_state).unwrap();
+    assert_eq!(&state.height, "36");
+    assert_eq!(state.round, 0);
+    assert_eq!(state.step, 3);
+}


### PR DESCRIPTION
## Describe your changes

- reduced the number of validators (and hence nodes) involved in the test
- added a retry mechanism:
  - Often, the `validator_0_copy` detects the duplicate votes and doesn't report them. It then stores the sig in `priv_validator_state.json` which prevents it from attempting to double sign again
  - To get around it, we try to stop the `validator_1` that owns the consensus so that it stops producing blocks while we're clearing out the signature and restarting the duplicate validator node

## Indicate on which release or other PRs this topic is based on

0.41.0
