### PR TITLE
Test enabling rewards after shielding and large amounts in the masp

### DIFF
--- a/.changelog/unreleased/bug-fixes/3959-fix-masp-change.md
+++ b/.changelog/unreleased/bug-fixes/3959-fix-masp-change.md
@@ -1,0 +1,5 @@
+- Fix a variety of MASP rewards related client bugs. Moreover, add
+  regression tests that cover the expected behavior. The client logic
+  that made MASP fee payments possible was also dramatically simplified,
+  making this code easier to maintain in the foreseeable future.
+  ([\#3959](https://github.com/anoma/namada/pull/3959))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -4661,9 +4661,8 @@ pub mod args {
                 });
             }
 
-            let gas_spending_key = self
-                .gas_spending_key
-                .map(|key| chain_ctx.get_cached(&key));
+            let gas_spending_key =
+                self.gas_spending_key.map(|key| chain_ctx.get_cached(&key));
 
             Ok(TxShieldedTransfer::<SdkTypes> {
                 tx,
@@ -4825,9 +4824,8 @@ pub mod args {
                     amount: transfer_data.amount,
                 });
             }
-            let gas_spending_key = self
-                .gas_spending_key
-                .map(|key| chain_ctx.get_cached(&key));
+            let gas_spending_key =
+                self.gas_spending_key.map(|key| chain_ctx.get_cached(&key));
 
             Ok(TxUnshieldingTransfer::<SdkTypes> {
                 tx,
@@ -4909,9 +4907,8 @@ pub mod args {
         ) -> Result<TxIbcTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
-            let gas_spending_key = self
-                .gas_spending_key
-                .map(|key| chain_ctx.get_cached(&key));
+            let gas_spending_key =
+                self.gas_spending_key.map(|key| chain_ctx.get_cached(&key));
 
             Ok(TxIbcTransfer::<SdkTypes> {
                 tx,

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -4661,16 +4661,14 @@ pub mod args {
                 });
             }
 
-            let gas_spending_keys = self
-                .gas_spending_keys
-                .iter()
-                .map(|key| chain_ctx.get_cached(key))
-                .collect();
+            let gas_spending_key = self
+                .gas_spending_key
+                .map(|key| chain_ctx.get_cached(&key));
 
             Ok(TxShieldedTransfer::<SdkTypes> {
                 tx,
                 data,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key: self.disposable_signing_key,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
@@ -4691,16 +4689,13 @@ pub mod args {
                 token,
                 amount,
             }];
-            let mut gas_spending_keys = vec![];
-            if let Some(key) = GAS_SPENDING_KEY.parse(matches) {
-                gas_spending_keys.push(key);
-            }
+            let gas_spending_key = GAS_SPENDING_KEY.parse(matches);
             let disposable_gas_payer = DISPOSABLE_SIGNING_KEY.parse(matches);
 
             Self {
                 tx,
                 data,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key: disposable_gas_payer,
                 tx_code_path,
             }
@@ -4830,16 +4825,14 @@ pub mod args {
                     amount: transfer_data.amount,
                 });
             }
-            let gas_spending_keys = self
-                .gas_spending_keys
-                .iter()
-                .map(|key| chain_ctx.get_cached(key))
-                .collect();
+            let gas_spending_key = self
+                .gas_spending_key
+                .map(|key| chain_ctx.get_cached(&key));
 
             Ok(TxUnshieldingTransfer::<SdkTypes> {
                 tx,
                 data,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key: self.disposable_signing_key,
                 source: chain_ctx.get_cached(&self.source),
                 tx_code_path: self.tx_code_path.to_path_buf(),
@@ -4860,17 +4853,14 @@ pub mod args {
                 token,
                 amount,
             }];
-            let mut gas_spending_keys = vec![];
-            if let Some(key) = GAS_SPENDING_KEY.parse(matches) {
-                gas_spending_keys.push(key);
-            }
+            let gas_spending_key = GAS_SPENDING_KEY.parse(matches);
             let disposable_signing_key = DISPOSABLE_SIGNING_KEY.parse(matches);
 
             Self {
                 tx,
                 source,
                 data,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key,
                 tx_code_path,
             }
@@ -4919,11 +4909,9 @@ pub mod args {
         ) -> Result<TxIbcTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
-            let gas_spending_keys = self
-                .gas_spending_keys
-                .iter()
-                .map(|key| chain_ctx.get_cached(key))
-                .collect();
+            let gas_spending_key = self
+                .gas_spending_key
+                .map(|key| chain_ctx.get_cached(&key));
 
             Ok(TxIbcTransfer::<SdkTypes> {
                 tx,
@@ -4938,7 +4926,7 @@ pub mod args {
                 refund_target: chain_ctx.get_opt(&self.refund_target),
                 ibc_shielding_data: self.ibc_shielding_data,
                 ibc_memo: self.ibc_memo,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key: self.disposable_signing_key,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
@@ -4965,10 +4953,7 @@ pub mod args {
                         .expect("Failed to decode IBC shielding data")
                 });
             let ibc_memo = IBC_MEMO.parse(matches);
-            let mut gas_spending_keys = vec![];
-            if let Some(key) = GAS_SPENDING_KEY.parse(matches) {
-                gas_spending_keys.push(key);
-            }
+            let gas_spending_key = GAS_SPENDING_KEY.parse(matches);
             let disposable_signing_key = DISPOSABLE_SIGNING_KEY.parse(matches);
             let tx_code_path = PathBuf::from(TX_IBC_WASM);
             Self {
@@ -4984,7 +4969,7 @@ pub mod args {
                 refund_target,
                 ibc_shielding_data,
                 ibc_memo,
-                gas_spending_keys,
+                gas_spending_key,
                 disposable_signing_key,
                 tx_code_path,
             }

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -195,11 +195,9 @@ impl AssetData {
 
     /// Give this pre-asset type the given epoch if already has an epoch. Return
     /// the replaced value.
-    pub fn redate(&mut self, to: MaspEpoch) -> Option<MaspEpoch> {
+    pub fn redate(&mut self, to: MaspEpoch) {
         if self.epoch.is_some() {
-            self.epoch.replace(to)
-        } else {
-            None
+            self.epoch = Some(to);
         }
     }
 
@@ -1121,14 +1119,12 @@ mod test {
         assert!(data.epoch.is_none());
 
         let epoch_0 = MaspEpoch::new(3);
-        let old = data.redate(epoch_0);
-        assert!(old.is_none());
+        data.redate(epoch_0);
         assert!(data.epoch.is_none());
         data.epoch = Some(epoch_0);
 
         let epoch_1 = MaspEpoch::new(5);
-        let old = data.redate(epoch_1);
-        assert_eq!(old, Some(epoch_0));
+        data.redate(epoch_1);
         assert_eq!(data.epoch, Some(epoch_1));
     }
 

--- a/crates/core/src/token.rs
+++ b/crates/core/src/token.rs
@@ -910,6 +910,14 @@ pub enum MaspDigitPos {
     Three,
 }
 
+impl From<usize> for MaspDigitPos {
+    fn from(denom: usize) -> Self {
+        u8::try_from(denom)
+            .expect("Possible MASP denominations must be between 0 and 3")
+            .into()
+    }
+}
+
 impl From<u8> for MaspDigitPos {
     fn from(denom: u8) -> Self {
         match denom {

--- a/crates/core/src/token.rs
+++ b/crates/core/src/token.rs
@@ -56,6 +56,11 @@ pub const NATIVE_SCALE: u64 = 1_000_000;
 pub type Change = I256;
 
 impl Amount {
+    /// Iterate over all words in this [`Amount`].
+    pub fn iter_words(self) -> impl Iterator<Item = u64> {
+        self.raw.0.into_iter()
+    }
+
     /// Convert a [`u64`] to an [`Amount`].
     pub const fn from_u64(x: u64) -> Self {
         Self {

--- a/crates/core/src/token.rs
+++ b/crates/core/src/token.rs
@@ -910,22 +910,16 @@ pub enum MaspDigitPos {
     Three,
 }
 
-impl From<usize> for MaspDigitPos {
-    fn from(denom: usize) -> Self {
-        u8::try_from(denom)
-            .expect("Possible MASP denominations must be between 0 and 3")
-            .into()
-    }
-}
+impl TryFrom<u8> for MaspDigitPos {
+    type Error = &'static str;
 
-impl From<u8> for MaspDigitPos {
-    fn from(denom: u8) -> Self {
+    fn try_from(denom: u8) -> Result<Self, Self::Error> {
         match denom {
-            0 => Self::Zero,
-            1 => Self::One,
-            2 => Self::Two,
-            3 => Self::Three,
-            _ => panic!("Possible MASP denominations must be between 0 and 3"),
+            0 => Ok(Self::Zero),
+            1 => Ok(Self::One),
+            2 => Ok(Self::Two),
+            3 => Ok(Self::Three),
+            _ => Err("Possible MASP denominations must be between 0 and 3"),
         }
     }
 }
@@ -933,8 +927,13 @@ impl From<u8> for MaspDigitPos {
 impl MaspDigitPos {
     /// Iterator over the possible denominations
     pub fn iter() -> impl Iterator<Item = MaspDigitPos> {
-        // 0, 1, 2, 3
-        (0u8..4).map(Self::from)
+        [
+            MaspDigitPos::Zero,
+            MaspDigitPos::One,
+            MaspDigitPos::Two,
+            MaspDigitPos::Three,
+        ]
+        .into_iter()
     }
 
     /// Get the corresponding u64 word from the input uint256.

--- a/crates/core/src/uint.rs
+++ b/crates/core/src/uint.rs
@@ -611,12 +611,12 @@ impl I256 {
         Self(self.0.canonical())
     }
 
-    /// the maximum I256 value
+    /// The maximum value of an [`I256`].
     pub fn maximum() -> Self {
         Self(MAX_SIGNED_VALUE)
     }
 
-    /// Given a u128 and [`MaspDigitPos`], construct the corresponding
+    /// Given an i128 and [`MaspDigitPos`], construct the corresponding
     /// amount.
     pub fn from_masp_denominated(
         val: i128,

--- a/crates/core/src/uint.rs
+++ b/crates/core/src/uint.rs
@@ -547,7 +547,7 @@ impl FromStr for I256 {
 
 impl I256 {
     const N_WORDS: usize = 4;
-    
+
     /// Compute the two's complement of a number.
     pub fn negate(&self) -> Option<Self> {
         let (uint, overflow) = self.0.negate();

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -591,10 +591,7 @@ impl<C: NamadaTypes> TxIbcTransfer<C> {
     }
 
     /// Gas spending keys
-    pub fn gas_spending_keys(
-        self,
-        gas_spending_key: C::SpendingKey,
-    ) -> Self {
+    pub fn gas_spending_keys(self, gas_spending_key: C::SpendingKey) -> Self {
         Self {
             gas_spending_key: Some(gas_spending_key),
             ..self

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -356,7 +356,7 @@ pub struct TxShieldedTransfer<C: NamadaTypes = SdkTypes> {
     /// Transfer-specific data
     pub data: Vec<TxShieldedTransferData<C>>,
     /// Optional additional keys for gas payment
-    pub gas_spending_keys: Vec<C::SpendingKey>,
+    pub gas_spending_key: Option<C::SpendingKey>,
     /// Generate an ephemeral signing key to be used only once to sign the
     /// wrapper tx
     pub disposable_signing_key: bool,
@@ -453,7 +453,7 @@ pub struct TxUnshieldingTransfer<C: NamadaTypes = SdkTypes> {
     /// Transfer-specific data
     pub data: Vec<TxUnshieldingTransferData<C>>,
     /// Optional additional keys for gas payment
-    pub gas_spending_keys: Vec<C::SpendingKey>,
+    pub gas_spending_key: Option<C::SpendingKey>,
     /// Generate an ephemeral signing key to be used only once to sign the
     /// wrapper tx
     pub disposable_signing_key: bool,
@@ -499,7 +499,7 @@ pub struct TxIbcTransfer<C: NamadaTypes = SdkTypes> {
     /// Memo for IBC transfer packet
     pub ibc_memo: Option<String>,
     /// Optional additional keys for gas payment
-    pub gas_spending_keys: Vec<C::SpendingKey>,
+    pub gas_spending_key: Option<C::SpendingKey>,
     /// Generate an ephemeral signing key to be used only once to sign the
     /// wrapper tx
     pub disposable_signing_key: bool,
@@ -593,10 +593,10 @@ impl<C: NamadaTypes> TxIbcTransfer<C> {
     /// Gas spending keys
     pub fn gas_spending_keys(
         self,
-        gas_spending_keys: Vec<C::SpendingKey>,
+        gas_spending_key: C::SpendingKey,
     ) -> Self {
         Self {
-            gas_spending_keys,
+            gas_spending_key: Some(gas_spending_key),
             ..self
         }
     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -173,12 +173,12 @@ pub trait Namada: NamadaIo {
     fn new_shielded_transfer(
         &self,
         data: Vec<args::TxShieldedTransferData>,
-        gas_spending_keys: Vec<ExtendedSpendingKey>,
+        gas_spending_key: Option<ExtendedSpendingKey>,
         disposable_signing_key: bool,
     ) -> args::TxShieldedTransfer {
         args::TxShieldedTransfer {
             data,
-            gas_spending_keys,
+            gas_spending_key,
             tx_code_path: PathBuf::from(TX_TRANSFER_WASM),
             disposable_signing_key,
             tx: self.tx_builder(),
@@ -206,13 +206,13 @@ pub trait Namada: NamadaIo {
         &self,
         source: ExtendedSpendingKey,
         data: Vec<args::TxUnshieldingTransferData>,
-        gas_spending_keys: Vec<ExtendedSpendingKey>,
+        gas_spending_key: Option<ExtendedSpendingKey>,
         disposable_signing_key: bool,
     ) -> args::TxUnshieldingTransfer {
         args::TxUnshieldingTransfer {
             source,
             data,
-            gas_spending_keys,
+            gas_spending_key,
             disposable_signing_key,
             tx_code_path: PathBuf::from(TX_TRANSFER_WASM),
             tx: self.tx_builder(),
@@ -318,7 +318,7 @@ pub trait Namada: NamadaIo {
             refund_target: None,
             ibc_shielding_data: None,
             ibc_memo: None,
-            gas_spending_keys: Default::default(),
+            gas_spending_key: Default::default(),
             tx: self.tx_builder(),
             tx_code_path: PathBuf::from(TX_IBC_WASM),
         }

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2620,7 +2620,7 @@ pub async fn build_ibc_transfer(
         &args.tx,
         fee_per_gas_unit,
         &signing_data.fee_payer,
-        args.gas_spending_key.clone(),
+        args.gas_spending_key,
     )
     .await?;
     if let Some(fee_data) = &masp_fee_data {
@@ -3086,7 +3086,7 @@ pub async fn build_shielded_transfer<N: Namada>(
         &args.tx,
         fee_per_gas_unit,
         &signing_data.fee_payer,
-        args.gas_spending_key.clone(),
+        args.gas_spending_key,
     )
     .await?;
     if let Some(fee_data) = &masp_fee_data {
@@ -3374,7 +3374,7 @@ pub async fn build_unshielding_transfer<N: Namada>(
         &args.tx,
         fee_per_gas_unit,
         &signing_data.fee_payer,
-        args.gas_spending_key.clone(),
+        args.gas_spending_key,
     )
     .await?;
     if let Some(fee_data) = &masp_fee_data {

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2620,7 +2620,7 @@ pub async fn build_ibc_transfer(
         &args.tx,
         fee_per_gas_unit,
         &signing_data.fee_payer,
-        args.gas_spending_keys.clone(),
+        args.gas_spending_key.clone(),
     )
     .await?;
     if let Some(fee_data) = &masp_fee_data {
@@ -3086,7 +3086,7 @@ pub async fn build_shielded_transfer<N: Namada>(
         &args.tx,
         fee_per_gas_unit,
         &signing_data.fee_payer,
-        args.gas_spending_keys.clone(),
+        args.gas_spending_key.clone(),
     )
     .await?;
     if let Some(fee_data) = &masp_fee_data {
@@ -3159,7 +3159,7 @@ async fn get_masp_fee_payment_amount<N: Namada>(
     args: &args::Tx<SdkTypes>,
     fee_amount: DenominatedAmount,
     fee_payer: &common::PublicKey,
-    gas_spending_keys: Vec<ExtendedSpendingKey>,
+    gas_spending_key: Option<ExtendedSpendingKey>,
 ) -> Result<Option<MaspFeeData>> {
     let fee_payer_address = Address::from(fee_payer);
     let balance_key = balance_key(&args.fee_token, &fee_payer_address);
@@ -3174,7 +3174,7 @@ async fn get_masp_fee_payment_amount<N: Namada>(
 
     Ok(match total_fee.checked_sub(balance) {
         Some(diff) if !diff.is_zero() => Some(MaspFeeData {
-            sources: gas_spending_keys,
+            source: gas_spending_key,
             target: fee_payer_address,
             token: args.fee_token.clone(),
             amount: DenominatedAmount::new(diff, fee_amount.denom()),
@@ -3374,7 +3374,7 @@ pub async fn build_unshielding_transfer<N: Namada>(
         &args.tx,
         fee_per_gas_unit,
         &signing_data.fee_payer,
-        args.gas_spending_keys.clone(),
+        args.gas_spending_key.clone(),
     )
     .await?;
     if let Some(fee_data) = &masp_fee_data {

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -116,13 +116,13 @@ struct MaspTargetTransferData {
 pub struct MaspDataLog {
     pub source: Option<TransferSource>,
     pub token: Address,
-    pub amount: token::DenominatedAmount,
+    pub amount: token::Amount,
 }
 
 #[allow(missing_docs)]
 pub struct MaspTxReorderedData {
-    source_data: HashMap<MaspSourceTransferData, token::DenominatedAmount>,
-    target_data: HashMap<MaspTargetTransferData, token::DenominatedAmount>,
+    source_data: HashMap<MaspSourceTransferData, token::Amount>,
+    target_data: HashMap<MaspTargetTransferData, token::Amount>,
     denoms: HashMap<Address, Denomination>,
 }
 

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -811,7 +811,7 @@ pub mod testing {
     prop_compose! {
         /// Generate an arbitrary MASP denomination
         pub fn arb_masp_digit_pos()(denom in 0..4u8) -> MaspDigitPos {
-            MaspDigitPos::from(denom)
+            MaspDigitPos::try_from(denom).unwrap()
         }
     }
 

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -103,8 +103,8 @@ pub struct MaspSourceTransferData {
 }
 
 /// The data for a masp transfer relative to a given target
-#[derive(Hash, Eq, PartialEq)]
-struct MaspTargetTransferData {
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub struct MaspTargetTransferData {
     source: TransferSource,
     target: TransferTarget,
     token: Address,
@@ -125,11 +125,6 @@ pub struct MaspTxReorderedData {
     target_data: HashMap<MaspTargetTransferData, token::Amount>,
     denoms: HashMap<Address, Denomination>,
 }
-
-/// Data about the unspent amounts for any given shielded source coming from the
-/// spent notes in their posses that have been added to the builder. Can be used
-/// to either pay fees or to return a change
-pub type Changes = HashMap<namada_core::masp::ExtendedSpendingKey, I128Sum>;
 
 /// Shielded pool data for a token
 #[allow(missing_docs)]

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -79,7 +79,7 @@ pub struct ShieldedTransfer {
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub struct MaspFeeData {
-    pub sources: Vec<ExtendedSpendingKey>,
+    pub source: Option<ExtendedSpendingKey>,
     pub target: Address,
     pub token: Address,
     pub amount: token::DenominatedAmount,
@@ -105,7 +105,7 @@ pub struct MaspSourceTransferData {
 /// The data for a masp transfer relative to a given target
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct MaspTargetTransferData {
-    source: TransferSource,
+    source: Option<TransferSource>,
     target: TransferTarget,
     token: Address,
 }

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -316,11 +316,11 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
         input: &mut I128Sum,
         output: &mut I128Sum,
     ) -> Result<(), eyre::Error> {
-        // we do not need to convert negative values
+        // We do not need to convert negative values
         if value <= 0 {
             return Ok(());
         }
-        // If conversion if possible, accumulate the exchanged amount
+        // If conversion is possible, accumulate the exchanged amount
         let conv: I128Sum = I128Sum::from_sum(conv.into());
         // The amount required of current asset to qualify for conversion
         let threshold = -conv[&asset_type];

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -670,13 +670,16 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
                     .is_positive()
             {
                 // Convert the delta into Namada amounts
-                let mut converted_delta = ValueSum::zero();
-                for ((_, asset_data), value) in decoded_delta.components() {
-                    converted_delta += ValueSum::from_pair(
-                        (asset_data.position, asset_data.token.clone()),
-                        *value,
-                    );
-                }
+                let converted_delta = decoded_delta.components().fold(
+                    ValueSum::zero(),
+                    |accum, ((_, asset_data), value)| {
+                        accum
+                            + ValueSum::from_pair(
+                                (asset_data.position, asset_data.token.clone()),
+                                *value,
+                            )
+                    },
+                );
                 return Some(converted_delta);
             }
         }

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -652,8 +652,11 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
     async fn is_amount_required(
         &mut self,
         client: &(impl Client + Sync),
+        // NB: value accumulated thus far
         src: ValueSum<(MaspDigitPos, Address), i128>,
+        // NB: the target amount remaining
         dest: ValueSum<(MaspDigitPos, Address), i128>,
+        // NB: current contribution (from a note + rewards if any)
         delta: I128Sum,
     ) -> Option<ValueSum<(MaspDigitPos, Address), i128>> {
         // If the delta causes any regression, then do not use it

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -331,6 +331,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
                  0, this is a bug, please report it.",
                 asset_type
             );
+            eyre::bail!("Conversion asset threshold cannot be null");
         }
         // We should use an amount of the AllowedConversion that almost
         // cancels the original amount

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -657,8 +657,7 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
         delta: I128Sum,
     ) -> Option<ValueSum<(MaspDigitPos, Address), i128>> {
         // If the delta causes any regression, then do not use it
-        #[allow(clippy::neg_cmp_op_on_partial_ord)]
-        if !(delta >= I128Sum::zero()) {
+        if delta < I128Sum::zero() {
             return None;
         }
         let gap = dest.clone() - src;

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -1226,9 +1226,7 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
             // change.
             change += ValueSum::from_pair(*asset_type, value - covered);
             // Denominate the cover and decrease the required amount accordingly
-            let covered =
-                Change::from_masp_denominated(covered, asset_data.position)
-                    .map_err(|e| TransferErr::General(e.to_string()))?;
+            let covered = Change::from(covered);
             required_amt -= ValueSum::from_pair(
                 (asset_data.position, asset_data.token.clone()),
                 covered,

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -1105,7 +1105,7 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
             Ok(denom)
         } else {
             Err(TransferErr::General(format!(
-                "denomination for token {token}"
+                "Could not find the denomination of token {token}"
             )))
         }
     }

--- a/crates/shielded_token/src/storage.rs
+++ b/crates/shielded_token/src/storage.rs
@@ -1,5 +1,6 @@
 use namada_core::address::{self, Address};
 use namada_core::arith::checked;
+use namada_core::masp::TokenMap;
 use namada_core::token;
 use namada_core::token::Amount;
 use namada_core::uint::Uint;
@@ -76,4 +77,22 @@ where
     let total_rewards: token::Amount =
         storage.read(&total_rewards_key)?.unwrap_or_default();
     Ok(total_rewards)
+}
+
+/// Read the masp token map.
+pub fn read_token_map<S>(storage: &S) -> Result<TokenMap>
+where
+    S: StorageRead,
+{
+    let token_map_key = masp_token_map_key();
+    Ok(storage.read(&token_map_key)?.unwrap_or_default())
+}
+
+/// Write a new masp token map.
+pub fn write_token_map<S>(storage: &mut S, token_map: TokenMap) -> Result<()>
+where
+    S: StorageWrite,
+{
+    let token_map_key = masp_token_map_key();
+    storage.write(&token_map_key, token_map)
 }

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -3283,7 +3283,7 @@ fn masp_fee_payment_with_custom_spending_key() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 241000"));
+    assert!(captured.contains("nam: 240000"));
 
     let captured = CapturedOutput::of(|| {
         run(
@@ -3592,7 +3592,7 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 241000"));
+    assert!(captured.contains("btc: 240000"));
 
     Ok(())
 }

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -3047,6 +3047,25 @@ fn dynamic_assets() -> Result<()> {
         vec!["shielded-sync", "--node", validator_one_rpc],
     )?;
 
+    // Assert that the NAM at VK(A) is now null
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                NAM,
+                "--node",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains("nam: 0"));
+
     // Unshield the principal
     let captured = CapturedOutput::of(|| {
         run(
@@ -3071,6 +3090,32 @@ fn dynamic_assets() -> Result<()> {
     });
     assert!(captured.result.is_ok());
     assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec!["shielded-sync", "--node", validator_one_rpc],
+    )?;
+
+    // Assert that the principal's balance is now null
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                BTC,
+                "--node",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains("btc: 0"));
 
     Ok(())
 }

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -6,6 +6,7 @@ use color_eyre::owo_colors::OwoColorize;
 use namada_apps_lib::wallet::defaults::{
     albert_keypair, bertha_keypair, christel_keypair,
 };
+use namada_core::address::Address;
 use namada_core::dec::Dec;
 use namada_core::masp::TokenMap;
 use namada_node::shell::testing::client::run;
@@ -17,12 +18,12 @@ use namada_sdk::signing::SigningTxData;
 use namada_sdk::state::{StorageRead, StorageWrite};
 use namada_sdk::time::DateTimeUtc;
 use namada_sdk::token::storage_key::masp_token_map_key;
-use namada_sdk::token::{self, DenominatedAmount};
+use namada_sdk::token::{self, Amount, DenominatedAmount};
 use namada_sdk::tx::Tx;
 use namada_sdk::{tx, DEFAULT_GAS_LIMIT};
 use test_log::test;
 
-use super::setup;
+use super::{helpers, setup};
 use crate::e2e::setup::constants::{
     AA_PAYMENT_ADDRESS, AA_VIEWING_KEY, AB_PAYMENT_ADDRESS, AB_VIEWING_KEY,
     AC_PAYMENT_ADDRESS, AC_VIEWING_KEY, ALBERT, ALBERT_KEY, A_SPENDING_KEY,
@@ -30,6 +31,483 @@ use crate::e2e::setup::constants::{
     CHRISTEL_KEY, ETH, MASP, NAM,
 };
 use crate::strings::TX_APPLIED_SUCCESS;
+
+/// Enable masp rewards after some token had already been shielded.
+#[test]
+fn enable_rewards_after_shielding() -> Result<()> {
+    // Dummy validator rpc address
+    const RPC: &str = "http://127.0.0.1:26567";
+
+    // We will mint tokens with this address
+    const TEST_TOKEN_ADDR: &str =
+        "tnam1q9382etwdaekg6tpwdkkzar0wd5ku6r0wvu5ukqd";
+    let test_token_addr: Address = TEST_TOKEN_ADDR.parse().unwrap();
+
+    // Download the shielded pool parameters before starting node
+    let _ = FsShieldedUtils::new(PathBuf::new());
+    // Boot up a mock node
+    let (mut node, _services) = setup::setup()?;
+
+    // Initialize the test token
+    token::write_denom(
+        &mut node.shell.lock().unwrap().state,
+        &test_token_addr,
+        0u8.into(),
+    )?;
+
+    // Give Bertha some test tokens
+    let bertha_addr = helpers::find_address(&node, BERTHA)?;
+    token::credit_tokens(
+        &mut node.shell.lock().unwrap().state,
+        &test_token_addr,
+        &bertha_addr,
+        Amount::from_u64(1_000_000_000u64),
+    )?;
+
+    // Commit test token changes to a new block
+    node.finalize_and_commit(None);
+    assert_eq!(
+        token::read_total_supply(
+            &node.shell.lock().unwrap().state,
+            &test_token_addr,
+        )?,
+        Amount::from_u64(1_000_000_000u64),
+    );
+
+    // Shield 1_000_000 test tokens
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "shield",
+                "--source",
+                BERTHA,
+                "--target",
+                AA_PAYMENT_ADDRESS,
+                "--token",
+                TEST_TOKEN_ADDR,
+                "--amount",
+                "1000000",
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // Fetch the note we just created containing test tokens
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            "--node",
+            RPC,
+        ],
+    )?;
+
+    // Check the test token balance corresponds 1:1 to what
+    // we shielded
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                TEST_TOKEN_ADDR,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(&format!("{TEST_TOKEN_ADDR}: 1000000")));
+
+    // Skip a couple of masp epochs
+    for _ in 0..3 {
+        node.next_masp_epoch();
+    }
+
+    // The balance shouldn't have changed
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                TEST_TOKEN_ADDR,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(&format!("{TEST_TOKEN_ADDR}: 1000000")));
+
+    // Check that our NAM balance is null
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                NAM,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains("nam: 0"));
+
+    // Let us now start minting NAM rewards for any
+    // test tokens in the shielded pool
+    token::write_params(
+        &Some(token::ShieldedParams {
+            max_reward_rate: Dec::from_str("9999999999").unwrap(),
+            kp_gain_nom: Dec::from_str("9999999999").unwrap(),
+            kd_gain_nom: Dec::from_str("9999999999").unwrap(),
+            locked_amount_target: 999999999u64,
+        }),
+        &mut node.shell.lock().unwrap().state,
+        &test_token_addr,
+        &0u8.into(),
+    )?;
+    let mut token_map =
+        token::read_token_map(&node.shell.lock().unwrap().state)?;
+    token_map.insert("TEST".to_owned(), test_token_addr.clone());
+    token::write_token_map(&mut node.shell.lock().unwrap().state, token_map)?;
+    node.finalize_and_commit(None);
+
+    // Unshield and reshield some test tokens, such that they
+    // are now tagged with a masp epoch
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "unshield",
+                "--source",
+                A_SPENDING_KEY,
+                "--target",
+                BERTHA,
+                "--token",
+                TEST_TOKEN_ADDR,
+                "--amount",
+                "1000000",
+                "--signing-keys",
+                BERTHA_KEY,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // Fetch the latest test token notes
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            "--node",
+            RPC,
+        ],
+    )?;
+
+    // Check that the balance is now 0
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                TEST_TOKEN_ADDR,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(&format!("{TEST_TOKEN_ADDR}: 0")));
+
+    //
+    node.next_masp_epoch();
+
+    // Reshield
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "shield",
+                "--source",
+                BERTHA,
+                "--target",
+                AA_PAYMENT_ADDRESS,
+                "--token",
+                TEST_TOKEN_ADDR,
+                "--amount",
+                "1000000",
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // Fetch the latest test token notes
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            "--node",
+            RPC,
+        ],
+    )?;
+
+    // Check that we have some shielded test tokens once more
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                TEST_TOKEN_ADDR,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(&format!("{TEST_TOKEN_ADDR}: 1000000")));
+
+    // Skip a couple of masp epochs
+    for _ in 0..3 {
+        node.next_masp_epoch();
+    }
+
+    // Assert that we have minted NAM rewards
+    const EXPECTED_REWARDS: u128 = 6427858447239330;
+    const HALF_OF_EXPECTED_REWARDS: u128 = EXPECTED_REWARDS / 2;
+
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                NAM,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(&format!("nam: {EXPECTED_REWARDS}")));
+
+    // Unshield half of the rewards
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "unshield",
+                "--source",
+                A_SPENDING_KEY,
+                "--target",
+                BERTHA,
+                "--token",
+                NAM,
+                "--amount",
+                &HALF_OF_EXPECTED_REWARDS.to_string(),
+                "--signing-keys",
+                BERTHA_KEY,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // Fetch latest shielded state
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            "--node",
+            RPC,
+        ],
+    )?;
+
+    // Check that we now have half of the rewards
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                NAM,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(&format!("nam: {HALF_OF_EXPECTED_REWARDS}")));
+
+    // Transfer the other half of the rewards
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "transfer",
+                "--source",
+                A_SPENDING_KEY,
+                "--target",
+                AB_PAYMENT_ADDRESS,
+                "--token",
+                NAM,
+                "--amount",
+                &HALF_OF_EXPECTED_REWARDS.to_string(),
+                "--signing-keys",
+                BERTHA_KEY,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // Fetch latest shielded state
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            "--node",
+            RPC,
+        ],
+    )?;
+
+    // Check that we now a null NAM balance
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                NAM,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains("nam: 0"));
+
+    // Unshield half of our test tokens
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "unshield",
+                "--source",
+                A_SPENDING_KEY,
+                "--target",
+                BERTHA,
+                "--token",
+                TEST_TOKEN_ADDR,
+                "--amount",
+                "500000",
+                "--signing-keys",
+                BERTHA_KEY,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // Fetch latest shielded state
+    run(
+        &node,
+        Bin::Client,
+        vec![
+            "shielded-sync",
+            "--viewing-keys",
+            AA_VIEWING_KEY,
+            "--node",
+            RPC,
+        ],
+    )?;
+
+    // Check test token balance
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "balance",
+                "--owner",
+                AA_VIEWING_KEY,
+                "--token",
+                TEST_TOKEN_ADDR,
+                "--node",
+                RPC,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok(), "{:?}", captured.result);
+    assert!(captured.contains(&format!("{TEST_TOKEN_ADDR}: 500000")));
+
+    Ok(())
+}
 
 /// In this test we verify that users of the MASP receive the correct rewards
 /// for leaving their assets in the pool for varying periods of time.

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -2367,6 +2367,63 @@ fn dynamic_assets() -> Result<()> {
     assert!(captured.result.is_ok());
     assert!(captured.contains("nam: 0.156705"));
 
+    // Unshield the rewards
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "unshield",
+                "--source",
+                A_SPENDING_KEY,
+                "--target",
+                BERTHA,
+                "--token",
+                NAM,
+                "--amount",
+                "0.156705",
+                "--gas-payer",
+                BERTHA_KEY,
+                "--ledger-address",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+    // sync the shielded context
+    run(
+        &node,
+        Bin::Client,
+        vec!["shielded-sync", "--node", validator_one_rpc],
+    )?;
+
+    // Unshield the principal
+    let captured = CapturedOutput::of(|| {
+        run(
+            &node,
+            Bin::Client,
+            vec![
+                "unshield",
+                "--source",
+                A_SPENDING_KEY,
+                "--target",
+                BERTHA,
+                "--token",
+                BTC,
+                "--amount",
+                "2",
+                "--gas-payer",
+                BERTHA_KEY,
+                "--ledger-address",
+                validator_one_rpc,
+            ],
+        )
+    });
+    assert!(captured.result.is_ok());
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+
     Ok(())
 }
 

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -2675,6 +2675,8 @@ fn masp_fee_payment() -> Result<()> {
                 "10000",
                 "--gas-price",
                 "1",
+                "--gas-spending-key",
+                A_SPENDING_KEY,
                 "--disposable-gas-payer",
                 "--ledger-address",
                 validator_one_rpc,
@@ -3011,6 +3013,8 @@ fn masp_fee_payment_with_non_disposable() -> Result<()> {
                 "60000",
                 "--gas-payer",
                 ALBERT_KEY,
+                "--gas-spending-key",
+                A_SPENDING_KEY,
                 "--ledger-address",
                 validator_one_rpc,
             ],
@@ -3261,7 +3265,7 @@ fn masp_fee_payment_with_custom_spending_key() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0"));
+    assert!(captured.contains("nam: 1000"));
 
     let captured = CapturedOutput::of(|| {
         run(
@@ -3570,7 +3574,7 @@ fn masp_fee_payment_with_different_token() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0"));
+    assert!(captured.contains("btc: 1000"));
 
     let captured = CapturedOutput::of(|| {
         run(

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -346,7 +346,7 @@ fn enable_rewards_after_shielding() -> Result<()> {
     // test tokens in the shielded pool
     token::write_params(
         &Some(token::ShieldedParams {
-            max_reward_rate: Dec::from_str("9999999999").unwrap(),
+            max_reward_rate: Dec::from_str("1.0").unwrap(),
             kp_gain_nom: Dec::from_str("9999999999").unwrap(),
             kd_gain_nom: Dec::from_str("9999999999").unwrap(),
             locked_amount_target: 999999999u64,
@@ -483,8 +483,9 @@ fn enable_rewards_after_shielding() -> Result<()> {
     }
 
     // Assert that we have minted NAM rewards
-    const EXPECTED_REWARDS: u128 = 6427858447239330;
-    const HALF_OF_EXPECTED_REWARDS: u128 = EXPECTED_REWARDS / 2;
+    const EXPECTED_REWARDS: u128 = 21;
+    const UNSHIELD_REWARDS_AMT: u128 = EXPECTED_REWARDS / 2;
+    const REMAINING_REWARDS_AMT: u128 = EXPECTED_REWARDS - UNSHIELD_REWARDS_AMT;
 
     let captured = CapturedOutput::of(|| {
         run(
@@ -518,7 +519,7 @@ fn enable_rewards_after_shielding() -> Result<()> {
                 "--token",
                 NAM,
                 "--amount",
-                &HALF_OF_EXPECTED_REWARDS.to_string(),
+                &UNSHIELD_REWARDS_AMT.to_string(),
                 "--signing-keys",
                 BERTHA_KEY,
                 "--node",
@@ -559,7 +560,7 @@ fn enable_rewards_after_shielding() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok(), "{:?}", captured.result);
-    assert!(captured.contains(&format!("nam: {HALF_OF_EXPECTED_REWARDS}")));
+    assert!(captured.contains(&format!("nam: {REMAINING_REWARDS_AMT}")));
 
     // Transfer the other half of the rewards
     let captured = CapturedOutput::of(|| {
@@ -575,7 +576,7 @@ fn enable_rewards_after_shielding() -> Result<()> {
                 "--token",
                 NAM,
                 "--amount",
-                &HALF_OF_EXPECTED_REWARDS.to_string(),
+                &REMAINING_REWARDS_AMT.to_string(),
                 "--signing-keys",
                 BERTHA_KEY,
                 "--node",


### PR DESCRIPTION
## Describe your changes

~~Based on #3954 ([DIFF](https://github.com/anoma/namada/compare/murisi/fix-masp-change..tiago+murisi/fix-masp-change))~~
Rebases commits from #3954, therefore it essentially supersedes it.

This PR accomplishes the following:

- Fixes clippy lints
- Fixes formatting
- Adds new storage functions to update the masp token map
- Adds a new masp integration test to check the behavior of enabling rewards on some asset that had already been shielded
- Adds a new masp integration test to check the behavior of interacting with tokens in the masp whose values span across multiple notes (because to represent them we need more than 64 bits)
- Adds a new masp integration test to check the behavior of initializing the token map with null rewards, shielding, then updating the rewards to some non-null value
- Modified change computation to deal with each individual masp denomination separately

To check the rest of the changes, check the description of #3954.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
