### PR TITLE
Optimize building chain ctx

### DIFF
--- a/.changelog/unreleased/improvements/3655-speed-up-ctx-build.md
+++ b/.changelog/unreleased/improvements/3655-speed-up-ctx-build.md
@@ -1,0 +1,5 @@
+- Speeds up client commands on networks with massive balances.toml
+  files. Previously, to retrieve the native token of some network,
+  we had to parse these giant files. Now, we only parse the
+  necessary genesis toml files required to retrieve the native token.
+  ([\#3655](https://github.com/anoma/namada/pull/3655))

--- a/crates/apps_lib/src/cli/context.rs
+++ b/crates/apps_lib/src/cli/context.rs
@@ -162,10 +162,9 @@ impl Context {
                 let mut config =
                     Config::load(&global_args.base_dir, chain_id, None);
                 let chain_dir = global_args.base_dir.join(chain_id.as_str());
-                let genesis =
-                    genesis::chain::Finalized::read_toml_files(&chain_dir)
+                let native_token =
+                    genesis::chain::Finalized::read_native_token(&chain_dir)
                         .expect("Missing genesis files");
-                let native_token = genesis.get_native_token().clone();
                 let wallet = if wallet::exists(&chain_dir) {
                     wallet::load(&chain_dir).unwrap()
                 } else {

--- a/crates/apps_lib/src/config/genesis/chain.rs
+++ b/crates/apps_lib/src/config/genesis/chain.rs
@@ -86,6 +86,24 @@ impl Finalized {
         Ok(())
     }
 
+    /// Attempt to read the address of the native token.
+    pub fn read_native_token(input_dir: &Path) -> eyre::Result<Address> {
+        let tokens_file = input_dir.join(templates::TOKENS_FILE_NAME);
+        let parameters_file = input_dir.join(templates::PARAMETERS_FILE_NAME);
+
+        let mut tokens: FinalizedTokens = read_toml(&tokens_file, "Tokens")?;
+        let parameters: FinalizedParameters =
+            read_toml(&parameters_file, "Parameters")?;
+
+        let alias = &parameters.parameters.native_token;
+
+        Ok(tokens
+            .token
+            .remove(alias)
+            .expect("The native token must exist")
+            .address)
+    }
+
     /// Try to read all genesis and the chain metadata TOML files from the given
     /// directory.
     pub fn read_toml_files(input_dir: &Path) -> eyre::Result<Self> {


### PR DESCRIPTION
## Describe your changes

Speeds up client commands on networks with massive `balances.toml` files. Previously, to retrieve the native token of some network, we had to parse these giant files. Now, we only parse the necessary genesis `toml` files required to retrieve the native token.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
