### PR TITLE
Enable the signing logic to fall back to the hardware wallet if secret key is not found.

### DIFF
--- a/.changelog/unreleased/bug-fixes/3730-enable-hw-fallback.md
+++ b/.changelog/unreleased/bug-fixes/3730-enable-hw-fallback.md
@@ -1,0 +1,3 @@
+- Enable the signing logic to fall back to the hardware wallet
+  if a secret key is not found in software wallet store.
+  ([\#3730](https://github.com/anoma/namada/pull/3730))

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -232,7 +232,13 @@ where
 
         for public_key in &signing_data.public_keys {
             if !used_pubkeys.contains(public_key) {
-                let secret_key = find_key_by_pk(&mut wallet, args, public_key)?;
+                let Ok(secret_key) =
+                    find_key_by_pk(&mut wallet, args, public_key)
+                else {
+                    // If the secret key is not found, continue because the
+                    // hardware wallet may still be able to sign this
+                    continue;
+                };
                 used_pubkeys.insert(public_key.clone());
                 signing_tx_keypairs.push(secret_key);
             }


### PR DESCRIPTION
## Describe your changes
Currently the transaction signing logic fails fall back to the hardware wallet if the secret key is not found in the wallet store. This is because an error is propagated as soon as the secret key lookup fails. This PR fixes that. Additionally, the signing code now checks that the number of public keys used in signing exceeds the given account's threshold.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
