### PR TITLE
Fix masp events

### DIFF
--- a/.changelog/unreleased/improvements/3669-fix-masp-ident.md
+++ b/.changelog/unreleased/improvements/3669-fix-masp-ident.md
@@ -1,0 +1,2 @@
+- Improved the consistency and safety of MASP events construction in protocol.
+  ([\#3669](https://github.com/anoma/namada/pull/3669))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -7108,8 +7108,7 @@ pub mod args {
             )))
             .arg(FEE_TOKEN.def().help(wrap!("The token for paying the gas")))
             .arg(GAS_LIMIT.def().help(wrap!(
-                "The multiplier of the gas limit resolution defining the \
-                 maximum amount of gas needed to run transaction."
+                "The maximum amount of gas the transaction can use."
             )))
             .arg(WALLET_ALIAS_FORCE.def().help(wrap!(
                 "Override the alias without confirmation if it already exists."

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -401,30 +401,20 @@ where
                 );
                 if is_accepted {
                     // If the transaction was a masp one append the
-                    // transaction refs for the events
-                    let actions =
-                        state.read_actions().map_err(Error::StateError)?;
-                    if let Some(masp_section_ref) =
-                        action::get_masp_section_ref(&actions).map_err(
-                            |msg| {
-                                Error::StateError(state::Error::Temporary {
-                                    error: msg.to_string(),
-                                })
-                            },
-                        )?
-                    {
-                        extended_tx_result
-                            .masp_tx_refs
-                            .0
-                            .push(masp_section_ref);
-                    }
-                    if action::is_ibc_shielding_transfer(&*state)
-                        .map_err(Error::StateError)?
-                    {
-                        extended_tx_result
-                            .ibc_tx_data_refs
-                            .0
-                            .push(*cmt.data_sechash())
+                    // transaction refs for the events.
+                    if let Some(masp_ref) = get_optional_masp_ref(state, cmt)? {
+                        match masp_ref {
+                            Either::Left(masp_section_ref) => {
+                                extended_tx_result
+                                    .masp_tx_refs
+                                    .0
+                                    .push(masp_section_ref);
+                            }
+                            Either::Right(data_sechash) => extended_tx_result
+                                .ibc_tx_data_refs
+                                .0
+                                .push(data_sechash),
+                        }
                     }
                     state.write_log_mut().commit_tx_to_batch();
                 } else {
@@ -745,7 +735,13 @@ where
                 // cause we might need to discard the effects of this valid
                 // unshield (e.g. if it unshield an amount which is not enough
                 // to pay the fees)
+                // FIXME: can join this with what we do after?
+                // FIXME: actually, I think this if is completely useless, I can
+                // bring all of its content in the else branch (None) of the
+                // next if-else
                 if !result.is_accepted() {
+                    // FIXME: review this drop, if anythign, we should do it
+                    // below before returning None
                     state.write_log_mut().drop_tx();
                     tracing::error!(
                         "The first transaction in the batch failed to pay \
@@ -754,36 +750,19 @@ where
                     );
                 }
 
-                let actions =
-                    state.read_actions().map_err(Error::StateError)?;
-
                 // Ensure that the transaction is actually a masp one, otherwise
                 // reject
+                // FIXME: also need a test for this, test that using a non masp
+                // tx to pay fees doesn't work
                 if is_masp_transfer(&result.changed_keys)
                     && result.is_accepted()
                 {
-                    if let Some(masp_tx_id) = action::get_masp_section_ref(
-                        &actions,
-                    )
-                    .map_err(|msg| {
-                        Error::StateError(state::Error::Temporary {
-                            error: msg.to_string(),
-                        })
-                    })? {
-                        Some(MaspTxResult {
+                    get_optional_masp_ref(*state, first_tx.cmt)?.map(
+                        |masp_section_ref| MaspTxResult {
                             tx_result: result,
-                            masp_section_ref: Either::Left(masp_tx_id),
-                        })
-                    } else {
-                        action::is_ibc_shielding_transfer(*state)
-                            .map_err(Error::StateError)?
-                            .then_some(MaspTxResult {
-                                tx_result: result,
-                                masp_section_ref: Either::Right(
-                                    *first_tx.cmt.data_sechash(),
-                                ),
-                            })
-                    }
+                            masp_section_ref,
+                        },
+                    )
                 } else {
                     None
                 }
@@ -811,6 +790,39 @@ where
         .map_err(|e| Error::GasError(e.to_string()))?;
 
     Ok(valid_batched_tx_result)
+}
+
+// Extract the MASP tx reference (if any) in the same order that the MASP VP
+// follows (IBC first, Actions second). The order is important to prevent
+// malicious transactions from messing up with indexers/clients. Also a
+// transaction can only be of one of the two types, not both at the same time
+// (the MASP VP accepts a single Transaction)
+fn get_optional_masp_ref<S: Read<Err = state::Error>>(
+    state: &S,
+    cmt: &TxCommitments,
+) -> Result<Option<Either<namada_sdk::masp::MaspTxId, Hash>>> {
+    let masp_ref = if action::is_ibc_shielding_transfer(state)
+        .map_err(Error::StateError)?
+    {
+        Either::Right(cmt.data_sechash().to_owned())
+    } else {
+        let actions = state.read_actions().map_err(Error::StateError)?;
+        let masp_tx_id = action::get_masp_section_ref(&actions)
+            .map_err(|msg| {
+                Error::StateError(state::Error::Temporary {
+                    error: msg.to_string(),
+                })
+            })?
+            .ok_or_else(|| {
+                Error::MissingSection(
+                    "Missing MASP section in transaction".to_string(),
+                )
+            })?;
+
+        Either::Left(masp_tx_id)
+    };
+
+    Ok(Some(masp_ref))
 }
 
 // Manage the token transfer for the fee payment. If an error is detected the

--- a/crates/shielded_token/src/vp.rs
+++ b/crates/shielded_token/src/vp.rs
@@ -410,12 +410,13 @@ where
             .data(batched_tx.cmt)
             .ok_or_err_msg("No transaction data")?;
         let actions = self.ctx.read_actions()?;
+        // Try to get the Transaction object from the tx first (IBC) and from
+        // the actions afterwards
         let shielded_tx = if let Some(tx) =
             Ibc::try_extract_masp_tx_from_envelope::<Transfer>(&tx_data)?
         {
             tx
         } else {
-            // Get the Transaction object from the actions
             let masp_section_ref =
                 namada_tx::action::get_masp_section_ref(&actions)
                     .map_err(native_vp::Error::new_const)?
@@ -424,6 +425,7 @@ where
                             "Missing MASP section reference in action",
                         )
                     })?;
+
             batched_tx
                 .tx
                 .get_masp_section(&masp_section_ref)


### PR DESCRIPTION
## Describe your changes

This PR addresses some minor issues:

- enforces the same order of retrieval for MASP data across protocol and the MASP VP
- ensures that, before extracting any possible MASP section reference from an Action, we verify that the tx was indeed a MASP one (the Action itself is not enough since it does not trigger the MASP VP)
- Adds an additional integration test to check that only MASP transaction can be used to pay fees when the payer's balance is not enough
- Improves the help message of `--gas-limit` which was still referring to the old logic using the multiplier

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
