### PR TITLE
make: change "make build" recipe to build in release

### DIFF
--- a/.changelog/unreleased/miscellaneous/3971-make-build-in-release.md
+++ b/.changelog/unreleased/miscellaneous/3971-make-build-in-release.md
@@ -1,0 +1,2 @@
+- The `make build` recipe now builds in release. Use `make build-debug` for a
+  dev build. ([\#3971](https://github.com/anoma/namada/pull/3971))

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ all-crates := $(foreach crate,$(crates), -p $(crate))
 
 
 build:
-	$(cargo) build $(jobs) --workspace --exclude namada_benchmarks --exclude namada_fuzz
+	make build-release
 
 build-test:
 	$(cargo) +$(nightly) build --tests $(jobs)


### PR DESCRIPTION
## Describe your changes

closes #3950

The `make build` recipe now builds in release. Use `make build-debug` for a dev build.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
