### PR TITLE
Batch events tests

### DIFF
--- a/.changelog/unreleased/testing/3857-batch-events-tests.md
+++ b/.changelog/unreleased/testing/3857-batch-events-tests.md
@@ -1,0 +1,2 @@
+- Added testing for batched tx events.
+  ([\#3857](https://github.com/anoma/namada/pull/3857))

--- a/crates/events/src/extend.rs
+++ b/crates/events/src/extend.rs
@@ -542,20 +542,6 @@ impl EventAttributeEntry<'static> for MaspDataRefs {
     }
 }
 
-/// Extend an [`Event`] with success data.
-pub struct Success(pub bool);
-
-impl EventAttributeEntry<'static> for Success {
-    type Value = bool;
-    type ValueOwned = Self::Value;
-
-    const KEY: &'static str = "success";
-
-    fn into_value(self) -> Self::Value {
-        self.0
-    }
-}
-
 /// Extend an [`Event`] with a new domain.
 pub struct Domain<E>(PhantomData<E>);
 

--- a/crates/node/src/shell/prepare_proposal.rs
+++ b/crates/node/src/shell/prepare_proposal.rs
@@ -949,7 +949,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        eprintln!("Proposal: {:?}", result.txs);
         assert_eq!(result.txs.len(), 0);
     }
 
@@ -985,7 +984,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        eprintln!("Proposal: {:?}", result.txs);
         assert!(result.txs.is_empty());
     }
 
@@ -1019,7 +1017,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        eprintln!("Proposal: {:?}", result.txs);
         assert!(result.txs.is_empty());
     }
 
@@ -1073,7 +1070,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        eprintln!("Proposal: {:?}", result.txs);
         assert!(result.txs.is_empty());
     }
 
@@ -1114,7 +1110,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        eprintln!("Proposal: {:?}", result.txs);
         assert!(result.txs.is_empty());
     }
 
@@ -1180,8 +1175,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        // FIXME: why println here????
-        eprintln!("Proposal: {:?}", result.txs);
         assert_eq!(result.txs.first().unwrap(), &wrapper_tx.to_bytes());
     }
 
@@ -1227,7 +1220,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        eprintln!("Proposal: {:?}", result.txs);
         assert!(result.txs.is_empty());
     }
 
@@ -1260,7 +1252,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        eprintln!("Proposal: {:?}", result.txs);
         assert!(result.txs.is_empty());
     }
 
@@ -1294,7 +1285,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        eprintln!("Proposal: {:?}", result.txs);
         assert!(result.txs.is_empty());
     }
 
@@ -1328,7 +1318,6 @@ mod test_prepare_proposal {
             ..Default::default()
         };
         let result = shell.prepare_proposal(req);
-        eprintln!("Proposal: {:?}", result.txs);
         assert!(result.txs.is_empty());
     }
 

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -569,6 +569,8 @@ where
 // process proposals
 #[cfg(test)]
 mod test_process_proposal {
+    use std::collections::BTreeMap;
+
     use namada_apps_lib::wallet;
     use namada_replay_protection as replay_protection;
     use namada_sdk::address;
@@ -579,7 +581,7 @@ mod test_process_proposal {
     use namada_sdk::state::StorageWrite;
     use namada_sdk::token::{read_denom, Amount, DenominatedAmount};
     use namada_sdk::tx::data::Fee;
-    use namada_sdk::tx::{Authorization, Code, Data, Signed};
+    use namada_sdk::tx::{Code, Data, Signed};
     use namada_vote_ext::{
         bridge_pool_roots, ethereum_events, validator_set_update,
     };
@@ -591,7 +593,7 @@ mod test_process_proposal {
     };
     use crate::shims::abcipp_shim_types::shim::request::ProcessedTx;
 
-    const GAS_LIMIT_MULTIPLIER: u64 = 100_000;
+    const GAS_LIMIT: u64 = 100_000;
 
     /// Check that we reject a validator set update protocol tx
     /// if the bridge is not active.
@@ -885,7 +887,7 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 public_key,
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         outer_tx.header.chain_id = shell.chain_id.clone();
         outer_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
@@ -935,16 +937,12 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 keypair.ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         outer_tx.header.chain_id = shell.chain_id.clone();
         outer_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         outer_tx.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        outer_tx.add_section(Section::Authorization(Authorization::new(
-            outer_tx.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        outer_tx.sign_wrapper(keypair);
         let mut new_tx = outer_tx.clone();
         if let TxType::Wrapper(wrapper) = &mut new_tx.header.tx_type {
             // we mount a malleability attack to try and remove the fee
@@ -1007,16 +1005,12 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 keypair.ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         outer_tx.header.chain_id = shell.chain_id.clone();
         outer_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         outer_tx.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        outer_tx.add_section(Section::Authorization(Authorization::new(
-            outer_tx.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        outer_tx.sign_wrapper(keypair);
 
         let response = {
             let request = ProcessProposal {
@@ -1071,16 +1065,12 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 keypair.ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         outer_tx.header.chain_id = shell.chain_id.clone();
         outer_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         outer_tx.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        outer_tx.add_section(Section::Authorization(Authorization::new(
-            outer_tx.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        outer_tx.sign_wrapper(keypair);
 
         let response = {
             let request = ProcessProposal {
@@ -1162,16 +1152,12 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 keypair.ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        wrapper.sign_wrapper(keypair);
 
         // Write wrapper hash to storage
         let mut batch = namada_sdk::state::testing::TestState::batch();
@@ -1230,16 +1216,12 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 keypair.ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        wrapper.sign_wrapper(keypair);
 
         // Run validation
         let request = ProcessProposal {
@@ -1282,16 +1264,12 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 keypair.ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        wrapper.sign_wrapper(keypair);
 
         // Write inner hash to storage
         let mut batch = namada_sdk::state::testing::TestState::batch();
@@ -1341,17 +1319,13 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 keypair.ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
         let mut new_wrapper = wrapper.clone();
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        wrapper.sign_wrapper(keypair);
 
         new_wrapper.update_header(TxType::Wrapper(Box::new(WrapperTx::new(
             Fee {
@@ -1359,13 +1333,9 @@ mod test_process_proposal {
                 token: shell.state.in_mem().native_token.clone(),
             },
             keypair_2.ref_to(),
-            GAS_LIMIT_MULTIPLIER.into(),
+            GAS_LIMIT.into(),
         ))));
-        new_wrapper.add_section(Section::Authorization(Authorization::new(
-            new_wrapper.sechashes(),
-            [(0, keypair_2)].into_iter().collect(),
-            None,
-        )));
+        new_wrapper.sign_wrapper(keypair_2);
 
         // Run validation
         let request = ProcessProposal {
@@ -1393,17 +1363,13 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 keypair.ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         let wrong_chain_id = ChainId("Wrong chain id".to_string());
         wrapper.header.chain_id = wrong_chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        wrapper.sign_wrapper(keypair);
 
         let protocol_key = shell.mode.get_protocol_key().expect("Test failed");
         let protocol_tx = EthereumTxData::EthEventsVext({
@@ -1453,17 +1419,13 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 keypair.ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.header.expiration = Some(DateTimeUtc::default());
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        wrapper.sign_wrapper(keypair);
 
         // Run validation
         let request = ProcessProposal {
@@ -1502,11 +1464,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        wrapper.sign_wrapper(keypair);
 
         // Run validation
         let request = ProcessProposal {
@@ -1542,11 +1500,7 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, keypair)].into_iter().collect(),
-            None,
-        )));
+        wrapper.sign_wrapper(keypair);
 
         // Run validation
         let request = ProcessProposal {
@@ -1583,18 +1537,13 @@ mod test_process_proposal {
                     token: address::testing::apfel(),
                 },
                 namada_apps_lib::wallet::defaults::albert_keypair().ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, namada_apps_lib::wallet::defaults::albert_keypair())]
-                .into_iter()
-                .collect(),
-            None,
-        )));
+        wrapper
+            .sign_wrapper(namada_apps_lib::wallet::defaults::albert_keypair());
 
         // Run validation
         let request = ProcessProposal {
@@ -1611,6 +1560,66 @@ mod test_process_proposal {
         }
     }
 
+    // Check that a wrapper using a whitelisted non-native token for fee payment
+    // is accepted
+    #[test]
+    fn test_fee_whitelisted_non_native_token() {
+        let (mut shell, _recv, _, _) = test_utils::setup();
+
+        let apfel_denom = read_denom(&shell.state, &address::testing::apfel())
+            .expect("unable to read denomination from storage")
+            .expect("unable to find denomination of apfels");
+        let fee_amount: token::Amount = GAS_LIMIT.into();
+
+        // Credit some tokens for fee payment
+        namada_sdk::token::credit_tokens(
+            &mut shell.state,
+            &address::testing::apfel(),
+            &Address::from(&wallet::defaults::albert_keypair().to_public()),
+            fee_amount,
+        )
+        .unwrap();
+        let balance = token::read_balance(
+            &shell.state,
+            &address::testing::apfel(),
+            &Address::from(&wallet::defaults::albert_keypair().to_public()),
+        )
+        .unwrap();
+        assert_eq!(balance, fee_amount.clone());
+
+        // Whitelist Apfel for fee payment
+        let gas_cost_key = namada_sdk::parameters::storage::get_gas_cost_key();
+        let mut gas_prices: BTreeMap<Address, token::Amount> =
+            shell.read_storage_key(&gas_cost_key).unwrap();
+        gas_prices.insert(address::testing::apfel(), 1.into());
+        shell.shell.state.write(&gas_cost_key, gas_prices).unwrap();
+        shell.commit();
+
+        let mut wrapper =
+            Tx::from_type(TxType::Wrapper(Box::new(WrapperTx::new(
+                Fee {
+                    amount_per_gas_unit: DenominatedAmount::new(
+                        1.into(),
+                        apfel_denom,
+                    ),
+                    token: address::testing::apfel(),
+                },
+                namada_apps_lib::wallet::defaults::albert_keypair().ref_to(),
+                GAS_LIMIT.into(),
+            ))));
+        wrapper.header.chain_id = shell.chain_id.clone();
+        wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
+        wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
+        wrapper
+            .sign_wrapper(namada_apps_lib::wallet::defaults::albert_keypair());
+
+        // Run validation
+        let request = ProcessProposal {
+            txs: vec![wrapper.to_bytes()],
+        };
+        assert!(shell.process_proposal(request).is_ok());
+    }
+
     // Check that a wrapper setting a fee amount lower than the minimum required
     // causes a block rejection
     #[test]
@@ -1624,18 +1633,13 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 namada_apps_lib::wallet::defaults::albert_keypair().ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, namada_apps_lib::wallet::defaults::albert_keypair())]
-                .into_iter()
-                .collect(),
-            None,
-        )));
+        wrapper
+            .sign_wrapper(namada_apps_lib::wallet::defaults::albert_keypair());
 
         // Run validation
         let request = ProcessProposal {
@@ -1672,13 +1676,8 @@ mod test_process_proposal {
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, namada_apps_lib::wallet::defaults::albert_keypair())]
-                .into_iter()
-                .collect(),
-            None,
-        )));
+        wrapper
+            .sign_wrapper(namada_apps_lib::wallet::defaults::albert_keypair());
 
         // Run validation
         let request = ProcessProposal {
@@ -1710,18 +1709,13 @@ mod test_process_proposal {
                     token: shell.state.in_mem().native_token.clone(),
                 },
                 namada_apps_lib::wallet::defaults::albert_keypair().ref_to(),
-                GAS_LIMIT_MULTIPLIER.into(),
+                GAS_LIMIT.into(),
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm code".as_bytes().to_owned(), None));
         wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
-        wrapper.add_section(Section::Authorization(Authorization::new(
-            wrapper.sechashes(),
-            [(0, namada_apps_lib::wallet::defaults::albert_keypair())]
-                .into_iter()
-                .collect(),
-            None,
-        )));
+        wrapper
+            .sign_wrapper(namada_apps_lib::wallet::defaults::albert_keypair());
 
         // Run validation
         let request = ProcessProposal {
@@ -1764,17 +1758,13 @@ mod test_process_proposal {
                         token: shell.state.in_mem().native_token.clone(),
                     },
                     keypair.ref_to(),
-                    GAS_LIMIT_MULTIPLIER.into(),
+                    GAS_LIMIT.into(),
                 ))));
             wrapper.header.chain_id = shell.chain_id.clone();
             wrapper
                 .set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
             wrapper.set_data(Data::new(vec![0; size as usize]));
-            wrapper.add_section(Section::Authorization(Authorization::new(
-                wrapper.sechashes(),
-                [(0, keypair)].into_iter().collect(),
-                None,
-            )));
+            wrapper.sign_wrapper(keypair);
             wrapper
         };
 

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -19,8 +19,10 @@ pub const WASM_FOR_TESTS_DIR: &str = "wasm_for_tests";
 #[derive(Debug, Clone, Copy, EnumIter)]
 pub enum TestWasms {
     TxFail,
+    TxFailEvent,
     TxMemoryLimit,
     TxNoOp,
+    TxNoOpEvent,
     TxInvalidData,
     TxInfiniteGuestGas,
     TxInfiniteHostGas,
@@ -44,8 +46,10 @@ impl TestWasms {
     pub fn path(&self) -> PathBuf {
         let filename = match self {
             TestWasms::TxFail => "tx_fail.wasm",
+            TestWasms::TxFailEvent => "tx_fail_event.wasm",
             TestWasms::TxMemoryLimit => "tx_memory_limit.wasm",
             TestWasms::TxNoOp => "tx_no_op.wasm",
+            TestWasms::TxNoOpEvent => "tx_no_op_event.wasm",
             TestWasms::TxInvalidData => "tx_invalid_data.wasm",
             TestWasms::TxInfiniteGuestGas => "tx_infinite_guest_gas.wasm",
             TestWasms::TxInfiniteHostGas => "tx_infinite_host_gas.wasm",

--- a/crates/tx_prelude/src/lib.rs
+++ b/crates/tx_prelude/src/lib.rs
@@ -38,7 +38,10 @@ use namada_core::internal::HostEnvResult;
 use namada_core::key::common;
 use namada_core::storage::TxIndex;
 pub use namada_core::{address, encode, eth_bridge_pool, storage, *};
-use namada_events::{EmitEvents, Event, EventToEmit, EventType};
+pub use namada_events::extend::Log;
+pub use namada_events::{
+    EmitEvents, Event, EventLevel, EventToEmit, EventType,
+};
 pub use namada_governance::storage as gov_storage;
 pub use namada_macros::transaction;
 pub use namada_parameters::storage as parameters_storage;

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -3694,6 +3694,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tx_fail_event"
+version = "0.41.0"
+dependencies = [
+ "getrandom",
+ "namada_tx_prelude",
+ "rlsf",
+]
+
+[[package]]
 name = "tx_infinite_guest_gas"
 version = "0.41.0"
 dependencies = [
@@ -3731,6 +3740,15 @@ dependencies = [
 
 [[package]]
 name = "tx_no_op"
+version = "0.41.0"
+dependencies = [
+ "getrandom",
+ "namada_tx_prelude",
+ "rlsf",
+]
+
+[[package]]
+name = "tx_no_op_event"
 version = "0.41.0"
 dependencies = [
  "getrandom",

--- a/wasm_for_tests/Cargo.toml
+++ b/wasm_for_tests/Cargo.toml
@@ -3,11 +3,13 @@ resolver = "2"
 
 members = [
     "tx_fail",
+    "tx_fail_event",
     "tx_infinite_guest_gas",
     "tx_infinite_host_gas",
     "tx_invalid_data",
     "tx_memory_limit",
     "tx_no_op",
+    "tx_no_op_event",
     "tx_proposal_code",
     "tx_proposal_ibc_token_inflation",
     "tx_proposal_masp_reward",

--- a/wasm_for_tests/Makefile
+++ b/wasm_for_tests/Makefile
@@ -6,11 +6,13 @@ nightly := $(shell cat ../rust-nightly-version)
 # All the wasms that can be built from this source, switched via Cargo features
 # Wasms can be added via the Cargo.toml `[features]` list.
 wasms := tx_fail
+wasms += tx_fail_event
 wasms += tx_infinite_guest_gas
 wasms += tx_infinite_host_gas
 wasms += tx_invalid_data
 wasms += tx_memory_limit
 wasms += tx_no_op
+wasms += tx_no_op_event
 wasms += tx_proposal_code
 wasms += tx_proposal_ibc_token_inflation
 wasms += tx_proposal_masp_reward

--- a/wasm_for_tests/tx_fail_event/Cargo.toml
+++ b/wasm_for_tests/tx_fail_event/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tx_fail_event"
+description = "Wasm transaction used for testing."
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+namada_tx_prelude.workspace = true
+rlsf.workspace = true
+getrandom.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/wasm_for_tests/tx_fail_event/src/lib.rs
+++ b/wasm_for_tests/tx_fail_event/src/lib.rs
@@ -1,0 +1,14 @@
+use namada_tx_prelude::*;
+
+#[transaction]
+fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
+    // Emit an event with the message contained in the transaction's data
+    let data = ctx.get_tx_data(&tx_data)?;
+    let data_str = String::try_from_slice(&data[..])
+        .wrap_err("Failed to decode String tx data")?;
+    let mut event = Event::new(EventType::new("test"), EventLevel::Tx);
+    event.extend(Log(data_str));
+    ctx.emit_event(event).wrap_err("Failed to emit event")?;
+
+    Err(Error::SimpleMessage("failed tx"))
+}

--- a/wasm_for_tests/tx_no_op_event/Cargo.toml
+++ b/wasm_for_tests/tx_no_op_event/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tx_no_op_event"
+description = "Wasm transaction used for testing."
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+namada_tx_prelude.workspace = true
+rlsf.workspace = true
+getrandom.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/wasm_for_tests/tx_no_op_event/src/lib.rs
+++ b/wasm_for_tests/tx_no_op_event/src/lib.rs
@@ -1,0 +1,14 @@
+use namada_tx_prelude::*;
+
+#[transaction]
+fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
+    // Emit an event with the message contained in the transaction's data
+    let data = ctx.get_tx_data(&tx_data)?;
+    let data_str = String::try_from_slice(&data[..])
+        .wrap_err("Failed to decode String tx data")?;
+    let mut event = Event::new(EventType::new("test"), EventLevel::Tx);
+    event.extend(Log(data_str));
+    ctx.emit_event(event).wrap_err("Failed to emit event")?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Describe your changes

Partially addresses #3828.

- Adds unit tests for gas payment with whitelisted, non-native token
- Adds unit tests for batched txs' events
- Removes the unused `Success` event
- Misc refactor of tx signatures in unit tests

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
