### PR TITLE
Minor fixes to governance cli/msgs

### DIFF
--- a/.changelog/unreleased/improvements/3689-misc-gov-fixes.md
+++ b/.changelog/unreleased/improvements/3689-misc-gov-fixes.md
@@ -1,0 +1,2 @@
+- Improved some governance messages and cli commands arguments.
+  ([\#3689](https://github.com/anoma/namada/pull/3689))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -3379,7 +3379,6 @@ pub mod args {
         DefaultFn(|| PortId::from_str("transfer").unwrap()),
     );
     pub const PRE_GENESIS: ArgFlag = flag("pre-genesis");
-    pub const PROPOSAL_ETH: ArgFlag = flag("eth");
     pub const PROPOSAL_PGF_STEWARD: ArgFlag = flag("pgf-stewards");
     pub const PROPOSAL_PGF_FUNDING: ArgFlag = flag("pgf-funding");
     pub const PROTOCOL_KEY: ArgOpt<WalletPublicKey> = arg_opt("protocol-key");
@@ -5610,25 +5609,13 @@ pub mod args {
                     "The data path file (json) that describes the proposal."
                 )))
                 .arg(
-                    PROPOSAL_ETH
-                        .def()
-                        .help(wrap!("Flag if the proposal is of type eth."))
-                        .conflicts_with_all([
-                            PROPOSAL_PGF_FUNDING.name,
-                            PROPOSAL_PGF_STEWARD.name,
-                        ]),
-                )
-                .arg(
                     PROPOSAL_PGF_STEWARD
                         .def()
                         .help(wrap!(
                             "Flag if the proposal is of type pgf-stewards. \
                              Used to elect/remove stewards."
                         ))
-                        .conflicts_with_all([
-                            PROPOSAL_ETH.name,
-                            PROPOSAL_PGF_FUNDING.name,
-                        ]),
+                        .conflicts_with(PROPOSAL_PGF_FUNDING.name),
                 )
                 .arg(
                     PROPOSAL_PGF_FUNDING
@@ -5637,10 +5624,7 @@ pub mod args {
                             "Flag if the proposal is of type pgf-funding. \
                              Used to control continuous/retro PGF fundings."
                         ))
-                        .conflicts_with_all([
-                            PROPOSAL_ETH.name,
-                            PROPOSAL_PGF_STEWARD.name,
-                        ]),
+                        .conflicts_with(PROPOSAL_PGF_STEWARD.name),
                 )
         }
     }
@@ -5685,11 +5669,7 @@ pub mod args {
 
         fn def(app: App) -> App {
             app.add_args::<Tx<CliTypes>>()
-                .arg(
-                    PROPOSAL_ID_OPT
-                        .def()
-                        .help(wrap!("The proposal identifier.")),
-                )
+                .arg(PROPOSAL_ID.def().help(wrap!("The proposal identifier.")))
                 .arg(PROPOSAL_VOTE.def().help(wrap!(
                     "The vote for the proposal. Either yay, nay, or abstain."
                 )))

--- a/crates/governance/src/vp/mod.rs
+++ b/crates/governance/src/vp/mod.rs
@@ -373,7 +373,8 @@ where
 
         if !is_delegator {
             return Err(native_vp::Error::new_alloc(format!(
-                "Address {voter} is neither a validator nor a delegator."
+                "Address {voter} is neither a validator nor a delegator at \
+                 the beginning of epoch {pre_voting_start_epoch}."
             ))
             .into());
         }

--- a/wasm/vp_implicit/src/lib.rs
+++ b/wasm/vp_implicit/src/lib.rs
@@ -24,7 +24,8 @@ fn validate_tx(
     verifiers: BTreeSet<Address>,
 ) -> VpResult {
     debug_log!(
-        "vp_user called with user addr: {}, key_changed: {:?}, verifiers: {:?}",
+        "vp_implicit called with user addr: {}, key_changed: {:?}, verifiers: \
+         {:?}",
         addr,
         keys_changed,
         verifiers


### PR DESCRIPTION
## Describe your changes

Addresses some minor governance issues:

- Removed the unused `PROPOSAL_ETH` cli arg
- Fixes the fact that the required `--proposal-id` arg was not shown in the help message of `proposal-vote`
- Updates the error message in the governance vp that we raise when the voter is not a validator nor delegator to also mention the epoch at which they should have been so (someone might delegate after the beginning of the voting period and struggle to understand why the transaction fails)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
