### PR TITLE
Reworks masp fee payment error handling

### DIFF
--- a/.changelog/unreleased/improvements/3983-improve-masp-fee-messages.md
+++ b/.changelog/unreleased/improvements/3983-improve-masp-fee-messages.md
@@ -1,0 +1,2 @@
+- Streamlined the error propagation of masp fee payment. Improved the logs
+  provided to the user. ([\#3983](https://github.com/anoma/namada/pull/3983))

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -1045,13 +1045,12 @@ mod test_process_proposal {
             }
         };
         assert_eq!(response.result.code, u32::from(ResultCode::FeeError));
-        assert_eq!(
-            response.result.info,
-            String::from(
-                "Error trying to apply a transaction: Error while processing \
-                 transaction's fees: Insufficient funds for fee payment"
-            )
-        );
+        assert!(response.result.info.contains(
+            "Error trying to apply a transaction: Error while processing \
+             transaction's fees: The first transaction in the batch failed to \
+             pay fees via the MASP. Wasm run failed: Transaction runner \
+             error: Wasm validation error"
+        ));
     }
 
     /// Test that if the account submitting the tx does
@@ -1105,13 +1104,12 @@ mod test_process_proposal {
             }
         };
         assert_eq!(response.result.code, u32::from(ResultCode::FeeError));
-        assert_eq!(
-            response.result.info,
-            String::from(
-                "Error trying to apply a transaction: Error while processing \
-                 transaction's fees: Insufficient funds for fee payment"
-            )
-        );
+        assert!(response.result.info.contains(
+            "Error trying to apply a transaction: Error while processing \
+             transaction's fees: The first transaction in the batch failed to \
+             pay fees via the MASP. Wasm run failed: Transaction runner \
+             error: Wasm validation error"
+        ));
     }
 
     /// Process Proposal should reject a block containing a RawTx, but not panic


### PR DESCRIPTION
## Describe your changes

Closes #3961.
Partially addresses #3964.

Improves the error logs of masp fee payment.

`try_masp_fee_payment` now short circuits and returns error on all failures (not only gas ones) avoiding the need for an extra `Option` in the returned type. This allows for a better logging of the failures to the user and makes the code simpler to follow.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
