### PR TITLE
Check masp action

### DIFF
--- a/.changelog/unreleased/improvements/3632-check-masp-action.md
+++ b/.changelog/unreleased/improvements/3632-check-masp-action.md
@@ -1,0 +1,2 @@
+- Masp vp and protocol now ensure that a transaction can push at most one MASP
+  action. ([\#3632](https://github.com/anoma/namada/pull/3632))

--- a/crates/governance/src/vp/mod.rs
+++ b/crates/governance/src/vp/mod.rs
@@ -1366,7 +1366,7 @@ mod test {
             .write_log_mut()
             .write(&balance_key, amount.serialize_to_vec())
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
     }
 
     #[cfg(test)]
@@ -1612,7 +1612,7 @@ mod test {
             Ok(_)
         );
 
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().unwrap();
 
         let governance_balance_key = balance_key(&nam(), &ADDRESS);
@@ -2330,7 +2330,7 @@ mod test {
             Ok(_)
         );
 
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().unwrap();
 
         let height = state.in_mem().get_block_height().0 + (7 * 2);
@@ -2459,7 +2459,7 @@ mod test {
             Ok(_)
         );
 
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().unwrap();
 
         let height = state.in_mem().get_block_height().0 + (7 * 2);
@@ -2588,7 +2588,7 @@ mod test {
             Ok(_)
         );
 
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().unwrap();
 
         let height = state.in_mem().get_block_height().0 + (7 * 2);
@@ -2717,7 +2717,7 @@ mod test {
             Ok(_)
         );
 
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().unwrap();
 
         let height = state.in_mem().get_block_height().0 + (9 * 2);
@@ -2863,7 +2863,7 @@ mod test {
             Ok(_)
         );
 
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().unwrap();
 
         let height = state.in_mem().get_block_height().0 + (10 * 2);
@@ -3009,7 +3009,7 @@ mod test {
             Ok(_)
         );
 
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().unwrap();
 
         let height = state.in_mem().get_block_height().0 + (10 * 2);

--- a/crates/ibc/src/vp/mod.rs
+++ b/crates/ibc/src/vp/mod.rs
@@ -721,7 +721,7 @@ mod tests {
             .write_log_mut()
             .write(&client_update_height_key, host_height.encode_vec())
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
     }
 
     fn get_connection_id() -> ConnectionId {
@@ -1146,7 +1146,7 @@ mod tests {
         let mut keys_changed = BTreeSet::new();
         let mut state = init_storage();
         insert_init_client(&mut state);
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
 
         // for next block
@@ -1270,7 +1270,7 @@ mod tests {
         let mut keys_changed = BTreeSet::new();
         let mut state = init_storage();
         insert_init_client(&mut state);
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -1473,7 +1473,7 @@ mod tests {
         let mut keys_changed = BTreeSet::new();
         let mut state = init_storage();
         insert_init_client(&mut state);
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -1602,7 +1602,7 @@ mod tests {
             .write_log_mut()
             .write(&conn_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -1711,7 +1711,7 @@ mod tests {
             .write_log_mut()
             .write(&conn_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -1807,7 +1807,7 @@ mod tests {
             .write_log_mut()
             .write(&conn_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -1929,7 +1929,7 @@ mod tests {
             .write_log_mut()
             .write(&conn_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -2059,7 +2059,7 @@ mod tests {
             .write_log_mut()
             .write(&channel_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -2166,7 +2166,7 @@ mod tests {
             .write_log_mut()
             .write(&channel_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -2279,7 +2279,7 @@ mod tests {
             .write_log_mut()
             .write(&balance_key, amount.serialize_to_vec())
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -2424,7 +2424,7 @@ mod tests {
             .write_log_mut()
             .write(&channel_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -2669,7 +2669,7 @@ mod tests {
             .write_log_mut()
             .write(&commitment_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -2832,7 +2832,7 @@ mod tests {
             .write_log_mut()
             .write(&commitment_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -2989,7 +2989,7 @@ mod tests {
             .write_log_mut()
             .write(&commitment_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -3131,7 +3131,7 @@ mod tests {
             .write(&metadata_key, metadata.serialize_to_vec())
             .expect("write failed");
 
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state
@@ -3283,7 +3283,7 @@ mod tests {
             .write_log_mut()
             .write(&channel_key, bytes)
             .expect("write failed");
-        state.write_log_mut().commit_batch();
+        state.write_log_mut().commit_batch_and_current_tx();
         state.commit_block().expect("commit failed");
         // for next block
         state

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -405,7 +405,11 @@ where
                     let actions =
                         state.read_actions().map_err(Error::StateError)?;
                     if let Some(masp_section_ref) =
-                        action::get_masp_section_ref(&actions)
+                        action::get_masp_section_ref(&actions).expect(
+                            "A valid MASP transaction cannot push more than \
+                             one MASP action: this should be prevented by the \
+                             MASP VP",
+                        )
                     {
                         extended_tx_result
                             .masp_tx_refs
@@ -754,7 +758,11 @@ where
                     && result.is_accepted()
                 {
                     if let Some(masp_tx_id) =
-                        action::get_masp_section_ref(&actions)
+                        action::get_masp_section_ref(&actions).expect(
+                            "A valid MASP transaction cannot push more than \
+                             one MASP action: this should be prevented by the \
+                             MASP VP",
+                        )
                     {
                         Some(MaspTxResult {
                             tx_result: result,

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -405,11 +405,13 @@ where
                     let actions =
                         state.read_actions().map_err(Error::StateError)?;
                     if let Some(masp_section_ref) =
-                        action::get_masp_section_ref(&actions).expect(
-                            "A valid MASP transaction cannot push more than \
-                             one MASP action: this should be prevented by the \
-                             MASP VP",
-                        )
+                        action::get_masp_section_ref(&actions).map_err(
+                            |msg| {
+                                Error::StateError(state::Error::Temporary {
+                                    error: msg.to_string(),
+                                })
+                            },
+                        )?
                     {
                         extended_tx_result
                             .masp_tx_refs
@@ -492,7 +494,10 @@ where
     // Commit tx to the block write log even in case of subsequent errors (if
     // the fee payment failed instead, than the previous two functions must
     // have propagated an error)
-    shell_params.state.write_log_mut().commit_batch();
+    shell_params
+        .state
+        .write_log_mut()
+        .commit_batch_and_current_tx();
 
     let (batch_results, masp_section_refs) = payment_result.map_or_else(
         || (TxResult::default(), None),
@@ -757,13 +762,14 @@ where
                 if is_masp_transfer(&result.changed_keys)
                     && result.is_accepted()
                 {
-                    if let Some(masp_tx_id) =
-                        action::get_masp_section_ref(&actions).expect(
-                            "A valid MASP transaction cannot push more than \
-                             one MASP action: this should be prevented by the \
-                             MASP VP",
-                        )
-                    {
+                    if let Some(masp_tx_id) = action::get_masp_section_ref(
+                        &actions,
+                    )
+                    .map_err(|msg| {
+                        Error::StateError(state::Error::Temporary {
+                            error: msg.to_string(),
+                        })
+                    })? {
                         Some(MaspTxResult {
                             tx_result: result,
                             masp_section_ref: Either::Left(masp_tx_id),

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -392,7 +392,7 @@ where
                     .extend(Code(ResultCode::InvalidTx));
                 // Drop the batch write log which could contain invalid data.
                 // Important data that could be valid (e.g. a valid fee payment)
-                // must have already been moved to the bloc kwrite log by now
+                // must have already been moved to the block write log by now
                 self.state.write_log_mut().drop_batch();
             }
             Err(dispatch_error) => {

--- a/crates/node/src/shell/prepare_proposal.rs
+++ b/crates/node/src/shell/prepare_proposal.rs
@@ -142,7 +142,7 @@ where
                 );
                 match result {
                     Ok(gas) => {
-                        temp_state.write_log_mut().commit_batch();
+                        temp_state.write_log_mut().commit_batch_and_current_tx();
                         Some((tx_bytes.to_owned(), gas))
                     },
                     Err(()) => {

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -153,7 +153,7 @@ where
                 );
                 let error_code = ResultCode::from_u32(result.code).unwrap();
                 if let ResultCode::Ok = error_code {
-                    temp_state.write_log_mut().commit_batch();
+                    temp_state.write_log_mut().commit_batch_and_current_tx();
                 } else {
                     tracing::info!(
                         "Process proposal rejected an invalid tx. Error code: \

--- a/crates/shielded_token/src/vp.rs
+++ b/crates/shielded_token/src/vp.rs
@@ -416,14 +416,14 @@ where
             tx
         } else {
             // Get the Transaction object from the actions
-            let masp_section_ref = namada_tx::action::get_masp_section_ref(
-                &actions,
-            )
-            .ok_or_else(|| {
-                native_vp::Error::new_const(
-                    "Missing MASP section reference in action",
-                )
-            })?;
+            let masp_section_ref =
+                namada_tx::action::get_masp_section_ref(&actions)
+                    .map_err(native_vp::Error::new_const)?
+                    .ok_or_else(|| {
+                        native_vp::Error::new_const(
+                            "Missing MASP section reference in action",
+                        )
+                    })?;
             batched_tx
                 .tx
                 .get_masp_section(&masp_section_ref)

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -694,7 +694,7 @@ where
     /// Commit the current transaction's write log and the entire batch to the
     /// block. Starts a new transaction and batch write log.
     pub fn commit_tx_batch(&mut self) {
-        self.write_log.commit_batch()
+        self.write_log.commit_batch_and_current_tx()
     }
 
     /// Drop the current transaction's write log when it's declined by any of


### PR DESCRIPTION
## Describe your changes

Changes `get_masp_section_ref` to return an error if more than one MASP action is found (MASP VP doesn't handle multiple `Transaction` objects).
Also adjusts the logic, in case of an error propagation from tx execution, to prevent committing the changes applied by the failed tx.

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
