### PR TITLE
Avoid redundant wrapper signatures

### DIFF
--- a/.changelog/unreleased/improvements/3896-avoid-redundant-sigs.md
+++ b/.changelog/unreleased/improvements/3896-avoid-redundant-sigs.md
@@ -1,0 +1,3 @@
+- The reveal pk batching process now attaches only one wrapper
+  signature. Added an SDK function to de-bloat wrapper signatures.
+  ([\#3896](https://github.com/anoma/namada/pull/3896))

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -844,8 +844,6 @@ pub async fn submit_transparent_transfer(
 
     let transfer_data = args.clone().build(namada).await?;
 
-    // FIXME: issue here, if they dump we don't dump the reveal pk tx, so they
-    // sign an incomplete tx
     if args.tx.dump_tx {
         tx::dump_tx(namada.io(), &args.tx, transfer_data.0);
     } else {

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -255,7 +255,8 @@ where
     }
 
     // FIXME: maybe export this whole thing to a function that we epoxse in the
-    // sdk?
+    // sdk and call that function every time after build_batch?
+    // FIXME: write a test for this thing?
     // Find the wrapper signature with the least targets and keep it, delete all
     // the others (redundant)
     if let Some(expected_wrapper_signer) =
@@ -274,6 +275,10 @@ where
                         Signer::PubKeys(ref sigs)
                             if sigs.as_slice()
                                 == [expected_wrapper_signer.clone()] => {}
+                        Signer::Address(ref addr)
+                            if addr
+                                == &Address::from(&expected_wrapper_signer) => {
+                        }
                         _ => {
                             remove_sigs.push(auth.to_owned());
                             continue;
@@ -298,6 +303,10 @@ where
             _ => true,
         });
     }
+
+    // FIXME: remove after having checked that the new implementation doesn't
+    // carry multiple sigs for wrapper (the old one does, I checked it)
+    display_line!(namada.io(), "Submitting tx: {:#?}", batched_tx);
 
     namada.submit(batched_tx, args).await
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -629,6 +629,35 @@ pub trait Namada: NamadaIo {
         .await
     }
 
+    /// Reworks the wrapper signatures of the given transaction using the given
+    /// signing data
+    async fn rework_batch_wrapper_signatures<D, F>(
+        &self,
+        tx: &mut Tx,
+        args: &args::Tx,
+        signing_data: SigningTxData,
+        with: impl Fn(Tx, common::PublicKey, HashSet<signing::Signable>, D) -> F
+        + MaybeSend
+        + MaybeSync,
+        user_data: D,
+    ) -> crate::error::Result<()>
+    where
+        D: Clone + MaybeSend + MaybeSync,
+        F: MaybeSend
+            + MaybeSync
+            + std::future::Future<Output = crate::error::Result<Tx>>,
+    {
+        signing::rework_batch_wrapper_signatures(
+            self.wallet_lock(),
+            args,
+            tx,
+            signing_data,
+            with,
+            user_data,
+        )
+        .await
+    }
+
     /// Process the given transaction using the given flags
     async fn submit(
         &self,

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2883,7 +2883,11 @@ async fn used_asset_types<P, K, N>(
 }
 
 /// Constructs the batched tx from the provided list. Returns also the data for
-/// signing
+/// signing.
+///
+/// Before submitting the batch consider calling
+/// `crate::signing::rework_batch_wrapper_signatures` to remove any possible
+/// redundant signature that might bloat your transaction.
 pub fn build_batch(
     mut txs: Vec<(Tx, SigningTxData)>,
 ) -> Result<(Tx, Vec<SigningTxData>)> {


### PR DESCRIPTION
## Describe your changes

Temporary, non-breaking workaround for #3883.

Adds an SDK function to remove the duplicated wrapper signatures that might come from `build_batch`. Updates `batch_opt_reveal_pk_and_submit` to call such function.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
