### PR TITLE
fix config from env var

### DIFF
--- a/.changelog/unreleased/bug-fixes/3971-fix-config-from-env.md
+++ b/.changelog/unreleased/bug-fixes/3971-fix-config-from-env.md
@@ -1,0 +1,3 @@
+- Fix the prefix separator for config key-vals set from env var to a
+  single underscore between the "NAMADA" prefix and the rest of the path.
+  ([\#3971](https://github.com/anoma/namada/pull/3971))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,13 +1169,13 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.14.0"
-source = "git+https://github.com/mehcode/config-rs.git?rev=e3c1d0b452639478662a44f15ef6d5b6d969bf9b#e3c1d0b452639478662a44f15ef6d5b6d969bf9b"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
  "async-trait",
  "convert_case",
  "json5",
- "lazy_static",
  "nom",
  "pathdiff",
  "ron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ clap_complete_nushell = "4.5"
 clru = {git = "https://github.com/marmeladema/clru-rs.git", rev = "71ca566"}
 color-eyre = "0.6.2"
 concat-idents = "1.1.2"
-config = { git = "https://github.com/mehcode/config-rs.git", rev = "e3c1d0b452639478662a44f15ef6d5b6d969bf9b" }
+config = "0.14.1"
 data-encoding = "2.3.2"
 derivation-path = "0.2.0"
 derivative = "2.2.0"

--- a/crates/apps_lib/src/config/mod.rs
+++ b/crates/apps_lib/src/config/mod.rs
@@ -287,7 +287,9 @@ impl Config {
             .add_source(defaults)
             .add_source(config::File::with_name(file_name))
             .add_source(
-                config::Environment::with_prefix("NAMADA").separator("__"),
+                config::Environment::with_prefix("NAMADA")
+                    .prefix_separator("_")
+                    .separator("__"),
             );
 
         let config = builder.build().map_err(Error::ReadError)?;


### PR DESCRIPTION
## Describe your changes

fixes #3953

The config-rs prefix separator behavior had a regression introduced after 0.11 https://github.com/rust-cli/config-rs/issues/291 where instead of the previous single underscore prefix separator it was using the field separator with double underscore. The fix was introduced in https://github.com/rust-cli/config-rs/pull/292 that allows to specify prefix separator.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
