### PR TITLE
Enforce gas spending key usage with disposable gas payers

### DIFF
--- a/.changelog/unreleased/bug-fixes/3979-restore-purged-commits.md
+++ b/.changelog/unreleased/bug-fixes/3979-restore-purged-commits.md
@@ -1,0 +1,2 @@
+- Enforce gas spending key usage with disposable gas payers.
+  ([\#3979](https://github.com/anoma/namada/pull/3979))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -4759,8 +4759,8 @@ pub mod args {
                         .help(wrap!("The amount to transfer in decimal.")),
                 )
                 .arg(GAS_SPENDING_KEY.def().help(wrap!(
-                    "The optional spending key that will be used in addition \
-                     to the source for gas payment."
+                    "The optional spending key that will be used for gas \
+                     payment."
                 )))
                 .arg(
                     DISPOSABLE_SIGNING_KEY
@@ -4769,6 +4769,7 @@ pub mod args {
                             "Generates an ephemeral, disposable keypair to \
                              sign the wrapper transaction."
                         ))
+                        .requires(GAS_SPENDING_KEY.name)
                         .conflicts_with(FEE_PAYER_OPT.name),
                 )
         }
@@ -4923,8 +4924,8 @@ pub mod args {
                         .help(wrap!("The amount to transfer in decimal.")),
                 )
                 .arg(GAS_SPENDING_KEY.def().help(wrap!(
-                    "The optional spending key that will be used in addition \
-                     to the source for gas payment."
+                    "The optional spending key that will be used for gas \
+                     payment."
                 )))
                 .arg(
                     DISPOSABLE_SIGNING_KEY
@@ -4933,6 +4934,7 @@ pub mod args {
                             "Generates an ephemeral, disposable keypair to \
                              sign the wrapper transaction."
                         ))
+                        .requires(GAS_SPENDING_KEY.name)
                         .conflicts_with(FEE_PAYER_OPT.name),
                 )
         }
@@ -5054,9 +5056,8 @@ pub mod args {
                         .help(wrap!("The memo for IBC transfer packet.")),
                 )
                 .arg(GAS_SPENDING_KEY.def().help(wrap!(
-                    "The optional spending key that will be used in addition \
-                     to the source for gas payment (if this is a shielded \
-                     action)."
+                    "The optional spending key that will be used for gas \
+                     payment (if this is a shielded action)."
                 )))
                 .arg(
                     DISPOSABLE_SIGNING_KEY
@@ -5065,6 +5066,7 @@ pub mod args {
                             "Generates an ephemeral, disposable keypair to \
                              sign the wrapper transaction."
                         ))
+                        .requires(GAS_SPENDING_KEY.name)
                         .conflicts_with(FEE_PAYER_OPT.name),
                 )
         }

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -116,7 +116,7 @@ pub struct MaspTargetTransferData {
 pub struct MaspDataLog {
     pub source: Option<TransferSource>,
     pub token: Address,
-    pub amount: token::Amount,
+    pub amount: token::DenominatedAmount,
 }
 
 #[allow(missing_docs)]

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -1552,7 +1552,9 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
                 data: Some(MaspDataLog {
                     source,
                     token,
-                    amount,
+                    amount: namada_core::token::DenominatedAmount::new(
+                        amount, denom,
+                    ),
                 }),
             });
         }

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -3810,6 +3810,8 @@ fn masp_fee_payment() -> Result<()> {
                 "20000",
                 "--gas-price",
                 "1",
+                "--gas-spending-key",
+                A_SPENDING_KEY,
                 "--disposable-gas-payer",
                 "--ledger-address",
                 validator_one_rpc,
@@ -4116,6 +4118,8 @@ fn masp_fee_payment_gas_limit() -> Result<()> {
                 "1",
                 "--gas-price",
                 "1",
+                "--gas-spending-key",
+                A_SPENDING_KEY,
                 "--disposable-gas-payer",
                 "--ledger-address",
                 validator_one_rpc,
@@ -4155,7 +4159,7 @@ fn masp_fee_payment_gas_limit() -> Result<()> {
     Ok(())
 }
 
-// Test masp fee payement with an unshield to a non-disposable address with
+// Test masp fee payment with an unshield to a non-disposable address with
 // already some funds on it.
 #[test]
 fn masp_fee_payment_with_non_disposable() -> Result<()> {


### PR DESCRIPTION
## Describe your changes

Restore commits accidentally purged from #3959 (more specifically, acafd29516a90b1b3705c568781ef066ffc1e591)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
