### PR TITLE
Removes old reference to encrypted txs

### DIFF
--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -116,8 +116,7 @@ where
     }
 
     /// Evaluates the corresponding [`TxResult`] for each tx in the
-    /// proposal. Additionally, counts the number of digest
-    /// txs and the bytes used by encrypted txs in the proposal.
+    /// proposal.
     ///
     /// `ProcessProposal` should be able to make a decision on whether a
     /// proposed block is acceptable or not based solely on what this
@@ -274,8 +273,8 @@ where
             // If it is a raw transaction, we do no further validation
             TxType::Raw => TxResult {
                 code: ResultCode::InvalidTx.into(),
-                info: "Transaction rejected: Non-encrypted transactions are \
-                       not supported"
+                info: "Transaction rejected: Raw transactions are not \
+                       supported"
                     .into(),
             },
             TxType::Protocol(protocol_tx) => {
@@ -1141,8 +1140,7 @@ mod test_process_proposal {
         assert_eq!(
             response.result.info,
             String::from(
-                "Transaction rejected: Non-encrypted transactions are not \
-                 supported"
+                "Transaction rejected: Raw transactions are not supported"
             ),
         );
     }


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
