### PR TITLE
mergify: add backport strategy

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,7 +9,7 @@ queue_rules:
         
 
 pull_request_rules:
-  - name: main-automatic-merge
+  - name: automatic merge to main
     conditions:
         - label = "merge"
         - label != "do-not-merge"
@@ -31,3 +31,11 @@ pull_request_rules:
 
           Sorry about that, but you can requeue the PR by using `@mergifyio requeue`
           if you think this was a mistake.
+
+  - name: backport PR to 0.44.0 lane
+    conditions:
+      - label = backport-44
+    actions:
+      backport:
+        branches:
+          - "0.44.0"


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
