### PR TITLE
Memo integrity check in validity predicates

### DIFF
--- a/.changelog/unreleased/bug-fixes/3960-memo-validation-in-vp.md
+++ b/.changelog/unreleased/bug-fixes/3960-memo-validation-in-vp.md
@@ -1,0 +1,2 @@
+- Added validation of the transaction's memo in the validity predicates to catch
+  any possible tamperings. ([\#3960](https://github.com/anoma/namada/pull/3960))

--- a/crates/core/src/hash.rs
+++ b/crates/core/src/hash.rs
@@ -175,7 +175,7 @@ impl Hash {
     }
 
     /// Return zeros
-    pub fn zero() -> Self {
+    pub const fn zero() -> Self {
         Self([0u8; HASH_LENGTH])
     }
 

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -5166,13 +5166,7 @@ fn identical_output_descriptions() -> Result<()> {
     let tx: namada_sdk::tx::Tx = serde_json::from_slice(&tx_bytes).unwrap();
     // Inject some randomness in the cloned tx to change the hash
     let mut tx_clone = tx.clone();
-    let mut cmt = tx_clone.header.batch.first().unwrap().to_owned();
-    let random_hash: Vec<_> = (0..namada_sdk::hash::HASH_LENGTH)
-        .map(|_| rand::random::<u8>())
-        .collect();
-    cmt.memo_hash = namada_sdk::hash::Hash(random_hash.try_into().unwrap());
-    tx_clone.header.batch.clear();
-    tx_clone.header.batch.insert(cmt);
+    tx_clone.add_memo(&[1, 2, 3]);
 
     let signing_data = SigningTxData {
         owner: None,

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -2145,6 +2145,8 @@ fn masp_incentives() -> Result<()> {
                 NAM,
                 "--amount",
                 "1.451732",
+                "--gas-limit",
+                "60000",
                 "--signing-keys",
                 BERTHA_KEY,
                 "--node",

--- a/crates/vp_prelude/src/lib.rs
+++ b/crates/vp_prelude/src/lib.rs
@@ -52,7 +52,7 @@ use namada_vm_env::vp::*;
 use namada_vm_env::{read_from_buffer, read_key_val_bytes_from_buffer};
 pub use namada_vp_env::{collection_validation, VpEnv};
 pub use sha2::{Digest, Sha256, Sha384, Sha512};
-use tx::BatchedTxRef;
+use tx::{BatchedTxRef, TxCommitments};
 pub use {
     namada_account as account, namada_parameters as parameters,
     namada_proof_of_stake as proof_of_stake, namada_token as token,
@@ -131,20 +131,19 @@ impl VerifySigGadget {
         &mut self,
         ctx: &Ctx,
         tx_data: &Tx,
+        cmt: &TxCommitments,
         owner: &Address,
     ) -> VpResult {
         if !self.has_validated_sig {
-            //FIXME: change the api and do the check for this inner tx only
-            // First check that none of the memo sections of this batch have been tampered with
-            for cmt in &tx_data.header.batch {
-                if cmt.memo_hash != namada_core::hash::Hash::zero() {
-                    tx_data.get_section(&cmt.memo_hash).ok_or_else(|| {
-                        VpError::Erased(format!(
-                            "Memo section with hash {} is missing",
-                            cmt.memo_hash
-                        ))
-                    })?;
-                }
+            // First check that the memo section of this inner tx has not been
+            // tampered with
+            if cmt.memo_hash != namada_core::hash::Hash::zero() {
+                tx_data.get_section(&cmt.memo_hash).ok_or_else(|| {
+                    VpError::Erased(format!(
+                        "Memo section with hash {} is missing",
+                        cmt.memo_hash
+                    ))
+                })?;
             }
 
             // Then check the signature
@@ -163,10 +162,11 @@ impl VerifySigGadget {
         predicate: F,
         ctx: &Ctx,
         tx_data: &Tx,
+        cmt: &TxCommitments,
         owner: &Address,
     ) -> VpResult {
         if predicate() {
-            self.verify_signatures(ctx, tx_data, owner)?;
+            self.verify_signatures(ctx, tx_data, cmt, owner)?;
         }
         Ok(())
     }

--- a/crates/vp_prelude/src/lib.rs
+++ b/crates/vp_prelude/src/lib.rs
@@ -134,6 +134,20 @@ impl VerifySigGadget {
         owner: &Address,
     ) -> VpResult {
         if !self.has_validated_sig {
+            //FIXME: change the api and do the check for this inner tx only
+            // First check that none of the memo sections of this batch have been tampered with
+            for cmt in &tx_data.header.batch {
+                if cmt.memo_hash != namada_core::hash::Hash::zero() {
+                    tx_data.get_section(&cmt.memo_hash).ok_or_else(|| {
+                        VpError::Erased(format!(
+                            "Memo section with hash {} is missing",
+                            cmt.memo_hash
+                        ))
+                    })?;
+                }
+            }
+
+            // Then check the signature
             verify_signatures(ctx, tx_data, owner)?;
             self.has_validated_sig = true;
         }

--- a/wasm/vp_user/src/lib.rs
+++ b/wasm/vp_user/src/lib.rs
@@ -68,6 +68,7 @@ fn validate_tx(
                     || source == addr,
                     ctx,
                     &tx,
+                    cmt,
                     &addr,
                 )?,
                 PosAction::Bond(Bond {
@@ -84,6 +85,7 @@ fn validate_tx(
                         || source == addr,
                         ctx,
                         &tx,
+                        cmt,
                         &addr,
                     )?
                 }
@@ -99,10 +101,17 @@ fn validate_tx(
                 || source == addr,
                 ctx,
                 &tx,
+                cmt,
                 &addr,
             )?,
             Action::Masp(MaspAction::MaspAuthorizer(source)) => gadget
-                .verify_signatures_when(|| source == addr, ctx, &tx, &addr)?,
+                .verify_signatures_when(
+                    || source == addr,
+                    ctx,
+                    &tx,
+                    cmt,
+                    &addr,
+                )?,
             Action::Masp(MaspAction::MaspSectionRef(_)) => (),
             Action::IbcShielding => (),
         }
@@ -124,6 +133,7 @@ fn validate_tx(
                         || change.is_negative(),
                         ctx,
                         &tx,
+                        cmt,
                         &addr,
                     )?;
                     let sign = if change.non_negative() { "" } else { "-" };
@@ -153,6 +163,7 @@ fn validate_tx(
                 || minter_addr == &addr,
                 ctx,
                 &tx,
+                cmt,
                 &addr,
             ),
             KeyType::Vp(owner) => {
@@ -162,13 +173,14 @@ fn validate_tx(
                     || owner == &addr && vp_overwritten,
                     ctx,
                     &tx,
+                    cmt,
                     &addr,
                 )
             }
             KeyType::Masp | KeyType::Ibc => Ok(()),
             KeyType::Unknown => {
                 // Unknown changes require a valid signature
-                gadget.verify_signatures(ctx, &tx, &addr)
+                gadget.verify_signatures(ctx, &tx, cmt, &addr)
             }
         };
         validate_change().inspect_err(|reason| {
@@ -1531,6 +1543,178 @@ mod tests {
         assert!(
             validate_tx(&CTX, signed_tx, vp_owner, keys_changed, verifiers)
                 .is_ok()
+        );
+    }
+
+    // Test malleability attacks on memo sections
+    #[test]
+    fn test_tampered_memo_section() {
+        // Initialize a tx environment
+        let mut tx_env = TestTxEnv::default();
+
+        let vp_owner = address::testing::established_address_1();
+        let keypair = key::testing::keypair_1();
+        let public_key = keypair.ref_to();
+        let target = address::testing::established_address_2();
+        let token = address::testing::nam();
+        let amount = token::Amount::from_uint(10_098_123, 0).unwrap();
+
+        // Spawn the accounts to be able to modify their storage
+        tx_env.spawn_accounts([&vp_owner, &target, &token]);
+        tx_env.init_account_storage(&vp_owner, vec![public_key.clone()], 1);
+
+        // Credit the tokens to the VP owner before running the transaction to
+        // be able to transfer from it
+        tx_env.credit_tokens(&vp_owner, &token, amount);
+        // write the denomination of NAM into storage
+        token::write_denom(
+            &mut tx_env.state,
+            &token,
+            token::NATIVE_MAX_DECIMAL_PLACES.into(),
+        )
+        .unwrap();
+
+        let amount = token::DenominatedAmount::new(
+            amount,
+            token::NATIVE_MAX_DECIMAL_PLACES.into(),
+        );
+
+        // Initialize VP environment from a transaction that requires a
+        // signature check
+        vp_host_env::init_from_tx(vp_owner.clone(), tx_env, |address| {
+            // Apply transfer in a transaction
+            tx_host_env::token::transfer(
+                tx::ctx(),
+                address,
+                &target,
+                &token,
+                amount.amount(),
+            )
+            .unwrap();
+        });
+        let mut vp_env = vp_host_env::take();
+        let pks_map = AccountPublicKeysMap::from_iter(vec![public_key]);
+
+        let mut tx = vp_env.batched_tx.tx.clone();
+        tx.set_data(Data::new(vec![]));
+        tx.set_code(Code::new(vec![], None));
+        let (_, memo_hash) = tx.add_memo(&[1, 2, 3]);
+        tx.push_default_inner_tx();
+        tx.set_data(Data::new(vec![]));
+        tx.set_code(Code::new(vec![], None));
+        tx.add_memo(&[1, 2, 3]);
+        tx.add_section(Section::Authorization(Authorization::new(
+            vec![tx.raw_header_hash()],
+            pks_map.index_secret_keys(vec![keypair]),
+            None,
+        )));
+
+        // Tamper with the first memo section
+        let memo_section = tx
+            .sections
+            .iter_mut()
+            .find(|sec| sec.get_hash() == memo_hash)
+            .unwrap();
+        let mut bytes = memo_section.extra_data().unwrap();
+        *bytes.last_mut().unwrap() = 4;
+        *memo_section = Section::ExtraData(Code::new(bytes, None));
+
+        let signed_tx = tx.clone().batch_first_tx();
+        vp_env.batched_tx = signed_tx.clone();
+        let keys_changed: BTreeSet<storage::Key> =
+            vp_env.all_touched_storage_keys();
+        let verifiers: BTreeSet<Address> = BTreeSet::default();
+        vp_host_env::set(vp_env);
+
+        // 1. Tampared memo section of the current inner tx causes tx rejection
+        //    when validating the signature
+        let err = validate_tx(
+            &CTX,
+            signed_tx.clone(),
+            vp_owner.clone(),
+            keys_changed,
+            verifiers,
+        )
+        .unwrap_err();
+        if let VpError::Erased(msg) = err {
+            assert_eq!(
+                msg,
+                format!("Memo section with hash {} is missing", memo_hash)
+            );
+        } else {
+            panic!("Got wrong error message");
+        }
+
+        // 2. If signature is not checked, a tampered memo section should not
+        //    cause rejection
+        assert!(
+            validate_tx(
+                &CTX,
+                signed_tx,
+                vp_owner.clone(),
+                Default::default(),
+                Default::default(),
+            )
+            .is_ok()
+        );
+
+        // 3. If the memo section of another inner tx has been tampered with the
+        //    current inner tx does not get rejected
+        let mut tx_env = TestTxEnv::default();
+        let vp_owner = address::testing::established_address_1();
+        let keypair = key::testing::keypair_1();
+        let public_key = keypair.ref_to();
+        let target = address::testing::established_address_2();
+        let token = address::testing::nam();
+        let amount = token::Amount::from_uint(10_098_123, 0).unwrap();
+
+        // Spawn the accounts to be able to modify their storage
+        tx_env.spawn_accounts([&vp_owner, &target, &token]);
+        tx_env.init_account_storage(&vp_owner, vec![public_key.clone()], 1);
+
+        // Credit the tokens to the VP owner before running the transaction to
+        // be able to transfer from it
+        tx_env.credit_tokens(&vp_owner, &token, amount);
+        // write the denomination of NAM into storage
+        token::write_denom(
+            &mut tx_env.state,
+            &token,
+            token::NATIVE_MAX_DECIMAL_PLACES.into(),
+        )
+        .unwrap();
+
+        let amount = token::DenominatedAmount::new(
+            amount,
+            token::NATIVE_MAX_DECIMAL_PLACES.into(),
+        );
+
+        // Initialize VP environment from a transaction that requires a
+        // signature check
+        vp_host_env::init_from_tx(vp_owner.clone(), tx_env, |address| {
+            // Apply transfer in a transaction
+            tx_host_env::token::transfer(
+                tx::ctx(),
+                address,
+                &target,
+                &token,
+                amount.amount(),
+            )
+            .unwrap();
+        });
+        let mut vp_env = vp_host_env::take();
+        let second_inner_tx = tx.header.batch.get_index(1).unwrap().clone();
+        let signed_tx = tx.batch_tx(second_inner_tx);
+        vp_env.batched_tx = signed_tx.clone();
+        vp_host_env::set(vp_env);
+        assert!(
+            validate_tx(
+                &CTX,
+                signed_tx,
+                vp_owner,
+                Default::default(),
+                Default::default(),
+            )
+            .is_ok()
         );
     }
 }

--- a/wasm_for_tests/tx_proposal_token_gas/src/lib.rs
+++ b/wasm_for_tests/tx_proposal_token_gas/src/lib.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
-use namada_tx_prelude::{
-    parameters_storage::get_gas_cost_key, token::Amount, *,
-};
+use namada_tx_prelude::parameters_storage::get_gas_cost_key;
+use namada_tx_prelude::token::Amount;
+use namada_tx_prelude::*;
 
 #[transaction]
 fn apply_tx(ctx: &mut Ctx, _tx_data: BatchedTx) -> TxResult {

--- a/wasm_for_tests/vp_verify_signature/src/lib.rs
+++ b/wasm_for_tests/vp_verify_signature/src/lib.rs
@@ -9,5 +9,5 @@ fn validate_tx(
     _verifiers: BTreeSet<Address>,
 ) -> VpResult {
     let mut gadget = VerifySigGadget::new();
-    gadget.verify_signatures(ctx, &tx_data.tx, &addr)
+    gadget.verify_signatures(ctx, &tx_data.tx, &tx_data.cmt, &addr)
 }


### PR DESCRIPTION
## Describe your changes

Extended the `VerifySigGadget` to also check the integrity of the memo section (if present). Added wasm tests to cover this scenario.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
