### PR TITLE
Murisi/fix masp change

### DIFF
--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -4661,16 +4661,14 @@ pub mod args {
                 });
             }
 
-            let gas_spending_keys = self
-                .gas_spending_keys
-                .iter()
-                .map(|key| chain_ctx.get_cached(key))
-                .collect();
+            let gas_spending_key = self
+                .gas_spending_key
+                .map(|key| chain_ctx.get_cached(&key));
 
             Ok(TxShieldedTransfer::<SdkTypes> {
                 tx,
                 data,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key: self.disposable_signing_key,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
@@ -4691,16 +4689,13 @@ pub mod args {
                 token,
                 amount,
             }];
-            let mut gas_spending_keys = vec![];
-            if let Some(key) = GAS_SPENDING_KEY.parse(matches) {
-                gas_spending_keys.push(key);
-            }
+            let gas_spending_key = GAS_SPENDING_KEY.parse(matches);
             let disposable_gas_payer = DISPOSABLE_SIGNING_KEY.parse(matches);
 
             Self {
                 tx,
                 data,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key: disposable_gas_payer,
                 tx_code_path,
             }
@@ -4830,16 +4825,14 @@ pub mod args {
                     amount: transfer_data.amount,
                 });
             }
-            let gas_spending_keys = self
-                .gas_spending_keys
-                .iter()
-                .map(|key| chain_ctx.get_cached(key))
-                .collect();
+            let gas_spending_key = self
+                .gas_spending_key
+                .map(|key| chain_ctx.get_cached(&key));
 
             Ok(TxUnshieldingTransfer::<SdkTypes> {
                 tx,
                 data,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key: self.disposable_signing_key,
                 source: chain_ctx.get_cached(&self.source),
                 tx_code_path: self.tx_code_path.to_path_buf(),
@@ -4860,17 +4853,14 @@ pub mod args {
                 token,
                 amount,
             }];
-            let mut gas_spending_keys = vec![];
-            if let Some(key) = GAS_SPENDING_KEY.parse(matches) {
-                gas_spending_keys.push(key);
-            }
+            let gas_spending_key = GAS_SPENDING_KEY.parse(matches);
             let disposable_signing_key = DISPOSABLE_SIGNING_KEY.parse(matches);
 
             Self {
                 tx,
                 source,
                 data,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key,
                 tx_code_path,
             }
@@ -4919,11 +4909,9 @@ pub mod args {
         ) -> Result<TxIbcTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
-            let gas_spending_keys = self
-                .gas_spending_keys
-                .iter()
-                .map(|key| chain_ctx.get_cached(key))
-                .collect();
+            let gas_spending_key = self
+                .gas_spending_key
+                .map(|key| chain_ctx.get_cached(&key));
 
             Ok(TxIbcTransfer::<SdkTypes> {
                 tx,
@@ -4938,7 +4926,7 @@ pub mod args {
                 refund_target: chain_ctx.get_opt(&self.refund_target),
                 ibc_shielding_data: self.ibc_shielding_data,
                 ibc_memo: self.ibc_memo,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key: self.disposable_signing_key,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
@@ -4965,10 +4953,7 @@ pub mod args {
                         .expect("Failed to decode IBC shielding data")
                 });
             let ibc_memo = IBC_MEMO.parse(matches);
-            let mut gas_spending_keys = vec![];
-            if let Some(key) = GAS_SPENDING_KEY.parse(matches) {
-                gas_spending_keys.push(key);
-            }
+            let gas_spending_key = GAS_SPENDING_KEY.parse(matches);
             let disposable_signing_key = DISPOSABLE_SIGNING_KEY.parse(matches);
             let tx_code_path = PathBuf::from(TX_IBC_WASM);
             Self {
@@ -4984,7 +4969,7 @@ pub mod args {
                 refund_target,
                 ibc_shielding_data,
                 ibc_memo,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key,
                 tx_code_path,
             }

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -195,11 +195,9 @@ impl AssetData {
 
     /// Give this pre-asset type the given epoch if already has an epoch. Return
     /// the replaced value.
-    pub fn redate(&mut self, to: MaspEpoch) -> Option<MaspEpoch> {
+    pub fn redate(&mut self, to: MaspEpoch) {
         if self.epoch.is_some() {
-            self.epoch.replace(to)
-        } else {
-            None
+            self.epoch = Some(to);
         }
     }
 
@@ -1121,14 +1119,12 @@ mod test {
         assert!(data.epoch.is_none());
 
         let epoch_0 = MaspEpoch::new(3);
-        let old = data.redate(epoch_0);
-        assert!(old.is_none());
+        data.redate(epoch_0);
         assert!(data.epoch.is_none());
         data.epoch = Some(epoch_0);
 
         let epoch_1 = MaspEpoch::new(5);
-        let old = data.redate(epoch_1);
-        assert_eq!(old, Some(epoch_0));
+        data.redate(epoch_1);
         assert_eq!(data.epoch, Some(epoch_1));
     }
 

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -356,7 +356,7 @@ pub struct TxShieldedTransfer<C: NamadaTypes = SdkTypes> {
     /// Transfer-specific data
     pub data: Vec<TxShieldedTransferData<C>>,
     /// Optional additional keys for gas payment
-    pub gas_spending_keys: Vec<C::SpendingKey>,
+    pub gas_spending_key: Option<C::SpendingKey>,
     /// Generate an ephemeral signing key to be used only once to sign the
     /// wrapper tx
     pub disposable_signing_key: bool,
@@ -453,7 +453,7 @@ pub struct TxUnshieldingTransfer<C: NamadaTypes = SdkTypes> {
     /// Transfer-specific data
     pub data: Vec<TxUnshieldingTransferData<C>>,
     /// Optional additional keys for gas payment
-    pub gas_spending_keys: Vec<C::SpendingKey>,
+    pub gas_spending_key: Option<C::SpendingKey>,
     /// Generate an ephemeral signing key to be used only once to sign the
     /// wrapper tx
     pub disposable_signing_key: bool,
@@ -499,7 +499,7 @@ pub struct TxIbcTransfer<C: NamadaTypes = SdkTypes> {
     /// Memo for IBC transfer packet
     pub ibc_memo: Option<String>,
     /// Optional additional keys for gas payment
-    pub gas_spending_keys: Vec<C::SpendingKey>,
+    pub gas_spending_key: Option<C::SpendingKey>,
     /// Generate an ephemeral signing key to be used only once to sign the
     /// wrapper tx
     pub disposable_signing_key: bool,
@@ -593,10 +593,10 @@ impl<C: NamadaTypes> TxIbcTransfer<C> {
     /// Gas spending keys
     pub fn gas_spending_keys(
         self,
-        gas_spending_keys: Vec<C::SpendingKey>,
+        gas_spending_key: C::SpendingKey,
     ) -> Self {
         Self {
-            gas_spending_keys,
+            gas_spending_key: Some(gas_spending_key),
             ..self
         }
     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -173,12 +173,12 @@ pub trait Namada: NamadaIo {
     fn new_shielded_transfer(
         &self,
         data: Vec<args::TxShieldedTransferData>,
-        gas_spending_keys: Vec<ExtendedSpendingKey>,
+        gas_spending_key: Option<ExtendedSpendingKey>,
         disposable_signing_key: bool,
     ) -> args::TxShieldedTransfer {
         args::TxShieldedTransfer {
             data,
-            gas_spending_keys,
+            gas_spending_key,
             tx_code_path: PathBuf::from(TX_TRANSFER_WASM),
             disposable_signing_key,
             tx: self.tx_builder(),
@@ -206,13 +206,13 @@ pub trait Namada: NamadaIo {
         &self,
         source: ExtendedSpendingKey,
         data: Vec<args::TxUnshieldingTransferData>,
-        gas_spending_keys: Vec<ExtendedSpendingKey>,
+        gas_spending_key: Option<ExtendedSpendingKey>,
         disposable_signing_key: bool,
     ) -> args::TxUnshieldingTransfer {
         args::TxUnshieldingTransfer {
             source,
             data,
-            gas_spending_keys,
+            gas_spending_key,
             disposable_signing_key,
             tx_code_path: PathBuf::from(TX_TRANSFER_WASM),
             tx: self.tx_builder(),
@@ -318,7 +318,7 @@ pub trait Namada: NamadaIo {
             refund_target: None,
             ibc_shielding_data: None,
             ibc_memo: None,
-            gas_spending_keys: Default::default(),
+            gas_spending_key: Default::default(),
             tx: self.tx_builder(),
             tx_code_path: PathBuf::from(TX_IBC_WASM),
         }

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2620,7 +2620,7 @@ pub async fn build_ibc_transfer(
         &args.tx,
         fee_per_gas_unit,
         &signing_data.fee_payer,
-        args.gas_spending_keys.clone(),
+        args.gas_spending_key.clone(),
     )
     .await?;
     if let Some(fee_data) = &masp_fee_data {
@@ -3086,7 +3086,7 @@ pub async fn build_shielded_transfer<N: Namada>(
         &args.tx,
         fee_per_gas_unit,
         &signing_data.fee_payer,
-        args.gas_spending_keys.clone(),
+        args.gas_spending_key.clone(),
     )
     .await?;
     if let Some(fee_data) = &masp_fee_data {
@@ -3159,7 +3159,7 @@ async fn get_masp_fee_payment_amount<N: Namada>(
     args: &args::Tx<SdkTypes>,
     fee_amount: DenominatedAmount,
     fee_payer: &common::PublicKey,
-    gas_spending_keys: Vec<ExtendedSpendingKey>,
+    gas_spending_key: Option<ExtendedSpendingKey>,
 ) -> Result<Option<MaspFeeData>> {
     let fee_payer_address = Address::from(fee_payer);
     let balance_key = balance_key(&args.fee_token, &fee_payer_address);
@@ -3174,7 +3174,7 @@ async fn get_masp_fee_payment_amount<N: Namada>(
 
     Ok(match total_fee.checked_sub(balance) {
         Some(diff) if !diff.is_zero() => Some(MaspFeeData {
-            sources: gas_spending_keys,
+            source: gas_spending_key,
             target: fee_payer_address,
             token: args.fee_token.clone(),
             amount: DenominatedAmount::new(diff, fee_amount.denom()),
@@ -3374,7 +3374,7 @@ pub async fn build_unshielding_transfer<N: Namada>(
         &args.tx,
         fee_per_gas_unit,
         &signing_data.fee_payer,
-        args.gas_spending_keys.clone(),
+        args.gas_spending_key.clone(),
     )
     .await?;
     if let Some(fee_data) = &masp_fee_data {

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -116,13 +116,13 @@ struct MaspTargetTransferData {
 pub struct MaspDataLog {
     pub source: Option<TransferSource>,
     pub token: Address,
-    pub amount: token::DenominatedAmount,
+    pub amount: token::Amount,
 }
 
 #[allow(missing_docs)]
 pub struct MaspTxReorderedData {
-    source_data: HashMap<MaspSourceTransferData, token::DenominatedAmount>,
-    target_data: HashMap<MaspTargetTransferData, token::DenominatedAmount>,
+    source_data: HashMap<MaspSourceTransferData, token::Amount>,
+    target_data: HashMap<MaspTargetTransferData, token::Amount>,
     denoms: HashMap<Address, Denomination>,
 }
 

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -103,8 +103,8 @@ pub struct MaspSourceTransferData {
 }
 
 /// The data for a masp transfer relative to a given target
-#[derive(Hash, Eq, PartialEq)]
-struct MaspTargetTransferData {
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub struct MaspTargetTransferData {
     source: TransferSource,
     target: TransferTarget,
     token: Address,
@@ -125,11 +125,6 @@ pub struct MaspTxReorderedData {
     target_data: HashMap<MaspTargetTransferData, token::Amount>,
     denoms: HashMap<Address, Denomination>,
 }
-
-/// Data about the unspent amounts for any given shielded source coming from the
-/// spent notes in their posses that have been added to the builder. Can be used
-/// to either pay fees or to return a change
-pub type Changes = HashMap<namada_core::masp::ExtendedSpendingKey, I128Sum>;
 
 /// Shielded pool data for a token
 #[allow(missing_docs)]

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -79,7 +79,7 @@ pub struct ShieldedTransfer {
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub struct MaspFeeData {
-    pub sources: Vec<ExtendedSpendingKey>,
+    pub source: Option<ExtendedSpendingKey>,
     pub target: Address,
     pub token: Address,
     pub amount: token::DenominatedAmount,
@@ -105,7 +105,7 @@ pub struct MaspSourceTransferData {
 /// The data for a masp transfer relative to a given target
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct MaspTargetTransferData {
-    source: TransferSource,
+    source: Option<TransferSource>,
     target: TransferTarget,
     token: Address,
 }

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -2677,6 +2677,8 @@ fn masp_fee_payment() -> Result<()> {
                 "10000",
                 "--gas-price",
                 "1",
+                "--gas-spending-key",
+                A_SPENDING_KEY,
                 "--disposable-gas-payer",
                 "--ledger-address",
                 validator_one_rpc,
@@ -3015,6 +3017,8 @@ fn masp_fee_payment_with_non_disposable() -> Result<()> {
                 "1",
                 "--gas-payer",
                 ALBERT_KEY,
+                "--gas-spending-key",
+                A_SPENDING_KEY,
                 "--ledger-address",
                 validator_one_rpc,
             ],
@@ -3265,7 +3269,7 @@ fn masp_fee_payment_with_custom_spending_key() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0"));
+    assert!(captured.contains("nam: 1000"));
 
     let captured = CapturedOutput::of(|| {
         run(
@@ -3283,7 +3287,7 @@ fn masp_fee_payment_with_custom_spending_key() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 1000"));
+    assert!(captured.contains("nam: 0"));
 
     let captured = CapturedOutput::of(|| {
         run(
@@ -3574,7 +3578,7 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0"));
+    assert!(captured.contains("btc: 1000"));
 
     let captured = CapturedOutput::of(|| {
         run(
@@ -3592,7 +3596,7 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 1000"));
+    assert!(captured.contains("btc: 0"));
 
     Ok(())
 }

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -2369,6 +2369,63 @@ fn dynamic_assets() -> Result<()> {
     assert!(captured.result.is_ok());
     assert!(captured.contains("nam: 0.156705"));
 
+    // Unshield the rewards
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "unshield",
+                "--source",
+                A_SPENDING_KEY,
+                "--target",
+                BERTHA,
+                "--token",
+                NAM,
+                "--amount",
+                "0.156705",
+                "--gas-payer",
+                BERTHA_KEY,
+                "--ledger-address",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec!["shielded-sync", "--node", validator_one_rpc],
+    )?;
+
+    // Unshield the principal
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "unshield",
+                "--source",
+                A_SPENDING_KEY,
+                "--target",
+                BERTHA,
+                "--token",
+                BTC,
+                "--amount",
+                "2",
+                "--gas-payer",
+                BERTHA_KEY,
+                "--ledger-address",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
     Ok(())
 }
 


### PR DESCRIPTION
## Describe your changes
An attempt to fix the MASP so that rewards can always be withdrawn without restrictions and to also enable the unshielding of untimestamped assets in all circumstances (including those where an asset is subsequently removed from the reward set). More specifically, the following changes have been made:
* Removed the normed asset computations because they were harder to reason about and encouraged mistakes in their maintenance
* Where possible, replaced computations over sums of `AssetType`s with computations over sums of `Address`es to reduce the chances that mismatched epochs cause parts of a balance to be hidden
* Adjusted the MASP fee UX so that users always have to specify which single MASP key they want to use to pay the fees. This is done instead of trying to construct this value from left over change
* Removed the fee computation logic and subsumed it into the logic for constructing ordinary transaction inputs and outputs. The purpose was to simplify code maintenance.
* Added integration tests to verify that MASP rewards can be withdrawn without withdrawing the principle and to also verify that the principal amount can be withdrawn though it is untimestamped

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
