### PR TITLE
[fix]: Fix clap panic on parsing relayer commands

### DIFF
--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -75,10 +75,8 @@ pub mod cmds {
     impl Cmd for Namada {
         fn add_sub(app: App) -> App {
             app.subcommand(NamadaNode::def().display_order(1))
-                // .subcommand(NamadaRelayer::def().display_order(1))
                 .subcommand(NamadaClient::def().display_order(1))
                 .subcommand(NamadaWallet::def().display_order(1))
-                // .subcommand(EthBridgePool::def().display_order(2))
                 .subcommand(Ledger::def().display_order(2))
                 .subcommand(TxCustom::def().display_order(2))
                 .subcommand(TxTransparentTransfer::def().display_order(2))
@@ -96,9 +94,6 @@ pub mod cmds {
         fn parse(matches: &ArgMatches) -> Option<Self> {
             let node = SubCmd::parse(matches).map(Self::Node);
             let client = SubCmd::parse(matches).map(Self::Client);
-            let relayer = SubCmd::parse(matches).map(Self::Relayer);
-            let eth_bridge_pool =
-                SubCmd::parse(matches).map(Self::EthBridgePool);
             let wallet = SubCmd::parse(matches).map(Self::Wallet);
             let ledger = SubCmd::parse(matches).map(Self::Ledger);
             let tx_custom = SubCmd::parse(matches).map(Self::TxCustom);
@@ -121,8 +116,6 @@ pub mod cmds {
             let tx_reveal_pk = SubCmd::parse(matches).map(Self::TxRevealPk);
             let complete = SubCmd::parse(matches).map(Self::Complete);
             node.or(client)
-                .or(relayer)
-                .or(eth_bridge_pool)
                 .or(wallet)
                 .or(ledger)
                 .or(tx_custom)

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -102,20 +102,24 @@ fn run_ledger() -> Result<()> {
         None,
     );
 
-    let cmd_combinations = vec![vec!["ledger"], vec!["ledger", "run"]];
+    let cmd_combinations = vec![
+        (Bin::Node, vec!["ledger"]),
+        (Bin::Node, vec!["ledger", "run"]),
+        (Bin::Namada, vec!["node", "ledger"]),
+    ];
 
     // Start the ledger as a validator
-    for args in &cmd_combinations {
+    for (bin, args) in &cmd_combinations {
         let mut ledger =
-            run_as!(test, Who::Validator(0), Bin::Node, args, Some(40))?;
+            run_as!(test, Who::Validator(0), *bin, args, Some(40))?;
         ledger.exp_string(LEDGER_STARTED)?;
         ledger.exp_string(VALIDATOR_NODE)?;
     }
 
     // Start the ledger as a non-validator
-    for args in &cmd_combinations {
+    for (bin, args) in &cmd_combinations {
         let mut ledger =
-            run_as!(test, Who::NonValidator, Bin::Node, args, Some(40))?;
+            run_as!(test, Who::NonValidator, *bin, args, Some(40))?;
         ledger.exp_string(LEDGER_STARTED)?;
         ledger.exp_string(NON_VALIDATOR_NODE)?;
     }

--- a/crates/tests/src/e2e/setup.rs
+++ b/crates/tests/src/e2e/setup.rs
@@ -1105,6 +1105,12 @@ where
         &working_dir.as_ref().join("Cargo.toml"),
     );
 
+    if let Bin::Namada = bin {
+        // Avoid `namada` running via "cargo" (see `fn handle_subcommand` in
+        // crates/apps/src/bin/namada/cli.rs)
+        run_cmd.env_remove("CARGO");
+    }
+
     run_cmd
         .env("NAMADA_LOG", log_level)
         .env("NAMADA_CMT_STDOUT", "true")

--- a/crates/tests/src/e2e/setup.rs
+++ b/crates/tests/src/e2e/setup.rs
@@ -605,13 +605,14 @@ pub fn network(
 }
 
 /// Namada binaries
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 pub enum Bin {
     Node,
     Client,
     Wallet,
     Relayer,
+    Namada,
 }
 
 #[derive(Debug)]
@@ -1092,6 +1093,7 @@ where
 {
     // Root cargo workspace manifest path
     let (bin_name, log_level) = match bin {
+        Bin::Namada => ("namada", "info"),
         Bin::Node => ("namadan", "info"),
         Bin::Client => ("namadac", "tendermint_rpc=debug"),
         Bin::Wallet => ("namadaw", "info"),


### PR DESCRIPTION
## Describe your changes
Currently, the binaries panic on trying to parse commands pertaining to the relayer binary. This fixes that.
## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
