### PR TITLE
Murisi/fix masp vp mint case

### DIFF
--- a/.changelog/unreleased/bug-fixes/3611-fix-masp-vp-mint-case.md
+++ b/.changelog/unreleased/bug-fixes/3611-fix-masp-vp-mint-case.md
@@ -1,0 +1,2 @@
+- Fix the behavior of the MASP VP when processing an IBC Receive message
+  involves unescrowing. ([\#3611](https://github.com/anoma/namada/pull/3611))

--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -102,8 +102,9 @@ use primitives::Timestamp;
 use prost::Message;
 use thiserror::Error;
 use trace::{
-    convert_to_address, ibc_trace_for_nft, is_receiver_chain_source_str,
-    is_sender_chain_source_str,
+    convert_to_address, ibc_trace_for_nft,
+    is_receiver_chain_source as is_receiver_chain_source_str,
+    is_sender_chain_source,
 };
 
 use crate::storage::{
@@ -439,7 +440,7 @@ where
         let delta = ValueSum::from_pair(token, *amount);
         // If there is a transfer to the IBC account, then deduplicate the
         // balance increase since we already account for it below
-        if is_sender_chain_source_str(ibc_trace, src_port_id, src_channel_id) {
+        if is_sender_chain_source(ibc_trace, src_port_id, src_channel_id) {
             let ibc_taddr = addr_taddr(address::IBC);
             let post_entry = accum
                 .post

--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -390,6 +390,7 @@ where
     Ok(())
 }
 
+// Check that the packet receipt key has been changed
 fn check_packet_receiving(
     msg: &IbcMsgRecvPacket,
     keys_changed: &BTreeSet<Key>,
@@ -401,7 +402,7 @@ fn check_packet_receiving(
     );
     if !keys_changed.contains(&receipt_key) {
         return Err(namada_storage::Error::new_alloc(format!(
-            "The packet has not been received: Port ID  {}, Channel ID {}, \
+            "The packet has not been received: Port ID {}, Channel ID {}, \
              Sequence {}",
             msg.packet.port_id_on_b,
             msg.packet.chan_id_on_b,
@@ -478,7 +479,8 @@ where
     S: StorageRead,
 {
     // Ensure that the event corresponds to the current changes to storage
-    let ack_key = storage::ack_key(dst_port_id, dst_channel_id, sequence); // If the receive is a success, then the commitment is unique
+    let ack_key = storage::ack_key(dst_port_id, dst_channel_id, sequence);
+    // If the receive is a success, then the commitment is unique
     let succ_ack_commitment = compute_ack_commitment(
         &AcknowledgementStatus::success(ack_success_b64()).into(),
     );
@@ -504,8 +506,8 @@ fn apply_recv_msg<S>(
 where
     S: StorageRead,
 {
+    // First check that the packet receipt is reflecteed in the state changes
     check_packet_receiving(msg, keys_changed)?;
-
     // If the transfer was a failure, then enable funds to
     // be withdrawn from the IBC internal address
     if is_receiving_success(

--- a/crates/ibc/src/trace.rs
+++ b/crates/ibc/src/trace.rs
@@ -108,13 +108,24 @@ pub fn is_nft_trace(
     }
 }
 
-/// Return true if the source of the given IBC trace is this chain
-pub fn is_sender_chain_source(
+/// Returns true if the denomination originally came from the sender chain, and
+/// false otherwise.
+pub fn is_sender_chain_source_str(
     trace: impl AsRef<str>,
     src_port_id: &PortId,
     src_channel_id: &ChannelId,
 ) -> bool {
-    !trace
+    !is_receiver_chain_source_str(trace, src_port_id, src_channel_id)
+}
+
+/// Returns true if the denomination originally came from the receiving chain,
+/// and false otherwise.
+pub fn is_receiver_chain_source_str(
+    trace: impl AsRef<str>,
+    src_port_id: &PortId,
+    src_channel_id: &ChannelId,
+) -> bool {
+    trace
         .as_ref()
         .starts_with(&format!("{src_port_id}/{src_channel_id}"))
 }

--- a/crates/ibc/src/trace.rs
+++ b/crates/ibc/src/trace.rs
@@ -110,17 +110,17 @@ pub fn is_nft_trace(
 
 /// Returns true if the denomination originally came from the sender chain, and
 /// false otherwise.
-pub fn is_sender_chain_source_str(
+pub fn is_sender_chain_source(
     trace: impl AsRef<str>,
     src_port_id: &PortId,
     src_channel_id: &ChannelId,
 ) -> bool {
-    !is_receiver_chain_source_str(trace, src_port_id, src_channel_id)
+    !is_receiver_chain_source(trace, src_port_id, src_channel_id)
 }
 
 /// Returns true if the denomination originally came from the receiving chain,
 /// and false otherwise.
-pub fn is_receiver_chain_source_str(
+pub fn is_receiver_chain_source(
     trace: impl AsRef<str>,
     src_port_id: &PortId,
     src_channel_id: &ChannelId,

--- a/crates/shielded_token/src/vp.rs
+++ b/crates/shielded_token/src/vp.rs
@@ -673,7 +673,7 @@ fn validate_transparent_input<A: Authorization>(
                 .checked_sub(&ValueSum::from_pair(asset.token.clone(), amount))
                 .ok_or_else(|| {
                     Error::NativeVpError(native_vp::Error::SimpleMessage(
-                        "Overflow in bundle balance",
+                        "Underflow in bundle balance",
                     ))
                 })?;
         }
@@ -703,7 +703,7 @@ fn validate_transparent_input<A: Authorization>(
                     .checked_sub(&ValueSum::from_pair(token.clone(), amount))
                     .ok_or_else(|| {
                         Error::NativeVpError(native_vp::Error::SimpleMessage(
-                            "Overflow in bundle balance",
+                            "Underflow in bundle balance",
                         ))
                     })?;
             }
@@ -751,7 +751,7 @@ fn validate_transparent_output(
                 .checked_sub(&ValueSum::from_pair(asset.token.clone(), amount))
                 .ok_or_else(|| {
                     Error::NativeVpError(native_vp::Error::SimpleMessage(
-                        "Overflow in bundle balance",
+                        "Underflow in bundle balance",
                     ))
                 })?;
         }
@@ -766,7 +766,7 @@ fn validate_transparent_output(
                 .checked_sub(&ValueSum::from_pair(token.clone(), amount))
                 .ok_or_else(|| {
                     Error::NativeVpError(native_vp::Error::SimpleMessage(
-                        "Overflow in bundle balance",
+                        "Underflow in bundle balance",
                     ))
                 })?;
         }
@@ -869,7 +869,7 @@ fn apply_balance_component(
     })
 }
 
-// Verify that the pre balance + the Sapling value balance = the post balance
+// Verify that the pre balance - the Sapling value balance = the post balance
 // using the decodings in tokens and conversion_state for assistance.
 fn verify_sapling_balancing_value(
     pre: &ValueSum<Address, Amount>,

--- a/crates/systems/src/ibc.rs
+++ b/crates/systems/src/ibc.rs
@@ -29,7 +29,7 @@ pub trait Read<S> {
 /// Balances changed by a transaction
 #[derive(Default, Debug, Clone)]
 pub struct ChangedBalances {
-    /// Map between MASP transparent address and namada types
+    /// Map between MASP transparent address and Namada types
     pub decoder: BTreeMap<TransparentAddress, TAddrData>,
     /// Balances before the tx
     pub pre: BTreeMap<TransparentAddress, ValueSum<Address, token::Amount>>,

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -551,6 +551,31 @@ fn ibc_namada_gaia() -> Result<()> {
     check_balance(&test, AB_VIEWING_KEY, &ibc_denom, 40)?;
     check_gaia_balance(&test_gaia, GAIA_USER, GAIA_COIN, 810)?;
 
+    // Shielding transfer back from Gaia to Namada
+    let ibc_denom = format!("{port_id_gaia}/{channel_id_gaia}/{token_addr}");
+    let memo_path = gen_ibc_shielding_data(
+        &test,
+        AA_PAYMENT_ADDRESS,
+        &ibc_denom,
+        100,
+        &port_id_namada,
+        &channel_id_namada,
+    )?;
+    transfer_from_gaia(
+        &test_gaia,
+        GAIA_USER,
+        AA_PAYMENT_ADDRESS,
+        get_gaia_denom_hash(&ibc_denom),
+        100000000,
+        &port_id_gaia,
+        &channel_id_gaia,
+        Some(memo_path),
+    )?;
+    wait_for_packet_relay(&port_id_gaia, &channel_id_gaia, &test)?;
+
+    // Check the token on Namada
+    check_balance(&test, AA_VIEWING_KEY, APFEL, 100)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Describe your changes
Addressed some of the MASP-IBC issues brought up during an audit. More specifically, the following changes have been made:
* The IBC internal address pre-balance is now only increased when a IbcMsgReceive packet requiring minting occurs
* Modified the MASP-VP to make an early exit if non-allowed keys are modified
* Updated/corrected outdated comments

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
