### PR TITLE
Add birthdays to MASP keys

### DIFF
--- a/.changelog/unreleased/features/3653-masp-key-birthdays.md
+++ b/.changelog/unreleased/features/3653-masp-key-birthdays.md
@@ -1,0 +1,4 @@
+ - Partially addresses Issue [\#2900](https://github.com/anoma/namada/issues/2900). Viewing and spending keys can now
+   be given birthdays in the form of block heights which are loaded into 
+   shielded sync. Shielded sync will not try to decrypt a block before a 
+   keys birthday with said key. ([\#3653](https://github.com/anoma/namada/pull/3653))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -3256,7 +3256,6 @@ pub mod args {
         arg_opt("success-sleep");
     pub const DATA_PATH_OPT: ArgOpt<PathBuf> = arg_opt("data-path");
     pub const DATA_PATH: Arg<PathBuf> = arg("data-path");
-    pub const DATED_VIEWING_KEY: Arg<WalletDatedViewingKey> = arg("key");
     pub const DB_KEY: Arg<String> = arg("db-key");
     pub const DB_COLUMN_FAMILY: ArgDefault<String> = arg_default(
         "db-column-family",
@@ -6984,8 +6983,6 @@ pub mod args {
         type BpConversionTable = PathBuf;
         type ConfigRpcTendermintAddress = ConfigRpcAddress;
         type Data = PathBuf;
-        type DatedSpendingKey = WalletDatedSpendingKey;
-        type DatedViewingKey = WalletDatedViewingKey;
         type EthereumAddress = String;
         type Keypair = WalletKeypair;
         type MaspIndexerAddress = String;
@@ -7342,7 +7339,8 @@ pub mod args {
                 find_viewing_key(&mut wallet)
             } else {
                 find_viewing_key(&mut ctx.borrow_mut_chain_or_exit().wallet)
-            };
+            }
+            .key;
 
             Ok(PayAddressGen::<SdkTypes> {
                 alias: self.alias,
@@ -7356,7 +7354,7 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
-            let viewing_key = DATED_VIEWING_KEY.parse(matches);
+            let viewing_key = VIEWING_KEY.parse(matches);
             Self {
                 alias,
                 alias_force,
@@ -7371,7 +7369,7 @@ pub mod args {
             .arg(ALIAS_FORCE.def().help(wrap!(
                 "Override the alias without confirmation if it already exists."
             )))
-            .arg(DATED_VIEWING_KEY.def().help(wrap!("The viewing key.")))
+            .arg(VIEWING_KEY.def().help(wrap!("The viewing key.")))
         }
     }
 

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -3211,6 +3211,7 @@ pub mod args {
             Err(_) => config::get_default_namada_folder(),
         }),
     );
+    pub const BIRTHDAY: ArgOpt<BlockHeight> = arg_opt("birthday");
     pub const BLOCK_HEIGHT: Arg<BlockHeight> = arg("block-height");
     pub const BLOCK_HEIGHT_OPT: ArgOpt<BlockHeight> = arg_opt("height");
     pub const BLOCK_HEIGHT_FROM_OPT: ArgOpt<BlockHeight> =
@@ -3255,6 +3256,7 @@ pub mod args {
         arg_opt("success-sleep");
     pub const DATA_PATH_OPT: ArgOpt<PathBuf> = arg_opt("data-path");
     pub const DATA_PATH: Arg<PathBuf> = arg("data-path");
+    pub const DATED_VIEWING_KEY: Arg<WalletDatedViewingKey> = arg("key");
     pub const DB_KEY: Arg<String> = arg("db-key");
     pub const DB_COLUMN_FAMILY: ArgDefault<String> = arg_default(
         "db-column-family",
@@ -6982,6 +6984,8 @@ pub mod args {
         type BpConversionTable = PathBuf;
         type ConfigRpcTendermintAddress = ConfigRpcAddress;
         type Data = PathBuf;
+        type DatedSpendingKey = WalletDatedSpendingKey;
+        type DatedViewingKey = WalletDatedViewingKey;
         type EthereumAddress = String;
         type Keypair = WalletKeypair;
         type MaspIndexerAddress = String;
@@ -7352,7 +7356,7 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
-            let viewing_key = VIEWING_KEY.parse(matches);
+            let viewing_key = DATED_VIEWING_KEY.parse(matches);
             Self {
                 alias,
                 alias_force,
@@ -7367,7 +7371,7 @@ pub mod args {
             .arg(ALIAS_FORCE.def().help(wrap!(
                 "Override the alias without confirmation if it already exists."
             )))
-            .arg(VIEWING_KEY.def().help(wrap!("The viewing key.")))
+            .arg(DATED_VIEWING_KEY.def().help(wrap!("The viewing key.")))
         }
     }
 
@@ -7377,6 +7381,7 @@ pub mod args {
             let shielded = SHIELDED.parse(matches);
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
+            let birthday = BIRTHDAY.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             let derivation_path = HD_DERIVATION_PATH.parse(matches);
             let allow_non_compliant =
@@ -7396,6 +7401,7 @@ pub mod args {
                 prompt_bip39_passphrase,
                 use_device,
                 device_transport,
+                birthday,
             }
         }
 
@@ -7417,6 +7423,11 @@ pub mod args {
                     "Force overwrite the alias if it already exists."
                 )),
             )
+            .arg(BIRTHDAY.def().help(wrap!(
+                "A block height after which this key is being created. Used \
+                 for optimizing MASP operations. If none is provided, \
+                 defaults to the first block height."
+            )))
             .arg(UNSAFE_DONT_ENCRYPT.def().help(wrap!(
                 "UNSAFE: Do not encrypt the keypair. Do not use this for keys \
                  used in a live network."
@@ -7465,6 +7476,7 @@ pub mod args {
             let raw = RAW_KEY_GEN.parse(matches);
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
+            let birthday = BIRTHDAY.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             let derivation_path = HD_DERIVATION_PATH.parse(matches);
             let allow_non_compliant =
@@ -7477,6 +7489,7 @@ pub mod args {
                 raw,
                 alias,
                 alias_force,
+                birthday,
                 unsafe_dont_encrypt,
                 derivation_path,
                 allow_non_compliant,
@@ -7508,6 +7521,11 @@ pub mod args {
             .arg(ALIAS.def().help(wrap!("The key and address alias.")))
             .arg(ALIAS_FORCE.def().help(wrap!(
                 "Override the alias without confirmation if it already exists."
+            )))
+            .arg(BIRTHDAY.def().help(wrap!(
+                "A block height after which this key is being created. Used \
+                 for optimizing MASP operations. If none is provided, \
+                 defaults to the first block height."
             )))
             .arg(UNSAFE_DONT_ENCRYPT.def().help(wrap!(
                 "UNSAFE: Do not encrypt the keypair. Do not use this for keys \
@@ -7680,11 +7698,13 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
+            let birthday = BIRTHDAY.parse(matches);
             let value = VALUE.parse(matches);
             let unsafe_dont_encrypt = UNSAFE_DONT_ENCRYPT.parse(matches);
             Self {
                 alias,
                 alias_force,
+                birthday,
                 value,
                 unsafe_dont_encrypt,
             }
@@ -7698,6 +7718,11 @@ pub mod args {
             )
             .arg(ALIAS_FORCE.def().help(wrap!(
                 "Override the alias without confirmation if it already exists."
+            )))
+            .arg(BIRTHDAY.def().help(wrap!(
+                "A block height after which this key is being created. Used \
+                 for optimizing MASP operations. If none is provided, \
+                 defaults to the first block height."
             )))
             .arg(VALUE.def().help(wrap!(
                 "Any value of the following:\n- transparent pool secret \

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -3256,6 +3256,10 @@ pub mod args {
         arg_opt("success-sleep");
     pub const DATA_PATH_OPT: ArgOpt<PathBuf> = arg_opt("data-path");
     pub const DATA_PATH: Arg<PathBuf> = arg("data-path");
+    pub const DATED_SPENDING_KEYS: ArgMulti<WalletDatedSpendingKey, GlobStar> =
+        arg_multi("spending-keys");
+    pub const DATED_VIEWING_KEYS: ArgMulti<WalletDatedViewingKey, GlobStar> =
+        arg_multi("viewing-keys");
     pub const DB_KEY: Arg<String> = arg("db-key");
     pub const DB_COLUMN_FAMILY: ArgDefault<String> = arg_default(
         "db-column-family",
@@ -6599,8 +6603,8 @@ pub mod args {
             let ledger_address = CONFIG_RPC_LEDGER_ADDRESS.parse(matches);
             let start_query_height = BLOCK_HEIGHT_FROM_OPT.parse(matches);
             let last_query_height = BLOCK_HEIGHT_TO_OPT.parse(matches);
-            let spending_keys = SPENDING_KEYS.parse(matches);
-            let viewing_keys = VIEWING_KEYS.parse(matches);
+            let spending_keys = DATED_SPENDING_KEYS.parse(matches);
+            let viewing_keys = DATED_VIEWING_KEYS.parse(matches);
             let with_indexer = WITH_INDEXER.parse(matches);
             Self {
                 ledger_address,
@@ -6622,13 +6626,17 @@ pub mod args {
                         .def()
                         .help(wrap!("Option block height to sync from.")),
                 )
-                .arg(SPENDING_KEYS.def().help(wrap!(
+                .arg(DATED_SPENDING_KEYS.def().help(wrap!(
                     "List of new spending keys with which to check note \
-                     ownership. These will be added to the shielded context."
+                     ownership. These will be added to the shielded context. \
+                     Appending \"<<$BLOCKHEIGHT\" to the end of each key adds \
+                     a birthday."
                 )))
-                .arg(VIEWING_KEYS.def().help(wrap!(
+                .arg(DATED_VIEWING_KEYS.def().help(wrap!(
                     "List of new viewing keys with which to check note \
-                     ownership. These will be added to the shielded context."
+                     ownership. These will be added to the shielded context. \
+                     Appending \"<<$BLOCKHEIGHT\" to the end of each key adds \
+                     a birthday."
                 )))
                 .arg(WITH_INDEXER.def().help(wrap!(
                     "Address of a `namada-masp-indexer` live instance. If \
@@ -6983,6 +6991,8 @@ pub mod args {
         type BpConversionTable = PathBuf;
         type ConfigRpcTendermintAddress = ConfigRpcAddress;
         type Data = PathBuf;
+        type DatedSpendingKey = WalletDatedSpendingKey;
+        type DatedViewingKey = WalletDatedViewingKey;
         type EthereumAddress = String;
         type Keypair = WalletKeypair;
         type MaspIndexerAddress = String;

--- a/crates/apps_lib/src/cli/client.rs
+++ b/crates/apps_lib/src/cli/client.rs
@@ -350,7 +350,6 @@ impl CliApi {
                             .wallet
                             .get_viewing_keys()
                             .values()
-                            .cloned()
                             .map(|vk| vk.map(|vk| vk.as_viewing_key()))
                             .chain(args.viewing_keys.into_iter().map(|vk| {
                                 DatedKeypair::from(vk.as_viewing_key())

--- a/crates/apps_lib/src/cli/client.rs
+++ b/crates/apps_lib/src/cli/client.rs
@@ -2,7 +2,6 @@ use std::io::Read;
 
 use color_eyre::eyre::Result;
 use namada_sdk::io::Io;
-use namada_sdk::wallet::DatedKeypair;
 use namada_sdk::{display_line, Namada, NamadaImpl};
 
 use crate::cli;
@@ -350,15 +349,9 @@ impl CliApi {
                             .wallet
                             .get_viewing_keys()
                             .values()
+                            .copied()
+                            .chain(args.viewing_keys)
                             .map(|vk| vk.map(|vk| vk.as_viewing_key()))
-                            .chain(args.viewing_keys.into_iter().map(|vk| {
-                                DatedKeypair::from(vk.as_viewing_key())
-                            }))
-                            .collect::<Vec<_>>();
-                        let sks = args
-                            .spending_keys
-                            .into_iter()
-                            .map(|sk| sk.into())
                             .collect::<Vec<_>>();
                         crate::client::masp::syncing(
                             chain_ctx.shielded,
@@ -367,7 +360,7 @@ impl CliApi {
                             &io,
                             args.start_query_height,
                             args.last_query_height,
-                            &sks,
+                            &args.spending_keys,
                             &vks,
                         )
                         .await?;

--- a/crates/apps_lib/src/cli/client.rs
+++ b/crates/apps_lib/src/cli/client.rs
@@ -1,8 +1,8 @@
 use std::io::Read;
 
 use color_eyre::eyre::Result;
-use masp_primitives::zip32::ExtendedFullViewingKey;
 use namada_sdk::io::Io;
+use namada_sdk::wallet::DatedKeypair;
 use namada_sdk::{display_line, Namada, NamadaImpl};
 
 use crate::cli;
@@ -350,10 +350,10 @@ impl CliApi {
                             .wallet
                             .get_viewing_keys()
                             .values()
-                            .copied()
-                            .map(|vk| ExtendedFullViewingKey::from(vk).fvk.vk)
+                            .cloned()
+                            .map(|vk| vk.map(|vk| vk.as_viewing_key()))
                             .chain(args.viewing_keys.into_iter().map(|vk| {
-                                ExtendedFullViewingKey::from(vk).fvk.vk
+                                DatedKeypair::from(vk.as_viewing_key())
                             }))
                             .collect::<Vec<_>>();
                         let sks = args

--- a/crates/apps_lib/src/cli/context.rs
+++ b/crates/apps_lib/src/cli/context.rs
@@ -14,8 +14,7 @@ use namada_sdk::io::Io;
 use namada_sdk::key::*;
 use namada_sdk::masp::fs::FsShieldedUtils;
 use namada_sdk::masp::{ShieldedContext, *};
-use namada_sdk::wallet::store::{DatedSpendingKey, DatedViewingKey};
-use namada_sdk::wallet::Wallet;
+use namada_sdk::wallet::{DatedSpendingKey, DatedViewingKey, Wallet};
 use namada_sdk::{Namada, NamadaImpl};
 
 use super::args;

--- a/crates/apps_lib/src/cli/context.rs
+++ b/crates/apps_lib/src/cli/context.rs
@@ -14,6 +14,7 @@ use namada_sdk::io::Io;
 use namada_sdk::key::*;
 use namada_sdk::masp::fs::FsShieldedUtils;
 use namada_sdk::masp::{ShieldedContext, *};
+use namada_sdk::wallet::store::{DatedSpendingKey, DatedViewingKey};
 use namada_sdk::wallet::Wallet;
 use namada_sdk::{Namada, NamadaImpl};
 
@@ -45,6 +46,10 @@ pub type WalletAddrOrNativeToken = FromContext<AddrOrNativeToken>;
 /// spending key in the wallet
 pub type WalletSpendingKey = FromContext<ExtendedSpendingKey>;
 
+/// A raw dated extended spending key (bech32m encoding) or an alias of an
+/// extended spending key in the wallet
+pub type WalletDatedSpendingKey = FromContext<DatedSpendingKey>;
+
 /// A raw payment address (bech32m encoding) or an alias of a payment address
 /// in the wallet
 pub type WalletPaymentAddr = FromContext<PaymentAddress>;
@@ -52,6 +57,10 @@ pub type WalletPaymentAddr = FromContext<PaymentAddress>;
 /// A raw full viewing key (bech32m encoding) or an alias of a full viewing key
 /// in the wallet
 pub type WalletViewingKey = FromContext<ExtendedViewingKey>;
+
+/// A raw full dated viewing key (bech32m encoding) or an alias of a full
+/// viewing key in the wallet
+pub type WalletDatedViewingKey = FromContext<DatedViewingKey>;
 
 /// A raw address or a raw extended spending key (bech32m encoding) or an alias
 /// of either in the wallet
@@ -571,12 +580,47 @@ impl ArgFromMutContext for ExtendedSpendingKey {
             // Or it is a stored alias of one
             ctx.wallet
                 .find_spending_key(raw, None)
+                .map(|k| k.key)
+                .map_err(|_find_err| format!("Unknown spending key {}", raw))
+        })
+    }
+}
+
+impl ArgFromMutContext for DatedSpendingKey {
+    fn arg_from_mut_ctx(
+        ctx: &mut ChainContext,
+        raw: impl AsRef<str>,
+    ) -> Result<Self, String> {
+        let raw = raw.as_ref();
+        // Either the string is a raw extended spending key
+        FromStr::from_str(raw).or_else(|_parse_err| {
+            // Or it is a stored alias of one
+            ctx.wallet
+                .find_spending_key(raw, None)
                 .map_err(|_find_err| format!("Unknown spending key {}", raw))
         })
     }
 }
 
 impl ArgFromMutContext for ExtendedViewingKey {
+    fn arg_from_mut_ctx(
+        ctx: &mut ChainContext,
+        raw: impl AsRef<str>,
+    ) -> Result<Self, String> {
+        let raw = raw.as_ref();
+        // Either the string is a raw full viewing key
+        FromStr::from_str(raw).or_else(|_parse_err| {
+            // Or it is a stored alias of one
+            ctx.wallet
+                .find_viewing_key(raw)
+                .copied()
+                .map(|k| k.key)
+                .map_err(|_find_err| format!("Unknown viewing key {}", raw))
+        })
+    }
+}
+
+impl ArgFromMutContext for DatedViewingKey {
     fn arg_from_mut_ctx(
         ctx: &mut ChainContext,
         raw: impl AsRef<str>,

--- a/crates/apps_lib/src/cli/wallet.rs
+++ b/crates/apps_lib/src/cli/wallet.rs
@@ -329,7 +329,7 @@ fn payment_address_gen(
 ) {
     let mut wallet = load_wallet(ctx);
     let alias = alias.to_lowercase();
-    let viewing_key = viewing_key.key.as_viewing_key();
+    let viewing_key = viewing_key.as_viewing_key();
     let (div, _g_d) = find_valid_diversifier(&mut OsRng);
     let masp_payment_addr = viewing_key
         .to_payment_address(div)

--- a/crates/apps_lib/src/cli/wallet.rs
+++ b/crates/apps_lib/src/cli/wallet.rs
@@ -9,7 +9,7 @@ use borsh_ext::BorshSerializeExt;
 use color_eyre::eyre::Result;
 use itertools::sorted;
 use ledger_namada_rs::{BIP44Path, NamadaApp};
-use masp_primitives::zip32::ExtendedFullViewingKey;
+use namada_core::storage::BlockHeight;
 use namada_sdk::address::{Address, DecodeError};
 use namada_sdk::io::Io;
 use namada_sdk::key::*;
@@ -193,6 +193,7 @@ fn shielded_key_derive(
         allow_non_compliant,
         prompt_bip39_passphrase,
         use_device,
+        birthday,
         ..
     }: args::KeyDerive,
 ) {
@@ -216,6 +217,7 @@ fn shielded_key_derive(
             .derive_store_spending_key_from_mnemonic_code(
                 alias,
                 alias_force,
+                birthday,
                 derivation_path,
                 None,
                 prompt_bip39_passphrase,
@@ -254,6 +256,7 @@ fn shielded_key_gen(
         derivation_path,
         allow_non_compliant,
         prompt_bip39_passphrase,
+        birthday,
         ..
     }: args::KeyGen,
 ) {
@@ -261,7 +264,13 @@ fn shielded_key_gen(
     let alias = alias.to_lowercase();
     let password = read_and_confirm_encryption_password(unsafe_dont_encrypt);
     let alias = if raw {
-        wallet.gen_store_spending_key(alias, password, alias_force, &mut OsRng)
+        wallet.gen_store_spending_key(
+            alias,
+            birthday,
+            password,
+            alias_force,
+            &mut OsRng,
+        )
     } else {
         let derivation_path = decode_shielded_derivation_path(derivation_path)
             .unwrap_or_else(|err| {
@@ -281,9 +290,10 @@ fn shielded_key_gen(
             &mut OsRng,
             prompt_bip39_passphrase,
         );
-        wallet.derive_store_hd_spendind_key(
+        wallet.derive_store_hd_spending_key(
             alias,
             alias_force,
+            birthday,
             seed,
             derivation_path,
             password,
@@ -319,7 +329,7 @@ fn payment_address_gen(
 ) {
     let mut wallet = load_wallet(ctx);
     let alias = alias.to_lowercase();
-    let viewing_key = ExtendedFullViewingKey::from(viewing_key).fvk.vk;
+    let viewing_key = viewing_key.key.as_viewing_key();
     let (div, _g_d) = find_valid_diversifier(&mut OsRng);
     let masp_payment_addr = viewing_key
         .to_payment_address(div)
@@ -346,6 +356,7 @@ fn shielded_key_address_add(
     io: &impl Io,
     alias: String,
     alias_force: bool,
+    birthday: Option<BlockHeight>,
     masp_value: MaspValue,
     unsafe_dont_encrypt: bool,
 ) {
@@ -354,7 +365,7 @@ fn shielded_key_address_add(
     let (alias, typ) = match masp_value {
         MaspValue::FullViewingKey(viewing_key) => {
             let alias = wallet
-                .insert_viewing_key(alias, viewing_key, alias_force)
+                .insert_viewing_key(alias, viewing_key, birthday, alias_force)
                 .unwrap_or_else(|| {
                     edisplay_line!(io, "Viewing key not added");
                     cli::safe_exit(1);
@@ -369,6 +380,7 @@ fn shielded_key_address_add(
                     alias,
                     alias_force,
                     spending_key,
+                    birthday,
                     password,
                     None,
                 )
@@ -444,8 +456,8 @@ async fn transparent_key_and_address_derive(
         allow_non_compliant,
         prompt_bip39_passphrase,
         use_device,
-        shielded: _,
         device_transport,
+        ..
     }: args::KeyDerive,
 ) {
     let mut wallet = load_wallet(ctx);
@@ -788,6 +800,7 @@ fn add_key_or_address(
     io: &impl Io,
     alias: String,
     alias_force: bool,
+    birthday: Option<BlockHeight>,
     value: KeyAddrAddValue,
     unsafe_dont_encrypt: bool,
 ) {
@@ -813,6 +826,7 @@ fn add_key_or_address(
             io,
             alias,
             alias_force,
+            birthday,
             masp_value,
             unsafe_dont_encrypt,
         ),
@@ -827,8 +841,8 @@ fn key_address_add(
         alias,
         alias_force,
         value,
+        birthday,
         unsafe_dont_encrypt,
-        ..
     }: args::KeyAddressAdd,
 ) {
     let value = KeyAddrAddValue::from_str(&value).unwrap_or_else(|err| {
@@ -836,7 +850,15 @@ fn key_address_add(
         display_line!(io, "No changes are persisted. Exiting.");
         cli::safe_exit(1)
     });
-    add_key_or_address(ctx, io, alias, alias_force, value, unsafe_dont_encrypt)
+    add_key_or_address(
+        ctx,
+        io,
+        alias,
+        alias_force,
+        birthday,
+        value,
+        unsafe_dont_encrypt,
+    )
 }
 
 /// Remove keys and addresses
@@ -1293,6 +1315,7 @@ fn key_import(
             io,
             alias,
             alias_force,
+            None,
             masp_value,
             unsafe_dont_encrypt,
         );

--- a/crates/apps_lib/src/client/masp.rs
+++ b/crates/apps_lib/src/client/masp.rs
@@ -14,6 +14,7 @@ use namada_sdk::masp::utils::{
 use namada_sdk::masp::{IndexedNoteEntry, ShieldedContext, ShieldedUtils};
 use namada_sdk::queries::Client;
 use namada_sdk::storage::BlockHeight;
+use namada_sdk::wallet::DatedKeypair;
 use namada_sdk::{display, display_line, MaybeSend, MaybeSync};
 
 #[allow(clippy::too_many_arguments)]
@@ -29,7 +30,7 @@ pub async fn syncing<
     start_query_height: Option<BlockHeight>,
     last_query_height: Option<BlockHeight>,
     sks: &[ExtendedSpendingKey],
-    fvks: &[ViewingKey],
+    fvks: &[DatedKeypair<ViewingKey>],
 ) -> Result<ShieldedContext<U>, Error> {
     if indexer_addr.is_some() {
         display_line!(

--- a/crates/apps_lib/src/client/masp.rs
+++ b/crates/apps_lib/src/client/masp.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use color_eyre::owo_colors::OwoColorize;
 use masp_primitives::sapling::ViewingKey;
-use masp_primitives::zip32::ExtendedSpendingKey;
 use namada_sdk::error::Error;
 use namada_sdk::io::Io;
 use namada_sdk::masp::utils::{
@@ -14,7 +13,7 @@ use namada_sdk::masp::utils::{
 use namada_sdk::masp::{IndexedNoteEntry, ShieldedContext, ShieldedUtils};
 use namada_sdk::queries::Client;
 use namada_sdk::storage::BlockHeight;
-use namada_sdk::wallet::DatedKeypair;
+use namada_sdk::wallet::{DatedKeypair, DatedSpendingKey};
 use namada_sdk::{display, display_line, MaybeSend, MaybeSync};
 
 #[allow(clippy::too_many_arguments)]
@@ -29,7 +28,7 @@ pub async fn syncing<
     io: &IO,
     start_query_height: Option<BlockHeight>,
     last_query_height: Option<BlockHeight>,
-    sks: &[ExtendedSpendingKey],
+    sks: &[DatedSpendingKey],
     fvks: &[DatedKeypair<ViewingKey>],
 ) -> Result<ShieldedContext<U>, Error> {
     if indexer_addr.is_some() {

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -397,7 +397,7 @@ fn prepare_ibc_tx_and_ctx(bench_name: &str) -> (BenchShieldedCtx, BatchedTx) {
             shielded_ctx.shell.commit_block();
             shielded_ctx.generate_shielded_action(
                 Amount::native_whole(10),
-                TransferSource::ExtendedSpendingKey(albert_spending_key),
+                TransferSource::ExtendedSpendingKey(albert_spending_key.key),
                 defaults::bertha_address().to_string(),
             )
         }
@@ -575,12 +575,12 @@ fn setup_storage_for_masp_verification(
         ),
         "unshielding" => shielded_ctx.generate_masp_tx(
             amount,
-            TransferSource::ExtendedSpendingKey(albert_spending_key),
+            TransferSource::ExtendedSpendingKey(albert_spending_key.key),
             TransferTarget::Address(defaults::albert_address()),
         ),
         "shielded" => shielded_ctx.generate_masp_tx(
             amount,
-            TransferSource::ExtendedSpendingKey(albert_spending_key),
+            TransferSource::ExtendedSpendingKey(albert_spending_key.key),
             TransferTarget::PaymentAddress(bertha_payment_addr),
         ),
         _ => panic!("Unexpected bench test"),

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use masp_primitives::asset_type::AssetType;
+use masp_primitives::sapling::ViewingKey;
 use masp_primitives::transaction::TransparentAddress;
 use namada_macros::BorshDeserializer;
 #[cfg(feature = "migrations")]
@@ -256,6 +257,11 @@ impl ExtendedViewingKey {
     pub fn decode_bytes(bytes: &[u8]) -> Result<Self, std::io::Error> {
         masp_primitives::zip32::ExtendedFullViewingKey::read(&mut &bytes[..])
             .map(Self)
+    }
+
+    /// Get the underlying viewing key
+    pub fn as_viewing_key(&self) -> ViewingKey {
+        self.0.fvk.vk
     }
 }
 

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -1042,6 +1042,7 @@ impl Default for BenchShieldedCtx {
                     .wallet
                     .find_viewing_key(viewing_alias)
                     .unwrap()
+                    .key
                     .to_string(),
             );
             let viewing_key = ExtendedFullViewingKey::from(

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -1017,11 +1017,13 @@ impl Default for BenchShieldedCtx {
         chain_ctx.wallet.gen_store_spending_key(
             ALBERT_SPENDING_KEY.to_string(),
             None,
+            None,
             true,
             &mut OsRng,
         );
         chain_ctx.wallet.gen_store_spending_key(
             BERTHA_SPENDING_KEY.to_string(),
+            None,
             None,
             true,
             &mut OsRng,
@@ -1091,7 +1093,7 @@ impl BenchShieldedCtx {
                 &StdIo,
                 None,
                 None,
-                &[spending_key.into()],
+                &[spending_key.key.into()],
                 &[],
             ))
             .unwrap();

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -28,8 +28,8 @@ use zeroize::Zeroizing;
 use crate::eth_bridge::bridge_pool;
 use crate::ibc::core::host::types::identifiers::{ChannelId, PortId};
 use crate::signing::SigningTxData;
-use crate::wallet::store::{DatedSpendingKey, DatedViewingKey};
 use crate::{rpc, tx, Namada};
+use crate::wallet::{DatedSpendingKey, DatedViewingKey};
 
 /// [`Duration`](StdDuration) wrapper that provides a
 /// method to parse a value from a string.

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -28,6 +28,7 @@ use zeroize::Zeroizing;
 use crate::eth_bridge::bridge_pool;
 use crate::ibc::core::host::types::identifiers::{ChannelId, PortId};
 use crate::signing::SigningTxData;
+use crate::wallet::{DatedSpendingKey, DatedViewingKey};
 use crate::{rpc, tx, Namada};
 
 /// [`Duration`](StdDuration) wrapper that provides a
@@ -66,6 +67,10 @@ pub trait NamadaTypes: Clone + std::fmt::Debug {
     type ViewingKey: Clone + std::fmt::Debug;
     /// Represents a shielded spending key
     type SpendingKey: Clone + std::fmt::Debug;
+    /// Represents a shielded viewing key
+    type DatedViewingKey: Clone + std::fmt::Debug;
+    /// Represents a shielded spending key
+    type DatedSpendingKey: Clone + std::fmt::Debug;
     /// Represents a shielded payment address
     type PaymentAddress: Clone + std::fmt::Debug;
     /// Represents the owner of a balance
@@ -106,6 +111,8 @@ impl NamadaTypes for SdkTypes {
     type BpConversionTable = HashMap<Address, BpConversionTableEntry>;
     type ConfigRpcTendermintAddress = tendermint_rpc::Url;
     type Data = Vec<u8>;
+    type DatedSpendingKey = DatedSpendingKey;
+    type DatedViewingKey = DatedViewingKey;
     type EthereumAddress = ();
     type Keypair = namada_core::key::common::SecretKey;
     type MaspIndexerAddress = ();
@@ -2125,9 +2132,9 @@ pub struct ShieldedSync<C: NamadaTypes = SdkTypes> {
     /// Height to sync up to. Defaults to most recent
     pub last_query_height: Option<BlockHeight>,
     /// Spending keys used to determine note ownership
-    pub spending_keys: Vec<C::SpendingKey>,
+    pub spending_keys: Vec<C::DatedSpendingKey>,
     /// Viewing keys used to determine note ownership
-    pub viewing_keys: Vec<C::ViewingKey>,
+    pub viewing_keys: Vec<C::DatedViewingKey>,
     /// Address of a `namada-masp-indexer` live instance
     ///
     /// If present, the shielded sync will be performed

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -29,7 +29,6 @@ use crate::eth_bridge::bridge_pool;
 use crate::ibc::core::host::types::identifiers::{ChannelId, PortId};
 use crate::signing::SigningTxData;
 use crate::{rpc, tx, Namada};
-use crate::wallet::{DatedSpendingKey, DatedViewingKey};
 
 /// [`Duration`](StdDuration) wrapper that provides a
 /// method to parse a value from a string.
@@ -65,12 +64,8 @@ pub trait NamadaTypes: Clone + std::fmt::Debug {
     type EthereumAddress: Clone + std::fmt::Debug;
     /// Represents a shielded viewing key
     type ViewingKey: Clone + std::fmt::Debug;
-    /// Represents a shielded viewing key along with a birthday
-    type DatedViewingKey: Clone + std::fmt::Debug;
     /// Represents a shielded spending key
     type SpendingKey: Clone + std::fmt::Debug;
-    /// Represents a shielded spending key along with a birthday
-    type DatedSpendingKey: Clone + std::fmt::Debug;
     /// Represents a shielded payment address
     type PaymentAddress: Clone + std::fmt::Debug;
     /// Represents the owner of a balance
@@ -111,8 +106,6 @@ impl NamadaTypes for SdkTypes {
     type BpConversionTable = HashMap<Address, BpConversionTableEntry>;
     type ConfigRpcTendermintAddress = tendermint_rpc::Url;
     type Data = Vec<u8>;
-    type DatedSpendingKey = DatedSpendingKey;
-    type DatedViewingKey = DatedViewingKey;
     type EthereumAddress = ();
     type Keypair = namada_core::key::common::SecretKey;
     type MaspIndexerAddress = ();
@@ -2613,7 +2606,7 @@ pub struct PayAddressGen<C: NamadaTypes = SdkTypes> {
     /// Whether to force overwrite the alias
     pub alias_force: bool,
     /// Viewing key
-    pub viewing_key: C::DatedViewingKey,
+    pub viewing_key: C::ViewingKey,
 }
 
 /// Bridge pool batch recommendation.

--- a/crates/sdk/src/wallet/keys.rs
+++ b/crates/sdk/src/wallet/keys.rs
@@ -1,12 +1,13 @@
 //! Cryptographic keys for digital signatures support for the wallet.
 
-use std::fmt::Display;
+use core::fmt::Display;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use data_encoding::HEXLOWER;
+use namada_core::storage::BlockHeight;
 use orion::{aead, kdf};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -111,6 +112,121 @@ pub enum DeserializeStoredKeypairError {
     InvalidStoredKeypairString(String),
     #[error("The stored keypair is missing a prefix")]
     MissingPrefix,
+}
+
+#[allow(missing_docs)]
+#[derive(Error, Debug)]
+pub enum DeserializeDatedKeypairError {
+    #[error("The stored keypair is not valid: {0}")]
+    InvalidKeypairString(String),
+    #[error("The stored keypair contains an invalid birthday: {0}")]
+    InvalidBirthday(String),
+}
+
+/// A keypair with a block height after which it was created
+#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub struct DatedKeypair<T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    /// The keypair itself
+    pub key: T,
+    /// A blockheight that precedes the creation of the keypair
+    pub birthday: BlockHeight,
+}
+
+impl<T> Copy for DatedKeypair<T> where
+    T: Copy + BorshSerialize + BorshDeserialize
+{
+}
+
+impl<T> Clone for DatedKeypair<T>
+where
+    T: Clone + BorshSerialize + BorshDeserialize,
+{
+    fn clone(&self) -> Self {
+        Self {
+            key: self.key.clone(),
+            birthday: self.birthday,
+        }
+    }
+}
+
+impl<T> DatedKeypair<T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    /// Create a new dated keypair. If no birthday is provided,
+    /// defaults to the first blockheight.
+    pub fn new(key: T, birthday: Option<BlockHeight>) -> Self {
+        Self {
+            key,
+            birthday: birthday.unwrap_or_else(BlockHeight::first),
+        }
+    }
+
+    /// Map the inner key type while maintaining the birthday.
+    pub fn map<U, F>(self, func: F) -> DatedKeypair<U>
+    where
+        F: Fn(T) -> U,
+        U: BorshSerialize + BorshDeserialize,
+    {
+        DatedKeypair {
+            key: func(self.key),
+            birthday: self.birthday,
+        }
+    }
+}
+
+impl<T> From<T> for DatedKeypair<T>
+where
+    T: BorshSerialize + BorshDeserialize,
+{
+    fn from(key: T) -> Self {
+        Self::new(key, None)
+    }
+}
+
+impl<T> Display for DatedKeypair<T>
+where
+    T: BorshSerialize + BorshDeserialize + Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}<<{}", self.key, self.birthday,)
+    }
+}
+
+impl<T> FromStr for DatedKeypair<T>
+where
+    T: Serialize + BorshSerialize + BorshDeserialize + FromStr,
+    <T as FromStr>::Err: Display,
+{
+    type Err = DeserializeDatedKeypairError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut pieces = s.split("<<");
+        let key_ser = pieces.next().ok_or(
+            DeserializeDatedKeypairError::InvalidKeypairString(
+                "Provided string was empty".to_string(),
+            ),
+        )?;
+        let birthday = pieces
+            .next()
+            .map(|b| {
+                BlockHeight::from_str(b).map_err(|_| {
+                    DeserializeDatedKeypairError::InvalidBirthday(b.to_string())
+                })
+            })
+            .transpose()?;
+        Ok(Self::new(
+            T::from_str(key_ser).map_err(|e| {
+                DeserializeDatedKeypairError::InvalidKeypairString(
+                    e.to_string(),
+                )
+            })?,
+            birthday,
+        ))
+    }
 }
 
 /// An encrypted keypair stored in a wallet

--- a/crates/sdk/src/wallet/keys.rs
+++ b/crates/sdk/src/wallet/keys.rs
@@ -1,12 +1,13 @@
 //! Cryptographic keys for digital signatures support for the wallet.
 
-use core::fmt::Display;
+use std::fmt::Display;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use borsh_ext::BorshSerializeExt;
 use data_encoding::HEXLOWER;
+use namada_core::masp::{ExtendedSpendingKey, ExtendedViewingKey};
 use namada_core::storage::BlockHeight;
 use orion::{aead, kdf};
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,11 @@ use crate::wallet::WalletIo;
 
 const ENCRYPTED_KEY_PREFIX: &str = "encrypted:";
 const UNENCRYPTED_KEY_PREFIX: &str = "unencrypted:";
+
+/// Type alias for a viewing key with a birthday.
+pub type DatedViewingKey = DatedKeypair<ExtendedViewingKey>;
+/// Type alias for a spending key with a birthday.
+pub type DatedSpendingKey = DatedKeypair<ExtendedSpendingKey>;
 
 /// A keypair stored in a wallet
 #[derive(Debug)]

--- a/crates/sdk/src/wallet/mod.rs
+++ b/crates/sdk/src/wallet/mod.rs
@@ -21,6 +21,7 @@ use namada_core::key::*;
 use namada_core::masp::{
     ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress,
 };
+use namada_core::storage::BlockHeight;
 use namada_core::time::DateTimeUtc;
 use namada_ibc::trace::is_ibc_denom;
 pub use pre_genesis::gen_key_to_store;
@@ -31,9 +32,12 @@ use thiserror::Error;
 use zeroize::Zeroizing;
 
 pub use self::derivation_path::{DerivationPath, DerivationPathError};
-pub use self::keys::{DecryptionError, StoredKeypair};
+pub use self::keys::{DatedKeypair, DecryptionError, StoredKeypair};
 pub use self::store::{ConfirmationResponse, ValidatorData, ValidatorKeys};
-use crate::wallet::store::{derive_hd_secret_key, derive_hd_spending_key};
+use crate::wallet::store::{
+    derive_hd_secret_key, derive_hd_spending_key, DatedSpendingKey,
+    DatedViewingKey,
+};
 
 const DISPOSABLE_KEY_LIFETIME_IN_SECONDS: i64 = 7 * 24 * 60 * 60; // 1 week
 
@@ -257,7 +261,7 @@ pub struct Wallet<U> {
     utils: U,
     store: Store,
     decrypted_key_cache: HashMap<Alias, common::SecretKey>,
-    decrypted_spendkey_cache: HashMap<Alias, ExtendedSpendingKey>,
+    decrypted_spendkey_cache: HashMap<Alias, DatedSpendingKey>,
 }
 
 impl<U> From<Wallet<U>> for Store {
@@ -419,7 +423,7 @@ impl<U> Wallet<U> {
     pub fn find_viewing_key(
         &self,
         alias: impl AsRef<str>,
-    ) -> Result<&ExtendedViewingKey, FindKeyError> {
+    ) -> Result<&DatedViewingKey, FindKeyError> {
         self.store.find_viewing_key(alias.as_ref()).ok_or_else(|| {
             FindKeyError::KeyNotFound(alias.as_ref().to_string())
         })
@@ -484,7 +488,7 @@ impl<U> Wallet<U> {
     }
 
     /// Get all known viewing keys by their alias
-    pub fn get_viewing_keys(&self) -> HashMap<String, ExtendedViewingKey> {
+    pub fn get_viewing_keys(&self) -> HashMap<String, DatedViewingKey> {
         self.store
             .get_viewing_keys()
             .iter()
@@ -495,7 +499,7 @@ impl<U> Wallet<U> {
     /// Get all known viewing keys by their alias
     pub fn get_spending_keys(
         &self,
-    ) -> HashMap<String, &StoredKeypair<ExtendedSpendingKey>> {
+    ) -> HashMap<String, &StoredKeypair<DatedSpendingKey>> {
         self.store
             .get_spending_keys()
             .iter()
@@ -544,10 +548,12 @@ impl<U: WalletIo> Wallet<U> {
     /// provided, will prompt for password from stdin.
     /// Stores the key in decrypted key cache and returns the alias of the key
     /// and a reference-counting pointer to the key.
+    #[allow(clippy::too_many_arguments)]
     pub fn derive_store_spending_key_from_mnemonic_code(
         &mut self,
         alias: String,
         alias_force: bool,
+        birthday: Option<BlockHeight>,
         derivation_path: DerivationPath,
         mnemonic_passphrase: Option<(Mnemonic, Zeroizing<String>)>,
         prompt_bip39_passphrase: bool,
@@ -573,6 +579,7 @@ impl<U: WalletIo> Wallet<U> {
             alias,
             alias_force,
             spend_key,
+            birthday,
             password,
             Some(derivation_path),
         )
@@ -633,13 +640,21 @@ impl<U: WalletIo> Wallet<U> {
     pub fn gen_store_spending_key(
         &mut self,
         alias: String,
+        birthday: Option<BlockHeight>,
         password: Option<Zeroizing<String>>,
         force_alias: bool,
         csprng: &mut (impl CryptoRng + RngCore),
     ) -> Option<(String, ExtendedSpendingKey)> {
         let spend_key = gen_spending_key(csprng);
-        self.insert_spending_key(alias, force_alias, spend_key, password, None)
-            .map(|alias| (alias, spend_key))
+        self.insert_spending_key(
+            alias,
+            force_alias,
+            spend_key,
+            birthday,
+            password,
+            None,
+        )
+        .map(|alias| (alias, spend_key))
     }
 
     /// Generate a new keypair, derive an implicit address from its public key
@@ -736,14 +751,20 @@ impl<U: WalletIo> Wallet<U> {
     /// into the store with the provided alias, converted to lower case. If the
     /// alias already exists, optionally force overwrite the key for the
     /// alias.
+    ///
+    /// An optional birthday can be provided saying that this key was created
+    /// after this blockheight.
+    ///
     /// If no encryption password is provided, the key will be stored raw
     /// without encryption.
+    ///
     /// Stores the key in decrypted key cache and returns the alias of the key
     /// and the key itself.
-    pub fn derive_store_hd_spendind_key(
+    pub fn derive_store_hd_spending_key(
         &mut self,
         alias: String,
         force_alias: bool,
+        birthday: Option<BlockHeight>,
         seed: Seed,
         derivation_path: DerivationPath,
         password: Option<Zeroizing<String>>,
@@ -754,6 +775,7 @@ impl<U: WalletIo> Wallet<U> {
             alias,
             force_alias,
             spend_key,
+            birthday,
             password,
             Some(derivation_path),
         )
@@ -886,7 +908,7 @@ impl<U: WalletIo> Wallet<U> {
         &mut self,
         alias: impl AsRef<str>,
         password: Option<Zeroizing<String>>,
-    ) -> Result<ExtendedSpendingKey, FindKeyError> {
+    ) -> Result<DatedSpendingKey, FindKeyError> {
         // Try cache first
         if let Some(cached_key) = self
             .decrypted_spendkey_cache
@@ -1082,10 +1104,16 @@ impl<U: WalletIo> Wallet<U> {
         &mut self,
         alias: String,
         view_key: ExtendedViewingKey,
+        birthday: Option<BlockHeight>,
         force_alias: bool,
     ) -> Option<String> {
         self.store
-            .insert_viewing_key::<U>(alias.into(), view_key, force_alias)
+            .insert_viewing_key::<U>(
+                alias.into(),
+                view_key,
+                birthday,
+                force_alias,
+            )
             .map(Into::into)
     }
 
@@ -1095,6 +1123,7 @@ impl<U: WalletIo> Wallet<U> {
         alias: String,
         force_alias: bool,
         spend_key: ExtendedSpendingKey,
+        birthday: Option<BlockHeight>,
         password: Option<Zeroizing<String>>,
         path: Option<DerivationPath>,
     ) -> Option<String> {
@@ -1102,14 +1131,17 @@ impl<U: WalletIo> Wallet<U> {
             .insert_spending_key::<U>(
                 alias.into(),
                 spend_key,
+                birthday,
                 password,
                 path,
                 force_alias,
             )
             .map(|alias| {
                 // Cache the newly added key
-                self.decrypted_spendkey_cache
-                    .insert(alias.clone(), spend_key);
+                self.decrypted_spendkey_cache.insert(
+                    alias.clone(),
+                    DatedKeypair::new(spend_key, birthday),
+                );
                 alias
             })
             .map(Into::into)

--- a/crates/sdk/src/wallet/mod.rs
+++ b/crates/sdk/src/wallet/mod.rs
@@ -32,12 +32,12 @@ use thiserror::Error;
 use zeroize::Zeroizing;
 
 pub use self::derivation_path::{DerivationPath, DerivationPathError};
-pub use self::keys::{DatedKeypair, DecryptionError, StoredKeypair};
-pub use self::store::{ConfirmationResponse, ValidatorData, ValidatorKeys};
-use crate::wallet::store::{
-    derive_hd_secret_key, derive_hd_spending_key, DatedSpendingKey,
-    DatedViewingKey,
+pub use self::keys::{
+    DatedKeypair, DatedSpendingKey, DatedViewingKey, DecryptionError,
+    StoredKeypair,
 };
+pub use self::store::{ConfirmationResponse, ValidatorData, ValidatorKeys};
+use crate::wallet::store::{derive_hd_secret_key, derive_hd_spending_key};
 
 const DISPOSABLE_KEY_LIFETIME_IN_SECONDS: i64 = 7 * 24 * 60 * 60; // 1 week
 

--- a/crates/sdk/src/wallet/store.rs
+++ b/crates/sdk/src/wallet/store.rs
@@ -15,12 +15,14 @@ use namada_core::key::*;
 use namada_core::masp::{
     ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress,
 };
+use namada_core::storage::BlockHeight;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
 use super::alias::{self, Alias};
 use super::derivation_path::DerivationPath;
 use super::pre_genesis;
+use crate::wallet::keys::DatedKeypair;
 use crate::wallet::{StoredKeypair, WalletIo};
 
 /// Actions that can be taken when there is an alias conflict
@@ -58,13 +60,18 @@ pub struct ValidatorData {
     pub keys: ValidatorKeys,
 }
 
+/// Type alias for a viewing key with a birthday.
+pub type DatedViewingKey = DatedKeypair<ExtendedViewingKey>;
+/// Type alias for a spending key with a birthday.
+pub type DatedSpendingKey = DatedKeypair<ExtendedSpendingKey>;
+
 /// A Storage area for keys and addresses
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Store {
     /// Known viewing keys
-    view_keys: BTreeMap<Alias, ExtendedViewingKey>,
+    view_keys: BTreeMap<Alias, DatedViewingKey>,
     /// Known spending keys
-    spend_keys: BTreeMap<Alias, StoredKeypair<ExtendedSpendingKey>>,
+    spend_keys: BTreeMap<Alias, StoredKeypair<DatedSpendingKey>>,
     /// Payment address book
     payment_addrs: BiBTreeMap<Alias, PaymentAddress>,
     /// Cryptographic keypairs
@@ -133,7 +140,7 @@ impl Store {
     pub fn find_spending_key(
         &self,
         alias: impl AsRef<str>,
-    ) -> Option<&StoredKeypair<ExtendedSpendingKey>> {
+    ) -> Option<&StoredKeypair<DatedSpendingKey>> {
         self.spend_keys.get(&alias.into())
     }
 
@@ -141,7 +148,7 @@ impl Store {
     pub fn find_viewing_key(
         &self,
         alias: impl AsRef<str>,
-    ) -> Option<&ExtendedViewingKey> {
+    ) -> Option<&DatedViewingKey> {
         self.view_keys.get(&alias.into())
     }
 
@@ -252,14 +259,14 @@ impl Store {
     }
 
     /// Get all known viewing keys by their alias.
-    pub fn get_viewing_keys(&self) -> &BTreeMap<Alias, ExtendedViewingKey> {
+    pub fn get_viewing_keys(&self) -> &BTreeMap<Alias, DatedViewingKey> {
         &self.view_keys
     }
 
     /// Get all known spending keys by their alias.
     pub fn get_spending_keys(
         &self,
-    ) -> &BTreeMap<Alias, StoredKeypair<ExtendedSpendingKey>> {
+    ) -> &BTreeMap<Alias, StoredKeypair<DatedSpendingKey>> {
         &self.spend_keys
     }
 
@@ -368,6 +375,7 @@ impl Store {
         &mut self,
         alias: Alias,
         spendkey: ExtendedSpendingKey,
+        birthday: Option<BlockHeight>,
         password: Option<Zeroizing<String>>,
         path: Option<DerivationPath>,
         force: bool,
@@ -388,19 +396,22 @@ impl Store {
                 ConfirmationResponse::Replace => {}
                 ConfirmationResponse::Reselect(new_alias) => {
                     return self.insert_spending_key::<U>(
-                        new_alias, spendkey, password, path, false,
+                        new_alias, spendkey, birthday, password, path, false,
                     );
                 }
                 ConfirmationResponse::Skip => return None,
             }
         }
         self.remove_alias(&alias);
+
         let (spendkey_to_store, _raw_spendkey) =
-            StoredKeypair::new(spendkey, password);
+            StoredKeypair::new(DatedKeypair::new(spendkey, birthday), password);
         self.spend_keys.insert(alias.clone(), spendkey_to_store);
         // Simultaneously add the derived viewing key to ease balance viewing
-        let viewkey =
-            zip32::ExtendedFullViewingKey::from(&spendkey.into()).into();
+        let viewkey = DatedKeypair::new(
+            zip32::ExtendedFullViewingKey::from(&spendkey.into()).into(),
+            birthday,
+        );
         self.view_keys.insert(alias.clone(), viewkey);
         path.map(|p| self.derivation_paths.insert(alias.clone(), p));
         Some(alias)
@@ -411,6 +422,7 @@ impl Store {
         &mut self,
         alias: Alias,
         viewkey: ExtendedViewingKey,
+        birthday: Option<BlockHeight>,
         force: bool,
     ) -> Option<Alias> {
         // abort if the alias is reserved
@@ -427,14 +439,16 @@ impl Store {
             match U::show_overwrite_confirmation(&alias, "a viewing key") {
                 ConfirmationResponse::Replace => {}
                 ConfirmationResponse::Reselect(new_alias) => {
-                    return self
-                        .insert_viewing_key::<U>(new_alias, viewkey, false);
+                    return self.insert_viewing_key::<U>(
+                        new_alias, viewkey, birthday, false,
+                    );
                 }
                 ConfirmationResponse::Skip => return None,
             }
         }
         self.remove_alias(&alias);
-        self.view_keys.insert(alias.clone(), viewkey);
+        self.view_keys
+            .insert(alias.clone(), DatedKeypair::new(viewkey, birthday));
         Some(alias)
     }
 

--- a/crates/sdk/src/wallet/store.rs
+++ b/crates/sdk/src/wallet/store.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 use super::alias::{self, Alias};
 use super::derivation_path::DerivationPath;
 use super::pre_genesis;
-use crate::wallet::keys::DatedKeypair;
+use crate::wallet::keys::{DatedKeypair, DatedSpendingKey, DatedViewingKey};
 use crate::wallet::{StoredKeypair, WalletIo};
 
 /// Actions that can be taken when there is an alias conflict
@@ -59,11 +59,6 @@ pub struct ValidatorData {
     /// special keys for a validator
     pub keys: ValidatorKeys,
 }
-
-/// Type alias for a viewing key with a birthday.
-pub type DatedViewingKey = DatedKeypair<ExtendedViewingKey>;
-/// Type alias for a spending key with a birthday.
-pub type DatedSpendingKey = DatedKeypair<ExtendedSpendingKey>;
 
 /// A Storage area for keys and addresses
 #[derive(Serialize, Deserialize, Debug, Default)]


### PR DESCRIPTION
## Describe your changes

Partially addresses Issue #2900. Viewing and spending keys can no be given birthdays in the form of block heights which are loaded into shielded sync. Shielded sync will not try to decrypt a block before a keys birthday with said key. 

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
