### PR TITLE
Fixes MASP tx expiration in the SDK

### DIFF
--- a/.changelog/unreleased/bug-fixes/3724-fix-masp-expiration.md
+++ b/.changelog/unreleased/bug-fixes/3724-fix-masp-expiration.md
@@ -1,0 +1,2 @@
+- Fixed the SDK to generate MASP transactions with the correct expiration (if
+  provided). ([\#3724](https://github.com/anoma/namada/pull/3724))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -6805,6 +6805,7 @@ pub mod args {
                 target: chain_ctx.get(&self.target),
                 token: self.token,
                 amount: self.amount,
+                expiration: self.expiration,
                 port_id: self.port_id,
                 channel_id: self.channel_id,
             })
@@ -6818,14 +6819,26 @@ pub mod args {
             let target = TRANSFER_TARGET.parse(matches);
             let token = TOKEN_STR.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
+            let expiration = EXPIRATION_OPT.parse(matches);
             let port_id = PORT_ID.parse(matches);
             let channel_id = CHANNEL_ID.parse(matches);
+            let no_expiration = NO_EXPIRATION.parse(matches);
+            let expiration = if no_expiration {
+                TxExpiration::NoExpiration
+            } else {
+                match expiration {
+                    Some(exp) => TxExpiration::Custom(exp),
+                    None => TxExpiration::Default,
+                }
+            };
+
             Self {
                 query,
                 output_folder,
                 target,
                 token,
                 amount,
+                expiration,
                 port_id,
                 channel_id,
             }
@@ -6842,6 +6855,28 @@ pub mod args {
                     AMOUNT
                         .def()
                         .help(wrap!("The amount to transfer in decimal.")),
+                )
+                .arg(
+                    EXPIRATION_OPT
+                        .def()
+                        .help(wrap!(
+                            "The expiration datetime of the masp transaction, \
+                             after which the tx won't be accepted anymore. If \
+                             not provided, a default will be set. All of \
+                             these examples are \
+                             equivalent:\n2012-12-12T12:12:12Z\n2012-12-12 \
+                             12:12:12Z\n2012-  12-12T12:  12:12Z"
+                        ))
+                        .conflicts_with_all([NO_EXPIRATION.name]),
+                )
+                .arg(
+                    NO_EXPIRATION
+                        .def()
+                        .help(wrap!(
+                            "Force the construction of the transaction \
+                             without an expiration (highly discouraged)."
+                        ))
+                        .conflicts_with_all([EXPIRATION_OPT.name]),
                 )
                 .arg(PORT_ID.def().help(wrap!(
                     "The port ID via which the token is received."

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -6862,10 +6862,8 @@ pub mod args {
                         .help(wrap!(
                             "The expiration datetime of the masp transaction, \
                              after which the tx won't be accepted anymore. If \
-                             not provided, a default will be set. All of \
-                             these examples are \
-                             equivalent:\n2012-12-12T12:12:12Z\n2012-12-12 \
-                             12:12:12Z\n2012-  12-12T12:  12:12Z"
+                             not provided, a default will be set. Example: \
+                             2012-12-12T12:12:12Z"
                         ))
                         .conflicts_with_all([NO_EXPIRATION.name]),
                 )
@@ -7319,10 +7317,8 @@ pub mod args {
                     .help(wrap!(
                         "The expiration datetime of the transaction, after \
                          which the tx won't be accepted anymore. If not \
-                         provided, a default will be set. All of these \
-                         examples are \
-                         equivalent:\n2012-12-12T12:12:12Z\n2012-12-12 \
-                         12:12:12Z\n2012-  12-12T12:  12:12Z"
+                         provided, a default will be set. Example: \
+                         2012-12-12T12:12:12Z"
                     ))
                     .conflicts_with_all([NO_EXPIRATION.name]),
             )

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -6090,7 +6090,7 @@ mod test_finalize_block {
         assert_eq!(tx_results.len(), 2);
 
         // all txs should have succeeded
-        assert!(tx_results.are_results_ok());
+        assert!(tx_results.are_results_successfull());
     }
 
     #[test]

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -758,8 +758,9 @@ impl MockNode {
         if !self.success() {
             panic!(
                 "Assert failed: The node did not execute \
-                 successfully:\nErrors:\n    {:?}",
-                self.tx_result_codes.lock().unwrap()
+                 successfully:\nErrors:\n    {:?},\nTxs results:\n    {:?}",
+                self.tx_result_codes.lock().unwrap(),
+                self.tx_results.lock().unwrap()
             );
         }
         self.clear_results();

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -261,7 +261,7 @@ pub struct InnerMockNode {
 pub struct MockNode(pub Arc<InnerMockNode>);
 
 impl Deref for MockNode {
-    type Target = Arc<InnerMockNode>;
+    type Target = InnerMockNode;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -247,17 +247,25 @@ pub enum NodeResults {
     Failed(ResultCode),
 }
 
-// TODO: wrap `MockNode` in a single `Arc`
-// FIXME: look at this todo, not sure it's correct though
-#[derive(Clone)]
-pub struct MockNode {
-    pub shell: Arc<Mutex<Shell<storage::PersistentDB, Sha256Hasher>>>,
-    pub test_dir: Arc<SalvageableTestDir>,
-    pub tx_result_codes: Arc<Mutex<Vec<NodeResults>>>,
-    pub tx_results: Arc<Mutex<Vec<namada_sdk::tx::data::TxResult<String>>>>,
-    pub blocks: Arc<Mutex<HashMap<BlockHeight, block::Response>>>,
-    pub services: Arc<MockServices>,
+pub struct InnerMockNode {
+    pub shell: Mutex<Shell<storage::PersistentDB, Sha256Hasher>>,
+    pub test_dir: SalvageableTestDir,
+    pub tx_result_codes: Mutex<Vec<NodeResults>>,
+    pub tx_results: Mutex<Vec<namada_sdk::tx::data::TxResult<String>>>,
+    pub blocks: Mutex<HashMap<BlockHeight, block::Response>>,
+    pub services: MockServices,
     pub auto_drive_services: bool,
+}
+
+#[derive(Clone)]
+pub struct MockNode(pub Arc<InnerMockNode>);
+
+impl Deref for MockNode {
+    type Target = Arc<InnerMockNode>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 pub struct SalvageableTestDir {

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -38,7 +38,7 @@ use namada_sdk::tendermint::abci::types::VoteInfo;
 use namada_sdk::tendermint_proto::google::protobuf::Timestamp;
 use namada_sdk::time::DateTimeUtc;
 use namada_sdk::tx::data::ResultCode;
-use namada_sdk::tx::event::Code as CodeAttr;
+use namada_sdk::tx::event::{Batch as BatchAttr, Code as CodeAttr};
 use namada_sdk::{ethereum_structs, governance};
 use regex::Regex;
 use tokio::sync::mpsc;
@@ -248,11 +248,13 @@ pub enum NodeResults {
 }
 
 // TODO: wrap `MockNode` in a single `Arc`
+// FIXME: look at this todo, not sure it's correct though
 #[derive(Clone)]
 pub struct MockNode {
     pub shell: Arc<Mutex<Shell<storage::PersistentDB, Sha256Hasher>>>,
     pub test_dir: Arc<SalvageableTestDir>,
-    pub results: Arc<Mutex<Vec<NodeResults>>>,
+    pub tx_result_codes: Arc<Mutex<Vec<NodeResults>>>,
+    pub tx_results: Arc<Mutex<Vec<namada_sdk::tx::data::TxResult<String>>>>,
     pub blocks: Arc<Mutex<HashMap<BlockHeight, block::Response>>>,
     pub services: Arc<MockServices>,
     pub auto_drive_services: bool,
@@ -505,9 +507,9 @@ impl MockNode {
         };
 
         let resp = locked.finalize_block(req).expect("Test failed");
-        let mut error_codes = resp
+        let mut result_codes = resp
             .events
-            .into_iter()
+            .iter()
             .map(|e| {
                 let code = e
                     .read_attribute_opt::<CodeAttr>()
@@ -520,7 +522,16 @@ impl MockNode {
                 }
             })
             .collect::<Vec<_>>();
-        self.results.lock().unwrap().append(&mut error_codes);
+        let mut tx_results = resp
+            .events
+            .into_iter()
+            .map(|e| e.read_attribute::<BatchAttr<'_>>().unwrap())
+            .collect::<Vec<_>>();
+        self.tx_result_codes
+            .lock()
+            .unwrap()
+            .append(&mut result_codes);
+        self.tx_results.lock().unwrap().append(&mut tx_results);
         locked.commit();
 
         // Cache the block
@@ -600,7 +611,7 @@ impl MockNode {
             })
             .collect();
         if result != tendermint::abci::response::ProcessProposal::Accept {
-            self.results.lock().unwrap().append(&mut errors);
+            self.tx_result_codes.lock().unwrap().append(&mut errors);
             return;
         }
 
@@ -644,7 +655,7 @@ impl MockNode {
         let resp = locked.finalize_block(req).unwrap();
         let mut error_codes = resp
             .events
-            .into_iter()
+            .iter()
             .map(|e| {
                 let code = e
                     .read_attribute_opt::<CodeAttr>()
@@ -657,7 +668,16 @@ impl MockNode {
                 }
             })
             .collect::<Vec<_>>();
-        self.results.lock().unwrap().append(&mut error_codes);
+        let mut txs_results = resp
+            .events
+            .into_iter()
+            .filter_map(|e| e.read_attribute_opt::<BatchAttr<'_>>().unwrap())
+            .collect::<Vec<_>>();
+        self.tx_result_codes
+            .lock()
+            .unwrap()
+            .append(&mut error_codes);
+        self.tx_results.lock().unwrap().append(&mut txs_results);
         self.blocks.lock().unwrap().insert(
             height,
             block::Response {
@@ -704,23 +724,34 @@ impl MockNode {
 
     /// Check that applying a tx succeeded.
     pub fn success(&self) -> bool {
-        self.results
+        self.tx_result_codes
             .lock()
             .unwrap()
             .iter()
             .all(|r| *r == NodeResults::Ok)
+            && self
+                .tx_results
+                .lock()
+                .unwrap()
+                .iter()
+                .all(|inner_results| inner_results.are_results_successfull())
     }
 
     /// Return a tx result if the tx failed in mempool
     pub fn is_broadcast_err(&self) -> Option<TxResult> {
-        self.results.lock().unwrap().iter().find_map(|r| match r {
-            NodeResults::Ok | NodeResults::Failed(_) => None,
-            NodeResults::Rejected(tx_result) => Some(tx_result.clone()),
-        })
+        self.tx_result_codes
+            .lock()
+            .unwrap()
+            .iter()
+            .find_map(|r| match r {
+                NodeResults::Ok | NodeResults::Failed(_) => None,
+                NodeResults::Rejected(tx_result) => Some(tx_result.clone()),
+            })
     }
 
     pub fn clear_results(&self) {
-        self.results.lock().unwrap().clear();
+        self.tx_result_codes.lock().unwrap().clear();
+        self.tx_results.lock().unwrap().clear();
     }
 
     pub fn assert_success(&self) {
@@ -728,11 +759,10 @@ impl MockNode {
             panic!(
                 "Assert failed: The node did not execute \
                  successfully:\nErrors:\n    {:?}",
-                self.results.lock().unwrap()
+                self.tx_result_codes.lock().unwrap()
             );
-        } else {
-            self.clear_results();
         }
+        self.clear_results();
     }
 }
 

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -533,7 +533,7 @@ impl MockNode {
         let mut tx_results = resp
             .events
             .into_iter()
-            .map(|e| e.read_attribute::<BatchAttr<'_>>().unwrap())
+            .filter_map(|e| e.read_attribute_opt::<BatchAttr<'_>>().unwrap())
             .collect::<Vec<_>>();
         self.tx_result_codes
             .lock()

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -2892,6 +2892,8 @@ pub struct GenIbcShieldingTransfer<C: NamadaTypes = SdkTypes> {
     pub token: String,
     /// Transferred token amount
     pub amount: InputAmount,
+    /// The optional expiration of the masp shielding transaction
+    pub expiration: TxExpiration,
     /// Port ID via which the token is received
     pub port_id: PortId,
     /// Channel ID via which the token is received

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2611,6 +2611,7 @@ pub async fn build_ibc_transfer(
         masp_transfer_data,
         masp_fee_data,
         !(args.tx.dry_run || args.tx.dry_run_wrapper),
+        args.tx.expiration.to_datetime(),
     )
     .await?;
     let shielded_tx_epoch = shielded_parts.as_ref().map(|trans| trans.0.epoch);
@@ -3071,6 +3072,7 @@ pub async fn build_shielded_transfer<N: Namada>(
         transfer_data,
         masp_fee_data,
         !(args.tx.dry_run || args.tx.dry_run_wrapper),
+        args.tx.expiration.to_datetime(),
     )
     .await?
     .expect("Shielded transfer must have shielded parts");
@@ -3236,6 +3238,7 @@ pub async fn build_shielding_transfer<N: Namada>(
         transfer_data,
         None,
         !(args.tx.dry_run || args.tx.dry_run_wrapper),
+        args.tx.expiration.to_datetime(),
     )
     .await?
     .expect("Shielding transfer must have shielded parts");
@@ -3357,6 +3360,7 @@ pub async fn build_unshielding_transfer<N: Namada>(
         transfer_data,
         masp_fee_data,
         !(args.tx.dry_run || args.tx.dry_run_wrapper),
+        args.tx.expiration.to_datetime(),
     )
     .await?
     .expect("Shielding transfer must have shielded parts");
@@ -3409,13 +3413,13 @@ async fn construct_shielded_parts<N: Namada>(
     data: Vec<MaspTransferData>,
     fee_data: Option<MaspFeeData>,
     update_ctx: bool,
+    expiration: Option<DateTimeUtc>,
 ) -> Result<Option<(ShieldedTransfer, HashSet<AssetData>)>> {
     // Precompute asset types to increase chances of success in decoding
     let token_map = context.wallet().await.get_addresses();
     let tokens = token_map.values().collect();
 
     let stx_result = {
-        let expiration = context.tx_builder().expiration.to_datetime();
         let mut shielded = context.shielded_mut().await;
         _ = shielded
             .precompute_asset_types(context.client(), tokens)
@@ -3775,7 +3779,6 @@ pub async fn gen_ibc_shielding_transfer<N: Namada>(
         amount: validated_amount,
     };
     let shielded_transfer = {
-        let expiration = context.tx_builder().expiration.to_datetime();
         let mut shielded = context.shielded_mut().await;
         shielded
             .gen_shielded_transfer(
@@ -3783,7 +3786,8 @@ pub async fn gen_ibc_shielding_transfer<N: Namada>(
                 vec![masp_transfer_data],
                 // Fees are paid from the transparent balance of the relayer
                 None,
-                expiration,
+                // Expiration can be set directly on the ibc transaction
+                None,
                 true,
             )
             .await

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -3786,8 +3786,7 @@ pub async fn gen_ibc_shielding_transfer<N: Namada>(
                 vec![masp_transfer_data],
                 // Fees are paid from the transparent balance of the relayer
                 None,
-                // Expiration can be set directly on the ibc transaction
-                None,
+                args.expiration.to_datetime(),
                 true,
             )
             .await

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -16,7 +16,6 @@ use namada_core::hash::Hash;
 use namada_core::storage::{DbColFam, Key};
 use namada_core::token::NATIVE_MAX_DECIMAL_PLACES;
 use namada_node::shell::testing::client::run;
-use namada_node::shell::testing::node::NodeResults;
 use namada_node::shell::testing::utils::{Bin, CapturedOutput};
 use namada_node::shell::SnapshotSync;
 use namada_node::storage::DbSnapshot;
@@ -1807,24 +1806,9 @@ fn enforce_fee_payment() -> Result<()> {
 
     node.clear_results();
     node.submit_txs(txs);
-    {
-        let results = node.results.lock().unwrap();
-        // If empty than failed in process proposal
-        assert!(!results.is_empty());
-
-        for result in results.iter() {
-            assert!(matches!(result, NodeResults::Ok));
-        }
-    }
-    // Finalize the next block to execute the txs
-    node.clear_results();
-    node.finalize_and_commit(None);
-    {
-        let results = node.results.lock().unwrap();
-        for result in results.iter() {
-            assert!(matches!(result, NodeResults::Ok));
-        }
-    }
+    // If empty than failed in process proposal
+    assert!(!node.tx_result_codes.lock().unwrap().is_empty());
+    node.assert_success();
 
     // Assert balances
     let captured = CapturedOutput::of(|| {

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -1517,28 +1517,9 @@ fn multiple_unfetched_txs_same_block() -> Result<()> {
 
     node.clear_results();
     node.submit_txs(txs);
-    {
-        let results = node.tx_result_codes.lock().unwrap();
-        // If empty than failed in process proposal
-        assert!(!results.is_empty());
-
-        // FIXME: can use is_success
-        for result in results.iter() {
-            assert!(matches!(result, NodeResults::Ok));
-        }
-    }
-    // FIXME: is this correct???
-    // FIXME: maybe should assert the length of the result? Or maybe this is not
-    // needed naymore Finalize the next block to actually execute the
-    // decrypted txs
-    node.clear_results();
-    node.finalize_and_commit(None);
-    {
-        let results = node.tx_result_codes.lock().unwrap();
-        for result in results.iter() {
-            assert!(matches!(result, NodeResults::Ok));
-        }
-    }
+    // If empty than failed in process proposal
+    assert!(!node.tx_result_codes.lock().unwrap().is_empty());
+    node.assert_success();
 
     Ok(())
 }
@@ -1671,7 +1652,7 @@ fn expired_masp_tx() -> Result<()> {
     // Skip at least 20 blocks to ensure expiration (this is because of the
     // default masp expiration)
     for _ in 0..=20 {
-        node.finalize_and_commit();
+        node.finalize_and_commit(None);
     }
     node.clear_results();
     node.submit_txs(vec![tx.to_bytes()]);

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -1597,8 +1597,13 @@ fn expired_masp_tx() -> Result<()> {
             "50",
             "--gas-payer",
             CHRISTEL_KEY,
-            // This is used to set the correct expiration in the masp object,
-            // we don't care about the expiration at the tx level
+            // We want to create an expired masp tx. Doing so will also set the
+            // expiration field of the header which can be a problem because
+            // this would lead to the transaction being rejected by the
+            // protocol check while we want to test expiration in the masp vp.
+            // However, this is not a real issue: to avoid the failure in
+            // protocol we are going to overwrite the header with one having no
+            // expiration
             "--expiration",
             #[allow(clippy::disallowed_methods)]
             &DateTimeUtc::now().to_string(),

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -1380,7 +1380,7 @@ fn multiple_unfetched_txs_same_block() -> Result<()> {
         vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
 
-    // 2. Shielded operations without fetching. Dump the txs to than reload and
+    // 2. Shielded operations without fetching. Dump the txs to then reload and
     // submit in the same block
     let tempdir = tempfile::tempdir().unwrap();
     let mut txs_bytes = vec![];
@@ -1578,7 +1578,7 @@ fn expired_masp_tx() -> Result<()> {
     )?;
 
     // 2. Shielded operation to avoid the need of a signature on the inner tx.
-    //    Dump the tx to than reload and submit
+    //    Dump the tx to then reload and submit
     let tempdir = tempfile::tempdir().unwrap();
 
     _ = node.next_epoch();

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -11,6 +11,7 @@ use namada_node::shell::testing::node::NodeResults;
 use namada_node::shell::testing::utils::{Bin, CapturedOutput};
 use namada_sdk::masp::fs::FsShieldedUtils;
 use namada_sdk::state::{StorageRead, StorageWrite};
+use namada_sdk::time::DateTimeUtc;
 use namada_sdk::token::storage_key::masp_token_map_key;
 use namada_sdk::token::{self, DenominatedAmount};
 use namada_sdk::DEFAULT_GAS_LIMIT;
@@ -1517,21 +1518,199 @@ fn multiple_unfetched_txs_same_block() -> Result<()> {
     node.clear_results();
     node.submit_txs(txs);
     {
-        let results = node.results.lock().unwrap();
+        let results = node.tx_result_codes.lock().unwrap();
         // If empty than failed in process proposal
         assert!(!results.is_empty());
 
+        // FIXME: can use is_success
         for result in results.iter() {
             assert!(matches!(result, NodeResults::Ok));
         }
     }
-    // Finalize the next block to actually execute the decrypted txs
+    // FIXME: is this correct???
+    // FIXME: maybe should assert the length of the result? Or maybe this is not
+    // needed naymore Finalize the next block to actually execute the
+    // decrypted txs
     node.clear_results();
     node.finalize_and_commit(None);
     {
-        let results = node.results.lock().unwrap();
+        let results = node.tx_result_codes.lock().unwrap();
         for result in results.iter() {
             assert!(matches!(result, NodeResults::Ok));
+        }
+    }
+
+    Ok(())
+}
+
+/// Tests that an expired masp tx is rejected by the vp
+#[test]
+fn expired_masp_tx() -> Result<()> {
+    // This address doesn't matter for tests. But an argument is required.
+    let validator_one_rpc = "http://127.0.0.1:26567";
+    // Download the shielded pool parameters before starting node
+    let _ = FsShieldedUtils::new(PathBuf::new());
+    let (mut node, _services) = setup::setup()?;
+    _ = node.next_epoch();
+
+    // Add the relevant viewing keys to the wallet otherwise the shielded
+    // context won't precache the masp data
+    run(
+        &node,
+        Bin::Wallet,
+        vec![
+            "add",
+            "--alias",
+            "alias_a",
+            "--value",
+            AA_VIEWING_KEY,
+            "--unsafe-dont-encrypt",
+        ],
+    )?;
+    node.assert_success();
+
+    // 1. Shield tokens
+    _ = node.next_epoch();
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shield",
+            "--source",
+            ALBERT_KEY,
+            "--target",
+            AA_PAYMENT_ADDRESS,
+            "--token",
+            NAM,
+            "--amount",
+            "100",
+            "--ledger-address",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
+    // sync shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec!["shielded-sync", "--node", validator_one_rpc],
+    )?;
+
+    // 2. Shielded operation to avoid the need of a signature on the inner tx.
+    //    Dump the tx to than reload and submit
+    let tempdir = tempfile::tempdir().unwrap();
+
+    _ = node.next_epoch();
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "transfer",
+            "--source",
+            A_SPENDING_KEY,
+            "--target",
+            AC_PAYMENT_ADDRESS,
+            "--token",
+            NAM,
+            "--amount",
+            "50",
+            "--gas-payer",
+            CHRISTEL_KEY,
+            // This is used to set the correct expiration in the masp object,
+            // we don't care about the expiration at the tx level
+            "--expiration",
+            #[allow(clippy::disallowed_methods)]
+            &DateTimeUtc::now().to_string(),
+            "--output-folder-path",
+            tempdir.path().to_str().unwrap(),
+            "--dump-tx",
+            "--ledger-address",
+            validator_one_rpc,
+        ],
+    )?;
+    node.assert_success();
+
+    let file_path = tempdir
+        .path()
+        .read_dir()
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let tx_bytes = std::fs::read(&file_path).unwrap();
+    std::fs::remove_file(&file_path).unwrap();
+
+    let sk = christel_keypair();
+    let pk = sk.to_public();
+
+    let native_token = node
+        .shell
+        .lock()
+        .unwrap()
+        .state
+        .in_mem()
+        .native_token
+        .clone();
+    let mut tx = namada_sdk::tx::Tx::deserialize(&tx_bytes).unwrap();
+    // Remove the expiration field to avoid a failure because of it, we only
+    // want to check the expiration in the masp vp
+    tx.header.expiration = None;
+    tx.add_wrapper(
+        namada_sdk::tx::data::wrapper::Fee {
+            amount_per_gas_unit: DenominatedAmount::native(1.into()),
+            token: native_token.clone(),
+        },
+        pk.clone(),
+        DEFAULT_GAS_LIMIT.into(),
+    );
+    tx.sign_wrapper(sk.clone());
+    let wrapper_hash = tx.wrapper_hash();
+    let inner_cmt = tx.first_commitments().unwrap();
+
+    // Skip at least 20 blocks to ensure expiration (this is because of the
+    // default masp expiration)
+    for _ in 0..=20 {
+        node.finalize_and_commit();
+    }
+    node.clear_results();
+    node.submit_txs(vec![tx.to_bytes()]);
+    {
+        let codes = node.tx_result_codes.lock().unwrap();
+        // If empty than failed in process proposal
+        assert!(!codes.is_empty());
+
+        for code in codes.iter() {
+            assert!(matches!(code, NodeResults::Ok));
+        }
+
+        let results = node.tx_results.lock().unwrap();
+        // We submitted a single batch
+        assert_eq!(results.len(), 1);
+
+        for result in results.iter() {
+            // The batch should contain a single inner tx
+            assert_eq!(result.0.len(), 1);
+
+            let inner_tx_result = result
+                .get_inner_tx_result(
+                    wrapper_hash.as_ref(),
+                    itertools::Either::Right(inner_cmt),
+                )
+                .expect("Missing expected tx result")
+                .as_ref()
+                .expect("Result is supposed to be Ok");
+
+            assert!(
+                inner_tx_result
+                    .vps_result
+                    .rejected_vps
+                    .contains(&namada_sdk::address::MASP)
+            );
+            assert!(inner_tx_result.vps_result.errors.contains(&(
+                namada_sdk::address::MASP,
+                "Native VP error: MASP transaction is expired".to_string()
+            )));
         }
     }
 

--- a/crates/tests/src/integration/setup.rs
+++ b/crates/tests/src/integration/setup.rs
@@ -224,7 +224,8 @@ fn create_node(
             test_dir: ManuallyDrop::new(test_dir),
         }),
         services: Arc::new(services),
-        results: Arc::new(Mutex::new(vec![])),
+        tx_result_codes: Arc::new(Mutex::new(vec![])),
+        tx_results: Arc::new(Mutex::new(vec![])),
         blocks: Arc::new(Mutex::new(HashMap::new())),
         auto_drive_services,
     };

--- a/crates/tests/src/integration/setup.rs
+++ b/crates/tests/src/integration/setup.rs
@@ -19,8 +19,8 @@ use namada_apps_lib::wallet::pre_genesis;
 use namada_core::chain::ChainIdPrefix;
 use namada_core::collections::HashMap;
 use namada_node::shell::testing::node::{
-    mock_services, MockNode, MockServicesCfg, MockServicesController,
-    MockServicesPackage, SalvageableTestDir,
+    mock_services, InnerMockNode, MockNode, MockServicesCfg,
+    MockServicesController, MockServicesPackage, SalvageableTestDir,
 };
 use namada_node::shell::testing::utils::TestDir;
 use namada_node::shell::Shell;
@@ -202,8 +202,8 @@ fn create_node(
         shell_handlers,
         controller,
     } = mock_services(services_cfg);
-    let node = MockNode {
-        shell: Arc::new(Mutex::new(Shell::new(
+    let node = MockNode(Arc::new(InnerMockNode {
+        shell: Mutex::new(Shell::new(
             config::Ledger::new(
                 global_args.base_dir,
                 chain_id.clone(),
@@ -218,17 +218,17 @@ fn create_node(
             None,
             50 * 1024 * 1024, // 50 kiB
             50 * 1024 * 1024, // 50 kiB
-        ))),
-        test_dir: Arc::new(SalvageableTestDir {
+        )),
+        test_dir: SalvageableTestDir {
             keep_temp,
             test_dir: ManuallyDrop::new(test_dir),
-        }),
-        services: Arc::new(services),
-        tx_result_codes: Arc::new(Mutex::new(vec![])),
-        tx_results: Arc::new(Mutex::new(vec![])),
-        blocks: Arc::new(Mutex::new(HashMap::new())),
+        },
+        services,
+        tx_result_codes: Mutex::new(vec![]),
+        tx_results: Mutex::new(vec![]),
+        blocks: Mutex::new(HashMap::new()),
         auto_drive_services,
-    };
+    }));
     let init_req =
         namada_apps_lib::tendermint::abci::request::InitChain {
             time: Timestamp {

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -383,13 +383,6 @@ impl<T> TxResult<T> {
         )
     }
 
-    // FIXME: check usage of this and maybe remove it
-    /// Check if the collection of inner tx results contains no errors.
-    #[inline]
-    pub fn are_results_ok(&self) -> bool {
-        self.iter().all(|(_, res)| res.is_ok())
-    }
-
     /// Check if the collection of inner tx results contains any ok results.
     #[inline]
     pub fn are_any_ok(&self) -> bool {

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -363,31 +363,40 @@ impl<T> TxResult<T> {
         self.0.iter()
     }
 
-    /// Return the length of the collecction of inner tx results.
+    /// Return the length of the collection of inner tx results.
     #[inline]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
-    /// Check if the collecction of inner tx results is empty.
+    /// Check if the collection of inner tx results is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
-    /// Check if the collecction of inner tx results contains no errors.
+    /// Check if all the inner txs in the collection have been successfully
+    /// applied.
+    #[inline]
+    pub fn are_results_successfull(&self) -> bool {
+        self.iter().all(|(_, res)| matches!(res, Ok(batched_result) if batched_result.is_accepted())
+        )
+    }
+
+    // FIXME: check usage of this and maybe remove it
+    /// Check if the collection of inner tx results contains no errors.
     #[inline]
     pub fn are_results_ok(&self) -> bool {
         self.iter().all(|(_, res)| res.is_ok())
     }
 
-    /// Check if the collecction of inner tx results contains any ok results.
+    /// Check if the collection of inner tx results contains any ok results.
     #[inline]
     pub fn are_any_ok(&self) -> bool {
         self.iter().any(|(_, res)| res.is_ok())
     }
 
-    /// Check if the collecction of inner tx results contains any errors.
+    /// Check if the collection of inner tx results contains any errors.
     #[inline]
     pub fn are_any_err(&self) -> bool {
         self.iter().any(|(_, res)| res.is_err())


### PR DESCRIPTION
## Describe your changes

Closes #3586.

- Fixes a bug by which the SDK would not set the correct expiration to MASP `Transaction`s
- Adds an integration test for masp expiration
- Removes some outdated assertions based on the old double-block execution scheme
- Improves assertions on `MockNode`
- Wraps `MockNode` into a single `Arc`

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
