### PR TITLE
use test-dir for network archive to avoid re-compilations after test run

### DIFF
--- a/crates/apps_lib/build.rs
+++ b/crates/apps_lib/build.rs
@@ -9,7 +9,7 @@ const PROTO_SRC: &str = "./proto";
 
 fn main() {
     // Discover the repository version, if it exists
-    println!("cargo:rerun-if-changed=../.git");
+    println!("cargo:rerun-if-changed=../../.git");
     let describe_opts = DescribeOptions::new();
     let mut describe_format = DescribeFormatOptions::new();
     describe_format.dirty_suffix("-dirty");

--- a/crates/tests/src/integration/setup.rs
+++ b/crates/tests/src/integration/setup.rs
@@ -102,7 +102,7 @@ pub fn initialize_genesis(
             wasm_checksums_path,
             chain_id_prefix,
             consensus_timeout_commit: Timeout::from_str("30s").unwrap(),
-            archive_dir: None,
+            archive_dir: Some(test_dir.path().to_path_buf()),
             genesis_time,
         },
     );


### PR DESCRIPTION
## Describe your changes

Without `archive_dir` init-network creates the archive file in the current dir (`crates/tests`) which forces recompilation.