### PR TITLE
update mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,8 @@
+merge_queue:
+  max_parallel_checks: 3
+
 queue_rules:
   - name: main-queue
-    speculative_checks: 3
     batch_size: 3
     queue_conditions:
       - "#approved-reviews-by >= 1"
@@ -8,7 +10,6 @@ queue_rules:
     merge_method: merge
 
   - name: backport-0.45-queue
-    speculative_checks: 3
     batch_size: 3
     queue_conditions:
       - "#approved-reviews-by >= 1"


### PR DESCRIPTION
## Describe your changes
`speculative_checks` is deprecated in favor of `max_parallel_checks`

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
