### PR TITLE
Test NAM reward unshields in `values_spanning_multiple_masp_digits`

### DIFF
--- a/.changelog/unreleased/testing/3982-test-unshields-multiple-digits.md
+++ b/.changelog/unreleased/testing/3982-test-unshields-multiple-digits.md
@@ -1,0 +1,3 @@
+- Increase the default masp fee payment gas limit to 65000 in genesis
+  localnet files. Moreover, add additional test cases for MASP fee unshields.
+  ([\#3982](https://github.com/anoma/namada/pull/3982))

--- a/genesis/hardware/parameters.toml
+++ b/genesis/hardware/parameters.toml
@@ -21,7 +21,7 @@ masp_epoch_multiplier = 2
 # Max gas for block
 max_block_gas = 3_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 50_000
+masp_fee_payment_gas_limit = 65_000
 # Gas scale
 gas_scale = 50_000
 

--- a/genesis/localnet/parameters.toml
+++ b/genesis/localnet/parameters.toml
@@ -21,7 +21,7 @@ masp_epoch_multiplier = 2
 # Max gas for block
 max_block_gas = 3_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 50_000
+masp_fee_payment_gas_limit = 65_000
 # Gas scale
 gas_scale = 50_000
 

--- a/genesis/starter/parameters.toml
+++ b/genesis/starter/parameters.toml
@@ -21,7 +21,7 @@ masp_epoch_multiplier = 2
 # Max gas for block
 max_block_gas = 3_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 50_000
+masp_fee_payment_gas_limit = 65_000
 # Gas scale
 gas_scale = 50_000
 


### PR DESCRIPTION
## Describe your changes

- Increase masp fee payment gas limit to `65000`
- Test NAM reward unshields in `values_spanning_multiple_masp_digits`.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
