### PR TITLE
ci/mergify: add merge rule for backport to 0.44

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,15 +6,24 @@ queue_rules:
       - "#approved-reviews-by >= 1"
       - base = main
     merge_method: merge
-        
+
+  - name: backport-0.44-queue
+    speculative_checks: 3
+    batch_size: 3
+    queue_conditions:
+      - "#approved-reviews-by >= 1"
+      - base = "0.44.0"
+    merge_method: merge
 
 pull_request_rules:
-  - name: automatic merge to main
+  - name: automatic merge to main or backport branch
     conditions:
         - label = "merge"
         - label != "do-not-merge"
         - "#approved-reviews-by >= 1"
-        - base = main
+        - or:
+          - base = main
+          - base = "0.44.0"
     actions:
       queue:
         autosquash: true   


### PR DESCRIPTION
## Describe your changes

Allows to use "merge" label with backported PRs

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
