### PR TITLE
Check length of validator name in metadata

### DIFF
--- a/.changelog/unreleased/improvements/3779-restrict-metadat-name-len.md
+++ b/.changelog/unreleased/improvements/3779-restrict-metadat-name-len.md
@@ -1,0 +1,2 @@
+- Check the string length of the validator name in provided metadata.
+  ([\#3779](https://github.com/anoma/namada/pull/3779))

--- a/crates/apps_lib/src/config/genesis/transactions.rs
+++ b/crates/apps_lib/src/config/genesis/transactions.rs
@@ -1417,6 +1417,15 @@ pub fn validate_validator_account(
             );
         }
     }
+    if let Some(name) = metadata.name.as_ref() {
+        if name.len() as u64 > MAX_VALIDATOR_METADATA_LEN {
+            panic!(
+                "The name metadata of the validator with address {} is too \
+                 long, must be within {MAX_VALIDATOR_METADATA_LEN} characters",
+                signed_tx.data.address
+            );
+        }
+    }
 
     // Check signature
     let mut is_valid = {

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -846,6 +846,18 @@ pub async fn build_validator_metadata_change(
             }
         }
     }
+    if let Some(name) = name.as_ref() {
+        if name.len() as u64 > MAX_VALIDATOR_METADATA_LEN {
+            edisplay_line!(
+                context.io(),
+                "Name provided is too long, must be within \
+                 {MAX_VALIDATOR_METADATA_LEN} characters"
+            );
+            if !tx_args.force {
+                return Err(Error::from(TxSubmitError::MetadataTooLong));
+            }
+        }
+    }
 
     // If there's a new commission rate, it must be valid
     if let Some(rate) = commission_rate.as_ref() {


### PR DESCRIPTION
## Describe your changes
When we added `name`, forgot to include a check on the string length

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
