### PR TITLE
Optimize state sync snapshot format

### DIFF
--- a/.changelog/unreleased/improvements/3701-snapshot-improvements.md
+++ b/.changelog/unreleased/improvements/3701-snapshot-improvements.md
@@ -1,0 +1,4 @@
+- Optimize the format of snapshots taken for state syncing purposes.
+  Snapshots are taken over the entire RocksDB database, packaged into
+  a `zstd` compressed `tar` archive, and split into 10 MB chunks.
+  ([\#3701](https://github.com/anoma/namada/pull/3701))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5101,6 +5101,7 @@ dependencies = [
  "smooth-operator",
  "sparse-merkle-tree",
  "sysinfo",
+ "tar",
  "tempfile",
  "test-log",
  "thiserror",
@@ -5112,6 +5113,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "warp",
+ "zstd",
 ]
 
 [[package]]
@@ -9937,10 +9939,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+name = "zstd"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,7 @@ winapi = "0.3.9"
 xorf = { version = "0.11.0", features = ["serde"] }
 yansi = "0.5.1"
 zeroize = { version = "1.5.5", features = ["zeroize_derive"] }
+zstd = "0.13.2"
 
 [patch.crates-io]
 # Patch to the fork containing the correct personalization and basepoints for masp

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -91,6 +91,7 @@ serde_json = {workspace = true, features = ["raw_value"]}
 sha2.workspace = true
 smooth-operator.workspace = true
 sysinfo.workspace = true
+tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = {workspace = true, features = ["full"]}
@@ -100,6 +101,7 @@ tower.workspace = true
 tracing-subscriber = { workspace = true, optional = true, features = ["std", "json", "ansi", "tracing-log"]}
 tracing.workspace = true
 warp = "0.3.2"
+zstd.workspace = true
 
 [dev-dependencies]
 namada_apps_lib = {path = "../apps_lib", features = ["testing"]}

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -2048,7 +2048,10 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod shell_tests {
+    use std::fs::File;
+
     use eth_bridge::storage::eth_bridge_queries::is_bridge_comptime_enabled;
+    use namada_apps_lib::state::StorageWrite;
     use namada_sdk::address;
     use namada_sdk::chain::Epoch;
     use namada_sdk::token::read_denom;
@@ -2058,10 +2061,13 @@ mod shell_tests {
     use namada_vote_ext::{
         bridge_pool_roots, ethereum_events, ethereum_tx_data_variants,
     };
+    use tempfile::tempdir;
     use {namada_replay_protection as replay_protection, wallet};
 
     use super::*;
+    use crate::shell::test_utils::top_level_directory;
     use crate::shell::token::DenominatedAmount;
+    use crate::storage::{DbSnapshot, PersistentDB, SnapshotPath};
 
     const GAS_LIMIT_MULTIPLIER: u64 = 100_000;
 
@@ -2916,5 +2922,81 @@ mod shell_tests {
             MempoolTxType::NewTransaction,
         );
         assert_eq!(result.code, ResultCode::TooLarge.into());
+    }
+
+    /// Test the that the shell can restore it's state
+    /// from a snapshot if it is not syncing
+    #[test]
+    fn test_restore_database_from_snapshot() {
+        let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+
+        let base_dir = tempdir().unwrap().as_ref().canonicalize().unwrap();
+        let vp_wasm_compilation_cache = 50 * 1024 * 1024; // 50 kiB
+        let tx_wasm_compilation_cache = 50 * 1024 * 1024; // 50 kiB
+        let config = config::Ledger::new(
+            base_dir.clone(),
+            Default::default(),
+            TendermintMode::Validator,
+        );
+        let mut shell = Shell::<PersistentDB, Sha256Hasher>::new(
+            config.clone(),
+            top_level_directory().join("wasm"),
+            sender,
+            None,
+            None,
+            None,
+            vp_wasm_compilation_cache,
+            tx_wasm_compilation_cache,
+        );
+        shell.state.in_mem_mut().block.height = BlockHeight::first();
+
+        shell.state.commit_block().expect("Test failed");
+        shell.state.db_mut().flush(true).expect("Test failed");
+        let original_root = shell.state.in_mem().merkle_root();
+        let snapshot = make_snapshot(config.db_dir(), base_dir);
+        shell
+            .state
+            .write(
+                &Key::parse("bing/fucking/bong").expect("Test failed"),
+                [1u8; 64],
+            )
+            .expect("Test failed");
+        shell.state.commit_block().expect("Test failed");
+        let new_root = shell.state.in_mem().merkle_root();
+        assert_ne!(new_root, original_root);
+
+        shell.restore_database_from_state_sync();
+        assert_eq!(shell.state.in_mem().merkle_root(), new_root,);
+        shell.syncing = Some(SnapshotSync {
+            next_chunk: 0,
+            height: BlockHeight::first(),
+            expected: vec![],
+            strikes: 0,
+            snapshot,
+        });
+        shell.restore_database_from_state_sync();
+        assert_eq!(shell.state.in_mem().merkle_root(), original_root,);
+    }
+
+    /// Helper function for the `test_restore_database_from_snapshot` test
+    fn make_snapshot(db_dir: PathBuf, base_dir: PathBuf) -> File {
+        let snapshot =
+            DbSnapshot(SnapshotPath(base_dir.clone(), BlockHeight::first()));
+        std::fs::create_dir_all(base_dir.join("snapshots"))
+            .expect("Test failed");
+        std::fs::create_dir_all(snapshot.0.base()).expect("Test failed");
+        std::fs::create_dir_all(snapshot.0.temp_rocksdb())
+            .expect("Test failed");
+        for entry in std::fs::read_dir(db_dir).expect("Test failed") {
+            let entry = entry.expect("Test failed");
+            let dest_file = snapshot
+                .0
+                .base()
+                .join("db")
+                .join(entry.file_name().to_string_lossy().to_string());
+            std::fs::copy(entry.path(), dest_file).expect("Test failed");
+        }
+        snapshot.clone().build_tarball().expect("Test failed");
+        File::open(snapshot.0.temp_tarball("zst")).expect("Test failed")
     }
 }

--- a/crates/node/src/shell/snapshots.rs
+++ b/crates/node/src/shell/snapshots.rs
@@ -4,7 +4,7 @@ use borsh::BorshDeserialize;
 use borsh_ext::BorshSerializeExt;
 use namada_sdk::arith::checked;
 use namada_sdk::hash::{Hash, Sha256Hasher};
-use namada_sdk::state::{BlockHeight, StorageRead, DB};
+use namada_sdk::state::{BlockHeight, StorageRead};
 
 use super::SnapshotSync;
 use crate::facade::tendermint::abci::response::ApplySnapshotChunkResult;

--- a/crates/node/src/shell/snapshots.rs
+++ b/crates/node/src/shell/snapshots.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use borsh::BorshDeserialize;
 use borsh_ext::BorshSerializeExt;
 use namada_sdk::arith::checked;
@@ -12,7 +14,7 @@ use crate::facade::tendermint::v0_37::abci::{
 };
 use crate::shell::Shell;
 use crate::storage;
-use crate::storage::{DbSnapshot, SnapshotMetadata};
+use crate::storage::{DbSnapshot, DbSnapshotMeta};
 
 pub const MAX_SENDER_STRIKES: u64 = 5;
 
@@ -26,25 +28,37 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
             Default::default()
         } else {
             tracing::info!("Request for snapshots received.");
-            let Ok(snapshots) = DbSnapshot::files(&self.base_dir) else {
+            let Ok(snapshot_heights) =
+                DbSnapshot::heights_of_stored_snapshots(&self.base_dir)
+            else {
+                tracing::debug!("Could not read heights of stored snapshots");
                 return Default::default();
             };
-            let snapshots = snapshots
-                .into_iter()
-                .map(|SnapshotMetadata { height, chunks, .. }| {
-                    let hashes =
-                        chunks.iter().map(|c| c.hash).collect::<Vec<_>>();
-                    let hash = Hash::sha256(hashes.serialize_to_vec()).0;
-                    Snapshot {
+            let snapshots = DbSnapshot::load_snapshot_metadata(
+                &self.base_dir,
+                snapshot_heights,
+            );
+            let Ok(snapshots) = snapshots
+                .map(|result| {
+                    let DbSnapshotMeta {
+                        height,
+                        chunk_hashes,
+                        root_hash,
+                    } = result?;
+                    std::io::Result::Ok(Snapshot {
                         height: u32::try_from(height.0).unwrap().into(),
-                        format: 0,
+                        format: DbSnapshot::FORMAT_MAGIC,
                         #[allow(clippy::cast_possible_truncation)]
-                        chunks: chunks.len() as u32,
-                        hash: hash.into_iter().collect(),
-                        metadata: hashes.serialize_to_vec().into(),
-                    }
+                        chunks: chunk_hashes.len() as u32,
+                        hash: root_hash.0.to_vec().into(),
+                        metadata: chunk_hashes.serialize_to_vec().into(),
+                    })
                 })
-                .collect();
+                .collect()
+            else {
+                tracing::debug!("Could not read stored snapshot meta");
+                return Default::default();
+            };
 
             tm_response::ListSnapshots { snapshots }
         }
@@ -56,19 +70,24 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
         &self,
         req: tm_request::LoadSnapshotChunk,
     ) -> tm_response::LoadSnapshotChunk {
-        let Ok(chunk) = DbSnapshot::load_chunk(
+        let chunk = match DbSnapshot::load_chunk(
             BlockHeight(req.height.into()),
             u64::from(req.chunk),
             &self.base_dir,
-        ) else {
-            tracing::debug!(
-                "Received a request for a snapshot we do not possess"
-            );
-            // N.B. if the snapshot is no longer present,
-            // this will not match the hash in the metadata and will
-            // be rejected by syncing nodes. We don't return an error
-            // so as not to crash this node.
-            return Default::default();
+        ) {
+            Ok(chunk) => chunk,
+            Err(err) => {
+                tracing::debug!(
+                    ?req,
+                    error = %err,
+                    "Received a request for a snapshot we do not possess"
+                );
+                // N.B. if the snapshot is no longer present,
+                // this will not match the hash in the metadata and will
+                // be rejected by syncing nodes. We don't return an error
+                // so as not to crash this node.
+                return Default::default();
+            }
         };
         tracing::info!(
             "Loading snapshot at height {}, chunk number {}",
@@ -76,7 +95,7 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
             req.chunk,
         );
         tm_response::LoadSnapshotChunk {
-            chunk: chunk.into_iter().collect(),
+            chunk: chunk.into(),
         }
     }
 
@@ -85,6 +104,13 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
         &mut self,
         req: tm_request::OfferSnapshot,
     ) -> tm_response::OfferSnapshot {
+        if req.snapshot.format != DbSnapshot::FORMAT_MAGIC {
+            tracing::debug!(
+                format = req.snapshot.format,
+                "Received snapshot with an incompatible format"
+            );
+            return tm_response::OfferSnapshot::Reject;
+        }
         match self.syncing.as_ref() {
             None => {
                 if self.state.get_block_height().unwrap_or_default().0
@@ -100,6 +126,8 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
                         height: u64::from(req.snapshot.height).into(),
                         expected: chunks,
                         strikes: 0,
+                        snapshot: tempfile::tempfile()
+                            .expect("Failed to create snapshot temp file"),
                     });
                     tracing::info!("Accepting snapshot offer");
                     tm_response::OfferSnapshot::Accept
@@ -121,6 +149,8 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
                         height: u64::from(req.snapshot.height).into(),
                         expected: chunks,
                         strikes: 0,
+                        snapshot: tempfile::tempfile()
+                            .expect("Failed to create snapshot temp file"),
                     });
                     tracing::info!("Accepting snapshot offer");
                     tm_response::OfferSnapshot::Accept
@@ -139,8 +169,8 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
     ) -> tm_response::ApplySnapshotChunk {
         let Some(snapshot_sync) = self.syncing.as_mut() else {
             tracing::warn!("Received a snapshot although none were requested");
-            // if we are not currently syncing, abort this sync protocol
-            // the syncing status is set by `OfferSnapshot`.
+            // if we are not currently syncing, abort this sync protocol the
+            // syncing status is set by `OfferSnapshot`.
             return tm_response::ApplySnapshotChunk {
                 result: ApplySnapshotChunkResult::Abort,
                 refetch_chunks: vec![],
@@ -215,45 +245,23 @@ impl Shell<storage::PersistentDB, Sha256Hasher> {
         } else {
             snapshot_sync.strikes = 0;
         };
-        // when we first start applying a snapshot,
-        // clear the existing db.
-        if req.index == 0 {
-            self.state.db_mut().clear(snapshot_sync.height).unwrap();
-        }
-        // apply snapshot changes to the database
-        // retry if an error occurs
-        let mut batch = Default::default();
-        for (cf, key, value) in DbSnapshot::parse_chunk(&req.chunk) {
-            if self
-                .state
-                .db()
-                .insert_entry(&mut batch, &cf, &key, value)
-                .is_err()
-            {
-                return tm_response::ApplySnapshotChunk {
-                    result: ApplySnapshotChunkResult::Retry,
-                    refetch_chunks: vec![],
-                    reject_senders: vec![],
-                };
-            }
-        }
-        if self.state.db().exec_batch(batch).is_err() {
-            return tm_response::ApplySnapshotChunk {
-                result: ApplySnapshotChunkResult::Retry,
-                refetch_chunks: vec![],
-                reject_senders: vec![],
-            };
-        }
+
+        // write snapshot chunk
+        snapshot_sync
+            .snapshot
+            .write_all(&req.chunk)
+            .expect("Failed to save snapshot chunk");
 
         // increment the chunk counter
         snapshot_sync.next_chunk =
             checked!(snapshot_sync.next_chunk + 1).unwrap();
-        // check if all chunks have been applied
+
+        // check if all chunks have been saved, and restore the
+        // database from the fetched tar archive
         if snapshot_sync.next_chunk == snapshot_sync.expected.len() as u64 {
-            tracing::info!("Snapshot completely applied");
+            self.restore_database_from_state_sync();
             self.syncing = None;
-            // rebuild the in-memory state
-            self.state.load_last_state();
+            tracing::info!("Snapshot completely applied");
         }
 
         tm_response::ApplySnapshotChunk {

--- a/crates/node/src/shims/abcipp_shim.rs
+++ b/crates/node/src/shims/abcipp_shim.rs
@@ -4,10 +4,11 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures::future::FutureExt;
+use namada_apps_lib::state::DbError;
 use namada_sdk::chain::BlockHeight;
 use namada_sdk::hash::Hash;
 use namada_sdk::migrations::ScheduledMigration;
-use namada_sdk::state::{ProcessProposalCachedResult, DB};
+use namada_sdk::state::ProcessProposalCachedResult;
 use namada_sdk::tendermint::abci::response::ProcessProposal;
 use namada_sdk::time::{DateTimeUtc, Utc};
 use namada_sdk::tx::data::hash_tx;
@@ -28,7 +29,6 @@ use crate::facade::tendermint::v0_37::abci::{
 };
 use crate::facade::tower_abci::BoxError;
 use crate::shell::{EthereumOracleChannels, Shell};
-use crate::storage::DbSnapshot;
 
 /// The shim wraps the shell, which implements ABCI++.
 /// The shim makes a crude translation between the ABCI interface currently used
@@ -221,28 +221,21 @@ impl AbcippShim {
             _ => {}
         }
 
-        let TakeSnapshot::Yes(db_path) = take_snapshot else {
+        let TakeSnapshot::Yes(db_path, height) = take_snapshot else {
             return;
         };
         let base_dir = self.service.base_dir.clone();
 
         let (snap_send, snap_recv) = tokio::sync::oneshot::channel();
-        let snapshots_to_keep = self.snapshots_to_keep;
+        // let snapshots_to_keep = self.snapshots_to_keep;
         let snapshot_task = std::thread::spawn(move || {
             let db = crate::storage::open(db_path, true, None)
                 .expect("Could not open DB");
-            let snapshot = db.snapshot();
+            let snapshot = db.checkpoint(base_dir, height).unwrap();
             // signal to main thread that the snapshot has finished
             snap_send.send(()).unwrap();
-
-            let last_height = db
-                .read_last_block()
-                .expect("Could not read database")
-                .expect("Last block should exists")
-                .height;
-            let cfs = db.column_families();
-            snapshot.write_to_file(cfs, base_dir.clone(), last_height)?;
-            DbSnapshot::cleanup(last_height, &base_dir, snapshots_to_keep)
+            snapshot.package().unwrap();
+            Ok(())
         });
 
         // it's important that the thread is

--- a/crates/node/src/shims/abcipp_shim_types.rs
+++ b/crates/node/src/shims/abcipp_shim_types.rs
@@ -4,6 +4,7 @@ pub mod shim {
     use std::fmt::Debug;
     use std::path::PathBuf;
 
+    use namada_sdk::state::BlockHeight;
     use thiserror::Error;
 
     use super::{Request as Req, Response as Resp};
@@ -36,14 +37,16 @@ pub mod shim {
     /// at a certain point in time
     pub enum TakeSnapshot {
         No,
-        Yes(PathBuf),
+        Yes(PathBuf, BlockHeight),
     }
 
-    impl<T: AsRef<std::path::Path>> From<Option<T>> for TakeSnapshot {
-        fn from(value: Option<T>) -> Self {
+    impl<T: AsRef<std::path::Path>> From<Option<(T, BlockHeight)>>
+        for TakeSnapshot
+    {
+        fn from(value: Option<(T, BlockHeight)>) -> Self {
             match value {
                 None => TakeSnapshot::No,
-                Some(p) => TakeSnapshot::Yes(p.as_ref().to_path_buf()),
+                Some(p) => TakeSnapshot::Yes(p.0.as_ref().to_path_buf(), p.1),
             }
         }
     }

--- a/crates/node/src/storage/mod.rs
+++ b/crates/node/src/storage/mod.rs
@@ -10,6 +10,8 @@ use arse_merkle_tree::traits::Hasher;
 use arse_merkle_tree::H256;
 use blake2b_rs::{Blake2b, Blake2bBuilder};
 use namada_sdk::state::{FullAccessState, StorageHasher};
+#[cfg(test)]
+pub use rocksdb::SnapshotPath;
 pub use rocksdb::{open, DbSnapshot, DbSnapshotMeta, RocksDBUpdateVisitor};
 
 #[derive(Default)]

--- a/crates/node/src/storage/mod.rs
+++ b/crates/node/src/storage/mod.rs
@@ -10,9 +10,7 @@ use arse_merkle_tree::traits::Hasher;
 use arse_merkle_tree::H256;
 use blake2b_rs::{Blake2b, Blake2bBuilder};
 use namada_sdk::state::{FullAccessState, StorageHasher};
-pub use rocksdb::{
-    open, Chunk, DbSnapshot, RocksDBUpdateVisitor, SnapshotMetadata,
-};
+pub use rocksdb::{open, DbSnapshot, DbSnapshotMeta, RocksDBUpdateVisitor};
 
 #[derive(Default)]
 pub struct PersistentStorageHasher(Blake2bHasher);

--- a/crates/node/src/storage/rocksdb.rs
+++ b/crates/node/src/storage/rocksdb.rs
@@ -46,7 +46,8 @@
 
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Write};
+use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Read, Seek, Write};
+use std::mem::ManuallyDrop;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Mutex;
@@ -114,15 +115,19 @@ const ADDRESS_GEN_KEY_SEGMENT: &str = "address_gen";
 
 const OLD_DIFF_PREFIX: &str = "old";
 const NEW_DIFF_PREFIX: &str = "new";
-const MAX_CHUNK_SIZE: usize = 10_000_000;
+
+// 10 MB
+const MAX_STATE_SYNC_CHUNK_SIZE: usize = 10_000_000;
 
 /// RocksDB handle
 #[derive(Debug)]
 pub struct RocksDB {
     /// Handle to the db
-    inner: rocksdb::DB,
+    inner: ManuallyDrop<rocksdb::DB>,
     /// Indicates if read only
     read_only: bool,
+    /// Whether the handle is invalid
+    invalid_handle: bool,
 }
 
 /// DB Handle for batch writes.
@@ -230,16 +235,22 @@ pub fn open(
     ));
     Ok(if read_only {
         RocksDB {
-            inner: rocksdb::DB::open_cf_descriptors_read_only(
-                &db_opts, path, cfs, false,
-            )
-            .map_err(|e| Error::DBError(e.into_string()))?,
+            inner: ManuallyDrop::new(
+                rocksdb::DB::open_cf_descriptors_read_only(
+                    &db_opts, path, cfs, false,
+                )
+                .map_err(|e| Error::DBError(e.into_string()))?,
+            ),
+            invalid_handle: false,
             read_only: true,
         }
     } else {
         RocksDB {
-            inner: rocksdb::DB::open_cf_descriptors(&db_opts, path, cfs)
-                .map_err(|e| Error::DBError(e.into_string()))?,
+            inner: ManuallyDrop::new(
+                rocksdb::DB::open_cf_descriptors(&db_opts, path, cfs)
+                    .map_err(|e| Error::DBError(e.into_string()))?,
+            ),
+            invalid_handle: false,
             read_only: false,
         }
     })
@@ -247,9 +258,13 @@ pub fn open(
 
 impl Drop for RocksDB {
     fn drop(&mut self) {
+        if self.invalid_handle {
+            return;
+        }
         if !self.read_only {
             self.flush(true).expect("flush failed");
         }
+        unsafe { ManuallyDrop::drop(&mut self.inner) }
     }
 }
 
@@ -500,8 +515,27 @@ impl RocksDB {
         buf.flush().expect("Unable to write to output file");
     }
 
-    pub fn snapshot(&self) -> DbSnapshot<'_> {
-        DbSnapshot(self.inner.snapshot())
+    /// Create a checkpoint of the state in RocksDB at block height
+    /// `block_height`.
+    pub fn checkpoint(
+        &self,
+        base_dir: PathBuf,
+        block_height: BlockHeight,
+    ) -> Result<DbSnapshot> {
+        let checkpoint = rocksdb::checkpoint::Checkpoint::new(&self.inner)
+            .map_err(|e| Error::DBError(e.to_string()))?;
+        let snapshot_path = SnapshotPath(base_dir, block_height);
+        std::fs::create_dir_all(snapshot_path.base()).or_else(|e| {
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                Ok(())
+            } else {
+                Err(Error::DBError(e.to_string()))
+            }
+        })?;
+        checkpoint
+            .create_checkpoint(snapshot_path.temp_rocksdb())
+            .map_err(|e| Error::DBError(e.to_string()))?;
+        Ok(DbSnapshot(snapshot_path))
     }
 
     /// Rollback to previous block. Given the inner working of tendermint
@@ -790,56 +824,187 @@ impl RocksDB {
     }
 }
 
-/// Information about a particular snapshot
-/// owned by a node
-pub struct SnapshotMetadata {
-    /// The height at which the snapshot was taken
-    pub height: BlockHeight,
-    /// The name of the paths to the file and metadata
-    /// holding the snapshot minus extensions
-    pub path_stem: String,
-    /// Data about the chunks that the snapshot is
-    /// partitioned into
-    pub chunks: Vec<Chunk>,
+/// The path to a snapshot.
+#[derive(Clone, Debug)]
+pub struct SnapshotPath(PathBuf, BlockHeight);
+
+impl SnapshotPath {
+    /// Return the root path where snapshots are stored.
+    pub fn snapshot_root_path(mut base_dir: PathBuf) -> PathBuf {
+        base_dir.push("snapshots");
+        base_dir
+    }
+
+    /// Remove all data pertaining to the current snapshot.
+    pub fn remove(&self) -> std::io::Result<()> {
+        std::fs::remove_dir_all(self.base())
+    }
+
+    /// Return the base path associated with this [`SnapshotPath`].
+    pub fn base(&self) -> PathBuf {
+        let mut buf = Self::snapshot_root_path(self.0.clone());
+        let height = self.1.0;
+        buf.push(format!("block-{height:016}"));
+        buf
+    }
+
+    /// Return the chunk hashes path associated with this [`SnapshotPath`].
+    pub fn chunk_hashes(&self) -> PathBuf {
+        let mut buf = self.base();
+        buf.push("chunks-hashed");
+        buf
+    }
+
+    /// Return the root of the chunk hashes tree path associated with this
+    /// [`SnapshotPath`].
+    pub fn chunks_root_hash(&self) -> PathBuf {
+        let mut buf = self.base();
+        buf.push("chunks-root-hash");
+        buf
+    }
+
+    /// Return the temporary rocksdb path associated with this [`SnapshotPath`].
+    pub fn temp_rocksdb(&self) -> PathBuf {
+        let mut buf = self.base();
+        buf.push("db");
+        buf
+    }
+
+    /// Return the temporary tarball path associated with this [`SnapshotPath`].
+    ///
+    /// The value of `compression_extension` should reflect the compression
+    /// algorithm used (e.g. `gz` for Gzip).
+    pub fn temp_tarball(&self, compression_extension: &str) -> PathBuf {
+        let mut buf = self.base();
+        buf.push(format!("db.tar.{compression_extension}"));
+        buf
+    }
+
+    /// Return the path of the chunk `chk` associated with this
+    /// [`SnapshotPath`].
+    pub fn chunk_with_id(&self, chk: usize) -> PathBuf {
+        let mut buf = self.base();
+        buf.push(format!("chunk-{chk:032}"));
+        buf
+    }
 }
 
-pub struct DbSnapshot<'a>(pub rocksdb::Snapshot<'a>);
+/// Metadata pertaining to some database snapshot.
+#[derive(Debug)]
+pub struct DbSnapshotMeta {
+    /// The height of the snapshot.
+    pub height: BlockHeight,
+    /// List of the hashes of all chunks.
+    pub chunk_hashes: Vec<Hash>,
+    /// Hash of all the chunk hashes, forming a shallow tree.
+    pub root_hash: Hash,
+}
 
-impl<'a> DbSnapshot<'a> {
-    /// Write a snapshot of the database out to file.  Also
-    /// creates a file containing metadata about how to break
-    /// the file into chunks.
-    pub fn write_to_file(
-        &self,
-        cfs: [(&'static str, &'a ColumnFamily); 6],
-        base_dir: PathBuf,
-        height: BlockHeight,
+pub struct DbSnapshot(pub SnapshotPath);
+
+impl DbSnapshot {
+    /// The magic number referring to the format of the snapshot.
+    pub const FORMAT_MAGIC: u32 = 0;
+
+    /// Package and chunk the contents of the db snapshot.
+    // NB: passing an owned `self` guarantees we don't attempt to call
+    // this method again, which removes the temporary checkpoint dir
+    // created by rocksdb
+    pub fn package(self) -> std::io::Result<()> {
+        self.build_tarball()?;
+        self.chunk_snapshot()?;
+        Ok(())
+    }
+
+    pub fn unpack(
+        archive_file: &mut std::fs::File,
+        dest: impl AsRef<Path>,
     ) -> std::io::Result<()> {
-        let [snap_file, metadata_file] = Self::paths(height, base_dir);
-        let file = File::create(snap_file)?;
-        let mut buf = BufWriter::new(file);
-        let mut chunker = Chunker::new(MAX_CHUNK_SIZE);
-        for (cf_name, cf) in cfs {
-            let read_opts = make_iter_read_opts(None);
-            let iter =
-                self.0.iterator_cf_opt(cf, read_opts, IteratorMode::Start);
+        use zstd::stream::read::Decoder;
 
-            for (key, raw_val, _gas) in PersistentPrefixIterator(
-                PrefixIterator::new(iter, String::default()),
-                // Empty string to prevent prefix stripping, the prefix is
-                // already in the enclosed iterator
-            ) {
-                let val = base64::encode(raw_val);
-                let bytes = format!("{cf_name}:{key}={val}\n");
-                chunker.add_line(&bytes);
-                buf.write_all(bytes.as_bytes())?;
+        let file_buf_reader = std::io::BufReader::new(archive_file);
+        let zstd_decoder = Decoder::new(file_buf_reader)?;
+
+        let mut archive = tar::Archive::new(zstd_decoder);
+        archive.unpack(dest)?;
+
+        Ok(())
+    }
+
+    fn build_tarball(&self) -> std::io::Result<()> {
+        use zstd::stream::write::Encoder;
+
+        let snapshot_temp_db_path = self.0.temp_rocksdb();
+
+        let mut tar_builder = {
+            let file_handle = File::create(self.0.temp_tarball("zst"))?;
+            let zstd_encoder = Encoder::new(file_handle, 0)?.auto_finish();
+            tar::Builder::new(zstd_encoder)
+        };
+
+        // build tarball with rocksdb checkpoint contents
+        tar_builder.append_dir_all("db", &snapshot_temp_db_path)?;
+        tar_builder.finish()?;
+        _ = tar_builder;
+
+        // remove aux checkpoint dir
+        std::fs::remove_dir_all(&snapshot_temp_db_path)
+    }
+
+    fn chunk_snapshot(&self) -> std::io::Result<()> {
+        let tarball_path = self.0.temp_tarball("zst");
+
+        let mut buf = vec![0; MAX_STATE_SYNC_CHUNK_SIZE];
+        let mut file = File::open(&tarball_path)?;
+
+        let mut eof = false;
+        let mut chunk_hashes = vec![];
+
+        // TODO: we can use tokio here to read chunks
+        // in parallel
+        //
+        // 1. determine tar archive size
+        // 2. spawn len / MAX_STATE_SYNC_CHUNK_SIZE tasks
+        // 3. spawn one more task if necessary to read chunk smaller than
+        //    MAX_STATE_SYNC_CHUNK_SIZE
+        // 4. assemble read data (need to store hash of the chunk)
+
+        for chunk_id in 0.. {
+            let mut read = 0;
+
+            // read up to `MAX_STATE_SYNC_CHUNK_SIZE` bytes
+            while read != MAX_STATE_SYNC_CHUNK_SIZE {
+                match file.read(&mut buf[read..]) {
+                    Ok(0) => {
+                        eof = true;
+                        break;
+                    }
+                    Ok(n) => checked!(read += n).unwrap(),
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                    Err(e) => return Err(e),
+                }
             }
-            buf.flush()?;
+
+            let chunk = &buf[..read];
+
+            std::fs::write(self.0.chunk_with_id(chunk_id), chunk)?;
+            chunk_hashes.push(Hash::sha256(chunk));
+
+            if eof {
+                break;
+            }
         }
-        buf.flush()?;
-        let chunks = chunker.finalize();
-        let metadata = base64::encode(chunks.serialize_to_vec());
-        std::fs::write(metadata_file, metadata.as_bytes())?;
+
+        let chunk_hashes = chunk_hashes.serialize_to_vec();
+        let hash_of_all_chunks = Hash::sha256(&chunk_hashes);
+        let snapshot_hash = Hash::sha256(
+            (Self::FORMAT_MAGIC, hash_of_all_chunks).serialize_to_vec(),
+        );
+
+        std::fs::remove_file(tarball_path)?;
+        std::fs::write(self.0.chunk_hashes(), chunk_hashes)?;
+        std::fs::write(self.0.chunks_root_hash(), snapshot_hash)?;
+
         Ok(())
     }
 
@@ -850,92 +1015,78 @@ impl<'a> DbSnapshot<'a> {
         base_dir: &Path,
         number_to_keep: u64,
     ) -> std::io::Result<()> {
-        for SnapshotMetadata {
-            height, path_stem, ..
-        } in Self::files(base_dir)?
-        {
+        let latest_height = latest_height.0;
+        for height in Self::heights_of_stored_snapshots(base_dir)? {
             // this is correct... don't worry about it
             if checked!(height + number_to_keep <= latest_height).unwrap() {
-                let path = PathBuf::from(path_stem);
-                _ = std::fs::remove_file(&path.with_extension("snap"));
-                _ = std::fs::remove_file(path.with_extension("meta"));
+                let snap = SnapshotPath(base_dir.into(), BlockHeight(height));
+                snap.remove()?;
             }
         }
         Ok(())
     }
 
-    /// List all snapshot files along with the block height at which
-    /// they were created and their chunks.
-    pub fn files(base_dir: &Path) -> std::io::Result<Vec<SnapshotMetadata>> {
-        let snap = OsStr::new("snap");
-        let meta = OsStr::new("meta");
-        let mut files =
-            HashMap::<BlockHeight, (Option<String>, Option<Vec<Chunk>>)>::new();
-        for entry in std::fs::read_dir(base_dir)? {
-            let entry = entry?;
-            let entry_path = entry.path();
-            let entry_ext = entry_path.extension();
-            if entry_path.is_file()
-                && (Some(snap) == entry_ext || Some(meta) == entry_ext)
-            {
-                if let Some(name) = entry.path().file_name() {
-                    // Extract the block height from the file name
-                    // (assuming the file name is of the correct format)
-                    let Some(height) = name
-                        .to_string_lossy()
-                        .strip_prefix("snapshot_")
-                        .and_then(|n| {
-                            n.strip_suffix(".meta").or(n.strip_suffix(".snap"))
-                        })
-                        .and_then(|h| BlockHeight::from_str(h).ok())
-                    else {
-                        continue;
-                    };
-                    // check if we have found the metadata file or snapshot file
-                    // for a given block height
-                    if entry_ext == Some(meta) {
-                        let metadata = std::fs::read_to_string(entry_path)?;
-                        let metadata_bytes = base64::decode(
-                            metadata.as_bytes(),
-                        )
-                        .map_err(|e| {
-                            std::io::Error::new(ErrorKind::InvalidData, e)
-                        })?;
-                        let chunks: Vec<Chunk> =
-                            BorshDeserialize::try_from_slice(
-                                &metadata_bytes[..],
-                            )?;
-                        files.entry(height).or_default().1 = Some(chunks);
-                    } else {
-                        files.entry(height).or_default().0 = Some(
-                            base_dir
-                                .join(format!("snapshot_{}", height))
-                                .to_string_lossy()
-                                .into(),
-                        );
-                    }
-                };
-            }
-        }
-        let mut res = Vec::with_capacity(files.len());
-        for (height, (path, chunks)) in files {
-            // only include snapshots which have both a .snap and .meta file.
-            if let Some((path_stem, chunks)) = path.zip(chunks) {
-                res.push(SnapshotMetadata {
+    /// Load the metadata of the given snapshot heights.
+    pub fn load_snapshot_metadata(
+        base_dir: &Path,
+        snapshot_heights: impl IntoIterator<Item = u64>,
+    ) -> impl Iterator<Item = std::io::Result<DbSnapshotMeta>> {
+        let mut iter = snapshot_heights.into_iter();
+        let base_dir = base_dir.to_owned();
+
+        std::iter::from_fn(move || {
+            let height = BlockHeight(iter.next()?);
+
+            let load = || {
+                let snap = SnapshotPath(base_dir.clone(), height);
+
+                let chunk_hashes = BorshDeserialize::try_from_slice(
+                    &std::fs::read(snap.chunk_hashes())?,
+                )?;
+                let root_hash = BorshDeserialize::try_from_slice(
+                    &std::fs::read(snap.chunks_root_hash())?,
+                )?;
+
+                Ok(DbSnapshotMeta {
                     height,
-                    path_stem,
-                    chunks,
-                });
-            }
-        }
-        Ok(res)
+                    chunk_hashes,
+                    root_hash,
+                })
+            };
+
+            Some(load())
+        })
     }
 
-    /// Create a path to save a snapshot at a specific block height.
-    pub fn paths(height: BlockHeight, base_dir: PathBuf) -> [PathBuf; 2] {
-        let snap_file = base_dir.join(format!("snapshot_{}.snap", height));
-        let metadata_file = base_dir.join(format!("snapshot_{}.meta", height));
-        [snap_file, metadata_file]
+    /// List all block heights whose state snapshots exist.
+    pub fn heights_of_stored_snapshots(
+        base_dir: &Path,
+    ) -> std::io::Result<Vec<u64>> {
+        let snapshot_root = SnapshotPath::snapshot_root_path(base_dir.into());
+        let mut heights = vec![];
+
+        for entry in std::fs::read_dir(snapshot_root)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+
+            if entry_path.is_dir() {
+                let Some(file_name) =
+                    entry_path.file_name().and_then(|f| f.to_str())
+                else {
+                    continue;
+                };
+                let Some(("block", height_str)) = file_name.split_once('-')
+                else {
+                    continue;
+                };
+                let Some(height): Option<u64> = height_str.parse().ok() else {
+                    continue;
+                };
+                heights.push(height);
+            }
+        }
+
+        Ok(heights)
     }
 
     /// Load the specified chunk of a snapshot at the given block height
@@ -944,149 +1095,23 @@ impl<'a> DbSnapshot<'a> {
         chunk: u64,
         base_dir: &Path,
     ) -> std::io::Result<Vec<u8>> {
-        let files = Self::files(base_dir)?;
-        let Some(metadata) = files.into_iter().find(|m| m.height == height)
-        else {
-            return Err(std::io::Error::new(
-                ErrorKind::NotFound,
-                format!(
-                    "Could not find the metadata file for the snapshot at \
-                     height {}",
-                    height,
-                ),
-            ));
-        };
-        let chunk_start = if chunk == 0 {
-            0usize
-        } else {
-            let prev = checked!(usize::try_from(chunk).unwrap() - 1).unwrap();
-            usize::try_from(metadata.chunks[prev].boundary).unwrap()
-        };
-        let chunk_end = metadata
-            .chunks
-            .get(usize::try_from(chunk).unwrap())
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    ErrorKind::InvalidInput,
-                    format!("Chunk {} not found", chunk),
-                )
-            })?
-            .boundary;
-        let chunk_end = usize::try_from(chunk_end).unwrap();
-
-        let file = File::open(
-            PathBuf::from(metadata.path_stem).with_extension("snap"),
-        )?;
-        let reader = BufReader::new(file);
-        let mut bytes: Vec<u8> = vec![];
-        for line in reader
-            .lines()
-            .skip(chunk_start)
-            .take(checked!(chunk_end - chunk_start).unwrap())
-        {
-            bytes.extend(line?.as_bytes());
-            bytes.push(b'\n');
-        }
-        Ok(bytes)
+        let snap = SnapshotPath(base_dir.into(), height);
+        #[allow(clippy::cast_possible_truncation)]
+        std::fs::read(snap.chunk_with_id(chunk as _))
     }
 
-    pub fn parse_chunk(chunk: &[u8]) -> ChunkIterator<'_> {
-        let reader = std::io::BufReader::new(chunk);
-        ChunkIterator {
-            lines: reader.lines(),
-        }
-    }
-}
-
-pub struct ChunkIterator<'a> {
-    lines: std::io::Lines<BufReader<&'a [u8]>>,
-}
-
-impl<'a> Iterator for ChunkIterator<'a> {
-    type Item = (DbColFam, Key, Vec<u8>);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let line = self.lines.next()?.ok()?;
-        let line = line.trim();
-        let mut iter = line.split(':');
-        let cf = iter.next()?;
-        let rest = iter.next()?;
-        let mut iter = rest.split('=');
-        let key = iter.next()?;
-        let value = iter.next()?;
-        let cf = DbColFam::from_str(cf).ok()?;
-        let key = Key::parse(key).ok()?;
-        let value = base64::decode(value.as_bytes()).ok()?;
-        Some((cf, key, value))
-    }
-}
-
-/// A chunk of a snapshot. Includes the last line number in the file
-/// for this chunk and a hash of the chunk contents.
-#[derive(
-    Debug, Clone, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize, Hash,
-)]
-pub struct Chunk {
-    /// The line number ending the chunk
-    pub boundary: u64,
-    /// Sha256 hash of the chunk
-    pub hash: Hash,
-}
-
-/// Builds a set of chunks from a stream of lines to be
-/// written to a file.
-#[derive(Debug, Clone)]
-struct Chunker {
-    chunks: Vec<Chunk>,
-    max_size: usize,
-    current_boundary: u64,
-    current_size: usize,
-    hasher: Sha256,
-}
-impl Chunker {
-    fn new(max_size: usize) -> Self {
-        Self {
-            chunks: vec![],
-            max_size,
-            current_boundary: 0,
-            current_size: 0,
-            hasher: Sha256::default(),
-        }
-    }
-
-    fn add_line(&mut self, line: &str) {
-        if checked!(self.current_size + line.as_bytes().len()).unwrap()
-            > self.max_size
-            && self.current_boundary != 0
-        {
-            let mut hasher = Sha256::default();
-            std::mem::swap(&mut hasher, &mut self.hasher);
-            let hash: [u8; 32] = hasher.finalize().into();
-            self.chunks.push(Chunk {
-                boundary: self.current_boundary,
-                hash: Hash(hash),
-            });
-            self.current_size = 0;
-        }
-
-        checked!(self.current_size += line.as_bytes().len()).unwrap();
-        self.hasher.update(line.as_bytes());
-        checked!(self.current_boundary += 1).unwrap();
-    }
-
-    fn finalize(mut self) -> Vec<Chunk> {
-        let hash: [u8; 32] = self.hasher.finalize().into();
-        self.chunks.push(Chunk {
-            boundary: self.current_boundary,
-            hash: Hash(hash),
-        });
-        self.chunks
-    }
+    // pub fn parse_chunk(chunk: &[u8]) -> ChunkIterator<'_> {
+    //    let reader = std::io::BufReader::new(chunk);
+    //    ChunkIterator {
+    //        lines: reader.lines(),
+    //    }
+    //}
 }
 
 impl DB for RocksDB {
     type Cache = rocksdb::Cache;
     type Migrator = DbUpdateType;
+    type RestoreSource<'a> = (&'a rocksdb::Cache, &'a mut std::fs::File);
     type WriteBatch = RocksDBWriteBatch;
 
     fn open(
@@ -1094,6 +1119,41 @@ impl DB for RocksDB {
         cache: Option<&Self::Cache>,
     ) -> Self {
         open(db_path, false, cache).expect("cannot open the DB")
+    }
+
+    fn restore_from(
+        &mut self,
+        (cache, snapshot): Self::RestoreSource<'_>,
+    ) -> Result<()> {
+        snapshot.rewind().map_err(|e| {
+            Error::DBError(format!("Failed to rewind snapshot file: {e}",))
+        })?;
+
+        let db_dir = self.inner.path().to_owned();
+
+        let unpack_dir = db_dir.parent().ok_or_else(|| {
+            Error::DBError(format!(
+                "Failed to query parent directory of db: {}",
+                db_dir.to_string_lossy()
+            ))
+        })?;
+
+        // NB: close the current database handle.
+        // DON'T TRY THIS AT HOME KIDS. we are
+        // trained monkeys.
+        unsafe {
+            self.invalid_handle = true;
+            ManuallyDrop::drop(&mut self.inner);
+        }
+
+        std::fs::remove_dir_all(&db_dir)
+            .expect("Failed to nuke database directory");
+        DbSnapshot::unpack(snapshot, unpack_dir)
+            .expect("Failed to unpack new db");
+
+        *self = Self::open(db_dir, Some(cache));
+
+        Ok(())
     }
 
     fn path(&self) -> Option<&Path> {

--- a/crates/node/src/storage/rocksdb.rs
+++ b/crates/node/src/storage/rocksdb.rs
@@ -44,9 +44,8 @@
 //!     - `current/{hash}`: a hash included in the current block
 //!     - `{hash}`: a hash included in previous blocks
 
-use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Read, Seek, Write};
+use std::io::{BufWriter, Read, Seek, Write};
 use std::mem::ManuallyDrop;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -58,7 +57,7 @@ use data_encoding::HEXLOWER;
 use itertools::Either;
 use namada_replay_protection as replay_protection;
 use namada_sdk::arith::checked;
-use namada_sdk::collections::{HashMap, HashSet};
+use namada_sdk::collections::HashSet;
 use namada_sdk::eth_bridge::storage::bridge_pool;
 use namada_sdk::eth_bridge::storage::proof::BridgePoolRootProof;
 use namada_sdk::hash::Hash;
@@ -83,7 +82,6 @@ use rocksdb::{
     DBCompressionType, Direction, FlushOptions, IteratorMode, Options,
     ReadOptions, WriteBatch,
 };
-use sha2::{Digest, Sha256};
 
 use crate::config::utils::num_of_threads;
 use crate::storage;
@@ -1016,6 +1014,7 @@ impl DbSnapshot {
         number_to_keep: u64,
     ) -> std::io::Result<()> {
         let latest_height = latest_height.0;
+
         for height in Self::heights_of_stored_snapshots(base_dir)? {
             // this is correct... don't worry about it
             if checked!(height + number_to_keep <= latest_height).unwrap() {

--- a/crates/node/src/storage/rocksdb.rs
+++ b/crates/node/src/storage/rocksdb.rs
@@ -797,7 +797,7 @@ impl RocksDB {
 
 /// The path to a snapshot.
 #[derive(Clone, Debug)]
-pub struct SnapshotPath(PathBuf, BlockHeight);
+pub struct SnapshotPath(pub PathBuf, pub BlockHeight);
 
 impl SnapshotPath {
     /// Return the root path where snapshots are stored.
@@ -871,6 +871,7 @@ pub struct DbSnapshotMeta {
     pub root_hash: Hash,
 }
 
+#[derive(Clone)]
 pub struct DbSnapshot(pub SnapshotPath);
 
 impl DbSnapshot {
@@ -902,7 +903,7 @@ impl DbSnapshot {
         Ok(())
     }
 
-    fn build_tarball(&self) -> std::io::Result<()> {
+    pub(crate) fn build_tarball(&self) -> std::io::Result<()> {
         use zstd::stream::write::Encoder;
 
         let snapshot_temp_db_path = self.0.temp_rocksdb();

--- a/crates/storage/src/db.rs
+++ b/crates/storage/src/db.rs
@@ -126,11 +126,18 @@ pub trait DB: Debug {
     /// change to DB.
     type Migrator: DbMigration + DeserializeOwned;
 
+    /// Source data to restore a database.
+    type RestoreSource<'a>;
+
     /// Open the database from provided path
     fn open(
         db_path: impl AsRef<std::path::Path>,
         cache: Option<&Self::Cache>,
     ) -> Self;
+
+    /// Overwrite the contents of the current database
+    /// with the data read from `source`.
+    fn restore_from(&mut self, source: Self::RestoreSource<'_>) -> Result<()>;
 
     /// Get the path to the db in the filesystem,
     /// if it exists (the DB may be in-memory only)

--- a/crates/storage/src/mockdb.rs
+++ b/crates/storage/src/mockdb.rs
@@ -91,10 +91,15 @@ impl DB for MockDB {
     /// There is no cache for MockDB
     type Cache = ();
     type Migrator = ();
+    type RestoreSource<'a> = ();
     type WriteBatch = MockDBWriteBatch;
 
     fn open(_db_path: impl AsRef<Path>, _cache: Option<&Self::Cache>) -> Self {
         Self::default()
+    }
+
+    fn restore_from(&mut self, _source: ()) -> Result<()> {
+        Ok(())
     }
 
     fn flush(&self, _wait: bool) -> Result<()> {

--- a/crates/storage/src/mockdb.rs
+++ b/crates/storage/src/mockdb.rs
@@ -87,19 +87,25 @@ impl MockDB {
     }
 }
 
+/// Source to restore a [`MockDB`] from.
+///
+/// Since this enum has no variants, you can't
+/// actually restore a [`MockDB`] instance.
+pub enum MockDBRestoreSource {}
+
 impl DB for MockDB {
     /// There is no cache for MockDB
     type Cache = ();
     type Migrator = ();
-    type RestoreSource<'a> = ();
+    type RestoreSource<'a> = MockDBRestoreSource;
     type WriteBatch = MockDBWriteBatch;
 
     fn open(_db_path: impl AsRef<Path>, _cache: Option<&Self::Cache>) -> Self {
         Self::default()
     }
 
-    fn restore_from(&mut self, _source: ()) -> Result<()> {
-        Ok(())
+    fn restore_from(&mut self, source: MockDBRestoreSource) -> Result<()> {
+        match source {}
     }
 
     fn flush(&self, _wait: bool) -> Result<()> {

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -1806,13 +1806,11 @@ fn apply_snapshot() -> Result<()> {
     let base_dir = node.test_dir.path();
     let db = namada_node::storage::open(node.db_path(), true, None)
         .expect("Could not open DB");
-    let snapshot = db.snapshot();
-
     let last_height = node.block_height();
-    let cfs = db.column_families();
-    snapshot
-        .write_to_file(cfs, base_dir.to_path_buf(), last_height)
+    let snapshot = db
+        .checkpoint(base_dir.to_path_buf(), last_height)
         .expect("Test failed");
+    snapshot.package().expect("Test failed");
     DbSnapshot::cleanup(last_height, base_dir, 1).expect("Test failed");
 
     let (node2, _services) = setup::setup()?;
@@ -1912,6 +1910,7 @@ fn snapshot_unhappy_flows() -> Result<()> {
             height: Default::default(),
             expected: vec![Default::default()],
             strikes: 0,
+            snapshot: tempfile::tempfile().unwrap(),
         });
     }
 


### PR DESCRIPTION
## Describe your changes

These changes optimize the format of snapshots taken for state syncing purposes. Snapshots are taken over the entire RocksDB database, packaged into a `zstd` compressed `tar` archive, and split into 10 MB chunks.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
