### PR TITLE
Test malleability attacks

### DIFF
--- a/.changelog/unreleased/testing/3925-test-malleability-attacks.md
+++ b/.changelog/unreleased/testing/3925-test-malleability-attacks.md
@@ -1,0 +1,2 @@
+- Added property testing for malleability attacks on transactions.
+  ([\#3925](https://github.com/anoma/namada/pull/3925))

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -1440,8 +1440,7 @@ pub async fn broadcast_tx(
 ///
 /// Checks that
 /// 1. The tx has been successfully included into the mempool of a validator
-/// 2. The tx with encrypted payload has been included on the blockchain
-/// 3. The decrypted payload of the tx has been included on the blockchain.
+/// 2. The tx has been included on the blockchain
 ///
 /// In the case of errors in any of those stages, an error message is returned
 pub async fn submit_tx(

--- a/crates/light_sdk/src/writing/asynchronous/mod.rs
+++ b/crates/light_sdk/src/writing/asynchronous/mod.rs
@@ -12,8 +12,7 @@ use tendermint_rpc::HttpClient;
 ///
 /// Checks that
 /// 1. The tx has been successfully included into the mempool of a validator
-/// 2. The tx with encrypted payload has been included on the blockchain
-/// 3. The decrypted payload of the tx has been included on the blockchain.
+/// 2. The tx has been included on the blockchain
 ///
 /// In the case of errors in any of those stages, an error message is returned
 pub async fn broadcast_tx(

--- a/crates/light_sdk/src/writing/blocking/mod.rs
+++ b/crates/light_sdk/src/writing/blocking/mod.rs
@@ -14,8 +14,7 @@ use tokio::runtime::Runtime;
 ///
 /// Checks that
 /// 1. The tx has been successfully included into the mempool of a validator
-/// 2. The tx with encrypted payload has been included on the blockchain
-/// 3. The decrypted payload of the tx has been included on the blockchain.
+/// 2. The tx has been included on the blockchain
 ///
 /// In the case of errors in any of those stages, an error message is returned
 pub fn broadcast_tx(tendermint_addr: &str, tx: Tx) -> Result<Response, Error> {
@@ -31,7 +30,7 @@ pub fn broadcast_tx(tendermint_addr: &str, tx: Tx) -> Result<Response, Error> {
     let rt = Runtime::new().unwrap();
 
     let wrapper_tx_hash = tx.header_hash().to_string();
-    // We use this to determine when the decrypted inner tx makes it
+    // We use this to determine when the inner tx makes it
     // on-chain
     let decrypted_tx_hash = tx.raw_header_hash().to_string();
 

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -1692,9 +1692,6 @@ mod tests {
         // Then test tampered txs
         let mut runner = TestRunner::new(Config::default());
         let result = runner.run(&arb_tampered_inner_tx(signing_key), |tx| {
-            // FIXME: this doesn't pass because at the moment we are not
-            // signing all the sections, so tampering with them does not
-            // necessarily invalidate the signature
             assert!(
                 wasm::run::vp(
                     code_hash,

--- a/crates/node/src/shell/block_alloc.rs
+++ b/crates/node/src/shell/block_alloc.rs
@@ -390,7 +390,7 @@ mod tests {
         // reserve block space for protocol txs
         let mut alloc = BsaInitialProtocolTxs::init(BLOCK_SIZE, BLOCK_GAS);
 
-        // allocate ~1/2 of the block space to encrypted txs
+        // allocate ~1/2 of the block space to wrapper txs
         assert!(alloc.try_alloc(&[0; 29]).is_ok());
 
         // reserve block space for normal txs
@@ -504,7 +504,7 @@ mod tests {
         // Fill the entire gas bin
         bins.normal_txs.gas.occupied = bins.normal_txs.gas.allotted;
 
-        // Make sure we can't dump any new wncrypted txs in the bin
+        // Make sure we can't dump any new wrapper txs in the bin
         assert_matches!(
             bins.try_alloc(BlockResources::new(b"arbitrary tx bytes", 1)),
             Err(AllocFailure::Rejected { .. })

--- a/crates/node/src/shell/block_alloc/states.rs
+++ b/crates/node/src/shell/block_alloc/states.rs
@@ -38,7 +38,7 @@ pub struct BuildingProtocolTxBatch<Mode> {
 /// [`crate::shell::block_alloc::states`].
 pub enum WithNormalTxs {}
 
-/// Allow block proposals to include encrypted txs.
+/// Allow block proposals to include wrapper txs.
 ///
 /// For more info, read the module docs of
 /// [`crate::shell::block_alloc::states`].

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -1357,9 +1357,8 @@ mod test_finalize_block {
                 WRAPPER_GAS_LIMIT.into(),
             ))));
         wrapper_tx.header.chain_id = shell.chain_id.clone();
-        wrapper_tx.set_data(Data::new(
-            "Encrypted transaction data".as_bytes().to_owned(),
-        ));
+        wrapper_tx
+            .set_data(Data::new("transaction data".as_bytes().to_owned()));
         wrapper_tx.set_code(Code::new(tx_code, None));
         wrapper_tx.add_section(Section::Authorization(Authorization::new(
             wrapper_tx.sechashes(),
@@ -3478,9 +3477,8 @@ mod test_finalize_block {
                     0.into(),
                 ))));
             wrapper_tx.header.chain_id = shell.chain_id.clone();
-            wrapper_tx.set_data(Data::new(
-                "Encrypted transaction data".as_bytes().to_owned(),
-            ));
+            wrapper_tx
+                .set_data(Data::new("transaction data".as_bytes().to_owned()));
             wrapper_tx.add_code(TestWasms::TxNoOp.read_bytes(), None);
             wrapper_tx.sign_wrapper(keypair.clone());
             wrapper_tx
@@ -3514,7 +3512,7 @@ mod test_finalize_block {
 
         failing_wrapper
             .add_code(TestWasms::TxFail.read_bytes(), None)
-            .add_data("Encrypted transaction data");
+            .add_data("transaction data");
 
         let mut wrong_commitment_wrapper = failing_wrapper.clone();
         let tx_code = TestWasms::TxInvalidData.read_bytes();
@@ -3691,9 +3689,7 @@ mod test_finalize_block {
             ))));
         wrapper.header.chain_id = shell.chain_id.clone();
         wrapper.set_code(Code::new("wasm_code".as_bytes().to_owned(), None));
-        wrapper.set_data(Data::new(
-            "Encrypted transaction data".as_bytes().to_owned(),
-        ));
+        wrapper.set_data(Data::new("transaction data".as_bytes().to_owned()));
         wrapper.add_section(Section::Authorization(Authorization::new(
             wrapper.sechashes(),
             [(0, keypair)].into_iter().collect(),

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -2491,7 +2491,7 @@ mod shell_tests {
         )
     }
 
-    /// Mempool validation must reject already applied wrapper and decrypted
+    /// Mempool validation must reject already applied wrapper and inner
     /// transactions
     #[test]
     fn test_replay_attack() {

--- a/crates/node/src/shell/prepare_proposal.rs
+++ b/crates/node/src/shell/prepare_proposal.rs
@@ -56,7 +56,7 @@ where
             let (alloc, mut txs) =
                 self.build_protocol_tx_with_normal_txs(alloc, &mut req.txs);
 
-            // add encrypted txs
+            // add wrapper txs
             let tm_raw_hash_string =
                 tm_raw_hash_to_string(req.proposer_address);
             let block_proposer =
@@ -100,7 +100,7 @@ where
         self.state.read_only().into()
     }
 
-    /// Builds a batch of encrypted transactions, retrieved from
+    /// Builds a batch of wrapper  transactions, retrieved from
     /// CometBFT's mempool.
     fn build_normal_txs(
         &self,
@@ -763,7 +763,7 @@ mod test_prepare_proposal {
         assert_eq!(signed_eth_ev_vote_extension, rsp_ext.0);
     }
 
-    /// Test that if the unsigned wrapper tx hash is known (replay attack), the
+    /// Test that if the wrapper tx hash is known (replay attack), the
     /// transaction is not included in the block
     #[test]
     fn test_wrapper_tx_hash() {
@@ -830,7 +830,7 @@ mod test_prepare_proposal {
         assert_eq!(received_txs.len(), 1);
     }
 
-    /// Test that if the unsigned inner tx hash is known (replay attack), the
+    /// Test that if the inner tx hash is known (replay attack), the
     /// transaction is not included in the block
     #[test]
     fn test_inner_tx_hash() {
@@ -870,7 +870,7 @@ mod test_prepare_proposal {
         assert_eq!(received_txs.len(), 0);
     }
 
-    /// Test that if two identical decrypted txs are proposed for this block,
+    /// Test that if two identical inner txs are proposed for this block,
     /// both get accepted
     #[test]
     fn test_inner_tx_hash_same_block() {

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -597,7 +597,7 @@ mod test_process_proposal {
     };
     use namada_sdk::key::*;
     use namada_sdk::state::StorageWrite;
-    use namada_sdk::testing::{arb_tampered_tx, arb_valid_signed_tx};
+    use namada_sdk::testing::{arb_tampered_wrapper_tx, arb_valid_signed_tx};
     use namada_sdk::token::{read_denom, Amount, DenominatedAmount};
     use namada_sdk::tx::data::Fee;
     use namada_sdk::tx::{Code, Data, Signed};
@@ -946,10 +946,6 @@ mod test_process_proposal {
     /// Test that a block including a wrapper tx with invalid signature is
     /// rejected
     #[test]
-    // FIXME: need a test in finalize bloc kfor malleability of an inner tx doen
-    // by the wrapper signer (check both one that fails because of signature and
-    // one that fails because of indirect inclusion in tx data), this does not
-    // need to be proptest. will probably need soe more wasm for tests
     fn test_wrapper_bad_signature() {
         let (shell, _recv, _, _) = test_utils::setup_at_height(3u64);
 
@@ -966,7 +962,7 @@ mod test_process_proposal {
 
         // Then test invalid tx
         let mut runner = TestRunner::new(Config::default());
-        let result = runner.run(&arb_tampered_tx(), |tx| {
+        let result = runner.run(&arb_tampered_wrapper_tx(), |tx| {
             let request = ProcessProposal {
                 txs: vec![tx.to_bytes()],
             };

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -954,6 +954,9 @@ mod test_process_proposal {
         let (shell, _recv, _, _) = test_utils::setup_at_height(3u64);
 
         let mut runner = TestRunner::new(Config::default());
+        // The arbitrary tx generator outputs txs with possible wrong
+        // expirations/chain ids. This is fine for the sake of this test cause
+        // we check the signature before everything else
         let result = runner.run(&arb_tampered_tx(), |tx| {
             let request = ProcessProposal {
                 txs: vec![tx.to_bytes()],
@@ -989,60 +992,6 @@ mod test_process_proposal {
         });
 
         assert!(result.is_ok());
-
-        // FIXME: remove
-        // let keypair = gen_keypair();
-        // let mut outer_tx =
-        //     Tx::from_type(TxType::Wrapper(Box::new(WrapperTx::new(
-        //         Fee {
-        //             amount_per_gas_unit: DenominatedAmount::native(
-        //                 Amount::from_uint(100, 0).expect("Test failed"),
-        //             ),
-        //             token: shell.state.in_mem().native_token.clone(),
-        //         },
-        //         keypair.ref_to(),
-        //         GAS_LIMIT.into(),
-        //     ))));
-        // outer_tx.header.chain_id = shell.chain_id.clone();
-        // outer_tx.set_code(Code::new("wasm_code".as_bytes().to_owned(),
-        // None)); outer_tx.set_data(Data::new("transaction
-        // data".as_bytes().to_owned()));
-        // outer_tx.sign_wrapper(keypair);
-        // let mut new_tx = outer_tx.clone();
-        // if let TxType::Wrapper(wrapper) = &mut new_tx.header.tx_type {
-        //     // we mount a malleability attack to try and remove the fee
-        //     wrapper.fee.amount_per_gas_unit =
-        //         DenominatedAmount::native(Default::default());
-        // } else {
-        //     panic!("Test failed")
-        // };
-        // let request = ProcessProposal {
-        //     txs: vec![new_tx.to_bytes()],
-        // };
-
-        // match shell.process_proposal(request) {
-        //     Ok(_) => panic!("Test failed"),
-        //     Err(TestError::RejectProposal(response)) => {
-        //         let response = if let [response] = response.as_slice() {
-        //             response.clone()
-        //         } else {
-        //             panic!("Test failed")
-        //         };
-        //         let expected_error = "WrapperTx signature verification \
-        //                               failed: The wrapper signature is \
-        //                               invalid.";
-        //         assert_eq!(
-        //             response.result.code,
-        //             u32::from(ResultCode::InvalidSig)
-        //         );
-        //         assert!(
-        //             response.result.info.contains(expected_error),
-        //             "Result info {} doesn't contain the expected error {}",
-        //             response.result.info,
-        //             expected_error
-        //         );
-        //     }
-        // }
     }
 
     /// Test that if the account submitting the tx is not known and the fee is

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -171,9 +171,7 @@ where
     /// Checks if the Tx can be deserialized from bytes. Checks the fees and
     /// signatures of the fee payer for a transaction if it is a wrapper tx.
     ///
-    /// Checks validity of a decrypted tx or that a tx marked un-decryptable
-    /// is in fact so. Also checks that decrypted txs were submitted in
-    /// correct order.
+    /// Checks validity of an inner tx.
     ///
     /// Error codes:
     ///   0: Ok

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1781,55 +1781,12 @@ pub mod testing {
         /// Generate an arbitrary signed inner tx that has been tampered with.
         pub fn arb_tampered_inner_tx(signer: common::SecretKey)
         (tx1 in arb_valid_signed_inner_tx(signer.clone()))(
-            tamper in prop_oneof![
-                Just(TamperTx::RemoveSection),
-                Just(TamperTx::AddExtraSection),
-                Just(TamperTx::SwapSection),
-                Just(TamperTx::SwapHeader)
-            ],
             tx2 in arb_valid_signed_inner_tx(signer.clone()),
-            selector in proptest::prelude::any::<proptest::prelude::prop::sample::Selector>(),
             mut tx in Just(tx1),
         ) -> Tx {
-            match tamper {
-               TamperTx::RemoveSection => {
-                    let to_remove = selector.select(&tx.sections).to_owned();
-                    tx.sections.retain(|section| section != &to_remove);
-
-                    tx
-                },
-               TamperTx::AddExtraSection => {
-                    let to_add = selector.select(&tx2.sections).to_owned();
-                    tx.sections.push(to_add);
-
-                    tx
-                },
-               TamperTx::SwapSection => {
-                    let mut to_remove = selector.select(&tx.sections).to_owned();
-                    let mut to_add = selector.select(&tx2.sections).to_owned();
-
-                    // Try to pick different sections of the same type for the swap if possible
-                    for source in tx.sections.iter() {
-                        if let Some(target) = tx2.sections.iter().find(|section| {
-                            std::mem::discriminant(*section) == std::mem::discriminant(&to_remove) && section.get_hash() != source.get_hash()
-                        }) {
-                            to_remove = source.to_owned();
-                            to_add = target.to_owned();
-                            break;
-                        }
-                    }
-
-                    tx.sections.retain(|section| section != &to_remove);
-                    tx.sections.push(to_add);
-
-                    tx
-                },
-               TamperTx::SwapHeader => {
-                    tx.header = tx2.header;
-
-                    tx
-                },
-            }
+            // Tamper with the header only since signature is computed on this alone
+            tx.header = tx2.header;
+            tx
         }
     }
 }

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -616,12 +616,9 @@ pub async fn dry_run_tx<N: Namada>(
     Ok(result)
 }
 
-/// Data needed for broadcasting a tx and
-/// monitoring its progress on chain
+/// Data needed for broadcasting a tx and monitoring its progress on chain.
 ///
-/// Txs may be either a dry run or else
-/// they should be encrypted and included
-/// in a wrapper.
+/// Txs may be either a dry run or else they should be included in a wrapper.
 #[derive(Debug, Clone)]
 pub enum TxBroadcastData {
     /// Dry run broadcast data

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -265,7 +265,7 @@ pub async fn process_tx(
         let tx_hash = tx.header_hash().to_string();
         let cmts = tx.commitments().clone();
         let wrapper_hash = tx.wrapper_hash();
-        // We use this to determine when the decrypted inner tx makes it
+        // We use this to determine when the inner tx makes it
         // on-chain
         let to_broadcast = TxBroadcastData::Live { tx, tx_hash };
         if args.broadcast_only {
@@ -393,8 +393,7 @@ pub async fn broadcast_tx(
 ///
 /// Checks that
 /// 1. The tx has been successfully included into the mempool of a validator
-/// 2. The tx with encrypted payload has been included on the blockchain
-/// 3. The decrypted payload of the tx has been included on the blockchain.
+/// 2. The tx has been included on the blockchain
 ///
 /// In the case of errors in any of those stages, an error message is returned
 pub async fn submit_tx(

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -39,6 +39,7 @@ pub enum TestWasms {
     VpInfiniteHostGas,
     VpMemoryLimit,
     VpReadStorageKey,
+    VpVerifySignature,
 }
 
 impl TestWasms {
@@ -69,6 +70,7 @@ impl TestWasms {
             TestWasms::VpInfiniteHostGas => "vp_infinite_host_gas.wasm",
             TestWasms::VpMemoryLimit => "vp_memory_limit.wasm",
             TestWasms::VpReadStorageKey => "vp_read_storage_key.wasm",
+            TestWasms::VpVerifySignature => "vp_verify_signature.wasm",
         };
         let cwd =
             env::current_dir().expect("Couldn't get current working directory");

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -7,7 +7,7 @@ pub mod pgf;
 pub mod pos;
 /// transaction protocols made by validators
 pub mod protocol;
-/// wrapper txs with encrypted payloads
+/// wrapper txs
 pub mod wrapper;
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/tx/src/data/wrapper.rs
+++ b/crates/tx/src/data/wrapper.rs
@@ -137,9 +137,8 @@ impl GasLimit {
     }
 }
 
-/// A transaction with an encrypted payload, an optional shielded pool
-/// unshielding tx for fee payment and some non-encrypted metadata for
-/// inclusion and / or verification purposes
+/// A wrapper transaction with some metadata for inclusion and / or verification
+/// purposes
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug,

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -46,8 +46,6 @@ pub enum DecodeError {
     InvalidJSONDeserialization(String),
 }
 
-/// Errors relating to decrypting a wrapper tx and its
-/// encrypted payload from a Tx type
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum TxError {
@@ -206,7 +204,7 @@ impl Tx {
         Section::Header(self.header.clone()).get_hash()
     }
 
-    /// Gets the hash of the decrypted transaction's header
+    /// Gets the hash of the raw transaction's header
     pub fn raw_header_hash(&self) -> namada_core::hash::Hash {
         let mut raw_header = self.header();
         raw_header.tx_type = TxType::Raw;
@@ -544,15 +542,9 @@ impl Tx {
 
     /// Determines the type of the input Tx
     ///
-    /// If it is a raw Tx, signed or not, the Tx is
-    /// returned unchanged inside an enum variant stating its type.
+    /// If it is a raw Tx, signed or not, we return `None`.
     ///
-    /// If it is a decrypted tx, signing it adds no security so we
-    /// extract the signed data without checking the signature (if it
-    /// is signed) or return as is. Either way, it is returned in
-    /// an enum variant stating its type.
-    ///
-    /// If it is a WrapperTx, we extract the signed data of
+    /// If it is a WrapperTx or ProtocolTx, we extract the signed data of
     /// the Tx and verify it is of the appropriate form. This means
     /// 1. The wrapper tx is indeed signed
     /// 2. The signature is valid

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -3974,6 +3974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vp_verify_signature"
+version = "0.41.0"
+dependencies = [
+ "getrandom",
+ "namada_vp_prelude",
+ "rlsf",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/wasm_for_tests/Cargo.toml
+++ b/wasm_for_tests/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "vp_infinite_host_gas",
     "vp_memory_limit",
     "vp_read_storage_key",
+    "vp_verify_signature"
 ]
 
 [workspace.package]

--- a/wasm_for_tests/Makefile
+++ b/wasm_for_tests/Makefile
@@ -26,6 +26,7 @@ wasms += vp_infinite_guest_gas
 wasms += vp_infinite_host_gas
 wasms += vp_memory_limit
 wasms += vp_read_storage_key
+wasms += vp_verify_signature
 
 
 # Build all wasms in release mode

--- a/wasm_for_tests/vp_verify_signature/Cargo.toml
+++ b/wasm_for_tests/vp_verify_signature/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "vp_verify_signature"
+description = "Wasm vp used for testing."
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+namada_vp_prelude.workspace = true
+rlsf.workspace = true
+getrandom.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/wasm_for_tests/vp_verify_signature/src/lib.rs
+++ b/wasm_for_tests/vp_verify_signature/src/lib.rs
@@ -1,0 +1,13 @@
+use namada_vp_prelude::*;
+
+#[validity_predicate]
+fn validate_tx(
+    ctx: &Ctx,
+    tx_data: BatchedTx,
+    addr: Address,
+    _keys_changed: BTreeSet<storage::Key>,
+    _verifiers: BTreeSet<Address>,
+) -> VpResult {
+    let mut gadget = VerifySigGadget::new();
+    gadget.verify_signatures(ctx, &tx_data.tx, &addr)
+}


### PR DESCRIPTION
## Describe your changes

- Adds property tests for malleability attacks on transactions
- Improves `test_wrapper_unknown_address`
- Removes old references to encrypted/decrypted txs

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
