### PR TITLE
Improve the performance of the shielded sync ledger client

### DIFF
--- a/.changelog/unreleased/improvements/4016-ss-ledger-client-improvements.md
+++ b/.changelog/unreleased/improvements/4016-ss-ledger-client-improvements.md
@@ -1,0 +1,2 @@
+- Improve the shielded sync's ledger client performance and user experience.
+  ([\#4016](https://github.com/anoma/namada/pull/4016))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -3386,6 +3386,8 @@ pub mod args {
         }),
     );
     pub const BIRTHDAY: ArgOpt<BlockHeight> = arg_opt("birthday");
+    pub const BLOCK_BATCH: ArgDefault<usize> =
+        arg_default("block-batch", DefaultFn(|| 10));
     pub const BLOCK_HEIGHT: Arg<BlockHeight> = arg("block-height");
     pub const BLOCK_HEIGHT_OPT: ArgOpt<BlockHeight> = arg_opt("height");
     pub const BLOCK_HEIGHT_TO_OPT: ArgOpt<BlockHeight> = arg_opt("to-height");
@@ -6803,6 +6805,7 @@ pub mod args {
                 Some(times) => RetryStrategy::Times(times),
                 None => RetryStrategy::Forever,
             };
+            let block_batch_size = BLOCK_BATCH.parse(matches);
             Self {
                 ledger_address,
                 last_query_height,
@@ -6812,6 +6815,7 @@ pub mod args {
                 wait_for_last_query_height,
                 max_concurrent_fetches,
                 retry_strategy,
+                block_batch_size,
             }
         }
 
@@ -6849,6 +6853,10 @@ pub mod args {
                     "Maximum number of times to retry fetching. If no \
                      argument is provided, defaults to retrying forever."
                 )))
+                .arg(BLOCK_BATCH.def().help(wrap!(
+                    "Number of blocks fetched per concurrent fetch job. The \
+                     default is 10."
+                )))
         }
     }
 
@@ -6862,6 +6870,7 @@ pub mod args {
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
             Ok(ShieldedSync {
+                block_batch_size: self.block_batch_size,
                 max_concurrent_fetches: self.max_concurrent_fetches,
                 wait_for_last_query_height: self.wait_for_last_query_height,
                 ledger_address: chain_ctx.get(&self.ledger_address),

--- a/crates/apps_lib/src/client/masp.rs
+++ b/crates/apps_lib/src/client/masp.rs
@@ -141,6 +141,7 @@ pub async fn syncing<
         dispatch_client!(LedgerMaspClient::new(
             client,
             args.max_concurrent_fetches,
+            Duration::from_millis(5),
         ))?
     };
 

--- a/crates/apps_lib/src/client/masp.rs
+++ b/crates/apps_lib/src/client/masp.rs
@@ -84,6 +84,7 @@ pub async fn syncing<
                 .shutdown_signal(install_shutdown_signal(false))
                 .wait_for_last_query_height(args.wait_for_last_query_height)
                 .retry_strategy(args.retry_strategy)
+                .block_batch_size(args.block_batch_size)
                 .build();
 
             let env = MaspLocalTaskEnv::new(500)

--- a/crates/core/src/control_flow/time.rs
+++ b/crates/core/src/control_flow/time.rs
@@ -256,7 +256,17 @@ impl<S: SleepStrategy> Sleep<S> {
     /// Update the sleep strategy state, and sleep for the given backoff.
     async fn sleep_update(&self, state: &mut S::State) {
         self.strategy.next_state(state);
-        sleep(self.strategy.backoff(state)).await;
+        self.sleep_with_current_backoff(state).await;
+    }
+
+    /// Sleep for a [`Duration`] equivalent to the value of
+    /// the current backoff.
+    pub fn sleep_with_current_backoff(
+        &self,
+        state: &S::State,
+    ) -> impl Future<Output = ()> + 'static {
+        let backoff_duration = self.strategy.backoff(state);
+        sleep(backoff_duration)
     }
 
     /// Run a future as many times as `iter_times`

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -1192,6 +1192,7 @@ impl BenchShieldedCtx {
                     wait_for_last_query_height: false,
                     max_concurrent_fetches: 100,
                     retry_strategy: RetryStrategy::Forever,
+                    block_batch_size: 10,
                 },
                 &StdIo,
             ))

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -2158,6 +2158,8 @@ pub struct ShieldedSync<C: NamadaTypes = SdkTypes> {
     /// Maximum number of fetch jobs that will ever
     /// execute concurrently during the shielded sync.
     pub max_concurrent_fetches: usize,
+    /// Number of blocks fetched per concurrent fetch job.
+    pub block_batch_size: usize,
     /// Maximum number of times to retry fetching. If `None`
     /// is provided, defaults to "forever".
     pub retry_strategy: RetryStrategy,

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -1,7 +1,7 @@
 //! Helper functions and types
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use borsh::BorshDeserialize;
 use masp_primitives::merkle_tree::{CommitmentTree, IncrementalWitness};
@@ -9,6 +9,9 @@ use masp_primitives::sapling::Node;
 use masp_primitives::transaction::Transaction as MaspTx;
 use namada_core::chain::BlockHeight;
 use namada_core::collections::HashMap;
+use namada_core::control_flow::time::{
+    Duration, LinearBackoff, Sleep, SleepStrategy,
+};
 use namada_core::storage::TxIndex;
 use namada_events::extend::IndexedMaspData;
 use namada_io::Client;
@@ -24,6 +27,8 @@ use crate::masp::{extract_masp_tx, get_indexed_masp_events_at_height};
 struct LedgerMaspClientInner<C> {
     client: C,
     semaphore: Semaphore,
+    backoff: RwLock<Duration>,
+    sleep: Sleep<LinearBackoff>,
 }
 
 /// An inefficient MASP client which simply uses a
@@ -43,25 +48,28 @@ impl<C> Clone for LedgerMaspClient<C> {
 impl<C> LedgerMaspClient<C> {
     /// Create a new [`MaspClient`] given an rpc client.
     #[inline(always)]
-    pub fn new(client: C, max_concurrent_fetches: usize) -> Self {
+    pub fn new(
+        client: C,
+        max_concurrent_fetches: usize,
+        linear_backoff_delta: Duration,
+    ) -> Self {
         Self {
             inner: Arc::new(LedgerMaspClientInner {
                 client,
                 semaphore: Semaphore::new(max_concurrent_fetches),
+                backoff: RwLock::new(Duration::from_secs(0)),
+                sleep: Sleep {
+                    strategy: LinearBackoff {
+                        delta: linear_backoff_delta,
+                    },
+                },
             }),
         }
     }
 }
 
-impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
-    type Error = Error;
-
-    async fn last_block_height(&self) -> Result<Option<BlockHeight>, Error> {
-        let maybe_block = crate::rpc::query_block(&self.inner.client).await?;
-        Ok(maybe_block.map(|b| b.height))
-    }
-
-    async fn fetch_shielded_transfers(
+impl<C: Client + Send + Sync> LedgerMaspClient<C> {
+    async fn fetch_shielded_transfers_inner(
         &self,
         from: BlockHeight,
         to: BlockHeight,
@@ -124,6 +132,43 @@ impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
         }
 
         Ok(txs)
+    }
+}
+
+impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
+    type Error = Error;
+
+    async fn last_block_height(&self) -> Result<Option<BlockHeight>, Error> {
+        let maybe_block = crate::rpc::query_block(&self.inner.client).await?;
+        Ok(maybe_block.map(|b| b.height))
+    }
+
+    async fn fetch_shielded_transfers(
+        &self,
+        from: BlockHeight,
+        to: BlockHeight,
+    ) -> Result<Vec<IndexedNoteEntry>, Error> {
+        const ZERO: Duration = Duration::from_secs(0);
+        let current_backoff = { *self.inner.backoff.read().unwrap() };
+
+        if current_backoff > ZERO {
+            self.inner
+                .sleep
+                .sleep_with_current_backoff(&current_backoff)
+                .await;
+        }
+
+        let result = self.fetch_shielded_transfers_inner(from, to).await;
+
+        if result.is_err() {
+            let mut backoff = self.inner.backoff.write().unwrap();
+            self.inner.sleep.strategy.next_state(&mut *backoff);
+        } else if current_backoff > ZERO {
+            let mut backoff = self.inner.backoff.write().unwrap();
+            self.inner.sleep.strategy.prev_state(&mut *backoff);
+        }
+
+        result
     }
 
     #[inline(always)]

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -702,7 +702,6 @@ where
         }
 
         if self.config.retry_strategy.may_retry() {
-            self.config.fetched_tracker.message(format!("{error}"));
             true
         } else {
             // NB: store last encountered error


### PR DESCRIPTION
## Describe your changes

The shielded sync's ledger client continues to perform poorly, even after #3578. This PR introduces some optimizations to the ledger client, and improves its UX a bit.

- Fetches are now logged more frequently on the progress bar. Previously, they weren't being logged because concurrent fetches were starving each other on the first semaphore. To fix this, `fetch_shielded_transfers` now has a single semaphore point, at the top of the method, rather than two.
- Errors returned from RPC servers are no longer printed. They weren't that helpful anyway, and were spamming the screen, obfuscating the output of the progress bars.
- A linear backoff sleep has been added to the ledger client, on errors, to allow the client to recover from potential rate limiting/throttling imposed by the CometBFT RPC server. On successful fetches, the backoff is reduced, returning to the normal/optimal fetch speed.
- The block batch size parameter has been exposed to the CLI and SDK, allowing users to specify the number of blocks that are fetched per concurrent fetch job. This may help performance, in some cases.

In general, the indexer masp client still performs about 10x better than the ledger masp client, while fetching shielded txs.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
