### PR TITLE
make build: exclude fuzz targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ all-crates := $(foreach crate,$(crates), -p $(crate))
 
 
 build:
-	$(cargo) build $(jobs) --workspace --exclude namada_benchmarks
+	$(cargo) build $(jobs) --workspace --exclude namada_benchmarks --exclude namada_fuzz
 
 build-test:
 	$(cargo) +$(nightly) build --tests $(jobs)


### PR DESCRIPTION
## Describe your changes

fixes the `make build` recipe to avoid enabling `"testing"` feature from fuzz targets

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
