### PR TITLE
Improve `gen_localnet.py` and `localnet-2.sh` scripts

### DIFF
--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -444,7 +444,7 @@ def to_edit_from_args(args):
     return args.edit
 
 
-def edit_templates(templates, to_edit):
+def edit_toml(data, to_edit):
     def invalid_dict(tab):
         return type(tab) != dict or len(tab) == 0
 
@@ -469,7 +469,7 @@ def edit_templates(templates, to_edit):
 
             table[key] = value
 
-    edit([], templates, to_edit)
+    edit([], data, to_edit)
 
 
 def write_templates(working_directory, templates):
@@ -483,7 +483,7 @@ def setup_templates(working_directory, args):
     to_edit = to_edit_from_args(args)
     info(f"Updating templates with provided args: {to_edit}")
     templates = load_base_templates(args.templates)
-    edit_templates(templates, to_edit)
+    edit_toml(templates, to_edit)
     write_templates(working_directory, templates)
     info("Templates have been updated")
     return templates

--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -512,6 +512,17 @@ def load_base_templates(base_templates):
     }
 
 
+def load_node_config(base_dir_prefix, chain_id, node_alias):
+    config_path = base_dir_prefix / node_alias / chain_id / "config.toml"
+    return toml.load(config_path)
+
+
+def write_node_config(config, base_dir_prefix, chain_id, node_alias):
+    config_path = base_dir_prefix / node_alias / chain_id / "config.toml"
+    with open(config_path, "w") as output_file:
+        toml.dump(config, output_file)
+
+
 def target_binary_paths(mode):
     bins = {}
 

--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -341,15 +341,15 @@ def parse_cli_args():
     group.add_argument(
         "--epoch-duration",
         type=parse_duration,
-        help="Epoch duration (eg: `1hr`, `30m`, `15s`). Defaults to `parameters.toml` value, and overrides value from `--edit`.",
+        help="Epoch duration (eg: `1hr`, `30m`, `15s`). Defaults to `parameters.toml` value, and overrides value from `--edit-templates`.",
     )
     group.add_argument(
         "--max-validator-slots",
         type=int,
-        help="Maximum number of validators. Defaults to `parameters.toml` value, and overrides value from `--edit`.",
+        help="Maximum number of validators. Defaults to `parameters.toml` value, and overrides value from `--edit-templates`.",
     )
     group.add_argument(
-        "--edit",
+        "--edit-templates",
         action="append",
         default=[],
         type=params_json_object,
@@ -358,7 +358,7 @@ def parse_cli_args():
     group.add_argument(
         "--eval",
         action=argparse.BooleanOptionalAction,
-        help="Evaluate strings passed to `--edit` as Python code.",
+        help="Evaluate strings passed to `--edit-templates` as Python code.",
     )
 
     args = parser.parse_args()
@@ -436,7 +436,7 @@ def load_json(s):
             return json.load(f)
 
 
-def to_edit_from_args(args):
+def to_edit_templates_from_args(args):
     if args.max_validator_slots:
         templates = {}
         value = args.max_validator_slots
@@ -444,7 +444,7 @@ def to_edit_from_args(args):
             value = repr(value)
         params = templates.setdefault(PARAMETERS_TEMPLATE, {})
         params.setdefault("pos_params", {})["max_validator_slots"] = value
-        args.edit.append(templates)
+        args.edit_templates.append(templates)
     if args.epoch_duration:
         templates = {}
         value = int(round(365 * 24 * 60 * 60 / args.epoch_duration.total_seconds()))
@@ -452,8 +452,8 @@ def to_edit_from_args(args):
             value = repr(value)
         params = templates.setdefault(PARAMETERS_TEMPLATE, {})
         params.setdefault("parameters", {})["epochs_per_year"] = value
-        args.edit.append(templates)
-    return args.edit
+        args.edit_templates.append(templates)
+    return args.edit_templates
 
 
 def edit_toml(data, to_edit_list, evaluate=False):
@@ -498,7 +498,7 @@ def write_templates(working_directory, templates):
 
 
 def setup_templates(working_directory, args):
-    to_edit = to_edit_from_args(args)
+    to_edit = to_edit_templates_from_args(args)
     info(f"Updating templates")
     templates = load_base_templates(args.templates)
     edit_toml(templates, to_edit, evaluate=args.eval)

--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -384,7 +384,7 @@ def parse_cli_args():
 
 
 def validator_aliases_json_object(s):
-    aliases = json.loads(s)
+    aliases = load_json(s)
 
     if type(aliases) != dict:
         die("Only JSON objects allowed for validator")
@@ -398,7 +398,7 @@ def validator_aliases_json_object(s):
 
 
 def params_json_object(s):
-    params = json.loads(s)
+    params = load_json(s)
 
     if type(params) != dict:
         die("Only JSON objects allowed for param updates")
@@ -407,7 +407,7 @@ def params_json_object(s):
 
 
 def full_nodes_object(s):
-    full_nodes = json.loads(s)
+    full_nodes = load_json(s)
 
     if type(full_nodes) != dict:
         die("Only JSON objects allowed for full nodes")
@@ -419,6 +419,15 @@ def full_nodes_object(s):
             )
 
     return full_nodes
+
+
+def load_json(s):
+    try:
+        return json.loads(s)
+    except json.decode.JSONDecodeError:
+        # assume we're dealing with a file path
+        with open(s, "r") as f:
+            return json.load(f)
 
 
 def to_edit_from_args(args):

--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -216,12 +216,20 @@ def join_network_with_fullnode(
         chain_id,
     )
 
+    config = load_node_config(
+        base_dir_prefix=base_dir_prefix,
+        chain_id=chain_id,
+        node_alias=fullnode_alias,
+    )
     update_fullnode_config(
+        config=config,
         full_node_base_port=fullnode_base_port,
-        fullnode_config_path=base_dir_prefix
-        / fullnode_alias
-        / chain_id
-        / "config.toml",
+    )
+    write_node_config(
+        config=config,
+        base_dir_prefix=base_dir_prefix,
+        chain_id=chain_id,
+        node_alias=fullnode_alias,
     )
 
     info(f"Full node {fullnode_alias} joined {chain_id}")
@@ -231,9 +239,7 @@ def join_network_with_fullnode(
     )
 
 
-def update_fullnode_config(full_node_base_port, fullnode_config_path):
-    config = toml.load(fullnode_config_path)
-
+def update_fullnode_config(config, full_node_base_port):
     config["ledger"]["cometbft"]["rpc"][
         "laddr"
     ] = f"tcp://127.0.0.1:{full_node_base_port}"
@@ -243,9 +249,6 @@ def update_fullnode_config(full_node_base_port, fullnode_config_path):
     config["ledger"]["cometbft"]["p2p"][
         "laddr"
     ] = f"tcp://0.0.0.0:{full_node_base_port + 2}"
-
-    with open(fullnode_config_path, "w") as output_file:
-        toml.dump(config, output_file)
 
 
 def log(color, descriptor, line):

--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -617,6 +617,18 @@ def parse_duration(time_str):
     return dur
 
 
+def append_list(l, *values):
+    for x in values:
+        l.append(x)
+    return l
+
+
+def insert_dict(d, **kwargs):
+    for k, v in kwargs.items():
+        d[k] = v
+    return d
+
+
 # https://stackoverflow.com/questions/8924173/how-can-i-print-bold-text-in-python
 class Color:
     PURPLE = "\033[95m"

--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -439,17 +439,19 @@ def load_json(s):
 def to_edit_from_args(args):
     if args.max_validator_slots:
         templates = {}
+        value = args.max_validator_slots
+        if args.eval:
+            value = repr(value)
         params = templates.setdefault(PARAMETERS_TEMPLATE, {})
-        params.setdefault("pos_params", {})[
-            "max_validator_slots"
-        ] = args.max_validator_slots
+        params.setdefault("pos_params", {})["max_validator_slots"] = value
         args.edit.append(templates)
     if args.epoch_duration:
         templates = {}
+        value = int(round(365 * 24 * 60 * 60 / args.epoch_duration.total_seconds()))
+        if args.eval:
+            value = repr(value)
         params = templates.setdefault(PARAMETERS_TEMPLATE, {})
-        params.setdefault("parameters", {})["epochs_per_year"] = int(
-            round(365 * 24 * 60 * 60 / args.epoch_duration.total_seconds())
-        )
+        params.setdefault("parameters", {})["epochs_per_year"] = value
         args.edit.append(templates)
     return args.edit
 

--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -464,6 +464,7 @@ def edit_templates(templates, to_edit):
             if type(value) == dict:
                 so_far.append(key)
                 edit(so_far, table[key], value)
+                so_far.pop()
                 return
 
             table[key] = value

--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -257,7 +257,7 @@ def info(msg):
 
 
 def warning(msg):
-    log(Color.YELLOW, "warning", msg)
+    log(Color.YELLOW, "warn", msg)
 
 
 def error(msg):

--- a/scripts/localnet-2.sh
+++ b/scripts/localnet-2.sh
@@ -55,18 +55,14 @@ main() {
         --alias validator-1
     cat "${_tmp}/signed.toml" >> "${_tmp}/localnet/transactions.toml"
 
-    # attribute balance to new validator
-    sed \
-        -i '' \
-        's/\(\[token\.BTC\]\)/tnam1qyq850fy0tdk8wkp40hhwu8a9wp2wn8stq3ldqrg = "200000"\ntnam1qr8l7l6rywucdarxg9q0zpggfe0jxddk6u09e8ez = "1000000"\n\1/' \
-        "${_tmp}/localnet/balances.toml"
-
     # generate localnet
     ./scripts/gen_localnet.py \
         --full-nodes '{"fullnode-0":12340}' \
         --templates "${_tmp}/localnet" \
         --validator-aliases '{"validator-0":"tnam1q9vhfdur7gadtwx4r223agpal0fvlqhywylf2mzx","validator-1":"tnam1qyq850fy0tdk8wkp40hhwu8a9wp2wn8stq3ldqrg"}' \
         --pre-genesis-path "${_tmp}/localnet/src/pre-genesis" \
+        --edit '{"balances.toml":{"token":{"NAM":"insert_dict(it,tnam1qyq850fy0tdk8wkp40hhwu8a9wp2wn8stq3ldqrg=\"200000\",tnam1qr8l7l6rywucdarxg9q0zpggfe0jxddk6u09e8ez=\"1000000\")"}}}' \
+        --eval \
         "$@"
 }
 

--- a/scripts/localnet-2.sh
+++ b/scripts/localnet-2.sh
@@ -53,7 +53,7 @@ main() {
         --path "${_tmp}/unsigned.toml" \
         --output "${_tmp}/signed.toml" \
         --alias validator-1
-    cat "${_tmp}/signed.toml" >> "${_tmp}/localnet/transactions.toml"
+    cat "${_tmp}/signed.toml" >>"${_tmp}/localnet/transactions.toml"
 
     # generate localnet
     ./scripts/gen_localnet.py \

--- a/scripts/localnet-2.sh
+++ b/scripts/localnet-2.sh
@@ -61,7 +61,7 @@ main() {
         --templates "${_tmp}/localnet" \
         --validator-aliases '{"validator-0":"tnam1q9vhfdur7gadtwx4r223agpal0fvlqhywylf2mzx","validator-1":"tnam1qyq850fy0tdk8wkp40hhwu8a9wp2wn8stq3ldqrg"}' \
         --pre-genesis-path "${_tmp}/localnet/src/pre-genesis" \
-        --edit '{"balances.toml":{"token":{"NAM":"insert_dict(it,tnam1qyq850fy0tdk8wkp40hhwu8a9wp2wn8stq3ldqrg=\"200000\",tnam1qr8l7l6rywucdarxg9q0zpggfe0jxddk6u09e8ez=\"1000000\")"}}}' \
+        --edit-temp '{"balances.toml":{"token":{"NAM":"insert_dict(it,tnam1qyq850fy0tdk8wkp40hhwu8a9wp2wn8stq3ldqrg=\"200000\",tnam1qr8l7l6rywucdarxg9q0zpggfe0jxddk6u09e8ez=\"1000000\")"}}}' \
         --eval \
         "$@"
 }


### PR DESCRIPTION
## Describe your changes

Improve `gen_localnet.py` script in various ways:

- Allow editing the `config.toml` of nodes, under `--edit-config`
- Rename `--edit` to `--edit-templates`
- Allow running arbitrary Python code to e.g. append new balance entries to `balances.toml` in `--edit-*` family of options
- Fix a minor bug in display paths
- Handle multiple `--edit-*` arguments in the CLI
- Support loading `--edit-*` params from a file path

With these changes, we also improve the `localnet-2.sh` script. Rather than using `sed` to assign a new balance, we use the new `gen_localnet.py` features.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
