### PR TITLE
Batch `reveal_pk`

### DIFF
--- a/.changelog/unreleased/improvements/3720-batch-reveal-pk.md
+++ b/.changelog/unreleased/improvements/3720-batch-reveal-pk.md
@@ -1,0 +1,3 @@
+- If an additional `reveal_pk` transaction is required, the client now groups
+  it with the actual transaction into a single batch instead of submitting it
+  separately. ([\#3720](https://github.com/anoma/namada/pull/3720))


### PR DESCRIPTION
## Describe your changes

Closes #1879.

When the client detects that an extra `reveal_pk` transaction is needed, instead of submitting it as a separate tx before the intended one, it now groups the two (or more) transactions together and submits them as a single batch.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
