### PR TITLE
docs: Fix broken CometBFT installation guide link

### DIFF
--- a/.changelog/unreleased/docs/4006-fix-cometbft-install-link.md
+++ b/.changelog/unreleased/docs/4006-fix-cometbft-install-link.md
@@ -1,0 +1,3 @@
+- Fixed broken link to CometBFT installation instructions in README.md
+  to ensure users can properly access the installation guide.
+  ([#4006](https://github.com/anoma/namada/issues/4006))

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Please see the [contributing page](./CONTRIBUTING.md).
 
 ### Dependencies
 
-The ledger currently requires [CometBFT v0.37.11](https://github.com/cometbft/cometbft/releases/tag/v0.37.11) is installed and available on path. This can be achieved through following [these instructions](https://github.com/cometbft/cometbft/blob/main/docs/guides/install.md)
+The ledger currently requires [CometBFT v0.37.11](https://github.com/cometbft/cometbft/releases/tag/v0.37.11) is installed and available on path. This can be achieved through following [these instructions](https://github.com/cometbft/cometbft/blob/main/docs/tutorials/install.md)
 
 #### Hermes
 


### PR DESCRIPTION
## Describe your changes
Updates the broken CometBFT installation guide link in README.md from `/docs/guides/install.md` to `/docs/tutorials/install.md` to ensure users can properly access the installation instructions.

Fixes #4006

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
    - N/A - documentation change only
- [x] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: N/A - README.md change only
- [x] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: N/A - README.md change only
