### PR TITLE
Minimum validator commission rate param

### DIFF
--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -830,6 +830,7 @@ pub async fn query_protocol_parameters(
                 liveness_threshold,
                 rewards_gain_p,
                 rewards_gain_d,
+                min_commission_rate,
             },
         max_proposal_period: _,
     } = query_pos_parameters(context.client()).await;
@@ -928,6 +929,12 @@ pub async fn query_protocol_parameters(
         "{:4}Votes per raw native token: {}",
         "",
         tm_votes_per_token
+    );
+    display_line!(
+        context.io(),
+        "{:4}Minimum allowable validator commission rate: {}",
+        "",
+        min_commission_rate
     );
 }
 

--- a/crates/apps_lib/src/config/genesis/chain.rs
+++ b/crates/apps_lib/src/config/genesis/chain.rs
@@ -409,6 +409,7 @@ impl Finalized {
             liveness_threshold,
             rewards_gain_p,
             rewards_gain_d,
+            min_commission_rate,
         } = self.parameters.pos_params.clone();
 
         namada_sdk::proof_of_stake::parameters::PosParams {
@@ -429,6 +430,7 @@ impl Finalized {
                 liveness_threshold,
                 rewards_gain_p,
                 rewards_gain_d,
+                min_commission_rate,
             },
             max_proposal_period: self.parameters.gov_params.max_proposal_period,
         }

--- a/crates/apps_lib/src/config/genesis/templates.rs
+++ b/crates/apps_lib/src/config/genesis/templates.rs
@@ -415,6 +415,8 @@ pub struct PosParams {
     pub rewards_gain_p: Dec,
     /// PoS gain d (read only)
     pub rewards_gain_d: Dec,
+    /// Minimum validator commission rate
+    pub min_commission_rate: Dec,
 }
 
 #[derive(

--- a/crates/proof_of_stake/src/error.rs
+++ b/crates/proof_of_stake/src/error.rs
@@ -92,6 +92,11 @@ pub enum CommissionRateChangeError {
     #[error("Rate change of {0} is too large for validator {1}")]
     RateChangeTooLarge(Dec, Address),
     #[error(
+        "Invalid commission rate of {0}; the minimum allowed by the protocol \
+         is {1}"
+    )]
+    RateBelowMin(Dec, Dec),
+    #[error(
         "There is no maximum rate change written in storage for validator {0}"
     )]
     NoMaxSetInStorage(Address),

--- a/crates/proof_of_stake/src/parameters.rs
+++ b/crates/proof_of_stake/src/parameters.rs
@@ -80,6 +80,8 @@ pub struct OwnedPosParams {
     pub rewards_gain_p: Dec,
     /// PoS gain d (read only)
     pub rewards_gain_d: Dec,
+    /// Minimum validator commission rate
+    pub min_commission_rate: Dec,
 }
 
 impl Default for OwnedPosParams {
@@ -108,6 +110,7 @@ impl Default for OwnedPosParams {
             liveness_threshold: Dec::new(9, 1).expect("Test failed"),
             rewards_gain_p: Dec::from_str("0.25").expect("Test failed"),
             rewards_gain_d: Dec::from_str("0.25").expect("Test failed"),
+            min_commission_rate: Dec::from_str("0.05").expect("Test failed"),
         }
     }
 }

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -636,6 +636,18 @@ pub async fn build_validator_commission_change(
                 *rate,
             )));
         }
+        if *rate < params.min_commission_rate {
+            edisplay_line!(
+                context.io(),
+                "New rate is below the minimum allowed by the protocol: {}",
+                params.min_commission_rate
+            );
+            if !tx_args.force {
+                return Err(Error::from(TxSubmitError::InvalidCommissionRate(
+                    *rate,
+                )));
+            }
+        }
 
         let pipeline_epoch_minus_one =
             epoch.unchecked_add(params.pipeline_len - 1);
@@ -873,6 +885,19 @@ pub async fn build_validator_metadata_change(
                 )));
             }
         }
+        if *rate < params.min_commission_rate {
+            edisplay_line!(
+                context.io(),
+                "New rate is below the minimum allowed by the protocol: {}",
+                params.min_commission_rate
+            );
+            if !tx_args.force {
+                return Err(Error::from(TxSubmitError::InvalidCommissionRate(
+                    *rate,
+                )));
+            }
+        }
+
         let pipeline_epoch_minus_one =
             epoch.unchecked_add(params.pipeline_len - 1);
 

--- a/genesis/hardware/parameters.toml
+++ b/genesis/hardware/parameters.toml
@@ -71,6 +71,8 @@ liveness_threshold = "0.9"
 rewards_gain_p = "0.25"
 # The D gain factor in the Proof of Stake rewards controller
 rewards_gain_d = "0.25"
+# Minimum allowable validator commission rate
+min_commission_rate = "0.05"
 
 # Governance parameters.
 [gov_params]

--- a/genesis/localnet/parameters.toml
+++ b/genesis/localnet/parameters.toml
@@ -71,6 +71,8 @@ liveness_threshold = "0.9"
 rewards_gain_p = "0.25"
 # The D gain factor in the Proof of Stake rewards controller
 rewards_gain_d = "0.25"
+# Minimum allowable validator commission rate
+min_commission_rate = "0.05"
 
 # Governance parameters.
 [gov_params]

--- a/genesis/starter/parameters.toml
+++ b/genesis/starter/parameters.toml
@@ -71,6 +71,8 @@ liveness_threshold = "0.9"
 rewards_gain_p = "0.25"
 # The D gain factor in the Proof of Stake rewards controller
 rewards_gain_d = "0.25"
+# Minimum allowable validator commission rate
+min_commission_rate = "0.05"
 
 # Governance parameters.
 [gov_params]


### PR DESCRIPTION
## Describe your changes
Adds a PoS param to enforce a minimum allowed validator commission rate.

Also includes logic in `init_chain` to set a validator's commission rate to the minimum if the one provided in the toml file is below.

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
