### PR TITLE
check consistency of genesis files with chain ID

### DIFF
--- a/.changelog/unreleased/improvements/3833-pre-genesis-chain-id.md
+++ b/.changelog/unreleased/improvements/3833-pre-genesis-chain-id.md
@@ -1,0 +1,2 @@
+- Let user customize the pre-genesis chain-id via environment variable
+  ([\#3833](https://github.com/anoma/namada/pull/3833))

--- a/.changelog/unreleased/improvements/3843-check-genesis.md
+++ b/.changelog/unreleased/improvements/3843-check-genesis.md
@@ -1,0 +1,3 @@
+- Validate a chain ID of genesis on ABCI InitChain request
+  prior to applying it to ensure it's not been tampered with.
+  ([\#3843](https://github.com/anoma/namada/pull/3843))

--- a/.github/workflows/scripts/e2e.json
+++ b/.github/workflows/scripts/e2e.json
@@ -29,5 +29,6 @@
     "e2e::wallet_tests::wallet_encrypted_key_cmds": 1,
     "e2e::wallet_tests::wallet_encrypted_key_cmds_env_var": 1,
     "e2e::wallet_tests::wallet_unencrypted_key_cmds": 1,
-    "e2e::ledger_tests::masp_txs_and_queries": 82
+    "e2e::ledger_tests::masp_txs_and_queries": 82,
+    "e2e::ledger_tests::test_genesis_chain_id_change": 35
 }

--- a/.github/workflows/scripts/e2e.json
+++ b/.github/workflows/scripts/e2e.json
@@ -30,5 +30,6 @@
     "e2e::wallet_tests::wallet_encrypted_key_cmds_env_var": 1,
     "e2e::wallet_tests::wallet_unencrypted_key_cmds": 1,
     "e2e::ledger_tests::masp_txs_and_queries": 82,
-    "e2e::ledger_tests::test_genesis_chain_id_change": 35
+    "e2e::ledger_tests::test_genesis_chain_id_change": 35,
+    "e2e::ledger_tests::test_genesis_manipulation": 103
 }

--- a/crates/apps_lib/src/config/genesis/transactions.rs
+++ b/crates/apps_lib/src/config/genesis/transactions.rs
@@ -109,7 +109,7 @@ fn pre_genesis_tx_timestamp() -> DateTimeUtc {
 /// Return a ready to sign genesis [`Tx`].
 fn get_tx_to_sign(tag: impl AsRef<str>, data: impl BorshSerialize) -> Tx {
     let genesis_chain_id = env::var(NAMADA_GENESIS_TX_ENV_VAR)
-        .unwrap_or_else(|| NAMADA_GENESIS_TX_CHAIN_ID.to_string());
+        .unwrap_or_else(|_| NAMADA_GENESIS_TX_CHAIN_ID.to_string());
 
     let mut tx = Tx::from_type(TxType::Raw);
     tx.header.chain_id = ChainId(genesis_chain_id);

--- a/crates/apps_lib/src/config/genesis/transactions.rs
+++ b/crates/apps_lib/src/config/genesis/transactions.rs
@@ -1,6 +1,7 @@
 //! Genesis transactions
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::env;
 use std::fmt::Debug;
 use std::net::SocketAddr;
 
@@ -46,6 +47,7 @@ use crate::config::genesis::{utils, GenesisAddress};
 use crate::wallet::{CliWalletUtils, WalletTransport};
 
 /// Dummy chain id used to sign [`Tx`] objects at pre-genesis.
+const NAMADA_GENESIS_TX_ENV_VAR: &str = "NAMADA_GENESIS_TX_CHAIN_ID";
 const NAMADA_GENESIS_TX_CHAIN_ID: &str = "namada-genesis";
 
 /// Helper trait to fetch tx data to sign.
@@ -106,8 +108,11 @@ fn pre_genesis_tx_timestamp() -> DateTimeUtc {
 
 /// Return a ready to sign genesis [`Tx`].
 fn get_tx_to_sign(tag: impl AsRef<str>, data: impl BorshSerialize) -> Tx {
+    let genesis_chain_id = env::var(NAMADA_GENESIS_TX_ENV_VAR)
+        .unwrap_or_else(|| NAMADA_GENESIS_TX_CHAIN_ID.to_string());
+
     let mut tx = Tx::from_type(TxType::Raw);
-    tx.header.chain_id = ChainId(NAMADA_GENESIS_TX_CHAIN_ID.to_string());
+    tx.header.chain_id = ChainId(genesis_chain_id);
     tx.header.timestamp = pre_genesis_tx_timestamp();
     tx.set_code(Code {
         salt: [0; 8],

--- a/crates/apps_lib/src/config/genesis/transactions.rs
+++ b/crates/apps_lib/src/config/genesis/transactions.rs
@@ -47,7 +47,7 @@ use crate::config::genesis::{utils, GenesisAddress};
 use crate::wallet::{CliWalletUtils, WalletTransport};
 
 /// Dummy chain id used to sign [`Tx`] objects at pre-genesis.
-const NAMADA_GENESIS_TX_ENV_VAR: &str = "NAMADA_GENESIS_TX_CHAIN_ID";
+pub const NAMADA_GENESIS_TX_ENV_VAR: &str = "NAMADA_GENESIS_TX_CHAIN_ID";
 const NAMADA_GENESIS_TX_CHAIN_ID: &str = "namada-genesis";
 
 /// Helper trait to fetch tx data to sign.
@@ -62,6 +62,15 @@ pub trait TxToSign {
     ) -> (Vec<common::PublicKey>, u8);
 
     fn get_owner(&self) -> GenesisAddress;
+}
+
+/// Get the genesis chain ID from "NAMADA_GENESIS_TX_CHAIN_ID" env var, if set,
+/// or the default
+pub fn genesis_chain_id() -> ChainId {
+    ChainId(
+        env::var(NAMADA_GENESIS_TX_ENV_VAR)
+            .unwrap_or_else(|_| NAMADA_GENESIS_TX_CHAIN_ID.to_string()),
+    )
 }
 
 /// Return a dummy set of tx arguments to sign with the
@@ -108,11 +117,8 @@ fn pre_genesis_tx_timestamp() -> DateTimeUtc {
 
 /// Return a ready to sign genesis [`Tx`].
 fn get_tx_to_sign(tag: impl AsRef<str>, data: impl BorshSerialize) -> Tx {
-    let genesis_chain_id = env::var(NAMADA_GENESIS_TX_ENV_VAR)
-        .unwrap_or_else(|_| NAMADA_GENESIS_TX_CHAIN_ID.to_string());
-
     let mut tx = Tx::from_type(TxType::Raw);
-    tx.header.chain_id = ChainId(genesis_chain_id);
+    tx.header.chain_id = genesis_chain_id();
     tx.header.timestamp = pre_genesis_tx_timestamp();
     tx.set_code(Code {
         salt: [0; 8],

--- a/crates/core/src/chain.rs
+++ b/crates/core/src/chain.rs
@@ -109,6 +109,13 @@ impl ChainId {
         }
         errors
     }
+
+    /// Find the prefix of a valid ChainId.
+    pub fn prefix(&self) -> Option<ChainIdPrefix> {
+        let ChainId(chain_id) = self;
+        let (prefix, _) = chain_id.rsplit_once(CHAIN_ID_PREFIX_SEP)?;
+        Some(ChainIdPrefix(prefix.to_string()))
+    }
 }
 
 /// Height of a block, i.e. the level. The `default` is the

--- a/crates/node/src/shell/init_chain.rs
+++ b/crates/node/src/shell/init_chain.rs
@@ -133,14 +133,14 @@ where
         let genesis = {
             let chain_dir = self.base_dir.join(chain_id);
             genesis::chain::Finalized::read_toml_files(&chain_dir)
-                .expect("Missing genesis files")
+                .expect("Missing or invalid genesis files")
         };
         #[cfg(any(test, fuzzing, feature = "benches"))]
         let genesis = {
             let chain_dir = self.base_dir.join(chain_id);
             if chain_dir.join(genesis::chain::METADATA_FILE_NAME).exists() {
                 genesis::chain::Finalized::read_toml_files(&chain_dir)
-                    .expect("Missing genesis files")
+                    .expect("Missing or invalid genesis files")
             } else {
                 genesis::make_dev_genesis(num_validators, &chain_dir)
             }

--- a/crates/node/src/utils.rs
+++ b/crates/node/src/utils.rs
@@ -19,7 +19,10 @@ pub fn test_genesis(args: TestGenesis, global_args: args::Global) {
         check_can_sign,
     } = args;
 
-    let templates = genesis::templates::load_and_validate(&path).unwrap();
+    let Some(templates) = genesis::templates::load_and_validate(&path) else {
+        eprintln!("Unable to load the genesis templates");
+        cli::safe_exit(1);
+    };
     let genesis = genesis::chain::finalize(
         templates,
         FromStr::from_str("namada-dryrun").unwrap(),

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -2721,6 +2721,9 @@ fn test_genesis_chain_id_change() -> Result<()> {
         None,
     );
 
+    // Unset the chain ID - the transaction signatures have been validated at
+    // init-network so we don't need it anymore
+    env::remove_var(config::genesis::transactions::NAMADA_GENESIS_TX_ENV_VAR);
     // Start the ledger as a validator
     let _bg_validator_0 =
         start_namada_ledger_node_wait_wasm(&test, Some(0), Some(40))?

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -22,14 +22,16 @@ use color_eyre::eyre::Result;
 use color_eyre::owo_colors::OwoColorize;
 use namada_apps_lib::cli::context::ENV_VAR_CHAIN_ID;
 use namada_apps_lib::client::utils::PRE_GENESIS_DIR;
+use namada_apps_lib::config::genesis::chain;
+use namada_apps_lib::config::genesis::templates::TokenBalances;
 use namada_apps_lib::config::utils::convert_tm_addr_to_socket_addr;
 use namada_apps_lib::config::{self, ethereum_bridge};
 use namada_apps_lib::tendermint_config::net::Address as TendermintAddress;
-use namada_apps_lib::wallet;
+use namada_apps_lib::wallet::{self, Alias};
 use namada_core::chain::ChainId;
 use namada_core::token::NATIVE_MAX_DECIMAL_PLACES;
 use namada_sdk::address::Address;
-use namada_sdk::chain::Epoch;
+use namada_sdk::chain::{ChainIdPrefix, Epoch};
 use namada_sdk::time::DateTimeUtc;
 use namada_sdk::token;
 use namada_test_utils::TestWasms;
@@ -2731,6 +2733,74 @@ fn test_genesis_chain_id_change() -> Result<()> {
 
     let rpc = get_actor_rpc(&test, Who::Validator(0));
     wait_for_block_height(&test, &rpc, 2, 30)?;
+
+    Ok(())
+}
+
+/// Test that any changes done to a genesis config after a chain is finalized
+/// will make it fail validation.
+#[test]
+fn test_genesis_manipulation() -> Result<()> {
+    let test = setup::single_node_net().unwrap();
+
+    set_ethereum_bridge_mode(
+        &test,
+        &test.net.chain_id,
+        Who::Validator(0),
+        ethereum_bridge::ledger::Mode::Off,
+        None,
+    );
+
+    let chain_dir = test.get_chain_dir(Who::Validator(0));
+    let genesis = chain::Finalized::read_toml_files(&chain_dir).unwrap();
+
+    let modified_genesis = [
+        {
+            let mut genesis = genesis.clone();
+            genesis
+                .balances
+                .token
+                .insert(Alias::from("test"), TokenBalances(Default::default()));
+            genesis
+        },
+        {
+            let mut genesis = genesis.clone();
+            genesis.balances.token.remove(&Alias::from("NAM"));
+            genesis
+        },
+        {
+            let mut genesis = genesis.clone();
+            genesis.metadata.address_gen = None;
+            genesis
+        },
+        {
+            let mut genesis = genesis.clone();
+            // Invalid chain ID
+            genesis.metadata.chain_id = ChainId("Invalid ID".to_string());
+            genesis
+        },
+        {
+            let mut genesis = genesis.clone();
+            // Random valid chain ID
+            genesis.metadata.chain_id = ChainId::from_genesis(
+                ChainIdPrefix::from_str("TEST").unwrap(),
+                [1, 2, 3],
+            );
+            genesis
+        },
+    ];
+
+    for genesis in modified_genesis {
+        // Any modification should invalide the genesis
+        assert!(!genesis.is_valid());
+
+        genesis.write_toml_files(&chain_dir).unwrap();
+
+        // A node should fail to start-up
+        let result =
+            start_namada_ledger_node_wait_wasm(&test, Some(0), Some(40));
+        assert!(result.is_err())
+    }
 
     Ok(())
 }

--- a/crates/tests/src/e2e/setup.rs
+++ b/crates/tests/src/e2e/setup.rs
@@ -1098,6 +1098,13 @@ where
         Bin::Relayer => ("namadar", "info"),
     };
 
+    let mut args = args.into_iter().peekable();
+    let is_node_ledger = matches!(bin, Bin::Node)
+        && args
+            .peek()
+            .map(|fst_arg| fst_arg.as_ref() == "ledger")
+            .unwrap_or_default();
+
     let mut run_cmd = generate_bin_command(
         bin_name,
         &working_dir.as_ref().join("Cargo.toml"),
@@ -1160,7 +1167,7 @@ where
 
     println!("{}:\n{}", "> Running".underline().green(), &cmd_process);
 
-    if let Bin::Node = &bin {
+    if is_node_ledger {
         // When running a node command, we need to wait a bit before checking
         // status
         sleep(1);


### PR DESCRIPTION
## Describe your changes

- Depends-On: #3833

On init-chain, the node should be checking that the genesis files have not been tempered with by using the Chain ID.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
