### PR TITLE
Unsigned MASP `Changes` in SDK

### DIFF
--- a/.changelog/unreleased/improvements/3716-unsigned-change-in-sdk.md
+++ b/.changelog/unreleased/improvements/3716-unsigned-change-in-sdk.md
@@ -1,0 +1,2 @@
+- Modified the `Changes` type to use unsigned integers.
+  ([\#3716](https://github.com/anoma/namada/pull/3716))

--- a/crates/core/src/token.rs
+++ b/crates/core/src/token.rs
@@ -232,16 +232,14 @@ impl Amount {
         Self { raw: Uint(raw) }
     }
 
-    /// Given a i128 and [`MaspDigitPos`], construct the corresponding
+    /// Given a u128 and [`MaspDigitPos`], construct the corresponding
     /// amount.
-    pub fn from_masp_denominated_i128(
-        val: i128,
+    pub fn from_masp_denominated_u128(
+        val: u128,
         denom: MaspDigitPos,
     ) -> Option<Self> {
-        #[allow(clippy::cast_sign_loss)]
         #[allow(clippy::cast_possible_truncation)]
         let lo = val as u64;
-        #[allow(clippy::cast_sign_loss)]
         let hi = (val >> 64) as u64;
         let lo_pos = denom as usize;
         let hi_pos = lo_pos.checked_add(1)?;


### PR DESCRIPTION
## Describe your changes

Closes #3425.

Modifies the `Changes` type in the SDK to wrap `U128Sum` instead of `I128Sum` since changes are guaranteed to be non-negative. Also adjusts `from_masp_denominated_i128` and swap the calls to `from_nonnegative` for `from_pair`.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
