### PR TITLE
Update storage gas cost

### DIFF
--- a/.changelog/unreleased/improvements/3746-fix-storage-gas-cost.md
+++ b/.changelog/unreleased/improvements/3746-fix-storage-gas-cost.md
@@ -1,0 +1,2 @@
+- Increased the gas cost for storage consumption and improved gas tracking for
+  masp fee payments. ([\#3746](https://github.com/anoma/namada/pull/3746))

--- a/crates/gas/src/lib.rs
+++ b/crates/gas/src/lib.rs
@@ -64,7 +64,7 @@ const WRAPPER_TX_VALIDATION_GAS_RAW: u64 = 1_526_700;
 // space as a resource. This way, the storage occupation cost is not completely
 // free-floating but it's tied to the other costs
 const STORAGE_OCCUPATION_GAS_PER_BYTE_RAW: u64 =
-    PHYSICAL_STORAGE_LATENCY_PER_BYTE_RAW * (1 + 10);
+    PHYSICAL_STORAGE_LATENCY_PER_BYTE_RAW * (1 + 1_000);
 // NOTE: this accounts for the latency of a physical drive access. For read
 // accesses we have no way to tell if data was in cache or in storage. Moreover,
 // the latency shouldn't really be accounted per single byte but rather per

--- a/crates/gas/src/lib.rs
+++ b/crates/gas/src/lib.rs
@@ -484,22 +484,6 @@ impl TxGasMeter {
             .checked_sub(self.transaction_gas)
             .unwrap_or_default()
     }
-
-    /// Copy the consumed gas from the other instance. Fails if this value
-    /// exceeds the gas limit of this gas meter or if overflow happened
-    pub fn copy_consumed_gas_from(&mut self, other: &Self) -> Result<()> {
-        self.transaction_gas = other.transaction_gas;
-        self.gas_overflow = other.gas_overflow;
-
-        if self.transaction_gas > self.tx_gas_limit {
-            return Err(Error::TransactionGasExceededError);
-        }
-        if self.gas_overflow {
-            return Err(Error::GasOverflow);
-        }
-
-        Ok(())
-    }
 }
 
 impl GasMetering for VpGasMeter {

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -1269,7 +1269,7 @@ mod test_finalize_block {
     };
     use crate::tendermint::abci::types::Validator;
 
-    const WRAPPER_GAS_LIMIT: u64 = 1_500_000;
+    const WRAPPER_GAS_LIMIT: u64 = 10_000_000;
     const STORAGE_VALUE: &str = "test_value";
 
     /// Make a wrapper tx and a processed tx from the wrapped tx that can be

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -82,7 +82,8 @@ use tx::{
 use wallet::{Wallet, WalletIo, WalletStorage};
 
 /// Default gas-limit
-pub const DEFAULT_GAS_LIMIT: u64 = 150_000;
+// FIXME: lower
+pub const DEFAULT_GAS_LIMIT: u64 = 200_000;
 
 #[allow(missing_docs)]
 #[cfg(not(feature = "async-send"))]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -82,7 +82,6 @@ use tx::{
 use wallet::{Wallet, WalletIo, WalletStorage};
 
 /// Default gas-limit
-// FIXME: lower
 pub const DEFAULT_GAS_LIMIT: u64 = 200_000;
 
 #[allow(missing_docs)]

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -1053,7 +1053,7 @@ fn transfer(
         "--port-id",
         &port_id,
         "--gas-limit",
-        "200000",
+        "250000",
         "--node",
         &rpc,
     ]);
@@ -1229,7 +1229,7 @@ fn propose_inflation(test: &Test) -> Result<Epoch> {
         "--data-path",
         proposal_json_path.to_str().unwrap(),
         "--gas-limit",
-        "4000000",
+        "10000000",
         "--node",
         &rpc,
     ]);

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -2044,7 +2044,7 @@ fn proposal_change_shielded_reward() -> Result<()> {
         "--data-path",
         valid_proposal_json_path.to_str().unwrap(),
         "--gas-limit",
-        "4000000",
+        "10000000",
         "--node",
         &validator_one_rpc,
     ]);

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -724,7 +724,7 @@ fn proposal_submission() -> Result<()> {
         "--data-path",
         valid_proposal_json_path.to_str().unwrap(),
         "--gas-limit",
-        "5000000",
+        "10000000",
         "--node",
         &validator_one_rpc,
     ]);
@@ -1463,7 +1463,7 @@ fn implicit_account_reveal_pk() -> Result<()> {
                 "--signing-keys",
                 source,
                 "--gas-limit",
-                "2000000",
+                "3500000",
                 "--node",
                 &validator_one_rpc,
             ]

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -685,8 +685,9 @@ fn masp_incentives() -> Result<()> {
             CHRISTEL,
             "--token",
             NAM,
+            // FIXME: lower if possible
             "--gas-limit",
-            "200000",
+            "300000",
             "--amount",
             "1.451732",
             "--signing-keys",
@@ -2969,8 +2970,9 @@ fn masp_fee_payment_with_custom_spending_key() -> Result<()> {
                 NAM,
                 "--amount",
                 "9000",
+                // FIXME: lower
                 "--gas-limit",
-                "200000",
+                "300000",
                 "--gas-price",
                 "1",
                 "--gas-spending-key",
@@ -3028,7 +3030,7 @@ fn masp_fee_payment_with_custom_spending_key() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 101000"));
+    assert!(captured.contains("nam: 1000"));
 
     let captured = CapturedOutput::of(|| {
         run(
@@ -3149,7 +3151,7 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
             "--token",
             BTC,
             "--amount",
-            "200000",
+            "300000",
             "--gas-payer",
             ALBERT_KEY,
             "--ledger-address",
@@ -3218,7 +3220,7 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 200000"));
+    assert!(captured.contains("btc: 300000"));
 
     // Masp fee payment with custom token and gas payer
     let captured = CapturedOutput::of(|| {
@@ -3237,8 +3239,9 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
                 "1",
                 "--gas-token",
                 BTC,
+                // FIXME: reduce this
                 "--gas-limit",
-                "200000",
+                "300000",
                 "--gas-price",
                 "1",
                 "--gas-spending-key",

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -685,9 +685,8 @@ fn masp_incentives() -> Result<()> {
             CHRISTEL,
             "--token",
             NAM,
-            // FIXME: lower if possible
             "--gas-limit",
-            "300000",
+            "250000",
             "--amount",
             "1.451732",
             "--signing-keys",
@@ -2903,7 +2902,7 @@ fn masp_fee_payment_with_custom_spending_key() -> Result<()> {
             "--token",
             NAM,
             "--amount",
-            "300000",
+            "250000",
             "--ledger-address",
             validator_one_rpc,
         ],
@@ -2953,7 +2952,7 @@ fn masp_fee_payment_with_custom_spending_key() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 300000"));
+    assert!(captured.contains("nam: 250000"));
 
     // Masp fee payment with custom gas payer
     let captured = CapturedOutput::of(|| {
@@ -2970,9 +2969,8 @@ fn masp_fee_payment_with_custom_spending_key() -> Result<()> {
                 NAM,
                 "--amount",
                 "9000",
-                // FIXME: lower
                 "--gas-limit",
-                "300000",
+                "250000",
                 "--gas-price",
                 "1",
                 "--gas-spending-key",
@@ -3151,7 +3149,7 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
             "--token",
             BTC,
             "--amount",
-            "300000",
+            "250000",
             "--gas-payer",
             ALBERT_KEY,
             "--ledger-address",
@@ -3220,7 +3218,7 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 300000"));
+    assert!(captured.contains("btc: 250000"));
 
     // Masp fee payment with custom token and gas payer
     let captured = CapturedOutput::of(|| {
@@ -3239,9 +3237,8 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
                 "1",
                 "--gas-token",
                 BTC,
-                // FIXME: reduce this
                 "--gas-limit",
-                "300000",
+                "250000",
                 "--gas-price",
                 "1",
                 "--gas-spending-key",

--- a/genesis/hardware/parameters.toml
+++ b/genesis/hardware/parameters.toml
@@ -19,9 +19,9 @@ epochs_per_year = 31_536_000
 # The multiplier for masp epochs
 masp_epoch_multiplier = 2
 # Max gas for block
-max_block_gas = 15_000_000
+max_block_gas = 20_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 300_000
+masp_fee_payment_gas_limit = 200_000
 # Gas scale
 gas_scale = 10_000
 

--- a/genesis/hardware/parameters.toml
+++ b/genesis/hardware/parameters.toml
@@ -19,11 +19,11 @@ epochs_per_year = 31_536_000
 # The multiplier for masp epochs
 masp_epoch_multiplier = 2
 # Max gas for block
-max_block_gas = 20000000
+max_block_gas = 15_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 150_000
+masp_fee_payment_gas_limit = 300_000
 # Gas scale
-gas_scale = 10_000_000
+gas_scale = 10_000
 
 # Map of the cost per gas unit for every token allowed for fee payment
 [parameters.minimum_gas_price]

--- a/genesis/localnet/parameters.toml
+++ b/genesis/localnet/parameters.toml
@@ -19,10 +19,9 @@ epochs_per_year = 31_536_000
 # The multiplier for masp epochs
 masp_epoch_multiplier = 2
 # Max gas for block
-max_block_gas = 15_000_000
+max_block_gas = 20_000_000
 # Masp fee payment gas limit
-# FIXME: lower 
-masp_fee_payment_gas_limit = 300_000
+masp_fee_payment_gas_limit = 200_000
 # Gas scale
 gas_scale = 10_000
 

--- a/genesis/localnet/parameters.toml
+++ b/genesis/localnet/parameters.toml
@@ -21,7 +21,8 @@ masp_epoch_multiplier = 2
 # Max gas for block
 max_block_gas = 15_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 200_000
+# FIXME: lower 
+masp_fee_payment_gas_limit = 300_000
 # Gas scale
 gas_scale = 10_000
 

--- a/genesis/starter/parameters.toml
+++ b/genesis/starter/parameters.toml
@@ -19,9 +19,9 @@ epochs_per_year = 31_536_000
 # The multiplier for masp epochs
 masp_epoch_multiplier = 2
 # Max gas for block
-max_block_gas = 15_000_000
+max_block_gas = 20_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 300_000
+masp_fee_payment_gas_limit = 200_000
 # Gas scale
 gas_scale = 10_000
 

--- a/genesis/starter/parameters.toml
+++ b/genesis/starter/parameters.toml
@@ -21,7 +21,7 @@ masp_epoch_multiplier = 2
 # Max gas for block
 max_block_gas = 15_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 200_000
+masp_fee_payment_gas_limit = 300_000
 # Gas scale
 gas_scale = 10_000
 


### PR DESCRIPTION
## Describe your changes

Recovers the fix to the storage gas cost that was done in #3510 and went lost in #3554. Adjusts the `DEFAULT_GAS_LIMIT` and the gas limits in the genesis files.

Also improves gas tracking for masp fee payment: the gas meter now does not account for the gas used up to that point (wrapper gas) which could prevent some txs that consume a lot of gas in that phase (e.g. batches) from successfully pay fees via the MASP.

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
