### PR TITLE
Propagates error from `is_proposal_accepted`

### DIFF
--- a/.changelog/unreleased/bug-fixes/3700-fix-error-mishandling.md
+++ b/.changelog/unreleased/bug-fixes/3700-fix-error-mishandling.md
@@ -1,0 +1,3 @@
+- Now we propagate the error coming from
+  `is_proposal_accepted` instead of falling back on a default.
+  ([\#3700](https://github.com/anoma/namada/pull/3700))

--- a/crates/governance/src/vp/mod.rs
+++ b/crates/governance/src/vp/mod.rs
@@ -90,9 +90,7 @@ where
         if is_proposal_accepted(
             &self.ctx.pre(),
             tx_data.tx.data(tx_data.cmt).unwrap_or_default().as_ref(),
-        )
-        .unwrap_or_default()
-        {
+        )? {
             return Ok(());
         }
 

--- a/crates/governance/src/vp/pgf.rs
+++ b/crates/governance/src/vp/pgf.rs
@@ -65,9 +65,7 @@ where
                 .data(batched_tx.cmt)
                 .unwrap_or_default()
                 .as_ref(),
-        )
-        .unwrap_or_default()
-        {
+        )? {
             return Ok(());
         }
 

--- a/crates/ibc/src/vp/mod.rs
+++ b/crates/ibc/src/vp/mod.rs
@@ -157,9 +157,7 @@ where
                 .data(batched_tx.cmt)
                 .unwrap_or_default()
                 .as_ref(),
-        )
-        .unwrap_or_default()
-        {
+        )? {
             return Ok(());
         }
 

--- a/crates/trans_token/src/vp.rs
+++ b/crates/trans_token/src/vp.rs
@@ -77,9 +77,7 @@ where
         if Gov::is_proposal_accepted(
             &self.ctx.pre(),
             tx_data.tx.data(tx_data.cmt).unwrap_or_default().as_ref(),
-        )
-        .unwrap_or_default()
-        {
+        )? {
             return Ok(());
         }
 


### PR DESCRIPTION
## Describe your changes

Closes #3238.

I've reviewed the code for our native vps and removed the wrong calls to `unwrap_or_default` applied to results (those on options are fine).

⚠️ **WARNING** ⚠️
Pay attention to merging this PR cause it carries breaking changes that span multiple vps, including especially the governance one: so even in the context of the multi-stage deployment of mainnet this could cause problems.

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
