### PR TITLE
Improve gas messages

### DIFF
--- a/.changelog/unreleased/improvements/3928-improve-gas-msgs.md
+++ b/.changelog/unreleased/improvements/3928-improve-gas-msgs.md
@@ -1,0 +1,3 @@
+- Improved the mesagges related to gas errors in
+  `process_proposal` and mempool validation. Added more tests.
+  ([\#3928](https://github.com/anoma/namada/pull/3928))

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -693,10 +693,11 @@ where
     // The fee payment is subject to a gas limit imposed by a protocol
     // parameter. Here we instantiate a custom gas meter for this step where the
     // gas limit is actually the lowest between the protocol parameter and the
-    // actual remaining gas of the transaction. The latter is because we only
-    // care about the masp execution, not any gas used before this step, which
-    // could prevent some transactions (e.g. batches consuming a lot of gas for
-    // their size) from being accepted
+    // actual remaining gas of the transaction. The latter is because we want to
+    // enforce that no tx exceeds its own gas limit, which could happen for
+    // some transactions (e.g. batches consuming a lot of gas for
+    // their size) if we were to take their gas limit instead of the remaining
+    // gas
     let max_gas_limit = state
         .read::<u64>(&parameters::storage::get_masp_fee_payment_gas_limit_key())
         .expect("Error reading the storage")

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -1250,16 +1250,18 @@ where
                 }
 
                 // Max block gas
-                let block_gas_limit: Gas = Gas::from_whole_units(
-                    parameters::get_max_block_gas(&self.state).unwrap().into(),
-                    gas_scale,
-                )
-                .expect("Gas limit from parameter must not overflow");
+                let max_block_gas =
+                    parameters::get_max_block_gas(&self.state).unwrap();
+                let block_gas_limit: Gas =
+                    Gas::from_whole_units(max_block_gas.into(), gas_scale)
+                        .expect("Gas limit from parameter must not overflow");
                 if gas_meter.tx_gas_limit > block_gas_limit {
                     response.code = ResultCode::AllocationError.into();
-                    response.log = "{INVALID_MSG}: Wrapper transaction \
-                                    exceeds the maximum block gas limit"
-                        .to_string();
+                    response.log = format!(
+                        "{INVALID_MSG}: Wrapper transaction exceeds the \
+                         maximum block gas limit: {}",
+                        max_block_gas
+                    );
                     return response;
                 }
 

--- a/crates/node/src/shell/prepare_proposal.rs
+++ b/crates/node/src/shell/prepare_proposal.rs
@@ -313,7 +313,6 @@ where
     super::replay_protection_checks(&tx, temp_state).map_err(|_| ())?;
 
     // Check fees and extract the gas limit of this transaction
-    // TODO(namada#2597): check if masp fee payment is required
     match prepare_proposal_fee_check(
         &wrapper,
         &tx,


### PR DESCRIPTION
## Describe your changes

Improves the gas error messages we emit from mempool validation and process proposal.
Adds two new unit tests.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
