### PR TITLE
Update default PR description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,7 @@
 ## Checklist before merging 
 - [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
     - This will require 2 reviewers to approve the changes
+- [ ] If this PR requires changes to the docs or specs, I have ensured that a corresponding PR is opened in the namada-docs repo
+    - Relevant PR if applies: 
+- [ ] If this PR affects services such as the namada-indexer or the namada-masp-indexer, I have ensured that a corresponding PR is opened in the appropriate rep
+    - Relevant PR if applies:


### PR DESCRIPTION
## Describe your changes
A new default PR description that reminds devs about needed updates to docs, specs, and services such as indexers.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
