### PR TITLE
e2e: run cleanup script before running e2e tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,17 @@
+experimental = ["setup-scripts"]
+
 [profile.default]
 retries = 0
 
 [[profile.default.overrides]]
 filter = 'test(e2e::)'
 retries = 2
+
+[[profile.default.scripts]]
+filter = 'test(e2e::)'
+setup = ['e2e-kill-processes']
+
+[script.e2e-kill-processes]
+command = '.github/workflows/scripts/pre-e2e-test.sh'
+capture-stdout = true
+capture-stderr = false

--- a/.github/workflows/scripts/pre-e2e-test.sh
+++ b/.github/workflows/scripts/pre-e2e-test.sh
@@ -1,0 +1,3 @@
+pkill -9 -f gaia || true
+pkill -9 -f namada* || true
+pkill -9 -f hermes || true


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
