### PR TITLE
Reduce event's masp attributes

### DIFF
--- a/.changelog/unreleased/improvements/3826-reduce-masp-events.md
+++ b/.changelog/unreleased/improvements/3826-reduce-masp-events.md
@@ -1,0 +1,2 @@
+- Reduced the number of a tx event's masp attributes to a single one.
+  ([\#3826](https://github.com/anoma/namada/pull/3826))

--- a/crates/events/src/extend.rs
+++ b/crates/events/src/extend.rs
@@ -488,21 +488,6 @@ impl EventAttributeEntry<'static> for Info {
     }
 }
 
-/// Extend an [`Event`] with `masp_tx_block_index` data, indicating that the tx
-/// at the specified index in the block contains a valid masp transaction.
-pub struct MaspTxBlockIndex(pub TxIndex);
-
-impl EventAttributeEntry<'static> for MaspTxBlockIndex {
-    type Value = TxIndex;
-    type ValueOwned = Self::Value;
-
-    const KEY: &'static str = "masp_tx_block_index";
-
-    fn into_value(self) -> Self::Value {
-        self.0
-    }
-}
-
 /// A type representing the possible reference to some MASP data, either a masp
 /// section or ibc tx data
 #[derive(Clone, Serialize, Deserialize)]
@@ -517,12 +502,14 @@ pub enum MaspTxRef {
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct MaspTxRefs(pub Vec<MaspTxRef>);
 
+// FIXME: need this?
 impl Display for MaspTxRefs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", serde_json::to_string(self).unwrap())
     }
 }
 
+// FIXME: need this?
 impl FromStr for MaspTxRefs {
     type Err = serde_json::Error;
 
@@ -531,13 +518,39 @@ impl FromStr for MaspTxRefs {
     }
 }
 
-/// Extend an [`Event`] with `masp_tx_batch_refs` data, indicating the
-/// references to either the MASP sections or the data sections for shielded
-/// actions.
-pub struct MaspTxBatchRefs(pub MaspTxRefs);
+/// A mapping between the index of a transaction in a block and the set of
+/// associated masp data
+#[derive(Clone, Serialize, Deserialize)]
+pub struct IndexedMaspData {
+    /// The transaction index in the block
+    pub tx_index: TxIndex,
+    /// The set of masp data
+    pub masp_refs: MaspTxRefs,
+}
+
+impl Display for IndexedMaspData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
+}
+
+impl FromStr for IndexedMaspData {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+/// Extend an [`Event`] with `masp_tx_batch_refs` data, mapping a transaction
+/// index in the block to a collection of either the MASP sections or the data
+/// sections for shielded actions.
+// FIXME: maybe rename? Also the KEY?
+// FIXME: maybe rename to masp_data_refs
+pub struct MaspTxBatchRefs(pub IndexedMaspData);
 
 impl EventAttributeEntry<'static> for MaspTxBatchRefs {
-    type Value = MaspTxRefs;
+    type Value = IndexedMaspData;
     type ValueOwned = Self::Value;
 
     const KEY: &'static str = "masp_tx_batch_refs";

--- a/crates/events/src/extend.rs
+++ b/crates/events/src/extend.rs
@@ -502,22 +502,6 @@ pub enum MaspTxRef {
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct MaspTxRefs(pub Vec<MaspTxRef>);
 
-// FIXME: need this?
-impl Display for MaspTxRefs {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).unwrap())
-    }
-}
-
-// FIXME: need this?
-impl FromStr for MaspTxRefs {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s)
-    }
-}
-
 /// A mapping between the index of a transaction in a block and the set of
 /// associated masp data
 #[derive(Clone, Serialize, Deserialize)]

--- a/crates/events/src/extend.rs
+++ b/crates/events/src/extend.rs
@@ -526,18 +526,16 @@ impl FromStr for IndexedMaspData {
     }
 }
 
-/// Extend an [`Event`] with `masp_tx_batch_refs` data, mapping a transaction
+/// Extend an [`Event`] with `masp_data_refs` data, mapping a transaction
 /// index in the block to a collection of either the MASP sections or the data
 /// sections for shielded actions.
-// FIXME: maybe rename? Also the KEY?
-// FIXME: maybe rename to masp_data_refs
-pub struct MaspTxBatchRefs(pub IndexedMaspData);
+pub struct MaspDataRefs(pub IndexedMaspData);
 
-impl EventAttributeEntry<'static> for MaspTxBatchRefs {
+impl EventAttributeEntry<'static> for MaspDataRefs {
     type Value = IndexedMaspData;
     type ValueOwned = Self::Value;
 
-    const KEY: &'static str = "masp_tx_batch_refs";
+    const KEY: &'static str = "masp_data_refs";
 
     fn into_value(self) -> Self::Value {
         self.0

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -26,7 +26,7 @@ use namada_sdk::args::ShieldedSync;
 use namada_sdk::chain::testing::get_dummy_header;
 use namada_sdk::chain::{BlockHeight, ChainId, Epoch};
 use namada_sdk::events::extend::{
-    ComposeEvent, MaspTxBatchRefs, MaspTxBlockIndex, MaspTxRef, MaspTxRefs,
+    ComposeEvent, IndexedMaspData, MaspTxBatchRefs, MaspTxRef, MaspTxRefs,
 };
 use namada_sdk::events::Event;
 use namada_sdk::gas::TxGasMeter;
@@ -1034,25 +1034,26 @@ impl Client for BenchShell {
                         };
                         let event: Event = new_tx_event(tx, height.value())
                             .with(Batch(&tx_result))
-                            .with(MaspTxBlockIndex(TxIndex::must_from_usize(
-                                idx,
-                            )))
-                            .with(MaspTxBatchRefs(MaspTxRefs(vec![
-                                tx.sections
-                                    .iter()
-                                    .find_map(|section| {
-                                        if let Section::MaspTx(transaction) =
-                                            section
-                                        {
-                                            Some(MaspTxRef::MaspSection(
-                                                transaction.txid().into(),
-                                            ))
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .unwrap(),
-                            ])))
+                            .with(MaspTxBatchRefs(IndexedMaspData {
+                                tx_index: TxIndex::must_from_usize(idx),
+                                masp_refs: MaspTxRefs(vec![
+                                    tx.sections
+                                        .iter()
+                                        .find_map(|section| {
+                                            if let Section::MaspTx(
+                                                transaction,
+                                            ) = section
+                                            {
+                                                Some(MaspTxRef::MaspSection(
+                                                    transaction.txid().into(),
+                                                ))
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .unwrap(),
+                                ]),
+                            }))
                             .into();
                         namada_sdk::tendermint::abci::Event::from(event)
                     })

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -26,7 +26,7 @@ use namada_sdk::args::ShieldedSync;
 use namada_sdk::chain::testing::get_dummy_header;
 use namada_sdk::chain::{BlockHeight, ChainId, Epoch};
 use namada_sdk::events::extend::{
-    ComposeEvent, IndexedMaspData, MaspTxBatchRefs, MaspTxRef, MaspTxRefs,
+    ComposeEvent, IndexedMaspData, MaspDataRefs, MaspTxRef, MaspTxRefs,
 };
 use namada_sdk::events::Event;
 use namada_sdk::gas::TxGasMeter;
@@ -1034,7 +1034,7 @@ impl Client for BenchShell {
                         };
                         let event: Event = new_tx_event(tx, height.value())
                             .with(Batch(&tx_result))
-                            .with(MaspTxBatchRefs(IndexedMaspData {
+                            .with(MaspDataRefs(IndexedMaspData {
                                 tx_index: TxIndex::must_from_usize(idx),
                                 masp_refs: MaspTxRefs(vec![
                                     tx.sections

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -4,7 +4,7 @@ use data_encoding::HEXUPPER;
 use masp_primitives::merkle_tree::CommitmentTree;
 use masp_primitives::sapling::Node;
 use namada_sdk::events::extend::{
-    ComposeEvent, Height, IndexedMaspData, Info, MaspTxBatchRefs, TxHash,
+    ComposeEvent, Height, IndexedMaspData, Info, MaspDataRefs, TxHash,
 };
 use namada_sdk::events::{EmitEvents, Event};
 use namada_sdk::gas::event::GasUsed;
@@ -1042,7 +1042,7 @@ impl<'finalize> TempTxLogs {
         // If at least one of the inner transactions is a valid masp tx, update
         // the events
         if !extended_tx_result.masp_tx_refs.0.is_empty() {
-            self.tx_event.extend(MaspTxBatchRefs(IndexedMaspData {
+            self.tx_event.extend(MaspDataRefs(IndexedMaspData {
                 tx_index: TxIndex::must_from_usize(tx_index),
                 masp_refs: extended_tx_result.masp_tx_refs.clone(),
             }));

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -4,7 +4,7 @@ use data_encoding::HEXUPPER;
 use masp_primitives::merkle_tree::CommitmentTree;
 use masp_primitives::sapling::Node;
 use namada_sdk::events::extend::{
-    ComposeEvent, Height, Info, MaspTxBatchRefs, MaspTxBlockIndex, TxHash,
+    ComposeEvent, Height, IndexedMaspData, Info, MaspTxBatchRefs, TxHash,
 };
 use namada_sdk::events::{EmitEvents, Event};
 use namada_sdk::gas::event::GasUsed;
@@ -1042,11 +1042,10 @@ impl<'finalize> TempTxLogs {
         // If at least one of the inner transactions is a valid masp tx, update
         // the events
         if !extended_tx_result.masp_tx_refs.0.is_empty() {
-            self.tx_event
-                .extend(MaspTxBlockIndex(TxIndex::must_from_usize(tx_index)));
-            self.tx_event.extend(MaspTxBatchRefs(
-                extended_tx_result.masp_tx_refs.clone(),
-            ));
+            self.tx_event.extend(MaspTxBatchRefs(IndexedMaspData {
+                tx_index: TxIndex::must_from_usize(tx_index),
+                masp_refs: extended_tx_result.masp_tx_refs.clone(),
+            }));
         }
 
         flags

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -13,8 +13,8 @@ use namada_core::masp::MaspEpoch;
 use namada_core::time::DurationSecs;
 use namada_core::token::{Denomination, MaspDigitPos};
 use namada_events::extend::{
-    IndexedMaspData, MaspTxBatchRefs as MaspTxBatchRefsAttr, MaspTxRef,
-    MaspTxRefs, ReadFromEventAttributes,
+    IndexedMaspData, MaspDataRefs as MaspDataRefsAttr, MaspTxRef, MaspTxRefs,
+    ReadFromEventAttributes,
 };
 use namada_ibc::{decode_message, extract_masp_tx_from_envelope, IbcMessage};
 use namada_io::client::Client;
@@ -128,7 +128,7 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
             events
                 .into_iter()
                 .filter_map(|event| {
-                    MaspTxBatchRefsAttr::read_from_event_attributes(
+                    MaspDataRefsAttr::read_from_event_attributes(
                         &event.attributes,
                     )
                     .ok()

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -10,6 +10,7 @@ use masp_primitives::transaction::Transaction as MaspTx;
 use namada_core::chain::BlockHeight;
 use namada_core::collections::HashMap;
 use namada_core::storage::TxIndex;
+use namada_events::extend::IndexedMaspData;
 use namada_io::Client;
 use namada_token::masp::utils::{
     IndexedNoteEntry, MaspClient, MaspClientCapabilities,
@@ -105,13 +106,22 @@ impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
                     .data
             };
 
-            for (idx, masp_refs) in txs_results {
-                let tx = Tx::try_from(block[idx.0 as usize].as_ref())
+            for IndexedMaspData {
+                tx_index,
+                masp_refs,
+            } in txs_results
+            {
+                let tx = Tx::try_from(block[tx_index.0 as usize].as_ref())
                     .map_err(|e| Error::Other(e.to_string()))?;
                 let extracted_masp_txs = extract_masp_tx(&tx, &masp_refs)
                     .map_err(|e| Error::Other(e.to_string()))?;
 
-                index_txs(&mut txs, extracted_masp_txs, height.into(), idx)?;
+                index_txs(
+                    &mut txs,
+                    extracted_masp_txs,
+                    height.into(),
+                    tx_index,
+                )?;
             }
         }
 

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -76,7 +76,6 @@ impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
                 get_indexed_masp_events_at_height(
                     &self.inner.client,
                     height.into(),
-                    None,
                 )
                 .await
             };


### PR DESCRIPTION
## Describe your changes

Closes #3824.

Reduces the number of a tx event's masp attributes down to a single one.

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [x] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: https://github.com/anoma/namada-masp-indexer/pull/22
