### PR TITLE
Adds comment for masp assets' epoch

### DIFF
--- a/crates/shielded_token/src/vp.rs
+++ b/crates/shielded_token/src/vp.rs
@@ -680,7 +680,18 @@ fn validate_transparent_input<A: Authorization>(
                 tracing::debug!("{error}");
                 return Err(error);
             } else {
-                // Otherwise note the contribution to this transparent input
+                // Otherwise note the contribution to this transparent input.
+                // This branch represents the case of an asset not being part
+                // of the conversion tree: the asset can carry no epoch at all
+                // or any epoch (even a future one). Given the way we construct
+                // conversions it's not an issue if we later add it to the
+                // conversion tree: if the epoch preceeds the one at which we
+                // start computing rewards or is missing, then this asset will
+                // not be entitled. If it had instead been constructed with a
+                // future epoch that matches or follows the one at which we
+                // start giving out rewards, then it will be entitled (and
+                // there's no issue with that since it was clearly in the pool
+                // even before that time)
                 let amount =
                     token::Amount::from_masp_denominated(vin.value, *digit);
                 *bal_ref = bal_ref


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
