### PR TITLE
env agnostic VPs

### DIFF
--- a/.changelog/unreleased/improvements/3807-env-agnostic-vps.md
+++ b/.changelog/unreleased/improvements/3807-env-agnostic-vps.md
@@ -1,0 +1,2 @@
+- Refactored most native VPs to be agnostic to VP environment (WASM or native).
+  ([\#3807](https://github.com/anoma/namada/pull/3807))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ dependencies = [
  "namada_tx",
  "namada_vm",
  "namada_vp",
+ "namada_vp_env",
  "proptest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5384,7 +5384,7 @@ dependencies = [
  "namada_systems",
  "namada_trans_token",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "namada_wallet",
  "proptest",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,6 +4941,7 @@ dependencies = [
  "namada_vm",
  "namada_vote_ext",
  "namada_vp",
+ "namada_vp_env",
  "proptest",
  "rand 0.8.5",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5262,7 +5262,7 @@ dependencies = [
  "namada_systems",
  "namada_trans_token",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "once_cell",
  "pretty_assertions",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5233,7 +5233,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "smooth-operator",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5564,6 +5564,7 @@ dependencies = [
  "namada_tx",
  "namada_vm",
  "namada_vp",
+ "namada_vp_env",
  "thiserror",
  "tracing",
 ]

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -513,7 +513,7 @@ fn vp_multitoken(c: &mut Criterion) {
         let gas_meter = RefCell::new(VpGasMeter::new_from_tx_meter(
             &TxGasMeter::new(u64::MAX),
         ));
-        let multitoken = MultitokenVp::new(Ctx::new(
+        let ctx = Ctx::new(
             &Address::Internal(InternalAddress::Multitoken),
             &shell.state,
             &signed_tx.tx,
@@ -523,18 +523,18 @@ fn vp_multitoken(c: &mut Criterion) {
             &keys_changed,
             &verifiers,
             shell.vp_wasm_cache.clone(),
-        ));
+        );
 
         group.bench_function(bench_name, |b| {
             b.iter(|| {
                 assert!(
-                    multitoken
-                        .validate_tx(
-                            &signed_tx.to_ref(),
-                            multitoken.ctx.keys_changed,
-                            multitoken.ctx.verifiers,
-                        )
-                        .is_ok()
+                    MultitokenVp::validate_tx(
+                        &ctx,
+                        &signed_tx.to_ref(),
+                        ctx.keys_changed,
+                        ctx.verifiers,
+                    )
+                    .is_ok()
                 )
             })
         });

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -1490,7 +1490,7 @@ fn eth_bridge_pool(c: &mut Criterion) {
     let vp_address = Address::Internal(InternalAddress::EthBridgePool);
     let gas_meter =
         RefCell::new(VpGasMeter::new_from_tx_meter(&TxGasMeter::new(u64::MAX)));
-    let bridge_pool = EthBridgePoolVp::new(Ctx::new(
+    let ctx = Ctx::new(
         &vp_address,
         &shell.state,
         &signed_tx.tx,
@@ -1500,18 +1500,18 @@ fn eth_bridge_pool(c: &mut Criterion) {
         &keys_changed,
         &verifiers,
         shell.vp_wasm_cache.clone(),
-    ));
+    );
 
     c.bench_function("vp_eth_bridge_pool", |b| {
         b.iter(|| {
             assert!(
-                bridge_pool
-                    .validate_tx(
-                        &signed_tx.to_ref(),
-                        bridge_pool.ctx.keys_changed,
-                        bridge_pool.ctx.verifiers,
-                    )
-                    .is_ok()
+                EthBridgePoolVp::validate_tx(
+                    &ctx,
+                    &signed_tx.to_ref(),
+                    ctx.keys_changed,
+                    ctx.verifiers,
+                )
+                .is_ok()
             )
         })
     });

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -1246,7 +1246,7 @@ fn pgf(c: &mut Criterion) {
         let gas_meter = RefCell::new(VpGasMeter::new_from_tx_meter(
             &TxGasMeter::new(u64::MAX),
         ));
-        let pgf = PgfVp::new(Ctx::new(
+        let ctx = Ctx::new(
             &Address::Internal(InternalAddress::Pgf),
             &shell.state,
             &signed_tx.tx,
@@ -1256,15 +1256,16 @@ fn pgf(c: &mut Criterion) {
             &keys_changed,
             &verifiers,
             shell.vp_wasm_cache.clone(),
-        ));
+        );
 
         group.bench_function(bench_name, |b| {
             b.iter(|| {
                 assert!(
-                    pgf.validate_tx(
+                    PgfVp::validate_tx(
+                        &ctx,
                         &signed_tx.to_ref(),
-                        pgf.ctx.keys_changed,
-                        pgf.ctx.verifiers,
+                        ctx.keys_changed,
+                        ctx.verifiers,
                     )
                     .is_ok()
                 )

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -1640,7 +1640,7 @@ fn pos(c: &mut Criterion) {
         let gas_meter = RefCell::new(VpGasMeter::new_from_tx_meter(
             &TxGasMeter::new(u64::MAX),
         ));
-        let pos = PosVp::new(Ctx::new(
+        let ctx = Ctx::new(
             &vp_address,
             &shell.state,
             &signed_tx.tx,
@@ -1650,15 +1650,16 @@ fn pos(c: &mut Criterion) {
             &keys_changed,
             &verifiers,
             shell.vp_wasm_cache.clone(),
-        ));
+        );
 
         group.bench_function(bench_name, |b| {
             b.iter(|| {
                 assert!(
-                    pos.validate_tx(
+                    PosVp::validate_tx(
+                        &ctx,
                         &signed_tx.to_ref(),
-                        pos.ctx.keys_changed,
-                        pos.ctx.verifiers,
+                        ctx.keys_changed,
+                        ctx.verifiers,
                     )
                     .is_ok()
                 )

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -220,7 +220,7 @@ fn governance(c: &mut Criterion) {
         let gas_meter = RefCell::new(VpGasMeter::new_from_tx_meter(
             &TxGasMeter::new(u64::MAX),
         ));
-        let governance = GovernanceVp::new(Ctx::new(
+        let ctx = Ctx::new(
             &Address::Internal(InternalAddress::Governance),
             &shell.state,
             &signed_tx.tx,
@@ -230,18 +230,18 @@ fn governance(c: &mut Criterion) {
             &keys_changed,
             &verifiers,
             shell.vp_wasm_cache.clone(),
-        ));
+        );
 
         group.bench_function(bench_name, |b| {
             b.iter(|| {
                 assert!(
-                    governance
-                        .validate_tx(
-                            &signed_tx.to_ref(),
-                            governance.ctx.keys_changed,
-                            governance.ctx.verifiers,
-                        )
-                        .is_ok()
+                    GovernanceVp::validate_tx(
+                        &ctx,
+                        &signed_tx.to_ref(),
+                        ctx.keys_changed,
+                        ctx.verifiers,
+                    )
+                    .is_ok()
                 )
             })
         });

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -1322,7 +1322,7 @@ fn eth_bridge_nut(c: &mut Criterion) {
         Address::Internal(InternalAddress::Nut(native_erc20_addres));
     let gas_meter =
         RefCell::new(VpGasMeter::new_from_tx_meter(&TxGasMeter::new(u64::MAX)));
-    let nut = EthBridgeNutVp::new(Ctx::new(
+    let ctx = Ctx::new(
         &vp_address,
         &shell.state,
         &signed_tx.tx,
@@ -1332,15 +1332,16 @@ fn eth_bridge_nut(c: &mut Criterion) {
         &keys_changed,
         &verifiers,
         shell.vp_wasm_cache.clone(),
-    ));
+    );
 
     c.bench_function("vp_eth_bridge_nut", |b| {
         b.iter(|| {
             assert!(
-                nut.validate_tx(
+                EthBridgeNutVp::validate_tx(
+                    &ctx,
                     &signed_tx.to_ref(),
-                    nut.ctx.keys_changed,
-                    nut.ctx.verifiers,
+                    ctx.keys_changed,
+                    ctx.verifiers,
                 )
                 .is_ok()
             )

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -1393,7 +1393,7 @@ fn eth_bridge(c: &mut Criterion) {
     let vp_address = Address::Internal(InternalAddress::EthBridge);
     let gas_meter =
         RefCell::new(VpGasMeter::new_from_tx_meter(&TxGasMeter::new(u64::MAX)));
-    let eth_bridge = EthBridgeVp::new(Ctx::new(
+    let ctx = Ctx::new(
         &vp_address,
         &shell.state,
         &signed_tx.tx,
@@ -1403,18 +1403,18 @@ fn eth_bridge(c: &mut Criterion) {
         &keys_changed,
         &verifiers,
         shell.vp_wasm_cache.clone(),
-    ));
+    );
 
     c.bench_function("vp_eth_bridge", |b| {
         b.iter(|| {
             assert!(
-                eth_bridge
-                    .validate_tx(
-                        &signed_tx.to_ref(),
-                        eth_bridge.ctx.keys_changed,
-                        eth_bridge.ctx.verifiers,
-                    )
-                    .is_ok()
+                EthBridgeVp::validate_tx(
+                    &ctx,
+                    &signed_tx.to_ref(),
+                    ctx.keys_changed,
+                    ctx.verifiers,
+                )
+                .is_ok()
             )
         })
     });

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -634,7 +634,7 @@ fn masp(c: &mut Criterion) {
             let gas_meter = RefCell::new(VpGasMeter::new_from_tx_meter(
                 &TxGasMeter::new(u64::MAX),
             ));
-            let masp = MaspVp::new(Ctx::new(
+            let ctx = Ctx::new(
                 &Address::Internal(InternalAddress::Masp),
                 &shell_read.state,
                 &signed_tx.tx,
@@ -644,14 +644,15 @@ fn masp(c: &mut Criterion) {
                 &keys_changed,
                 &verifiers,
                 shell_read.vp_wasm_cache.clone(),
-            ));
+            );
 
             b.iter(|| {
                 assert!(
-                    masp.validate_tx(
+                    MaspVp::validate_tx(
+                        &ctx,
                         &signed_tx.to_ref(),
-                        masp.ctx.keys_changed,
-                        masp.ctx.verifiers,
+                        ctx.keys_changed,
+                        ctx.verifiers,
                     )
                     .is_ok()
                 );

--- a/crates/ethereum_bridge/Cargo.toml
+++ b/crates/ethereum_bridge/Cargo.toml
@@ -41,7 +41,6 @@ namada_systems = { path = "../systems" }
 namada_trans_token = {path = "../trans_token"}
 namada_tx = {path = "../tx"}
 namada_vote_ext = {path = "../vote_ext"}
-namada_vp = {path = "../vp"}
 namada_vp_env = {path = "../vp_env"}
 
 borsh.workspace = true
@@ -65,6 +64,7 @@ namada_state = { path = "../state", features = ["testing"] }
 namada_token = {path = "../token", features = ["testing"]}
 namada_tx = {path = "../tx", features = ["testing"]}
 namada_vm = {path = "../vm", features = ["testing"]}
+namada_vp = {path = "../vp"}
 
 assert_matches.workspace = true
 data-encoding.workspace = true

--- a/crates/ethereum_bridge/Cargo.toml
+++ b/crates/ethereum_bridge/Cargo.toml
@@ -42,6 +42,7 @@ namada_trans_token = {path = "../trans_token"}
 namada_tx = {path = "../tx"}
 namada_vote_ext = {path = "../vote_ext"}
 namada_vp = {path = "../vp"}
+namada_vp_env = {path = "../vp_env"}
 
 borsh.workspace = true
 ethers.workspace = true

--- a/crates/governance/Cargo.toml
+++ b/crates/governance/Cargo.toml
@@ -30,6 +30,7 @@ namada_state = { path = "../state" }
 namada_systems = { path = "../systems" }
 namada_tx = { path = "../tx" }
 namada_vp = { path = "../vp" }
+namada_vp_env = { path = "../vp_env" }
 
 arbitrary = { workspace = true, optional = true }
 borsh.workspace = true

--- a/crates/governance/Cargo.toml
+++ b/crates/governance/Cargo.toml
@@ -29,7 +29,6 @@ namada_migrations = { path= "../migrations", optional = true }
 namada_state = { path = "../state" }
 namada_systems = { path = "../systems" }
 namada_tx = { path = "../tx" }
-namada_vp = { path = "../vp" }
 namada_vp_env = { path = "../vp_env" }
 
 arbitrary = { workspace = true, optional = true }
@@ -54,6 +53,7 @@ namada_state = { path = "../state", features = ["testing"] }
 namada_token = { path = "../token", features = ["testing"] }
 namada_tx = { path = "../tx", features = ["testing"] }
 namada_vm = { path = "../vm", features = ["testing"] }
+namada_vp = { path = "../vp" }
 
 assert_matches.workspace = true
 proptest.workspace = true

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -1297,14 +1297,13 @@ where
                                     .map_err(Error::NativeVpError)
                             }
                             InternalAddress::EthBridgePool => {
-                                let bridge_pool = EthBridgePoolVp::new(ctx);
-                                bridge_pool
-                                    .validate_tx(
-                                        batched_tx,
-                                        &keys_changed,
-                                        &verifiers,
-                                    )
-                                    .map_err(Error::NativeVpError)
+                                EthBridgePoolVp::validate_tx(
+                                    &ctx,
+                                    batched_tx,
+                                    &keys_changed,
+                                    &verifiers,
+                                )
+                                .map_err(Error::NativeVpError)
                             }
                             InternalAddress::Nut(_) => {
                                 let non_usable_tokens =

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -1238,14 +1238,13 @@ where
                                 .map_err(Error::NativeVpError)
                             }
                             InternalAddress::Parameters => {
-                                let parameters = ParametersVp::new(ctx);
-                                parameters
-                                    .validate_tx(
-                                        batched_tx,
-                                        &keys_changed,
-                                        &verifiers,
-                                    )
-                                    .map_err(Error::NativeVpError)
+                                ParametersVp::validate_tx(
+                                    &ctx,
+                                    batched_tx,
+                                    &keys_changed,
+                                    &verifiers,
+                                )
+                                .map_err(Error::NativeVpError)
                             }
                             InternalAddress::PosSlashPool => {
                                 Err(Error::AccessForbidden(

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -1219,15 +1219,13 @@ where
                         );
 
                         match internal_addr {
-                            InternalAddress::PoS => {
-                                let pos = PosVp::new(ctx);
-                                pos.validate_tx(
-                                    batched_tx,
-                                    &keys_changed,
-                                    &verifiers,
-                                )
-                                .map_err(Error::NativeVpError)
-                            }
+                            InternalAddress::PoS => PosVp::validate_tx(
+                                &ctx,
+                                batched_tx,
+                                &keys_changed,
+                                &verifiers,
+                            )
+                            .map_err(Error::NativeVpError),
                             InternalAddress::Ibc => {
                                 let ibc = IbcVp::new(ctx);
                                 ibc.validate_tx(

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -1260,16 +1260,13 @@ where
                                 )
                                 .map_err(Error::NativeVpError)
                             }
-                            InternalAddress::Pgf => {
-                                let pgf_vp = PgfVp::new(ctx);
-                                pgf_vp
-                                    .validate_tx(
-                                        batched_tx,
-                                        &keys_changed,
-                                        &verifiers,
-                                    )
-                                    .map_err(Error::NativeVpError)
-                            }
+                            InternalAddress::Pgf => PgfVp::validate_tx(
+                                &ctx,
+                                batched_tx,
+                                &keys_changed,
+                                &verifiers,
+                            )
+                            .map_err(Error::NativeVpError),
                             InternalAddress::Multitoken => {
                                 let multitoken = MultitokenVp::new(ctx);
                                 multitoken

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -1266,14 +1266,13 @@ where
                             )
                             .map_err(Error::NativeVpError),
                             InternalAddress::Multitoken => {
-                                let multitoken = MultitokenVp::new(ctx);
-                                multitoken
-                                    .validate_tx(
-                                        batched_tx,
-                                        &keys_changed,
-                                        &verifiers,
-                                    )
-                                    .map_err(Error::NativeVpError)
+                                MultitokenVp::validate_tx(
+                                    &ctx,
+                                    batched_tx,
+                                    &keys_changed,
+                                    &verifiers,
+                                )
+                                .map_err(Error::NativeVpError)
                             }
                             InternalAddress::Masp => {
                                 let masp = MaspVp::new(ctx);

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -1287,14 +1287,13 @@ where
                                 .map_err(Error::NativeVpError)
                             }
                             InternalAddress::EthBridge => {
-                                let bridge = EthBridgeVp::new(ctx);
-                                bridge
-                                    .validate_tx(
-                                        batched_tx,
-                                        &keys_changed,
-                                        &verifiers,
-                                    )
-                                    .map_err(Error::NativeVpError)
+                                EthBridgeVp::validate_tx(
+                                    &ctx,
+                                    batched_tx,
+                                    &keys_changed,
+                                    &verifiers,
+                                )
+                                .map_err(Error::NativeVpError)
                             }
                             InternalAddress::EthBridgePool => {
                                 EthBridgePoolVp::validate_tx(

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -1305,15 +1305,13 @@ where
                                 .map_err(Error::NativeVpError)
                             }
                             InternalAddress::Nut(_) => {
-                                let non_usable_tokens =
-                                    EthBridgeNutVp::new(ctx);
-                                non_usable_tokens
-                                    .validate_tx(
-                                        batched_tx,
-                                        &keys_changed,
-                                        &verifiers,
-                                    )
-                                    .map_err(Error::NativeVpError)
+                                EthBridgeNutVp::validate_tx(
+                                    &ctx,
+                                    batched_tx,
+                                    &keys_changed,
+                                    &verifiers,
+                                )
+                                .map_err(Error::NativeVpError)
                             }
                             internal_addr @ (InternalAddress::IbcToken(_)
                             | InternalAddress::Erc20(_)) => {

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -1252,14 +1252,13 @@ where
                                 ))
                             }
                             InternalAddress::Governance => {
-                                let governance = GovernanceVp::new(ctx);
-                                governance
-                                    .validate_tx(
-                                        batched_tx,
-                                        &keys_changed,
-                                        &verifiers,
-                                    )
-                                    .map_err(Error::NativeVpError)
+                                GovernanceVp::validate_tx(
+                                    &ctx,
+                                    batched_tx,
+                                    &keys_changed,
+                                    &verifiers,
+                                )
+                                .map_err(Error::NativeVpError)
                             }
                             InternalAddress::Pgf => {
                                 let pgf_vp = PgfVp::new(ctx);

--- a/crates/parameters/Cargo.toml
+++ b/crates/parameters/Cargo.toml
@@ -25,7 +25,7 @@ namada_macros = { path = "../macros" }
 namada_state = { path = "../state" }
 namada_systems = { path = "../systems" }
 namada_tx = { path = "../tx" }
-namada_vp = { path = "../vp" }
+namada_vp_env = { path = "../vp_env" }
 
 smooth-operator.workspace = true
 thiserror.workspace = true

--- a/crates/proof_of_stake/Cargo.toml
+++ b/crates/proof_of_stake/Cargo.toml
@@ -31,7 +31,7 @@ namada_migrations = { path = "../migrations", optional = true }
 namada_state = { path = "../state" }
 namada_systems = { path = "../systems" }
 namada_tx = { path = "../tx" }
-namada_vp = { path = "../vp" }
+namada_vp_env = { path = "../vp_env" }
 
 borsh.workspace = true
 konst.workspace = true

--- a/crates/sdk/src/validation.rs
+++ b/crates/sdk/src/validation.rs
@@ -101,8 +101,8 @@ pub type EthBridgePoolVp<'ctx, CTX> =
     eth_bridge::vp::BridgePool<'ctx, CTX, TokenKeys>;
 
 /// Native ETH bridge NUT VP
-pub type EthBridgeNutVp<'a, S, CA> =
-    eth_bridge::vp::NonUsableTokens<'a, S, VpCache<CA>, Eval<S, CA>, TokenKeys>;
+pub type EthBridgeNutVp<'ctx, CTX> =
+    eth_bridge::vp::NonUsableTokens<'ctx, CTX, TokenKeys>;
 
 /// Governance store implementation over the native prior context
 pub type GovPreStore<'a, S, CA> =

--- a/crates/sdk/src/validation.rs
+++ b/crates/sdk/src/validation.rs
@@ -68,13 +68,11 @@ pub type GovernanceVp<'ctx, CTX> = governance::vp::GovernanceVp<
 pub type PgfVp<'ctx, CTX> = governance::vp::pgf::PgfVp<'ctx, CTX>;
 
 /// Native multitoken VP
-pub type MultitokenVp<'a, S, CA> = token::vp::MultitokenVp<
-    'a,
-    S,
-    VpCache<CA>,
-    Eval<S, CA>,
-    ParamsPreStore<'a, S, CA>,
-    GovPreStore<'a, S, CA>,
+pub type MultitokenVp<'ctx, CTX> = token::vp::MultitokenVp<
+    'ctx,
+    CTX,
+    parameters::Store<<CTX as VpEnv<'ctx>>::Pre>,
+    governance::Store<<CTX as VpEnv<'ctx>>::Pre>,
 >;
 
 /// Native MASP VP

--- a/crates/sdk/src/validation.rs
+++ b/crates/sdk/src/validation.rs
@@ -67,8 +67,7 @@ pub type GovernanceVp<'ctx, CTX> = governance::vp::GovernanceVp<
 >;
 
 /// Native PGF VP
-pub type PgfVp<'a, S, CA> =
-    governance::vp::pgf::PgfVp<'a, S, VpCache<CA>, Eval<S, CA>>;
+pub type PgfVp<'ctx, CTX> = governance::vp::pgf::PgfVp<'ctx, CTX>;
 
 /// Native multitoken VP
 pub type MultitokenVp<'a, S, CA> = token::vp::MultitokenVp<

--- a/crates/sdk/src/validation.rs
+++ b/crates/sdk/src/validation.rs
@@ -76,15 +76,13 @@ pub type MultitokenVp<'ctx, CTX> = token::vp::MultitokenVp<
 >;
 
 /// Native MASP VP
-pub type MaspVp<'a, S, CA> = token::vp::MaspVp<
-    'a,
-    S,
-    VpCache<CA>,
-    Eval<S, CA>,
-    ParamsPreStore<'a, S, CA>,
-    GovPreStore<'a, S, CA>,
-    IbcPostStore<'a, S, CA>,
-    TokenPreStore<'a, S, CA>,
+pub type MaspVp<'ctx, CTX> = token::vp::MaspVp<
+    'ctx,
+    CTX,
+    parameters::Store<<CTX as VpEnv<'ctx>>::Pre>,
+    governance::Store<<CTX as VpEnv<'ctx>>::Pre>,
+    ibc::Store<<CTX as VpEnv<'ctx>>::Post>,
+    token::Store<<CTX as VpEnv<'ctx>>::Pre>,
     token::Transfer,
 >;
 

--- a/crates/sdk/src/validation.rs
+++ b/crates/sdk/src/validation.rs
@@ -17,12 +17,10 @@ pub type NativeVpCtx<'a, S, CA> =
 type Eval<S, CA> = VpEvalWasm<<S as StateRead>::D, <S as StateRead>::H, CA>;
 
 /// Native PoS VP
-pub type PosVp<'a, S, CA> = proof_of_stake::vp::PosVp<
-    'a,
-    S,
-    VpCache<CA>,
-    Eval<S, CA>,
-    GovPreStore<'a, S, CA>,
+pub type PosVp<'ctx, CTX> = proof_of_stake::vp::PosVp<
+    'ctx,
+    CTX,
+    governance::Store<<CTX as VpEnv<'ctx>>::Pre>,
 >;
 
 /// Native IBC VP

--- a/crates/sdk/src/validation.rs
+++ b/crates/sdk/src/validation.rs
@@ -97,8 +97,8 @@ pub type EthBridgeVp<'a, S, CA> =
     eth_bridge::vp::EthBridge<'a, S, VpCache<CA>, Eval<S, CA>, TokenKeys>;
 
 /// Native ETH bridge pool VP
-pub type EthBridgePoolVp<'a, S, CA> =
-    eth_bridge::vp::BridgePool<'a, S, VpCache<CA>, Eval<S, CA>, TokenKeys>;
+pub type EthBridgePoolVp<'ctx, CTX> =
+    eth_bridge::vp::BridgePool<'ctx, CTX, TokenKeys>;
 
 /// Native ETH bridge NUT VP
 pub type EthBridgeNutVp<'a, S, CA> =

--- a/crates/sdk/src/validation.rs
+++ b/crates/sdk/src/validation.rs
@@ -59,12 +59,10 @@ pub type ParametersVp<'ctx, CTX> = parameters::vp::ParametersVp<
 >;
 
 /// Native governance VP
-pub type GovernanceVp<'a, S, CA> = governance::vp::GovernanceVp<
-    'a,
-    S,
-    VpCache<CA>,
-    Eval<S, CA>,
-    PosPreStore<'a, S, CA>,
+pub type GovernanceVp<'ctx, CTX> = governance::vp::GovernanceVp<
+    'ctx,
+    CTX,
+    proof_of_stake::Store<<CTX as VpEnv<'ctx>>::Pre>,
     TokenKeys,
 >;
 

--- a/crates/sdk/src/validation.rs
+++ b/crates/sdk/src/validation.rs
@@ -4,6 +4,7 @@
 use namada_vm::wasm::run::VpEvalWasm;
 use namada_vm::wasm::VpCache;
 use namada_vp::native_vp::{self, CtxPostStorageRead, CtxPreStorageRead};
+use namada_vp::VpEnv;
 
 use crate::state::StateRead;
 use crate::{eth_bridge, governance, ibc, parameters, proof_of_stake, token};
@@ -51,12 +52,10 @@ pub type IbcVpContext<'view, 'a, S, CA, EVAL> =
     >;
 
 /// Native parameters VP
-pub type ParametersVp<'a, S, CA> = parameters::vp::ParametersVp<
-    'a,
-    S,
-    VpCache<CA>,
-    Eval<S, CA>,
-    GovPreStore<'a, S, CA>,
+pub type ParametersVp<'ctx, CTX> = parameters::vp::ParametersVp<
+    'ctx,
+    CTX,
+    governance::Store<<CTX as VpEnv<'ctx>>::Pre>,
 >;
 
 /// Native governance VP

--- a/crates/sdk/src/validation.rs
+++ b/crates/sdk/src/validation.rs
@@ -93,8 +93,8 @@ pub type MaspVp<'a, S, CA> = token::vp::MaspVp<
 >;
 
 /// Native ETH bridge VP
-pub type EthBridgeVp<'a, S, CA> =
-    eth_bridge::vp::EthBridge<'a, S, VpCache<CA>, Eval<S, CA>, TokenKeys>;
+pub type EthBridgeVp<'ctx, CTX> =
+    eth_bridge::vp::EthBridge<'ctx, CTX, TokenKeys>;
 
 /// Native ETH bridge pool VP
 pub type EthBridgePoolVp<'ctx, CTX> =

--- a/crates/shielded_token/Cargo.toml
+++ b/crates/shielded_token/Cargo.toml
@@ -47,7 +47,7 @@ namada_migrations = { path = "../migrations", optional = true }
 namada_state = { path = "../state" }
 namada_systems = { path = "../systems" }
 namada_tx = { path = "../tx" }
-namada_vp = { path = "../vp" }
+namada_vp_env = { path = "../vp_env" }
 namada_wallet = { path = "../wallet", optional = true }
 
 async-trait.workspace = true

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -54,7 +54,7 @@ pub use namada_merkle_tree::{
 };
 pub use namada_storage as storage;
 pub use namada_storage::conversion_state::{
-    ConversionLeaf, ConversionState, WithConversionState,
+    ConversionLeaf, ConversionState, ReadConversionState, WithConversionState,
 };
 pub use namada_storage::types::{KVBytes, PatternIterator, PrefixIterator};
 pub use namada_storage::{

--- a/crates/storage/src/conversion_state.rs
+++ b/crates/storage/src/conversion_state.rs
@@ -44,11 +44,14 @@ pub struct ConversionState {
     pub assets: BTreeMap<AssetType, ConversionLeaf>,
 }
 
-/// Able to borrow mutable conversion state.
-pub trait WithConversionState {
+/// Able to borrow conversion state.
+pub trait ReadConversionState {
     /// Borrow immutable conversion state
     fn conversion_state(&self) -> &ConversionState;
+}
 
+/// Able to borrow mutable conversion state.
+pub trait WithConversionState: ReadConversionState {
     /// Borrow mutable conversion state
     fn conversion_state_mut(&mut self) -> &mut ConversionState;
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -304,6 +304,7 @@ where
 /// Helpers for testing components that depend on storage
 #[cfg(any(test, feature = "testing"))]
 pub mod testing {
+    use conversion_state::ReadConversionState;
     use namada_core::address;
     use namada_core::chain::ChainId;
     use namada_core::collections::HashMap;
@@ -440,11 +441,13 @@ pub mod testing {
         }
     }
 
-    impl WithConversionState for TestStorage {
+    impl ReadConversionState for TestStorage {
         fn conversion_state(&self) -> &ConversionState {
             &self.conversion_state
         }
+    }
 
+    impl WithConversionState for TestStorage {
         fn conversion_state_mut(&mut self) -> &mut ConversionState {
             &mut self.conversion_state
         }

--- a/crates/tests/src/native_vp/eth_bridge_pool.rs
+++ b/crates/tests/src/native_vp/eth_bridge_pool.rs
@@ -118,8 +118,14 @@ mod test_bridge_pool_vp {
         ));
         let vp_env = TestNativeVpEnv::from_tx_env(tx_env, BRIDGE_POOL_ADDRESS);
 
-        let vp = vp_env.init_vp(&gas_meter, EthBridgePoolVp::new);
-        vp_env.validate_tx(&vp).is_ok()
+        let ctx = vp_env.ctx(&gas_meter);
+        EthBridgePoolVp::validate_tx(
+            &ctx,
+            &vp_env.tx_env.batched_tx.to_ref(),
+            &vp_env.keys_changed,
+            &vp_env.verifiers,
+        )
+        .is_ok()
     }
 
     fn validate_tx(tx: BatchedTx) {

--- a/crates/tests/src/native_vp/mod.rs
+++ b/crates/tests/src/native_vp/mod.rs
@@ -75,6 +75,24 @@ impl TestNativeVpEnv {
         init_native_vp(ctx)
     }
 
+    /// Instantiate a native VP ctx to run a VP
+    pub fn ctx<'ctx>(
+        &'ctx self,
+        gas_meter: &'ctx RefCell<VpGasMeter>,
+    ) -> NativeVpCtx<'ctx> {
+        NativeVpCtx::new(
+            &self.address,
+            &self.tx_env.state,
+            &self.tx_env.batched_tx.tx,
+            &self.tx_env.batched_tx.cmt,
+            &self.tx_env.tx_index,
+            gas_meter,
+            &self.keys_changed,
+            &self.verifiers,
+            self.tx_env.vp_wasm_cache.clone(),
+        )
+    }
+
     /// Run some transaction code `apply_tx` and validate it with a native VP
     pub fn validate_tx<'view, 'ctx: 'view, T>(
         &'ctx self,

--- a/crates/tests/src/native_vp/pos.rs
+++ b/crates/tests/src/native_vp/pos.rs
@@ -449,8 +449,13 @@ mod tests {
                 &tx_env.gas_meter.borrow(),
             ));
             let vp_env = TestNativeVpEnv::from_tx_env(tx_env, address::POS);
-            let vp = vp_env.init_vp(&gas_meter, PosVp::new);
-            let result = vp_env.validate_tx(&vp);
+            let ctx = vp_env.ctx(&gas_meter);
+            let result = PosVp::validate_tx(
+                &ctx,
+                &vp_env.tx_env.batched_tx.to_ref(),
+                &vp_env.keys_changed,
+                &vp_env.verifiers,
+            );
 
             // Put the tx_env back before checking the result
             tx_host_env::set(vp_env.tx_env);

--- a/crates/trans_token/Cargo.toml
+++ b/crates/trans_token/Cargo.toml
@@ -24,7 +24,7 @@ namada_events = { path = "../events", default-features = false }
 namada_state = { path = "../state" }
 namada_systems = { path = "../systems" }
 namada_tx = { path = "../tx" }
-namada_vp = { path = "../vp" }
+namada_vp_env = { path = "../vp_env" }
 
 konst.workspace = true
 linkme = {workspace =  true, optional = true}
@@ -40,5 +40,6 @@ namada_parameters = { path = "../parameters", features = ["testing"] }
 namada_state = { path = "../state", features = ["testing"] }
 namada_tx = { path = "../tx", features = ["testing"] }
 namada_vm = { path = "../vm", features = ["testing"] }
+namada_vp = { path = "../vp" }
 
 assert_matches.workspace = true

--- a/crates/vp/src/native_vp.rs
+++ b/crates/vp/src/native_vp.rs
@@ -11,6 +11,7 @@ use namada_core::borsh;
 use namada_core::borsh::BorshDeserialize;
 use namada_core::chain::{ChainId, Epochs};
 use namada_gas::{Gas, GasMetering, VpGasMeter};
+use namada_state::{ConversionState, ReadConversionState};
 use namada_tx::{BatchedTxRef, Tx, TxCommitments};
 
 use super::vp_host_fns;
@@ -533,6 +534,17 @@ where
         T: BorshDeserialize,
     {
         Ctx::read_pre(self, key)
+    }
+}
+
+impl<'a, S, CA, EVAL> ReadConversionState for Ctx<'a, S, CA, EVAL>
+where
+    S: StateRead + ReadConversionState,
+    EVAL: 'static + VpEvaluator<'a, S, CA, EVAL>,
+    CA: 'static + Clone,
+{
+    fn conversion_state(&self) -> &ConversionState {
+        self.state.conversion_state()
     }
 }
 

--- a/crates/vp_env/src/lib.rs
+++ b/crates/vp_env/src/lib.rs
@@ -25,10 +25,9 @@ use namada_core::borsh::BorshDeserialize;
 use namada_core::chain::ChainId;
 pub use namada_core::chain::{BlockHeader, BlockHeight, Epoch, Epochs};
 use namada_core::hash::Hash;
-pub use namada_core::storage::{Key, TxIndex};
 use namada_events::{Event, EventType};
 use namada_gas::Gas;
-pub use namada_storage::StorageRead;
+pub use namada_storage::{Error, Key, Result, StorageRead, TxIndex};
 use namada_tx::BatchedTxRef;
 
 /// Validity predicate's environment is available for native VPs and WASM VPs
@@ -56,56 +55,47 @@ where
     /// Storage read temporary state Borsh encoded value (after tx execution).
     /// It will try to read from only the write log and then decode it if
     /// found.
-    fn read_temp<T: BorshDeserialize>(
-        &self,
-        key: &Key,
-    ) -> Result<Option<T>, namada_storage::Error>;
+    fn read_temp<T: BorshDeserialize>(&self, key: &Key) -> Result<Option<T>>;
 
     /// Storage read temporary state raw bytes (after tx execution). It will try
     /// to read from only the write log.
-    fn read_bytes_temp(
-        &self,
-        key: &Key,
-    ) -> Result<Option<Vec<u8>>, namada_storage::Error>;
+    fn read_bytes_temp(&self, key: &Key) -> Result<Option<Vec<u8>>>;
 
     /// Getting the chain ID.
-    fn get_chain_id(&self) -> Result<ChainId, namada_storage::Error>;
+    fn get_chain_id(&self) -> Result<ChainId>;
 
     /// Getting the block height. The height is that of the block to which the
     /// current transaction is being applied.
-    fn get_block_height(&self) -> Result<BlockHeight, namada_storage::Error>;
+    fn get_block_height(&self) -> Result<BlockHeight>;
 
     /// Getting the block header.
     fn get_block_header(
         &self,
         height: BlockHeight,
-    ) -> Result<Option<BlockHeader>, namada_storage::Error>;
+    ) -> Result<Option<BlockHeader>>;
 
     /// Getting the block epoch. The epoch is that of the block to which the
     /// current transaction is being applied.
-    fn get_block_epoch(&self) -> Result<Epoch, namada_storage::Error>;
+    fn get_block_epoch(&self) -> Result<Epoch>;
 
     /// Get the shielded transaction index.
-    fn get_tx_index(&self) -> Result<TxIndex, namada_storage::Error>;
+    fn get_tx_index(&self) -> Result<TxIndex>;
 
     /// Get the address of the native token.
-    fn get_native_token(&self) -> Result<Address, namada_storage::Error>;
+    fn get_native_token(&self) -> Result<Address>;
 
     /// Given the information about predecessor block epochs
     fn get_pred_epochs(&self) -> namada_storage::Result<Epochs>;
 
     /// Get the events emitted by the current tx.
-    fn get_events(
-        &self,
-        event_type: &EventType,
-    ) -> Result<Vec<Event>, namada_storage::Error>;
+    fn get_events(&self, event_type: &EventType) -> Result<Vec<Event>>;
 
     /// Storage prefix iterator, ordered by storage keys. It will try to get an
     /// iterator from the storage.
     fn iter_prefix<'iter>(
         &'iter self,
         prefix: &Key,
-    ) -> Result<Self::PrefixIter<'iter>, namada_storage::Error>;
+    ) -> Result<Self::PrefixIter<'iter>>;
 
     /// Evaluate a validity predicate with given data. The address, changed
     /// storage keys and verifiers will have the same values as the input to
@@ -113,17 +103,13 @@ where
     ///
     /// If the execution fails for whatever reason, this will return `false`.
     /// Otherwise returns the result of evaluation.
-    fn eval(
-        &self,
-        vp_code: Hash,
-        input_data: BatchedTxRef<'_>,
-    ) -> Result<(), namada_storage::Error>;
+    fn eval(&self, vp_code: Hash, input_data: BatchedTxRef<'_>) -> Result<()>;
 
     /// Get a tx hash
-    fn get_tx_code_hash(&self) -> Result<Option<Hash>, namada_storage::Error>;
+    fn get_tx_code_hash(&self) -> Result<Option<Hash>>;
 
     /// Charge the provided gas for the current vp
-    fn charge_gas(&self, used_gas: Gas) -> Result<(), namada_storage::Error>;
+    fn charge_gas(&self, used_gas: Gas) -> Result<()>;
 
     // ---- Methods below have default implementation via `pre/post` ----
 
@@ -132,16 +118,13 @@ where
     fn read_pre<T: BorshDeserialize>(
         &'view self,
         key: &Key,
-    ) -> Result<Option<T>, namada_storage::Error> {
+    ) -> Result<Option<T>> {
         self.pre().read(key)
     }
 
     /// Storage read prior state raw bytes (before tx execution). It
     /// will try to read from the storage.
-    fn read_bytes_pre(
-        &'view self,
-        key: &Key,
-    ) -> Result<Option<Vec<u8>>, namada_storage::Error> {
+    fn read_bytes_pre(&'view self, key: &Key) -> Result<Option<Vec<u8>>> {
         self.pre().read_bytes(key)
     }
 
@@ -151,35 +134,26 @@ where
     fn read_post<T: BorshDeserialize>(
         &'view self,
         key: &Key,
-    ) -> Result<Option<T>, namada_storage::Error> {
+    ) -> Result<Option<T>> {
         self.post().read(key)
     }
 
     /// Storage read posterior state raw bytes (after tx execution). It will try
     /// to read from the write log first and if no entry found then from the
     /// storage.
-    fn read_bytes_post(
-        &'view self,
-        key: &Key,
-    ) -> Result<Option<Vec<u8>>, namada_storage::Error> {
+    fn read_bytes_post(&'view self, key: &Key) -> Result<Option<Vec<u8>>> {
         self.post().read_bytes(key)
     }
 
     /// Storage `has_key` in prior state (before tx execution). It will try to
     /// read from the storage.
-    fn has_key_pre(
-        &'view self,
-        key: &Key,
-    ) -> Result<bool, namada_storage::Error> {
+    fn has_key_pre(&'view self, key: &Key) -> Result<bool> {
         self.pre().has_key(key)
     }
 
     /// Storage `has_key` in posterior state (after tx execution). It will try
     /// to check the write log first and if no entry found then the storage.
-    fn has_key_post(
-        &'view self,
-        key: &Key,
-    ) -> Result<bool, namada_storage::Error> {
+    fn has_key_post(&'view self, key: &Key) -> Result<bool> {
         self.post().has_key(key)
     }
 }

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3717,7 +3717,6 @@ dependencies = [
  "namada_trans_token",
  "namada_tx",
  "namada_vote_ext",
- "namada_vp",
  "namada_vp_env",
  "serde",
  "smooth-operator",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3978,7 +3978,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "namada_wallet",
  "proptest",
  "rand 0.8.5",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3764,6 +3764,7 @@ dependencies = [
  "namada_systems",
  "namada_tx",
  "namada_vp",
+ "namada_vp_env",
  "proptest",
  "serde",
  "serde_json",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3763,7 +3763,6 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
  "namada_vp_env",
  "proptest",
  "serde",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3869,7 +3869,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "once_cell",
  "proptest",
  "serde",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3849,7 +3849,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "smooth-operator",
  "thiserror",
 ]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -4114,7 +4114,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "thiserror",
  "tracing",
 ]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3718,6 +3718,7 @@ dependencies = [
  "namada_tx",
  "namada_vote_ext",
  "namada_vp",
+ "namada_vp_env",
  "serde",
  "smooth-operator",
  "thiserror",

--- a/wasm/tx_bond/src/lib.rs
+++ b/wasm/tx_bond/src/lib.rs
@@ -329,8 +329,13 @@ mod tests {
             &tx_env.gas_meter.borrow(),
         ));
         let vp_env = TestNativeVpEnv::from_tx_env(tx_env, address::POS);
-        let vp = vp_env.init_vp(&gas_meter, PosVp::new);
-        let result = vp_env.validate_tx(&vp);
+        let ctx = vp_env.ctx(&gas_meter);
+        let result = PosVp::validate_tx(
+            &ctx,
+            &vp_env.tx_env.batched_tx.to_ref(),
+            &vp_env.keys_changed,
+            &vp_env.verifiers,
+        );
         assert!(
             result.is_ok(),
             "PoS Validity predicate must accept this transaction"

--- a/wasm/tx_change_validator_commission/src/lib.rs
+++ b/wasm/tx_change_validator_commission/src/lib.rs
@@ -154,8 +154,13 @@ mod tests {
             &tx_env.gas_meter.borrow(),
         ));
         let vp_env = TestNativeVpEnv::from_tx_env(tx_env, address::POS);
-        let vp = vp_env.init_vp(&gas_meter, PosVp::new);
-        let result = vp_env.validate_tx(&vp);
+        let ctx = vp_env.ctx(&gas_meter);
+        let result = PosVp::validate_tx(
+            &ctx,
+            &vp_env.tx_env.batched_tx.to_ref(),
+            &vp_env.keys_changed,
+            &vp_env.verifiers,
+        );
         assert!(
             result.is_ok(),
             "PoS Validity predicate must accept this transaction"

--- a/wasm/tx_redelegate/src/lib.rs
+++ b/wasm/tx_redelegate/src/lib.rs
@@ -365,8 +365,13 @@ mod tests {
             &tx_env.gas_meter.borrow(),
         ));
         let vp_env = TestNativeVpEnv::from_tx_env(tx_env, address::POS);
-        let vp = vp_env.init_vp(&gas_meter, PosVp::new);
-        let result = vp_env.validate_tx(&vp);
+        let ctx = vp_env.ctx(&gas_meter);
+        let result = PosVp::validate_tx(
+            &ctx,
+            &vp_env.tx_env.batched_tx.to_ref(),
+            &vp_env.keys_changed,
+            &vp_env.verifiers,
+        );
         assert!(
             result.is_ok(),
             "PoS Validity predicate must accept this transaction"

--- a/wasm/tx_unbond/src/lib.rs
+++ b/wasm/tx_unbond/src/lib.rs
@@ -341,8 +341,13 @@ mod tests {
             &tx_env.gas_meter.borrow(),
         ));
         let vp_env = TestNativeVpEnv::from_tx_env(tx_env, address::POS);
-        let vp = vp_env.init_vp(&gas_meter, PosVp::new);
-        let result = vp_env.validate_tx(&vp);
+        let ctx = vp_env.ctx(&gas_meter);
+        let result = PosVp::validate_tx(
+            &ctx,
+            &vp_env.tx_env.batched_tx.to_ref(),
+            &vp_env.keys_changed,
+            &vp_env.verifiers,
+        );
         assert!(
             result.is_ok(),
             "PoS Validity predicate must accept this transaction"

--- a/wasm/tx_withdraw/src/lib.rs
+++ b/wasm/tx_withdraw/src/lib.rs
@@ -227,8 +227,13 @@ mod tests {
             &tx_env.gas_meter.borrow(),
         ));
         let vp_env = TestNativeVpEnv::from_tx_env(tx_env, address::POS);
-        let vp = vp_env.init_vp(&gas_meter, PosVp::new);
-        let result = vp_env.validate_tx(&vp);
+        let ctx = vp_env.ctx(&gas_meter);
+        let result = PosVp::validate_tx(
+            &ctx,
+            &vp_env.tx_env.batched_tx.to_ref(),
+            &vp_env.keys_changed,
+            &vp_env.verifiers,
+        );
         assert!(
             result.is_ok(),
             "PoS Validity predicate must accept this transaction"

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2052,6 +2052,7 @@ dependencies = [
  "namada_systems",
  "namada_tx",
  "namada_vp",
+ "namada_vp_env",
  "serde",
  "serde_json",
  "smooth-operator",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2142,7 +2142,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "once_cell",
  "serde",
  "smooth-operator",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2178,7 +2178,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "rand",
  "rand_core",
  "ripemd",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2051,7 +2051,6 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
  "namada_vp_env",
  "serde",
  "serde_json",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2277,7 +2277,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "thiserror",
  "tracing",
 ]

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2122,7 +2122,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "smooth-operator",
  "thiserror",
 ]


### PR DESCRIPTION
## Describe your changes

Rewrite native VPs to be env-agnostic (WASM or native).

The goal is to:
- break the dep on `vp` crate from systems crates that implement their VP to use `vp_env` instead
- this will unblock #3787 to move WASM `Ctx` into `vp_env` so that it can be used directly by crates that depend on `vp_env` as an implementation of `trait VpEnv` that can be used for testing without additional deps (same refactor has already been applied in this P for `tx_env` and tx `Ctx`)
- `vp_env` can then depend on `vm` to implement VP eval over WASM without running into dep cycle

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
