### PR TITLE
governance: let validator vote even if it doesn't have a self-bond

### DIFF
--- a/crates/tx_prelude/src/proof_of_stake.rs
+++ b/crates/tx_prelude/src/proof_of_stake.rs
@@ -12,7 +12,9 @@ use namada_proof_of_stake::{
     claim_reward_tokens, deactivate_validator, reactivate_validator,
     redelegate_tokens, unbond_tokens, unjail_validator, withdraw_tokens,
 };
-pub use namada_proof_of_stake::{parameters, storage, storage_key, types};
+pub use namada_proof_of_stake::{
+    is_validator, parameters, storage, storage_key, types,
+};
 use namada_tx::action::{
     Action, ClaimRewards, PosAction, Redelegation, Unbond, Withdraw, Write,
 };

--- a/wasm/tx_vote_proposal/src/lib.rs
+++ b/wasm/tx_vote_proposal/src/lib.rs
@@ -1,7 +1,9 @@
 //! A tx to vote on a proposal
 
 use namada_tx_prelude::action::{Action, GovAction, Write};
-use namada_tx_prelude::proof_of_stake::find_delegation_validators;
+use namada_tx_prelude::proof_of_stake::{
+    find_delegation_validators, is_validator,
+};
 use namada_tx_prelude::*;
 
 #[transaction]
@@ -24,8 +26,13 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
     // vote will be counted based on the validator state will be determined
     // when tallying the votes and executing the proposal.
     let current_epoch = ctx.get_block_epoch()?;
-    let delegation_targets =
-        find_delegation_validators(ctx, &tx_data.voter, &current_epoch)?;
+
+    let is_validator = is_validator(ctx, &tx_data.voter).unwrap_or(false);
+    let delegation_targets = if !is_validator {
+        find_delegation_validators(ctx, &tx_data.voter, &current_epoch)?
+    } else {
+        [tx_data.voter.clone()].into()
+    };
 
     governance::vote_proposal(ctx, tx_data, delegation_targets)
         .wrap_err("Failed to vote on governance proposal")


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
