### PR TITLE
 Apply snapshot for state sync

### DIFF
--- a/.changelog/unreleased/improvements/3687-apply-snapshots.md
+++ b/.changelog/unreleased/improvements/3687-apply-snapshots.md
@@ -1,0 +1,7 @@
+- Addresses the remaining points of Issue [\#3307](https://github.com/anoma/namada/issues/3307)
+
+    - Implements the `OfferSnapshot` ABCI call
+    - Implements the `ApplySnapshotChunk` ABCI call
+    - Adds integration tests
+
+  ([\#3687](https://github.com/anoma/namada/pull/3687))

--- a/crates/apps_lib/src/config/mod.rs
+++ b/crates/apps_lib/src/config/mod.rs
@@ -127,6 +127,8 @@ pub struct Shell {
     /// When set, indicates after how many blocks a new snapshot
     /// will be taken (counting from the first block)
     pub blocks_between_snapshots: Option<NonZeroU64>,
+    /// Number of snapshots to keep
+    pub snapshots_to_keep: Option<NonZeroU64>,
 }
 
 impl Ledger {
@@ -156,6 +158,7 @@ impl Ledger {
                 action_at_height: None,
                 tendermint_mode: mode,
                 blocks_between_snapshots: None,
+                snapshots_to_keep: None,
             },
             cometbft: tendermint_config,
             ethereum_bridge: ethereum_bridge::ledger::Config::default(),

--- a/crates/merkle_tree/src/lib.rs
+++ b/crates/merkle_tree/src/lib.rs
@@ -804,7 +804,7 @@ impl<H: StorageHasher + Default> MerkleTree<H> {
 }
 
 /// The root hash of the merkle tree as bytes
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct MerkleRoot(pub [u8; 32]);
 
 impl From<H256> for MerkleRoot {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -184,14 +184,14 @@ impl Shell {
             Request::ListSnapshots => {
                 self.list_snapshots().map(Response::ListSnapshots)
             }
-            Request::OfferSnapshot(_) => {
-                Ok(Response::OfferSnapshot(Default::default()))
+            Request::OfferSnapshot(req) => {
+                Ok(Response::OfferSnapshot(self.offer_snapshot(req)))
             }
             Request::LoadSnapshotChunk(req) => self
                 .load_snapshot_chunk(req)
                 .map(Response::LoadSnapshotChunk),
-            Request::ApplySnapshotChunk(_) => {
-                Ok(Response::ApplySnapshotChunk(Default::default()))
+            Request::ApplySnapshotChunk(req) => {
+                Ok(Response::ApplySnapshotChunk(self.apply_snapshot_chunk(req)))
             }
         }
     }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -182,14 +182,14 @@ impl Shell {
                 Ok(Response::CheckTx(self.mempool_validate(&tx.tx, r#type)))
             }
             Request::ListSnapshots => {
-                self.list_snapshots().map(Response::ListSnapshots)
+                Ok(Response::ListSnapshots(self.list_snapshots()))
             }
             Request::OfferSnapshot(req) => {
                 Ok(Response::OfferSnapshot(self.offer_snapshot(req)))
             }
-            Request::LoadSnapshotChunk(req) => self
-                .load_snapshot_chunk(req)
-                .map(Response::LoadSnapshotChunk),
+            Request::LoadSnapshotChunk(req) => {
+                Ok(Response::LoadSnapshotChunk(self.load_snapshot_chunk(req)))
+            }
             Request::ApplySnapshotChunk(req) => {
                 Ok(Response::ApplySnapshotChunk(self.apply_snapshot_chunk(req)))
             }

--- a/crates/node/src/shell/snapshots.rs
+++ b/crates/node/src/shell/snapshots.rs
@@ -227,7 +227,7 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
             if self
                 .state
                 .db()
-                .insert_entry(&mut batch, None, &cf, &key, value)
+                .insert_entry(&mut batch, &cf, &key, value)
                 .is_err()
             {
                 return tm_response::ApplySnapshotChunk {

--- a/crates/node/src/shell/snapshots.rs
+++ b/crates/node/src/shell/snapshots.rs
@@ -19,7 +19,7 @@ pub const MAX_SENDER_STRIKES: u64 = 5;
 impl Shell<storage::PersistentDB, Sha256Hasher> {
     /// List the snapshot files held locally. Furthermore, the number
     /// of chunks, as hash of each chunk, and a hash of the chunk
-    /// metadata are provided so that syncing nodes can verify can verify
+    /// metadata are provided so that syncing nodes can verify
     /// snapshots they receive.
     pub fn list_snapshots(&self) -> tm_response::ListSnapshots {
         if self.blocks_between_snapshots.is_none() {

--- a/crates/node/src/shell/snapshots.rs
+++ b/crates/node/src/shell/snapshots.rs
@@ -1,8 +1,11 @@
+use borsh::BorshDeserialize;
 use borsh_ext::BorshSerializeExt;
+use namada_sdk::arith::checked;
 use namada_sdk::hash::{Hash, Sha256Hasher};
-use namada_sdk::state::BlockHeight;
+use namada_sdk::state::{BlockHeight, StorageRead, DB};
 
-use super::{Error, ShellResult};
+use super::{Error, ShellResult, SnapshotSync};
+use crate::facade::tendermint::abci::response::ApplySnapshotChunkResult;
 use crate::facade::tendermint::abci::types::Snapshot;
 use crate::facade::tendermint::v0_37::abci::{
     request as tm_request, response as tm_response,
@@ -10,6 +13,8 @@ use crate::facade::tendermint::v0_37::abci::{
 use crate::shell::Shell;
 use crate::storage;
 use crate::storage::{DbSnapshot, SnapshotMetadata};
+
+pub const MAX_SENDER_STRIKES: u64 = 5;
 
 impl Shell<storage::PersistentDB, Sha256Hasher> {
     /// List the snapshot files held locally. Furthermore, the number
@@ -20,18 +25,21 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
         if self.blocks_between_snapshots.is_none() {
             Ok(Default::default())
         } else {
+            tracing::info!("Request for snapshots received.");
             let snapshots = DbSnapshot::files(&self.base_dir)
                 .map_err(Error::Snapshot)?
                 .into_iter()
                 .map(|SnapshotMetadata { height, chunks, .. }| {
-                    let hash = Hash::sha256(chunks.serialize_to_vec()).0;
+                    let hashes =
+                        chunks.iter().map(|c| c.hash).collect::<Vec<_>>();
+                    let hash = Hash::sha256(hashes.serialize_to_vec()).0;
                     Snapshot {
                         height: u32::try_from(height.0).unwrap().into(),
                         format: 0,
                         #[allow(clippy::cast_possible_truncation)]
                         chunks: chunks.len() as u32,
                         hash: hash.into_iter().collect(),
-                        metadata: Default::default(),
+                        metadata: hashes.serialize_to_vec().into(),
                     }
                 })
                 .collect();
@@ -52,8 +60,196 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
             &self.base_dir,
         )
         .map_err(Error::Snapshot)?;
+        tracing::info!(
+            "Loading snapshot at height {}, chunk number {}",
+            req.height,
+            req.chunk,
+        );
         Ok(tm_response::LoadSnapshotChunk {
             chunk: chunk.into_iter().collect(),
         })
+    }
+
+    /// Decide if a snapshot should be accepted to sync the node forward in time
+    pub fn offer_snapshot(
+        &mut self,
+        req: tm_request::OfferSnapshot,
+    ) -> tm_response::OfferSnapshot {
+        match self.syncing.as_ref() {
+            None => {
+                if self.state.get_block_height().unwrap_or_default().0
+                    < u64::from(req.snapshot.height)
+                {
+                    let Ok(chunks) =
+                        Vec::<Hash>::try_from_slice(&req.snapshot.metadata)
+                    else {
+                        return tm_response::OfferSnapshot::Reject;
+                    };
+                    self.syncing = Some(SnapshotSync {
+                        next_chunk: 0,
+                        height: u64::from(req.snapshot.height).into(),
+                        expected: chunks,
+                        strikes: 0,
+                    });
+                    tracing::info!("Accepting snapshot offer");
+                    tm_response::OfferSnapshot::Accept
+                } else {
+                    tracing::info!("Rejecting snapshot offer");
+                    tm_response::OfferSnapshot::Reject
+                }
+            }
+            Some(snapshot_sync) => {
+                if snapshot_sync.height.0 < u64::from(req.snapshot.height) {
+                    let Ok(chunks) =
+                        Vec::<Hash>::try_from_slice(&req.snapshot.metadata)
+                    else {
+                        tracing::info!("Rejecting snapshot offer");
+                        return tm_response::OfferSnapshot::Reject;
+                    };
+                    self.syncing = Some(SnapshotSync {
+                        next_chunk: 0,
+                        height: u64::from(req.snapshot.height).into(),
+                        expected: chunks,
+                        strikes: 0,
+                    });
+                    tracing::info!("Accepting snapshot offer");
+                    tm_response::OfferSnapshot::Accept
+                } else {
+                    tracing::info!("Rejecting snapshot offer");
+                    tm_response::OfferSnapshot::Reject
+                }
+            }
+        }
+    }
+
+    /// Write a snapshot chunk to the database
+    pub fn apply_snapshot_chunk(
+        &mut self,
+        req: tm_request::ApplySnapshotChunk,
+    ) -> tm_response::ApplySnapshotChunk {
+        let Some(snapshot_sync) = self.syncing.as_mut() else {
+            tracing::warn!("Received a snapshot although none were requested");
+            // if we are not currently syncing, abort this sync protocol
+            // the syncing status is set by `OfferSnapshot`.
+            return tm_response::ApplySnapshotChunk {
+                result: ApplySnapshotChunkResult::Abort,
+                refetch_chunks: vec![],
+                reject_senders: vec![],
+            };
+        };
+
+        // make sure we have been given the correct chunk
+        if u64::from(req.index) != snapshot_sync.next_chunk {
+            tracing::error!(
+                "Received wrong chunk, expected {}, got {}",
+                snapshot_sync.next_chunk,
+                req.index,
+            );
+            return tm_response::ApplySnapshotChunk {
+                result: ApplySnapshotChunkResult::Unknown,
+                refetch_chunks: vec![
+                    u32::try_from(snapshot_sync.next_chunk).unwrap(),
+                ],
+                reject_senders: vec![],
+            };
+        }
+
+        let Some(expected_hash) =
+            snapshot_sync.expected.get(req.index as usize)
+        else {
+            tracing::error!(
+                "Received more chunks than expected; rejecting snapshot"
+            );
+            self.syncing = None;
+            // if we get more chunks than expected, there is something wrong
+            // with this snapshot and we should reject it.
+            return tm_response::ApplySnapshotChunk {
+                result: ApplySnapshotChunkResult::RejectSnapshot,
+                refetch_chunks: vec![],
+                reject_senders: vec![],
+            };
+        };
+
+        // check that the chunk matches the expected hash, otherwise
+        // re-fetch it in case it was corrupted. If the chunk fails
+        // to validate too many times, we reject the snapshot and sender.
+        let chunk_hash = Hash::sha256(&req.chunk);
+        if *expected_hash != chunk_hash {
+            tracing::error!(
+                "Hash of chunk did not match, expected {}, got {}",
+                expected_hash,
+                chunk_hash,
+            );
+            snapshot_sync.strikes =
+                checked!(snapshot_sync.strikes + 1).unwrap();
+            if snapshot_sync.strikes == MAX_SENDER_STRIKES {
+                snapshot_sync.strikes = 0;
+                self.syncing = None;
+
+                tracing::info!(
+                    "Max number of strikes reached on chunk, rejecting \
+                     snapshot"
+                );
+                return tm_response::ApplySnapshotChunk {
+                    result: ApplySnapshotChunkResult::RejectSnapshot,
+                    refetch_chunks: vec![],
+                    reject_senders: vec![req.sender],
+                };
+            } else {
+                return tm_response::ApplySnapshotChunk {
+                    result: ApplySnapshotChunkResult::Retry,
+                    refetch_chunks: vec![req.index],
+                    reject_senders: vec![],
+                };
+            }
+        } else {
+            snapshot_sync.strikes = 0;
+        };
+        // when we first start applying a snapshot,
+        // clear the existing db.
+        if req.index == 0 {
+            self.state.db_mut().clear(snapshot_sync.height).unwrap();
+        }
+        // apply snapshot changes to the database
+        // retry if an error occurs
+        let mut batch = Default::default();
+        for (cf, key, value) in DbSnapshot::parse_chunk(&req.chunk) {
+            if self
+                .state
+                .db()
+                .insert_entry(&mut batch, None, &cf, &key, value)
+                .is_err()
+            {
+                return tm_response::ApplySnapshotChunk {
+                    result: ApplySnapshotChunkResult::Retry,
+                    refetch_chunks: vec![],
+                    reject_senders: vec![],
+                };
+            }
+        }
+        if self.state.db().exec_batch(batch).is_err() {
+            return tm_response::ApplySnapshotChunk {
+                result: ApplySnapshotChunkResult::Retry,
+                refetch_chunks: vec![],
+                reject_senders: vec![],
+            };
+        }
+
+        // increment the chunk counter
+        snapshot_sync.next_chunk =
+            checked!(snapshot_sync.next_chunk + 1).unwrap();
+        // check if all chunks have been applied
+        if snapshot_sync.next_chunk == snapshot_sync.expected.len() as u64 {
+            tracing::info!("Snapshot completely applied");
+            self.syncing = None;
+            // rebuild the in-memory state
+            self.state.load_last_state();
+        }
+
+        tm_response::ApplySnapshotChunk {
+            result: ApplySnapshotChunkResult::Accept,
+            refetch_chunks: vec![],
+            reject_senders: vec![],
+        }
     }
 }

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -30,7 +30,7 @@ use namada_sdk::queries::{
     Client, EncodedResponseQuery, RequestCtx, RequestQuery, Router, RPC,
 };
 use namada_sdk::state::{
-    LastBlock, Sha256Hasher, StorageRead, EPOCH_SWITCH_BLOCKS_DELAY,
+    LastBlock, Sha256Hasher, StorageRead, DB, EPOCH_SWITCH_BLOCKS_DELAY,
 };
 use namada_sdk::tendermint::abci::response::Info;
 use namada_sdk::tendermint::abci::types::VoteInfo;
@@ -343,6 +343,11 @@ impl MockNode {
 
     pub fn wallet_path(&self) -> PathBuf {
         self.genesis_dir().join("wallet.toml")
+    }
+
+    pub fn db_path(&self) -> PathBuf {
+        let locked = self.shell.lock().unwrap();
+        locked.state.db().path().unwrap().to_path_buf()
     }
 
     pub fn block_height(&self) -> BlockHeight {

--- a/crates/node/src/storage/mod.rs
+++ b/crates/node/src/storage/mod.rs
@@ -10,7 +10,9 @@ use arse_merkle_tree::traits::Hasher;
 use arse_merkle_tree::H256;
 use blake2b_rs::{Blake2b, Blake2bBuilder};
 use namada_sdk::state::{FullAccessState, StorageHasher};
-pub use rocksdb::{open, DbSnapshot, RocksDBUpdateVisitor, SnapshotMetadata};
+pub use rocksdb::{
+    open, Chunk, DbSnapshot, RocksDBUpdateVisitor, SnapshotMetadata,
+};
 
 #[derive(Default)]
 pub struct PersistentStorageHasher(Blake2bHasher);

--- a/crates/node/src/storage/rocksdb.rs
+++ b/crates/node/src/storage/rocksdb.rs
@@ -738,32 +738,17 @@ impl RocksDB {
             .map_err(|e| Error::DBError(e.into_string()))
     }
 
-    /// Writes an entry directly to the db
+    /// Writes an entry directly to a db batch update
+    /// directly
     pub fn insert_entry(
         &self,
         batch: &mut RocksDBWriteBatch,
-        height: Option<BlockHeight>,
         cf: &DbColFam,
         key: &Key,
         new_value: impl AsRef<[u8]>,
     ) -> Result<()> {
-        let state_cf = self.get_column_family(STATE_CF)?;
-        let last_height: BlockHeight = self
-            .read_value(state_cf, BLOCK_HEIGHT_KEY)?
-            .ok_or_else(|| {
-                Error::DBError("No block height found".to_string())
-            })?;
-        let desired_height = height.unwrap_or(last_height);
-
-        if desired_height != last_height {
-            todo!(
-                "Overwriting values at heights different than the last \
-                 committed height hast yet to be implemented"
-            );
-        }
         // NB: the following code only updates values
         // written to at the last committed height
-
         let val = new_value.as_ref();
 
         // Write the new key-val in the Db column family

--- a/crates/node/src/storage/rocksdb.rs
+++ b/crates/node/src/storage/rocksdb.rs
@@ -870,7 +870,7 @@ impl<'a> DbSnapshot<'a> {
         } in Self::files(base_dir)?
         {
             // this is correct... don't worry about it
-            if height + number_to_keep  < latest_height + 1 {
+            if checked!(height + number_to_keep <= latest_height).unwrap() {
                 let path = PathBuf::from(path_stem);
                 _ = std::fs::remove_file(&path.with_extension("snap"));
                 _ = std::fs::remove_file(path.with_extension("meta"));

--- a/crates/node/src/storage/rocksdb.rs
+++ b/crates/node/src/storage/rocksdb.rs
@@ -1750,12 +1750,11 @@ impl DB for RocksDB {
     fn overwrite_entry(
         &self,
         batch: &mut Self::WriteBatch,
-        height: Option<BlockHeight>,
         cf: &DbColFam,
         key: &Key,
         new_value: impl AsRef<[u8]>,
     ) -> Result<()> {
-        self.insert_entry(batch, height, cf, key, new_value.as_ref())?;
+        self.insert_entry(batch, cf, key, new_value.as_ref())?;
         let state_cf = self.get_column_family(STATE_CF)?;
         let last_height: BlockHeight = self
             .read_value(state_cf, BLOCK_HEIGHT_KEY)?
@@ -1850,7 +1849,7 @@ impl<'db> DBUpdateVisitor for RocksDBUpdateVisitor<'db> {
 
     fn write(&mut self, key: &Key, cf: &DbColFam, value: impl AsRef<[u8]>) {
         self.db
-            .overwrite_entry(&mut self.batch, None, cf, key, value)
+            .overwrite_entry(&mut self.batch, cf, key, value)
             .expect("Failed to overwrite a key in storage")
     }
 

--- a/crates/node/src/storage/rocksdb.rs
+++ b/crates/node/src/storage/rocksdb.rs
@@ -737,6 +737,72 @@ impl RocksDB {
             .get_cf(rollback_cf, key)
             .map_err(|e| Error::DBError(e.into_string()))
     }
+
+    /// Writes an entry directly to the db
+    pub fn insert_entry(
+        &self,
+        batch: &mut RocksDBWriteBatch,
+        height: Option<BlockHeight>,
+        cf: &DbColFam,
+        key: &Key,
+        new_value: impl AsRef<[u8]>,
+    ) -> Result<()> {
+        let state_cf = self.get_column_family(STATE_CF)?;
+        let last_height: BlockHeight = self
+            .read_value(state_cf, BLOCK_HEIGHT_KEY)?
+            .ok_or_else(|| {
+                Error::DBError("No block height found".to_string())
+            })?;
+        let desired_height = height.unwrap_or(last_height);
+
+        if desired_height != last_height {
+            todo!(
+                "Overwriting values at heights different than the last \
+                 committed height hast yet to be implemented"
+            );
+        }
+        // NB: the following code only updates values
+        // written to at the last committed height
+
+        let val = new_value.as_ref();
+
+        // Write the new key-val in the Db column family
+        let cf_name = self.get_column_family(cf.to_str())?;
+        self.add_value_bytes_to_batch(
+            cf_name,
+            key.to_string(),
+            val.to_vec(),
+            batch,
+        );
+        Ok(())
+    }
+
+    /// Erase the entire db. Use with caution.
+    pub fn clear(&mut self, height: BlockHeight) -> Result<()> {
+        let state_cf = self.get_column_family(STATE_CF)?;
+        for (_, cf) in self.column_families() {
+            let read_opts = make_iter_read_opts(None);
+            let iter =
+                self.inner
+                    .iterator_cf_opt(cf, read_opts, IteratorMode::Start);
+
+            for (key, _, _) in PersistentPrefixIterator(
+                PrefixIterator::new(iter, String::default()),
+                // Empty string to prevent prefix stripping, the prefix is
+                // already in the enclosed iterator
+            ) {
+                self.inner
+                    .delete_cf(cf, key.as_bytes())
+                    .map_err(|e| Error::DBError(e.to_string()))?;
+            }
+        }
+        let height = height.serialize_to_vec();
+        self.inner
+            .put_cf(state_cf, BLOCK_HEIGHT_KEY, height)
+            .expect("Could not write to DB");
+
+        Ok(())
+    }
 }
 
 /// Information about a particular snapshot
@@ -841,11 +907,12 @@ impl<'a> DbSnapshot<'a> {
                     // for a given block height
                     if entry_ext == Some(meta) {
                         let metadata = std::fs::read_to_string(entry_path)?;
-                        let metadata_bytes = HEXLOWER
-                            .decode(metadata.as_bytes())
-                            .map_err(|e| {
-                                std::io::Error::new(ErrorKind::InvalidData, e)
-                            })?;
+                        let metadata_bytes = base64::decode(
+                            metadata.as_bytes(),
+                        )
+                        .map_err(|e| {
+                            std::io::Error::new(ErrorKind::InvalidData, e)
+                        })?;
                         let chunks: Vec<Chunk> =
                             BorshDeserialize::try_from_slice(
                                 &metadata_bytes[..],
@@ -930,8 +997,39 @@ impl<'a> DbSnapshot<'a> {
             .take(checked!(chunk_end - chunk_start).unwrap())
         {
             bytes.extend(line?.as_bytes());
+            bytes.push(b'\n');
         }
         Ok(bytes)
+    }
+
+    pub fn parse_chunk(chunk: &[u8]) -> ChunkIterator<'_> {
+        let reader = std::io::BufReader::new(chunk);
+        ChunkIterator {
+            lines: reader.lines(),
+        }
+    }
+}
+
+pub struct ChunkIterator<'a> {
+    lines: std::io::Lines<BufReader<&'a [u8]>>,
+}
+
+impl<'a> Iterator for ChunkIterator<'a> {
+    type Item = (DbColFam, Key, Vec<u8>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let line = self.lines.next()?.ok()?;
+        let line = line.trim();
+        let mut iter = line.split(':');
+        let cf = iter.next()?;
+        let rest = iter.next()?;
+        let mut iter = rest.split('=');
+        let key = iter.next()?;
+        let value = iter.next()?;
+        let cf = DbColFam::from_str(cf).ok()?;
+        let key = Key::parse(key).ok()?;
+        let value = base64::decode(value.as_bytes()).ok()?;
+        Some((cf, key, value))
     }
 }
 
@@ -1669,33 +1767,13 @@ impl DB for RocksDB {
         key: &Key,
         new_value: impl AsRef<[u8]>,
     ) -> Result<()> {
+        self.insert_entry(batch, height, cf, key, new_value.as_ref())?;
         let state_cf = self.get_column_family(STATE_CF)?;
         let last_height: BlockHeight = self
             .read_value(state_cf, BLOCK_HEIGHT_KEY)?
             .ok_or_else(|| {
                 Error::DBError("No block height found".to_string())
             })?;
-        let desired_height = height.unwrap_or(last_height);
-
-        if desired_height != last_height {
-            todo!(
-                "Overwriting values at heights different than the last \
-                 committed height hast yet to be implemented"
-            );
-        }
-        // NB: the following code only updates values
-        // written to at the last committed height
-
-        let val = new_value.as_ref();
-
-        // Write the new key-val in the Db column family
-        let cf_name = self.get_column_family(cf.to_str())?;
-        self.add_value_bytes_to_batch(
-            cf_name,
-            key.to_string(),
-            val.to_vec(),
-            batch,
-        );
 
         // If the CF is subspace, additionally update the diffs
         if cf == &DbColFam::SUBSPACE {
@@ -1708,7 +1786,7 @@ impl DB for RocksDB {
             self.add_value_bytes_to_batch(
                 diffs_cf,
                 diffs_key,
-                val.to_vec(),
+                new_value.as_ref().to_vec(),
                 batch,
             );
         }
@@ -2692,6 +2770,109 @@ mod test {
         db.add_block_to_batch(block, batch, true)
     }
 
+    /// Test the clear function deletes all keys from the db
+    /// and that we can still write keys to it afterward.
+    #[test]
+    fn test_clear_db() {
+        let temp = tempfile::tempdir().expect("Test failed");
+        let mut db = open(&temp, false, None).expect("Test failed");
+        let state_cf = db.get_column_family(STATE_CF).expect("Test failed");
+        db.inner
+            .put_cf(
+                state_cf,
+                BLOCK_HEIGHT_KEY,
+                BlockHeight(1).serialize_to_vec(),
+            )
+            .expect("Test failed");
+        db.write_subspace_val(
+            1.into(),
+            &Key::parse("bing/fucking/bong").expect("Test failed"),
+            [1u8; 1],
+            false,
+        )
+        .expect("Test failed");
+        db.write_subspace_val(
+            1.into(),
+            &Key::parse("ding/fucking/dong").expect("Test failed"),
+            [1u8; 1],
+            false,
+        )
+        .expect("Test failed");
+        let mut db_entries = HashMap::new();
+        for (_, cf) in db.column_families() {
+            let read_opts = make_iter_read_opts(None);
+            let iter =
+                db.inner.iterator_cf_opt(cf, read_opts, IteratorMode::Start);
+
+            for (key, raw_val, _gas) in PersistentPrefixIterator(
+                PrefixIterator::new(iter, String::default()),
+                // Empty string to prevent prefix stripping, the prefix is
+                // already in the enclosed iterator
+            ) {
+                db_entries.insert(key, raw_val);
+            }
+        }
+        let mut expected = HashMap::from([
+            ("height".to_string(), vec![1, 0, 0, 0, 0, 0, 0, 0]),
+            ("bing/fucking/bong".to_string(), vec![1u8]),
+            ("ding/fucking/dong".to_string(), vec![1u8]),
+            ("0000000000002/new/bing/fucking/bong".to_string(), vec![1u8]),
+            ("0000000000002/new/ding/fucking/dong".to_string(), vec![1u8]),
+        ]);
+        assert_eq!(db_entries, expected);
+        db.clear(2.into()).expect("Test failed");
+        let mut db_entries = HashMap::new();
+        for (_, cf) in db.column_families() {
+            let read_opts = make_iter_read_opts(None);
+            let iter =
+                db.inner.iterator_cf_opt(cf, read_opts, IteratorMode::Start);
+
+            for (key, raw_val, _gas) in PersistentPrefixIterator(
+                PrefixIterator::new(iter, String::default()),
+                // Empty string to prevent prefix stripping, the prefix is
+                // already in the enclosed iterator
+            ) {
+                db_entries.insert(key, raw_val);
+            }
+        }
+        let empty = HashMap::from([(
+            "height".to_string(),
+            vec![2u8, 0, 0, 0, 0, 0, 0, 0],
+        )]);
+        assert_eq!(db_entries, empty,);
+        db.write_subspace_val(
+            1.into(),
+            &Key::parse("bing/fucking/bong").expect("Test failed"),
+            [1u8; 1],
+            false,
+        )
+        .expect("Test failed");
+        db.write_subspace_val(
+            1.into(),
+            &Key::parse("ding/fucking/dong").expect("Test failed"),
+            [1u8; 1],
+            false,
+        )
+        .expect("Test failed");
+        let mut db_entries = HashMap::new();
+        for (_, cf) in db.column_families() {
+            let read_opts = make_iter_read_opts(None);
+            let iter =
+                db.inner.iterator_cf_opt(cf, read_opts, IteratorMode::Start);
+
+            for (key, raw_val, _gas) in PersistentPrefixIterator(
+                PrefixIterator::new(iter, String::default()),
+                // Empty string to prevent prefix stripping, the prefix is
+                // already in the enclosed iterator
+            ) {
+                db_entries.insert(key, raw_val);
+            }
+        }
+        expected.insert("height".to_string(), vec![2, 0, 0, 0, 0, 0, 0, 0]);
+
+        assert_eq!(db_entries, expected);
+    }
+
     /// Test that we chunk a series of lines
     /// up correctly based on a max chunk size.
     #[test]
@@ -2784,7 +2965,7 @@ mod test {
         let temp = tempfile::tempdir().expect("Test failed");
         let base_dir = temp.path().to_path_buf();
         let chunks = vec![Chunk::default()];
-        let chunk_bytes = HEXLOWER.encode(&chunks.serialize_to_vec());
+        let chunk_bytes = base64::encode(chunks.serialize_to_vec());
         for i in 0..4 {
             let mut path = base_dir.clone();
             path.push(format!("snapshot_{}.snap", i));
@@ -2990,10 +3171,10 @@ mod test {
             DbSnapshot::paths(1.into(), temp.path().to_path_buf());
         std::fs::write(
             &snap_file,
-            "fffffggggghh\naaaa\nbbbbb\ncc\ndddddddd".as_bytes(),
+            "fffffggggghh\naaaa\nbbbbb\ncc\ndddddddd\n".as_bytes(),
         )
         .expect("Test failed");
-        std::fs::write(meta_file, HEXLOWER.encode(&chunks.serialize_to_vec()))
+        std::fs::write(meta_file, base64::encode(chunks.serialize_to_vec()))
             .expect("Test failed");
         let chunks: Vec<_> = (0..3)
             .filter_map(|i| {
@@ -3001,9 +3182,9 @@ mod test {
             })
             .collect();
         let expected = vec![
-            "fffffggggghh".as_bytes().to_vec(),
-            "aaaabbbbb".as_bytes().to_vec(),
-            "ccdddddddd".as_bytes().to_vec(),
+            "fffffggggghh\n".as_bytes().to_vec(),
+            "aaaa\nbbbbb\n".as_bytes().to_vec(),
+            "cc\ndddddddd\n".as_bytes().to_vec(),
         ];
         assert_eq!(chunks, expected);
 
@@ -3011,5 +3192,39 @@ mod test {
         assert!(DbSnapshot::load_chunk(0.into(), 4, temp.path()).is_err());
         std::fs::remove_file(snap_file).unwrap();
         assert!(DbSnapshot::load_chunk(0.into(), 0, temp.path()).is_err());
+    }
+
+    #[test]
+    fn test_chunk_iterator() {
+        let chunk = "state:bing/fucking/bong=AQ==\nsubspace:I/AM/BATMAN=Ag==\n";
+        let iterator = DbSnapshot::parse_chunk(chunk.as_bytes());
+        let expected = vec![
+            (
+                DbColFam::STATE,
+                Key::parse("bing/fucking/bong").expect("Test failed"),
+                vec![1u8],
+            ),
+            (
+                DbColFam::SUBSPACE,
+                Key::parse("I/AM/BATMAN").expect("Test failed"),
+                vec![2u8],
+            ),
+        ];
+        let parsed: Vec<_> = iterator.collect();
+        assert_eq!(parsed, expected);
+        let bad_chunks = [
+            "bloop:bing/fucking/bong=AQ==\n",
+            "bing/fucking/bong=AQ==\n",
+            "state:bing/fucking/bong:AQ==\n",
+            "state=bing/fucking/bong=AQ==\n",
+            "state:bing/fucking/bong\n",
+            "state:#bing/fucking/bong=AQ==\n",
+            "state:bing/fucking/bong=0Z\n",
+        ];
+        for chunk in bad_chunks {
+            let iterator = DbSnapshot::parse_chunk(chunk.as_bytes());
+            let parsed: Vec<_> = iterator.collect();
+            assert!(parsed.is_empty());
+        }
     }
 }

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -486,7 +486,7 @@ where
 
     /// Load the full state at the last committed height, if any. Returns the
     /// Merkle root hash and the height of the committed block.
-    fn load_last_state(&mut self) {
+    pub fn load_last_state(&mut self) {
         if let Some(BlockStateRead {
             height,
             time,

--- a/crates/storage/src/db.rs
+++ b/crates/storage/src/db.rs
@@ -285,7 +285,6 @@ pub trait DB: Debug {
     fn overwrite_entry(
         &self,
         batch: &mut Self::WriteBatch,
-        height: Option<BlockHeight>,
         cf: &DbColFam,
         key: &Key,
         new_value: impl AsRef<[u8]>,

--- a/crates/storage/src/mockdb.rs
+++ b/crates/storage/src/mockdb.rs
@@ -619,7 +619,6 @@ impl DB for MockDB {
     fn overwrite_entry(
         &self,
         _batch: &mut Self::WriteBatch,
-        _height: Option<BlockHeight>,
         _cf: &DbColFam,
         _key: &Key,
         _new_value: impl AsRef<[u8]>,

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -1818,12 +1818,8 @@ fn apply_snapshot() -> Result<()> {
     let (node2, _services) = setup::setup()?;
     let (offer, resp) = {
         let shell = node.shell.lock().unwrap();
-        let offer = shell
-            .list_snapshots()
-            .expect("Test failed")
-            .snapshots
-            .pop()
-            .expect("Test failed");
+        let offer =
+            shell.list_snapshots().snapshots.pop().expect("Test failed");
         let mut shell = node2.shell.lock().unwrap();
         (
             offer.clone(),
@@ -1839,13 +1835,12 @@ fn apply_snapshot() -> Result<()> {
         let shell = node.shell.lock().unwrap();
         let mut shell2 = node2.shell.lock().unwrap();
         for c in 0..offer.chunks {
-            let chunk = shell
-                .load_snapshot_chunk(tm_request::LoadSnapshotChunk {
+            let chunk =
+                shell.load_snapshot_chunk(tm_request::LoadSnapshotChunk {
                     height: (last_height.0 as u32).into(),
                     format: 0,
                     chunk: c,
-                })
-                .expect("Test failed");
+                });
             let resp =
                 shell2.apply_snapshot_chunk(tm_request::ApplySnapshotChunk {
                     index: c,

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -1813,7 +1813,7 @@ fn apply_snapshot() -> Result<()> {
     snapshot
         .write_to_file(cfs, base_dir.to_path_buf(), last_height)
         .expect("Test failed");
-    DbSnapshot::cleanup(last_height, base_dir).expect("Test failed");
+    DbSnapshot::cleanup(last_height, base_dir, 1).expect("Test failed");
 
     let (node2, _services) = setup::setup()?;
     let (offer, resp) = {

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::num::NonZeroU64;
 use std::str::FromStr;
 
 use assert_matches::assert_matches;
@@ -17,6 +18,8 @@ use namada_core::token::NATIVE_MAX_DECIMAL_PLACES;
 use namada_node::shell::testing::client::run;
 use namada_node::shell::testing::node::NodeResults;
 use namada_node::shell::testing::utils::{Bin, CapturedOutput};
+use namada_node::shell::SnapshotSync;
+use namada_node::storage::DbSnapshot;
 use namada_sdk::account::AccountPublicKeysMap;
 use namada_sdk::collections::HashMap;
 use namada_sdk::migrations;
@@ -39,6 +42,7 @@ use crate::integration::setup;
 use crate::strings::{
     TX_APPLIED_SUCCESS, TX_INSUFFICIENT_BALANCE, TX_REJECTED,
 };
+use crate::tendermint::abci::response::ApplySnapshotChunkResult;
 use crate::tx::tx_host_env::gov_storage::proposal::{
     PGFInternalTarget, PGFTarget,
 };
@@ -1744,6 +1748,231 @@ fn enforce_fee_payment() -> Result<()> {
     });
     assert!(captured.result.is_ok());
     assert!(captured.contains("nam: 2000050"));
+    Ok(())
+}
+
+/// Test that we can successfully apply a snapshot
+/// from one node to another.
+#[test]
+fn apply_snapshot() -> Result<()> {
+    use namada_node::facade::tendermint::v0_37::abci::{
+        request as tm_request, response as tm_response,
+    };
+    // This address doesn't matter for tests. But an argument is required.
+    let validator_one_rpc = "http://127.0.0.1:26567";
+
+    let (mut node, _services) = setup::setup()?;
+    {
+        let mut locked = node.shell.lock().unwrap();
+        locked.blocks_between_snapshots =
+            Some(NonZeroU64::try_from(10_000u64).unwrap());
+    }
+    for _ in 0..3 {
+        node.next_epoch();
+    }
+    let tx_args = vec![
+        "transparent-transfer",
+        "--source",
+        BERTHA,
+        "--target",
+        ALBERT,
+        "--token",
+        NAM,
+        "--amount",
+        "1234",
+        "--signing-keys",
+        BERTHA_KEY,
+        "--node",
+        &validator_one_rpc,
+        "--force",
+    ];
+
+    let captured = CapturedOutput::of(|| run(&node, Bin::Client, tx_args));
+    assert_matches!(captured.result, Ok(_));
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    let args = vec![
+        "balance",
+        "--owner",
+        ALBERT,
+        "--token",
+        NAM,
+        "--node",
+        &validator_one_rpc,
+    ];
+    let captured = CapturedOutput::of(|| run(&node, Bin::Client, args));
+    assert!(captured.contains("1981234"));
+
+    let base_dir = node.test_dir.path();
+    let db = namada_node::storage::open(node.db_path(), true, None)
+        .expect("Could not open DB");
+    let snapshot = db.snapshot();
+
+    let last_height = node.block_height();
+    let cfs = db.column_families();
+    snapshot
+        .write_to_file(cfs, base_dir.to_path_buf(), last_height)
+        .expect("Test failed");
+    DbSnapshot::cleanup(last_height, base_dir).expect("Test failed");
+
+    let (node2, _services) = setup::setup()?;
+    let (offer, resp) = {
+        let shell = node.shell.lock().unwrap();
+        let offer = shell
+            .list_snapshots()
+            .expect("Test failed")
+            .snapshots
+            .pop()
+            .expect("Test failed");
+        let mut shell = node2.shell.lock().unwrap();
+        (
+            offer.clone(),
+            shell.offer_snapshot(tm_request::OfferSnapshot {
+                snapshot: offer,
+                app_hash: Default::default(),
+            }),
+        )
+    };
+
+    assert_eq!(tm_response::OfferSnapshot::Accept, resp);
+    {
+        let shell = node.shell.lock().unwrap();
+        let mut shell2 = node2.shell.lock().unwrap();
+        for c in 0..offer.chunks {
+            let chunk = shell
+                .load_snapshot_chunk(tm_request::LoadSnapshotChunk {
+                    height: (last_height.0 as u32).into(),
+                    format: 0,
+                    chunk: c,
+                })
+                .expect("Test failed");
+            let resp =
+                shell2.apply_snapshot_chunk(tm_request::ApplySnapshotChunk {
+                    index: c,
+                    chunk: chunk.chunk,
+                    sender: "".to_string(),
+                });
+            assert_eq!(
+                resp,
+                tm_response::ApplySnapshotChunk {
+                    result: ApplySnapshotChunkResult::Accept,
+                    refetch_chunks: vec![],
+                    reject_senders: vec![],
+                }
+            );
+        }
+    }
+    let (app_hash1, app_hash2) = {
+        (
+            node.shell.lock().unwrap().state.in_mem().merkle_root(),
+            node2.shell.lock().unwrap().state.in_mem().merkle_root(),
+        )
+    };
+    assert_eq!(app_hash1, app_hash2);
+    let args = vec![
+        "balance",
+        "--owner",
+        ALBERT,
+        "--token",
+        NAM,
+        "--node",
+        &validator_one_rpc,
+    ];
+    let captured = CapturedOutput::of(|| run(&node2, Bin::Client, args));
+    assert!(captured.contains("1981234"));
+
+    Ok(())
+}
+
+/// Test the various failure conditions of state sync
+#[test]
+fn snapshot_unhappy_flows() -> Result<()> {
+    use namada_node::facade::tendermint::v0_37::abci::{
+        request as tm_request, response as tm_response,
+    };
+    let (node, _services) = setup::setup()?;
+
+    // test we abort if not syncing
+    let resp = {
+        let mut shell = node.shell.lock().unwrap();
+        shell.apply_snapshot_chunk(tm_request::ApplySnapshotChunk {
+            index: 0,
+            chunk: Default::default(),
+            sender: "".to_string(),
+        })
+    };
+    assert_eq!(
+        resp,
+        tm_response::ApplySnapshotChunk {
+            result: ApplySnapshotChunkResult::Abort,
+            refetch_chunks: vec![],
+            reject_senders: vec![],
+        }
+    );
+
+    {
+        let mut locked = node.shell.lock().unwrap();
+        locked.syncing = Some(SnapshotSync {
+            next_chunk: 0,
+            height: Default::default(),
+            expected: vec![Default::default()],
+            strikes: 0,
+        });
+    }
+
+    // test we reject and re-fetch if the wrong chunk is given
+    let resp = {
+        let mut shell = node.shell.lock().unwrap();
+        shell.apply_snapshot_chunk(tm_request::ApplySnapshotChunk {
+            index: 1,
+            chunk: Default::default(),
+            sender: "".to_string(),
+        })
+    };
+    assert_eq!(
+        resp,
+        tm_response::ApplySnapshotChunk {
+            result: ApplySnapshotChunkResult::Unknown,
+            refetch_chunks: vec![0],
+            reject_senders: vec![],
+        }
+    );
+    // test we refetch a chunk if the hash is wrong up to five times.
+    for _ in 0..4 {
+        let resp = {
+            let mut shell = node.shell.lock().unwrap();
+            shell.apply_snapshot_chunk(tm_request::ApplySnapshotChunk {
+                index: 0,
+                chunk: Default::default(),
+                sender: "".to_string(),
+            })
+        };
+        assert_eq!(
+            resp,
+            tm_response::ApplySnapshotChunk {
+                result: ApplySnapshotChunkResult::Retry,
+                refetch_chunks: vec![0],
+                reject_senders: vec![],
+            }
+        );
+    }
+    let resp = {
+        let mut shell = node.shell.lock().unwrap();
+        shell.apply_snapshot_chunk(tm_request::ApplySnapshotChunk {
+            index: 0,
+            chunk: Default::default(),
+            sender: "satan".to_string(),
+        })
+    };
+    assert_eq!(
+        resp,
+        tm_response::ApplySnapshotChunk {
+            result: ApplySnapshotChunkResult::RejectSnapshot,
+            refetch_chunks: vec![],
+            reject_senders: vec!["satan".to_string()],
+        }
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
## Describe your changes
Addresses the remaining points of Issue #3307 
 - Adds chunking logic to snapshots
 - Implements the `OfferSnapshot` ABCI call
 - Implements the `ApplySnapshotChunk` ABCI call

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
