### PR TITLE
Remove relayer and bridge pool from help msgs

### DIFF
--- a/.changelog/unreleased/improvements/3830-rem-eth-help-msg.md
+++ b/.changelog/unreleased/improvements/3830-rem-eth-help-msg.md
@@ -1,0 +1,2 @@
+- Remove relayer help messages from namada binary.
+  ([\#3830](https://github.com/anoma/namada/pull/3830))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -75,10 +75,10 @@ pub mod cmds {
     impl Cmd for Namada {
         fn add_sub(app: App) -> App {
             app.subcommand(NamadaNode::def().display_order(1))
-                .subcommand(NamadaRelayer::def().display_order(1))
+                // .subcommand(NamadaRelayer::def().display_order(1))
                 .subcommand(NamadaClient::def().display_order(1))
                 .subcommand(NamadaWallet::def().display_order(1))
-                .subcommand(EthBridgePool::def().display_order(2))
+                // .subcommand(EthBridgePool::def().display_order(2))
                 .subcommand(Ledger::def().display_order(2))
                 .subcommand(TxCustom::def().display_order(2))
                 .subcommand(TxTransparentTransfer::def().display_order(2))


### PR DESCRIPTION
## Describe your changes
Small PR to remove them from help messages in binaries (not built anymore anyway)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
