### PR TITLE
Removes `disposable-gas-payer` arg for custom txs

### DIFF
--- a/.changelog/unreleased/improvements/3969-remove-custom-tx-arg.md
+++ b/.changelog/unreleased/improvements/3969-remove-custom-tx-arg.md
@@ -1,0 +1,2 @@
+- Removed the `disposable-gas-payer` cli argument for custom transactions.
+  ([\#3969](https://github.com/anoma/namada/pull/3969))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -4491,7 +4491,6 @@ pub mod args {
                 owner: self
                     .owner
                     .map(|owner| ctx.borrow_chain_or_exit().get(&owner)),
-                disposable_signing_key: self.disposable_signing_key,
             })
         }
     }
@@ -4503,14 +4502,12 @@ pub mod args {
             let data_path = DATA_PATH_OPT.parse(matches);
             let serialized_tx = TX_PATH_OPT.parse(matches);
             let owner = OWNER_OPT.parse(matches);
-            let disposable_signing_key = DISPOSABLE_SIGNING_KEY.parse(matches);
             Self {
                 tx,
                 code_path,
                 data_path,
                 serialized_tx,
                 owner,
-                disposable_signing_key,
             }
         }
 
@@ -4557,19 +4554,6 @@ pub mod args {
                     "The optional address corresponding to the signatures or \
                      signing keys."
                 )))
-                .arg(
-                    DISPOSABLE_SIGNING_KEY
-                        .def()
-                        .help(wrap!(
-                            "Generates an ephemeral, disposable keypair to \
-                             sign the wrapper transaction. If --gas-signature \
-                             is provided then that will take precedence."
-                        ))
-                        .conflicts_with_all([
-                            FEE_PAYER_OPT.name,
-                            WRAPPER_SIGNATURE_OPT.name,
-                        ]),
-                )
         }
     }
 

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -164,9 +164,6 @@ pub struct TxCustom<C: NamadaTypes = SdkTypes> {
     pub serialized_tx: Option<C::Data>,
     /// The optional address that correspond to the signatures/signing-keys
     pub owner: Option<C::Address>,
-    /// Generate an ephemeral signing key to be used only once to sign the
-    /// wrapper tx
-    pub disposable_signing_key: bool,
 }
 
 impl<C: NamadaTypes> TxBuilder<C> for TxCustom<C> {
@@ -209,15 +206,6 @@ impl<C: NamadaTypes> TxCustom<C> {
     /// The address that correspond to the signatures/signing-keys
     pub fn owner(self, owner: Option<C::Address>) -> Self {
         Self { owner, ..self }
-    }
-
-    /// The flag to request an ephemeral signing key to be used only once to
-    /// sign the wrapper tx
-    pub fn disposable_signing_key(self, disposable_signing_key: bool) -> Self {
-        Self {
-            disposable_signing_key,
-            ..self
-        }
     }
 }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -599,7 +599,6 @@ pub trait Namada: NamadaIo {
             code_path: None,
             data_path: None,
             serialized_tx: None,
-            disposable_signing_key: false,
         }
     }
 

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -3730,7 +3730,6 @@ pub async fn build_custom(
         data_path,
         serialized_tx,
         owner,
-        disposable_signing_key,
     }: &args::TxCustom,
 ) -> Result<(Tx, Option<SigningTxData>)> {
     let mut tx = if let Some(serialized_tx) = serialized_tx {
@@ -3805,7 +3804,7 @@ pub async fn build_custom(
             owner.clone(),
             default_signer,
             vec![],
-            *disposable_signing_key,
+            false,
         )
         .await?;
         prepare_tx(


### PR DESCRIPTION
## Describe your changes

Closes #3963.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
