### PR TITLE
Unify MASP refs events 

### DIFF
--- a/.changelog/unreleased/bug-fixes/3821-fix-masp-events.md
+++ b/.changelog/unreleased/bug-fixes/3821-fix-masp-events.md
@@ -1,0 +1,4 @@
+- The masp ref events are now published in a single collection
+  enforcing a correct ordering. Fixed the shielded sync command
+  to account for multiple masp transactions in a single tx.
+  ([\#3821](https://github.com/anoma/namada/pull/3821))

--- a/crates/core/src/ibc.rs
+++ b/crates/core/src/ibc.rs
@@ -57,24 +57,6 @@ impl FromStr for IbcTokenHash {
 /// IBC transaction data section hash
 pub type IbcTxDataHash = Hash;
 
-/// IBC transaction data references to retrieve IBC messages
-#[derive(Default, Clone, Serialize, Deserialize)]
-pub struct IbcTxDataRefs(pub Vec<IbcTxDataHash>);
-
-impl Display for IbcTxDataRefs {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).unwrap())
-    }
-}
-
-impl FromStr for IbcTxDataRefs {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s)
-    }
-}
-
 /// The target of a PGF payment
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -76,6 +76,12 @@ impl From<TxIdInner> for MaspTxId {
     }
 }
 
+impl Display for MaspTxId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// Wrapper type around `Epoch` for type safe operations involving the masp
 /// epoch
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -763,24 +769,6 @@ impl FromStr for MaspValue {
             .or_else(|_err| {
                 ExtendedViewingKey::from_str(s).map(Self::FullViewingKey)
             })
-    }
-}
-
-/// The masp transactions' references of a given batch
-#[derive(Default, Clone, Serialize, Deserialize)]
-pub struct MaspTxRefs(pub Vec<MaspTxId>);
-
-impl Display for MaspTxRefs {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).unwrap())
-    }
-}
-
-impl FromStr for MaspTxRefs {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s)
     }
 }
 

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -26,7 +26,7 @@ use namada_sdk::args::ShieldedSync;
 use namada_sdk::chain::testing::get_dummy_header;
 use namada_sdk::chain::{BlockHeight, ChainId, Epoch};
 use namada_sdk::events::extend::{
-    ComposeEvent, MaspTxBatchRefs, MaspTxBlockIndex,
+    ComposeEvent, MaspTxBatchRefs, MaspTxBlockIndex, MaspTxRefs,
 };
 use namada_sdk::events::Event;
 use namada_sdk::gas::TxGasMeter;
@@ -85,9 +85,7 @@ use namada_sdk::queries::{
 use namada_sdk::state::StorageRead;
 use namada_sdk::storage::{Key, KeySeg, TxIndex};
 use namada_sdk::time::DateTimeUtc;
-use namada_sdk::token::{
-    self, Amount, DenominatedAmount, MaspTxRefs, Transfer,
-};
+use namada_sdk::token::{self, Amount, DenominatedAmount, Transfer};
 use namada_sdk::tx::data::pos::Bond;
 use namada_sdk::tx::data::{BatchedTxResult, Fee, TxResult, VpsResult};
 use namada_sdk::tx::event::{new_tx_event, Batch};
@@ -1046,7 +1044,7 @@ impl Client for BenchShell {
                                         if let Section::MaspTx(transaction) =
                                             section
                                         {
-                                            Some(transaction.txid().into())
+                                            Some(namada_sdk::events::extend::MaspTxRef::MaspSection(transaction.txid().into()))
                                         } else {
                                             None
                                         }

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -26,7 +26,7 @@ use namada_sdk::args::ShieldedSync;
 use namada_sdk::chain::testing::get_dummy_header;
 use namada_sdk::chain::{BlockHeight, ChainId, Epoch};
 use namada_sdk::events::extend::{
-    ComposeEvent, MaspTxBatchRefs, MaspTxBlockIndex, MaspTxRefs,
+    ComposeEvent, MaspTxBatchRefs, MaspTxBlockIndex, MaspTxRef, MaspTxRefs,
 };
 use namada_sdk::events::Event;
 use namada_sdk::gas::TxGasMeter;
@@ -1044,7 +1044,9 @@ impl Client for BenchShell {
                                         if let Section::MaspTx(transaction) =
                                             section
                                         {
-                                            Some(namada_sdk::events::extend::MaspTxRef::MaspSection(transaction.txid().into()))
+                                            Some(MaspTxRef::MaspSection(
+                                                transaction.txid().into(),
+                                            ))
                                         } else {
                                             None
                                         }

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -4,8 +4,7 @@ use data_encoding::HEXUPPER;
 use masp_primitives::merkle_tree::CommitmentTree;
 use masp_primitives::sapling::Node;
 use namada_sdk::events::extend::{
-    ComposeEvent, Height, IbcMaspTxBatchRefs, Info, MaspTxBatchRefs,
-    MaspTxBlockIndex, TxHash,
+    ComposeEvent, Height, Info, MaspTxBatchRefs, MaspTxBlockIndex, TxHash,
 };
 use namada_sdk::events::{EmitEvents, Event};
 use namada_sdk::gas::event::GasUsed;
@@ -1047,14 +1046,6 @@ impl<'finalize> TempTxLogs {
                 .extend(MaspTxBlockIndex(TxIndex::must_from_usize(tx_index)));
             self.tx_event.extend(MaspTxBatchRefs(
                 extended_tx_result.masp_tx_refs.clone(),
-            ));
-        }
-
-        if !extended_tx_result.ibc_tx_data_refs.0.is_empty() {
-            self.tx_event
-                .extend(MaspTxBlockIndex(TxIndex::must_from_usize(tx_index)));
-            self.tx_event.extend(IbcMaspTxBatchRefs(
-                extended_tx_result.ibc_tx_data_refs.clone(),
             ));
         }
 

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -41,11 +41,11 @@ fn extract_masp_tx(
 ) -> Result<Vec<Transaction>, Error> {
     // NOTE: It is possible to have two identical references in a same batch:
     // this is because, some types of MASP data packet can be correctly executed
-    // more than once. We have to make sure we account for this by not using
-    // collections that allow for duplicates (both in the inputs and in the
-    // outputs): if the same reference shows up multiple times in the input we
-    // must process it the same number of times to ensure we contruct the
-    // correct state
+    // more than once (output descriptions). We have to make sure we account for
+    // this by using collections that allow for duplicates (both in the args
+    // and in the returned type): if the same reference shows up multiple
+    // times in the input we must process it the same number of times to
+    // ensure we contruct the correct state
     masp_refs
         .0
         .iter()

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -122,7 +122,7 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
     client: &C,
     height: BlockHeight,
     first_idx_to_query: Option<TxIndex>,
-) -> Result<Option<Vec<(TxIndex, Option<MaspTxRefs>)>>, Error> {
+) -> Result<Vec<(TxIndex, MaspTxRefs)>, Error> {
     let first_idx_to_query = first_idx_to_query.unwrap_or_default();
 
     Ok(client
@@ -146,7 +146,7 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
                             MaspTxBatchRefsAttr::read_from_event_attributes(
                                 &event.attributes,
                             )
-                            .ok();
+                            .unwrap_or_default();
 
                         Some((tx_index, masp_refs))
                     } else {
@@ -154,7 +154,8 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
                     }
                 })
                 .collect::<Vec<_>>()
-        }))
+        })
+        .unwrap_or_default())
 }
 
 /// An implementation of a shielded wallet

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -79,11 +79,9 @@ impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
                 .await
             };
 
-            let txs_results = match maybe_txs_results.await? {
-                Some(events) => events,
-                None => {
-                    continue;
-                }
+            let txs_results = maybe_txs_results.await?;
+            if txs_results.is_empty() {
+                continue;
             };
 
             let block = {
@@ -110,12 +108,10 @@ impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
                 let tx = Tx::try_from(block[idx.0 as usize].as_ref())
                     .map_err(|e| Error::Other(e.to_string()))?;
                 let mut extracted_masp_txs = vec![];
-                if let Some(masp_refs) = masp_refs {
-                    extracted_masp_txs.extend(
-                        extract_masp_tx(&tx, &masp_refs)
-                            .map_err(|e| Error::Other(e.to_string()))?,
-                    );
-                };
+                extracted_masp_txs.extend(
+                    extract_masp_tx(&tx, &masp_refs)
+                        .map_err(|e| Error::Other(e.to_string()))?,
+                );
 
                 txs.push((
                     IndexedTx {

--- a/crates/shielded_token/src/lib.rs
+++ b/crates/shielded_token/src/lib.rs
@@ -32,7 +32,7 @@ use std::str::FromStr;
 pub use masp_primitives::transaction::Transaction as MaspTransaction;
 use namada_core::borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 pub use namada_core::dec::Dec;
-pub use namada_core::masp::{MaspEpoch, MaspTxId, MaspTxRefs, MaspValue};
+pub use namada_core::masp::{MaspEpoch, MaspTxId, MaspValue};
 pub use namada_state::{
     ConversionLeaf, ConversionState, Error, Key, OptionExt, Result, ResultExt,
     StorageRead, StorageWrite, WithConversionState,

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -334,6 +334,8 @@ mod test_blocks_left_to_fetch {
     fn fetched_cache_with_blocks(
         blocks_in_cache: impl IntoIterator<Item = BlockHeight>,
     ) -> Fetched {
+        let masp_tx = arbitrary_masp_tx();
+
         let txs = blocks_in_cache
             .into_iter()
             .map(|height| {
@@ -343,7 +345,7 @@ mod test_blocks_left_to_fetch {
                         index: TxIndex(0),
                         batch_index: None,
                     },
-                    arbitrary_masp_tx(),
+                    masp_tx.clone(),
                 )
             })
             .collect();

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -11,13 +11,13 @@ use namada_core::collections::HashMap;
 use namada_tx::{IndexedTx, IndexedTxRange};
 
 /// Type alias for convenience and profit
-pub type IndexedNoteData = BTreeMap<IndexedTx, Vec<Transaction>>;
+pub type IndexedNoteData = BTreeMap<IndexedTx, Transaction>;
 
 /// Type alias for the entries of [`IndexedNoteData`] iterators
-pub type IndexedNoteEntry = (IndexedTx, Vec<Transaction>);
+pub type IndexedNoteEntry = (IndexedTx, Transaction);
 
 /// Borrowed version of an [`IndexedNoteEntry`]
-pub type IndexedNoteEntryRefs<'a> = (&'a IndexedTx, &'a Vec<Transaction>);
+pub type IndexedNoteEntryRefs<'a> = (&'a IndexedTx, &'a Transaction);
 
 /// Type alias for a successful note decryption.
 pub type DecryptedData = (Note, PaymentAddress, MemoBytes);
@@ -315,6 +315,7 @@ mod test_blocks_left_to_fetch {
     use proptest::prelude::*;
 
     use super::*;
+    use crate::masp::test_utils::arbitrary_masp_tx;
 
     struct ArbRange {
         max_from: u64,
@@ -340,8 +341,9 @@ mod test_blocks_left_to_fetch {
                     IndexedTx {
                         height,
                         index: TxIndex(0),
+                        batch_index: None,
                     },
-                    vec![],
+                    arbitrary_masp_tx(),
                 )
             })
             .collect();

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -22,9 +22,8 @@ use namada_core::borsh::{
     BorshDeserialize, BorshSchema, BorshSerialize, BorshSerializeExt,
 };
 use namada_core::hash::Hash;
-use namada_core::ibc::IbcTxDataRefs;
-use namada_core::masp::MaspTxRefs;
 use namada_core::storage;
+use namada_events::extend::MaspTxRefs;
 use namada_events::Event;
 use namada_gas::WholeGas;
 use namada_macros::BorshDeserializer;
@@ -189,10 +188,12 @@ pub fn compute_inner_tx_hash(
 pub struct ExtendedTxResult<T> {
     /// The transaction result
     pub tx_result: TxResult<T>,
-    /// The optional references to masp sections
+    /// The optional references to masp data (either MASP sections or tx Data
+    /// for shielded actions)
+    // NOTE: it's paramount to enforce a single, ordered collection for all the
+    // masp transactions to ensure that the exact view on the tx sequence is
+    // preserved in the events
     pub masp_tx_refs: MaspTxRefs,
-    /// The optional data section hashes of IBC transaction
-    pub ibc_tx_data_refs: IbcTxDataRefs,
 }
 
 impl<T> Default for ExtendedTxResult<T> {
@@ -200,7 +201,6 @@ impl<T> Default for ExtendedTxResult<T> {
         Self {
             tx_result: Default::default(),
             masp_tx_refs: Default::default(),
-            ibc_tx_data_refs: Default::default(),
         }
     }
 }
@@ -307,21 +307,11 @@ impl<T: Display> TxResult<T> {
     /// Converts this result to [`ExtendedTxResult`]
     pub fn to_extended_result(
         self,
-        masp_section_refs: Option<Either<MaspTxRefs, IbcTxDataRefs>>,
+        masp_tx_refs: Option<MaspTxRefs>,
     ) -> ExtendedTxResult<T> {
-        let (masp_tx_refs, ibc_tx_data_refs) = match masp_section_refs {
-            Some(Either::Left(masp_tx_refs)) => {
-                (masp_tx_refs, Default::default())
-            }
-            Some(Either::Right(ibc_tx_data_refs)) => {
-                (Default::default(), ibc_tx_data_refs)
-            }
-            None => (Default::default(), Default::default()),
-        };
         ExtendedTxResult {
             tx_result: self,
-            masp_tx_refs,
-            ibc_tx_data_refs,
+            masp_tx_refs: masp_tx_refs.unwrap_or_default(),
         }
     }
 }

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -192,7 +192,9 @@ pub struct ExtendedTxResult<T> {
     /// for shielded actions)
     // NOTE: it's paramount to enforce a single, ordered collection for all the
     // masp transactions to ensure that the exact view on the tx sequence is
-    // preserved in the events
+    // preserved in the events. Also, it is possible for two refs to be exactly
+    // the same, we must make sure to emit events for both so that the
+    // client/indexer can properly construct their internal state
     pub masp_tx_refs: MaspTxRefs,
 }
 

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -1856,7 +1856,8 @@ impl<'tx> Tx {
 }
 
 /// Represents the pointers to a indexed tx, which are the block height and the
-/// index inside that block
+/// index inside that block. Optionally points to a specific inner tx inside a
+/// batch if such level of granularity is required.
 #[derive(
     Debug,
     Copy,
@@ -1875,6 +1876,8 @@ pub struct IndexedTx {
     pub height: BlockHeight,
     /// The index in the block of the tx
     pub index: TxIndex,
+    /// The optional index of an inner tx within this batc
+    pub batch_index: Option<u32>,
 }
 
 impl IndexedTx {
@@ -1884,6 +1887,7 @@ impl IndexedTx {
         Self {
             height,
             index: TxIndex(u32::MAX),
+            batch_index: None,
         }
     }
 }
@@ -1893,6 +1897,7 @@ impl Default for IndexedTx {
         Self {
             height: BlockHeight::first(),
             index: TxIndex(0),
+            batch_index: None,
         }
     }
 }
@@ -1916,10 +1921,12 @@ impl IndexedTxRange {
             IndexedTx {
                 height: from,
                 index: TxIndex(0),
+                batch_index: None,
             },
             IndexedTx {
                 height: to,
                 index: TxIndex(u32::MAX),
+                batch_index: None,
             },
         )
     }


### PR DESCRIPTION
## Describe your changes

Unifies the previous two masp refs events into a single `MaspTxBatchRefs` event: this ensures that no reordering of masp data can happen on the client side that would lead to the construction of an invalid state.

Updates the `IndexedTx` type to carry an optional pointer to a specific inner tx inside a batch. This fixes an issue for which the shielded sync command could not properly process multiple masp transactions in a same batch: it was appending the decrypted tx to a map using as an index the same block height and tx index, effectively taking into account only the last masp transaction of a batch 

TODOs:

- <s>See if there's a better way to emit the masp ref event (maybe without the need for `ExtendedTxResult`)</s> (#3824 )
- <s>Update the indexer</s>

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [x] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: https://github.com/anoma/namada-masp-indexer/pull/21
