### PR TITLE
Add test coverage on token transfer struct

### DIFF
--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -184,9 +184,9 @@ impl Transfer {
     }
 
     /// Set the key to the given amount
-    fn set<K: Ord>(
-        map: &mut BTreeMap<K, DenominatedAmount>,
-        key: K,
+    fn set(
+        map: &mut BTreeMap<Account, DenominatedAmount>,
+        key: Account,
         val: DenominatedAmount,
     ) {
         if val.is_zero() {


### PR DESCRIPTION
## Describe your changes

Adds test coverage to `Transfer` struct and its methods.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
