### PR TITLE
ci: fix maintenance branch name pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
       - main
-      - 'maint-[0-9]+.[0-9]+.[0-9]+'
+      - 'maint-[0-9]+.[0-9]+'
   # Run in PRs with conflicts (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)
   pull_request_target:
     branches:
       - main
-      - 'maint-[0-9]+.[0-9]+.[0-9]+'
+      - 'maint-[0-9]+.[0-9]+'
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 


### PR DESCRIPTION
## Describe your changes

follow up to #4000 - maintenance branch name should not include patch version

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
