### PR TITLE
feat: Add new rpc query function to check validators' liveness(uptime)

### DIFF
--- a/.changelog/unreleased/improvements/3899-get-validators-livenesses.md
+++ b/.changelog/unreleased/improvements/3899-get-validators-livenesses.md
@@ -1,0 +1,2 @@
+- SDK query to get liveness information for the network and consensus validator
+  set. ([\#3899](https://github.com/anoma/namada/pull/3899))

--- a/crates/proof_of_stake/src/storage.rs
+++ b/crates/proof_of_stake/src/storage.rs
@@ -710,29 +710,6 @@ where
         .collect()
 }
 
-/// Read all validator addresses from the consensus set
-pub fn read_active_validator_addresses<S, Gov>(
-    storage: &S,
-    epoch: namada_core::chain::Epoch,
-) -> Result<HashSet<Address>>
-where
-    S: StorageRead,
-    Gov: governance::Read<S>,
-{
-    let params = read_pos_params::<S, Gov>(storage)?;
-    Ok(validator_addresses_handle()
-        .at(&epoch)
-        .iter(storage)?
-        .map(Result::unwrap)
-        .filter(|address| {
-            matches!(
-                validator_state_handle(address).get(storage, epoch, &params),
-                Ok(Some(ValidatorState::Consensus))
-            )
-        })
-        .collect())
-}
-
 /// Update PoS total deltas.
 /// Note: for EpochedDelta, write the value to change storage by
 pub fn update_total_deltas<S, Gov>(

--- a/crates/proof_of_stake/src/types/mod.rs
+++ b/crates/proof_of_stake/src/types/mod.rs
@@ -329,6 +329,28 @@ pub struct Redelegation {
     /// Redelegation amount
     pub amount: token::Amount,
 }
+
+/// Some liveness data for a consensus validator
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshDeserializer)]
+pub struct ValidatorLiveness {
+    /// Validator address
+    pub native_address: Address,
+    /// CometBFT address
+    pub comet_address: String,
+    /// Validator missed votes
+    pub missed_votes: u64,
+}
+
+/// Liveness data related to the network and set of consensus validators
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, BorshDeserializer)]
+pub struct LivenessInfo {
+    /// Length of liveness window
+    pub liveness_window_len: u64,
+    /// Liveness threshold
+    pub liveness_threshold: Dec,
+    /// Validators' liveness info
+    pub validators: Vec<ValidatorLiveness>,
+}
 // --------------------------------------------------------------------------------------------
 
 /// A genesis validator definition.

--- a/crates/sdk/src/queries/vp/pos.rs
+++ b/crates/sdk/src/queries/vp/pos.rs
@@ -274,15 +274,14 @@ where
         )? {
             let comet_address = tm_consensus_key_raw_hash(&pubkey);
             let sum_liveness_handle = liveness_sum_missed_votes_handle();
-            if let Some(missed_votes) =
-                sum_liveness_handle.get(ctx.state, &validator)?
-            {
-                result.push(ValidatorLiveness {
-                    native_address: validator,
-                    comet_address,
-                    missed_votes,
-                })
-            }
+            let missed_votes = sum_liveness_handle
+                .get(ctx.state, &validator)?
+                .unwrap_or_default();
+            result.push(ValidatorLiveness {
+                native_address: validator,
+                comet_address,
+                missed_votes,
+            })
         };
     }
 

--- a/crates/sdk/src/queries/vp/pos.rs
+++ b/crates/sdk/src/queries/vp/pos.rs
@@ -267,7 +267,7 @@ where
         read_consensus_validator_set_addresses(ctx.state, epoch)?;
     let params = read_pos_params::<_, governance::Store<_>>(ctx.state)?;
 
-    let mut result = vec![];
+    let mut result = Vec::with_capacity(consensus_validators.len());
     for validator in consensus_validators {
         if let Some(pubkey) = get_consensus_key::<_, governance::Store<_>>(
             ctx.state, &validator, epoch,

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -754,6 +754,13 @@ pub async fn get_all_validators<C: namada_io::Client + Sync>(
     )
 }
 
+/// Get validators livenesses in the given epoch
+pub async fn get_validators_livenesses<C: namada_io::Client + Sync>(
+    client: &C,
+) -> Result<Vec<(Address, String, u64)>, error::Error> {
+    convert_response::<C, _>(RPC.vp().pos().validator_livenesses(client).await)
+}
+
 /// Get all consensus validators in the given epoch
 pub async fn get_all_consensus_validators<C: namada_io::Client + Sync>(
     client: &C,

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -41,7 +41,7 @@ use namada_io::{display_line, edisplay_line, Client, Io};
 use namada_parameters::{storage as params_storage, EpochDuration};
 use namada_proof_of_stake::parameters::PosParams;
 use namada_proof_of_stake::types::{
-    BondsAndUnbondsDetails, CommissionPair, ValidatorMetaData,
+    BondsAndUnbondsDetails, CommissionPair, LivenessInfo, ValidatorMetaData,
     WeightedValidator,
 };
 use namada_state::LastBlock;
@@ -754,11 +754,11 @@ pub async fn get_all_validators<C: namada_io::Client + Sync>(
     )
 }
 
-/// Get validators livenesses in the given epoch
-pub async fn get_validators_livenesses<C: namada_io::Client + Sync>(
+/// Get liveness info for all consensus validators in the current epoch
+pub async fn get_validators_liveness_info<C: namada_io::Client + Sync>(
     client: &C,
-) -> Result<Vec<(Address, String, u64)>, error::Error> {
-    convert_response::<C, _>(RPC.vp().pos().validator_livenesses(client).await)
+) -> Result<LivenessInfo, error::Error> {
+    convert_response::<C, _>(RPC.vp().pos().liveness_info(client).await)
 }
 
 /// Get all consensus validators in the given epoch


### PR DESCRIPTION
## Describe your changes

Hello, I'm Jeongseup from Cosmostation. I hope the Namada mainnet genesis launch is successful. 

I believe it would be beneficial for each validator to monitor their own liveness(uptime) status during the current epoch to prevent slashsing or other penalties. 

Therefore, I have implemented a new RPC query function that retrieves the liveness status of validators who are active in this epoch. 

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
