### PR TITLE
write_log: iter batch logs in insertion order

### DIFF
--- a/crates/state/src/write_log.rs
+++ b/crates/state/src/write_log.rs
@@ -699,7 +699,6 @@ impl WriteLog {
         for (key, modification) in self.block_write_log.iter().chain(
             self.batch_write_log
                 .iter()
-                .rev()
                 .flat_map(|batch_log| batch_log.write_log.iter()),
         ) {
             if key.split_prefix(prefix).is_some() {
@@ -719,7 +718,6 @@ impl WriteLog {
         for (key, modification) in self.block_write_log.iter().chain(
             self.batch_write_log
                 .iter()
-                .rev()
                 .flat_map(|batch_log| batch_log.write_log.iter())
                 .chain(self.tx_write_log.write_log.iter()),
         ) {


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
