### PR TITLE
hw masp auto test

### DIFF
--- a/.changelog/unreleased/testing/3890-hw-masp-auto-test.md
+++ b/.changelog/unreleased/testing/3890-hw-masp-auto-test.md
@@ -1,0 +1,2 @@
+- Added MASP hardware wallet test automation.
+  ([\#3890](https://github.com/anoma/namada/pull/3890))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,7 +681,7 @@ jobs:
           chmod +x /usr/local/bin/hermes
       - name: Run e2e tests with device automation
         id: e2e
-        run: cargo +${{ env.NIGHTLY }} test --lib "e2e::ledger_tests::pos_bonds" -- --exact
+        run: cargo +${{ env.NIGHTLY }} test --lib -- "e2e::ledger_tests::pos_bonds" "e2e::ledger_tests::masp_txs_and_queries" --exact
         env:
           NAMADA_SPECULOS_PATH: "/root/.local/pipx/venvs/speculos/bin/speculos"
           NAMADA_SPECULOS_APP_ELF: "/ledger-namada/app_s2.elf"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,7 +681,11 @@ jobs:
           chmod +x /usr/local/bin/hermes
       - name: Run e2e tests with device automation
         id: e2e
-        run: cargo +${{ env.NIGHTLY }} test --lib -- "e2e::ledger_tests::pos_bonds" "e2e::ledger_tests::masp_txs_and_queries" --exact
+        run: |
+          cargo +${{ env.NIGHTLY }} test --lib -- \
+            "e2e::ledger_tests::pos_bonds" \
+            "e2e::ledger_tests::masp_txs_and_queries" \
+            --exact --test-threads=1
         env:
           NAMADA_SPECULOS_PATH: "/root/.local/pipx/venvs/speculos/bin/speculos"
           NAMADA_SPECULOS_APP_ELF: "/ledger-namada/app_s2.elf"

--- a/crates/tests/src/hw_wallet_automation.rs
+++ b/crates/tests/src/hw_wallet_automation.rs
@@ -254,6 +254,343 @@ pub fn gen_automation_e2e_pos_bonds() -> Automation {
     gen_automation(steps)
 }
 
+// Generate automation file for `e2e::ledger_tests::masp_tx_and_queries`
+pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
+    let view_key_steps = || -> Steps {
+        [
+            please_review_steps(),
+            vec![Step::Expect {
+                text: Text("Ext Full View Key (1/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Ext Full View Key (2/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Ext Full View Key (3/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Ext Full V...w Key (4/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Ext Full View Key (5/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Ext Full V...w Key (6/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("HD Path"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("APPROVE"),
+                action: Some(PressAndRelease(Button::Both)),
+            }],
+        ]
+        .concat()
+    };
+
+    let shielded_transfer_steps = || -> Steps {
+        [
+            please_review_steps(),
+            vec![
+                Step::Expect {
+                    text: Text("Type"),
+                    action: None,
+                },
+                Step::Expect {
+                    text: Text("Transfer"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+            ],
+            vec![Step::Expect {
+                text: Text("Sender (1/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (2/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (3/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (4/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (5/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (6/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sending Token"),
+                action: None,
+            }],
+            address_steps(),
+            vec![
+                Step::Expect {
+                    text: Text("Sending Amount"),
+                    action: None,
+                },
+                Step::Expect {
+                    text: Text("20.0"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+            ],
+            // Receiver of the transferred amount
+            vec![Step::Expect {
+                text: Text("Destination (1/2)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Destination (2/2)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Receiving Token"),
+                action: None,
+            }],
+            address_steps(),
+            vec![
+                Step::Expect {
+                    text: Text("Receiving Amount"),
+                    action: None,
+                },
+                Step::Expect {
+                    text: Text("7.0"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+            ],
+            // The change of balance that is kept by the sender
+            vec![Step::Expect {
+                text: Text("Destination (1/2)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Destination (2/2)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Receiving Token"),
+                action: None,
+            }],
+            address_steps(),
+            vec![
+                Step::Expect {
+                    text: Text("Receiving Amount"),
+                    action: None,
+                },
+                Step::Expect {
+                    text: Text("13.0"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+            ],
+            vec![Step::Expect {
+                text: Text("APPROVE"),
+                action: Some(PressAndRelease(Button::Both)),
+            }],
+        ]
+        .concat()
+    };
+
+    let unshielding_transfer_steps = || -> Steps {
+        [
+            please_review_steps(),
+            vec![
+                Step::Expect {
+                    text: Text("Type"),
+                    action: None,
+                },
+                Step::Expect {
+                    text: Text("Transfer"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+            ],
+            vec![Step::Expect {
+                text: Text("Sender (1/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (2/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (3/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (4/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (5/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sender (6/6)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Sending Token"),
+                action: None,
+            }],
+            address_steps(),
+            vec![
+                Step::Expect {
+                    text: Text("Sending Amount"),
+                    action: None,
+                },
+                Step::Expect {
+                    text: Text("7.0"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+            ],
+            // Receiver of the unshielded amount
+            vec![Step::Expect {
+                text: Text("Destination"),
+                action: None,
+            }],
+            address_steps(),
+            vec![Step::Expect {
+                text: Text("Receiving Token"),
+                action: None,
+            }],
+            address_steps(),
+            vec![
+                Step::Expect {
+                    text: Text("Receiving Amount"),
+                    action: None,
+                },
+                Step::Expect {
+                    text: Text("5.0"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+            ],
+            // The change of balance that is kept by the sender
+            vec![Step::Expect {
+                text: Text("Destination (1/2)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Destination (2/2)"),
+                action: Some(PressAndRelease(Button::Right)),
+            }],
+            vec![Step::Expect {
+                text: Text("Receiving Token"),
+                action: None,
+            }],
+            address_steps(),
+            vec![
+                Step::Expect {
+                    text: Text("Receiving Amount"),
+                    action: None,
+                },
+                Step::Expect {
+                    text: Text("2.0"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+            ],
+            vec![Step::Expect {
+                text: Text("APPROVE"),
+                action: Some(PressAndRelease(Button::Both)),
+            }],
+        ]
+        .concat()
+    };
+
+    let steps: Steps = [
+        // _____________________________________________________________________
+        // 1. tx - shield
+        please_review_steps(),
+        vec![
+            Step::Expect {
+                text: Text("Type"),
+                action: None,
+            },
+            Step::Expect {
+                text: Text("Transfer"),
+                action: Some(PressAndRelease(Button::Right)),
+            },
+        ],
+        vec![Step::Expect {
+            text: Text("Sender"),
+            action: None,
+        }],
+        address_steps(),
+        vec![Step::Expect {
+            text: Text("Sending Token"),
+            action: None,
+        }],
+        address_steps(),
+        vec![
+            Step::Expect {
+                text: Text("Sending Amount"),
+                action: None,
+            },
+            Step::Expect {
+                text: Text("20.0"),
+                action: Some(PressAndRelease(Button::Right)),
+            },
+        ],
+        vec![Step::Expect {
+            text: Text("Destination (1/2)"),
+            action: Some(PressAndRelease(Button::Right)),
+        }],
+        vec![Step::Expect {
+            text: Text("Destination (2/2)"),
+            action: Some(PressAndRelease(Button::Right)),
+        }],
+        vec![Step::Expect {
+            text: Text("Receiving Token"),
+            action: None,
+        }],
+        address_steps(),
+        vec![
+            Step::Expect {
+                text: Text("Receiving Amount"),
+                action: None,
+            },
+            Step::Expect {
+                text: Text("20.0"),
+                action: Some(PressAndRelease(Button::Right)),
+            },
+        ],
+        vec![Step::Expect {
+            text: Text("APPROVE"),
+            action: Some(PressAndRelease(Button::Both)),
+        }],
+        // _____________________________________________________________________
+        // 2. tx - shielded transfer
+        view_key_steps(),
+        // The same steps are repeated twice, first to generate the signature
+        // on the device ...
+        shielded_transfer_steps(),
+        // ... then to obtain the signature out of the device
+        shielded_transfer_steps(),
+        // _____________________________________________________________________
+        // 3. tx - unshielding transfer
+        view_key_steps(),
+        // The same steps are repeated twice, first to generate the signature
+        // on the device ...
+        unshielding_transfer_steps(),
+        // ... then to obtain the signature out of the device
+        unshielding_transfer_steps(),
+    ]
+    .concat();
+
+    gen_automation(steps)
+}
+
 type Steps = Vec<Step>;
 
 #[derive(Debug, Clone)]

--- a/crates/tests/src/hw_wallet_automation.rs
+++ b/crates/tests/src/hw_wallet_automation.rs
@@ -264,11 +264,11 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
                 action: Some(PressAndRelease(Button::Right)),
             }],
             vec![Step::Expect {
-                text: Text("Ext Full View Key (2/6)"),
+                text: Text("Ext Full V...w Key (2/6)"),
                 action: Some(PressAndRelease(Button::Right)),
             }],
             vec![Step::Expect {
-                text: Text("Ext Full View Key (3/6)"),
+                text: Text("Ext Full V...w Key (3/6)"),
                 action: Some(PressAndRelease(Button::Right)),
             }],
             vec![Step::Expect {
@@ -295,7 +295,28 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
         .concat()
     };
 
-    let shielded_transfer_steps = || -> Steps {
+    let destination_steps = |abbrev_dest: bool| -> Steps {
+        // Destination might be abbreviated during MASP signing
+        if abbrev_dest {
+            vec![Step::Expect {
+                text: Text("Destination"),
+                action: Some(PressAndRelease(Button::Right)),
+            }]
+        } else {
+            vec![
+                Step::Expect {
+                    text: Text("Destination (1/2)"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+                Step::Expect {
+                    text: Text("Destination (2/2)"),
+                    action: Some(PressAndRelease(Button::Right)),
+                },
+            ]
+        }
+    };
+
+    let shielded_transfer_steps = |abbrev_dest: bool| -> Steps {
         [
             please_review_steps(),
             vec![
@@ -348,14 +369,7 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
                 },
             ],
             // Receiver of the transferred amount
-            vec![Step::Expect {
-                text: Text("Destination (1/2)"),
-                action: Some(PressAndRelease(Button::Right)),
-            }],
-            vec![Step::Expect {
-                text: Text("Destination (2/2)"),
-                action: Some(PressAndRelease(Button::Right)),
-            }],
+            destination_steps(abbrev_dest),
             vec![Step::Expect {
                 text: Text("Receiving Token"),
                 action: None,
@@ -367,7 +381,7 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
                     action: None,
                 },
                 Step::Expect {
-                    text: Text("7.0"),
+                    text: Text("13.0"),
                     action: Some(PressAndRelease(Button::Right)),
                 },
             ],
@@ -391,10 +405,11 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
                     action: None,
                 },
                 Step::Expect {
-                    text: Text("13.0"),
+                    text: Text("7.0"),
                     action: Some(PressAndRelease(Button::Right)),
                 },
             ],
+            fee_steps(),
             vec![Step::Expect {
                 text: Text("APPROVE"),
                 action: Some(PressAndRelease(Button::Both)),
@@ -403,7 +418,7 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
         .concat()
     };
 
-    let unshielding_transfer_steps = || -> Steps {
+    let unshielding_transfer_steps = |abbrev_dest: bool| -> Steps {
         [
             please_review_steps(),
             vec![
@@ -477,14 +492,7 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
                 },
             ],
             // The change of balance that is kept by the sender
-            vec![Step::Expect {
-                text: Text("Destination (1/2)"),
-                action: Some(PressAndRelease(Button::Right)),
-            }],
-            vec![Step::Expect {
-                text: Text("Destination (2/2)"),
-                action: Some(PressAndRelease(Button::Right)),
-            }],
+            destination_steps(abbrev_dest),
             vec![Step::Expect {
                 text: Text("Receiving Token"),
                 action: None,
@@ -500,6 +508,7 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
                     action: Some(PressAndRelease(Button::Right)),
                 },
             ],
+            fee_steps(),
             vec![Step::Expect {
                 text: Text("APPROVE"),
                 action: Some(PressAndRelease(Button::Both)),
@@ -565,6 +574,7 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
                 action: Some(PressAndRelease(Button::Right)),
             },
         ],
+        fee_steps(),
         vec![Step::Expect {
             text: Text("APPROVE"),
             action: Some(PressAndRelease(Button::Both)),
@@ -574,17 +584,17 @@ pub fn gen_automation_e2e_masp_tx_and_queries() -> Automation {
         view_key_steps(),
         // The same steps are repeated twice, first to generate the signature
         // on the device ...
-        shielded_transfer_steps(),
+        shielded_transfer_steps(true),
         // ... then to obtain the signature out of the device
-        shielded_transfer_steps(),
+        shielded_transfer_steps(false),
         // _____________________________________________________________________
         // 3. tx - unshielding transfer
         view_key_steps(),
         // The same steps are repeated twice, first to generate the signature
         // on the device ...
-        unshielding_transfer_steps(),
+        unshielding_transfer_steps(true),
         // ... then to obtain the signature out of the device
-        unshielding_transfer_steps(),
+        unshielding_transfer_steps(false),
     ]
     .concat();
 


### PR DESCRIPTION
## Describe your changes

Adds a device automation for MASP e2e test to run in the CI.

Depends-On: #3797

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
