### PR TITLE
Validate genesis NAM MaspParams

### DIFF
--- a/.changelog/unreleased/improvements/3806-validate-nam-masp-params.md
+++ b/.changelog/unreleased/improvements/3806-validate-nam-masp-params.md
@@ -1,0 +1,2 @@
+ - When calling init chain, we now verify that the native token alias has masp
+   parameters set. ([\#3806](https://github.com/anoma/namada/pull/3806))


### PR DESCRIPTION
## Describe your changes
When calling init chain, we now verify that the native token alias has masp parameters set.
## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
