### PR TITLE
Avoid updating merkle paths of spent notes

### DIFF
--- a/.changelog/unreleased/improvements/4018-update-witness-map-on-spend.md
+++ b/.changelog/unreleased/improvements/4018-update-witness-map-on-spend.md
@@ -1,0 +1,3 @@
+- Avoid updating merkle paths of spent notes. This should optimize
+  the synchronous path of the shielded sync on the ledger client.
+  ([\#4018](https://github.com/anoma/namada/pull/4018))

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -400,7 +400,11 @@ where
         }
 
         for (indexed_tx, stx_batch) in self.cache.fetched.take() {
-            if self.client.capabilities().needs_witness_map_update()
+            let needs_witness_map_update =
+                self.client.capabilities().needs_witness_map_update();
+            self.ctx
+                .save_shielded_spends(&stx_batch, needs_witness_map_update);
+            if needs_witness_map_update
                 && Some(&indexed_tx) > last_witnessed_tx.as_ref()
             {
                 self.ctx.update_witness_map(indexed_tx, &stx_batch)?;
@@ -429,7 +433,6 @@ where
                     self.config.applied_tracker.increment_by(1);
                 }
             }
-            self.ctx.save_shielded_spends(&stx_batch);
             std::mem::swap(&mut vk_heights, &mut self.ctx.vk_heights);
         }
 

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -252,7 +252,11 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
     }
 
     #[allow(missing_docs)]
-    pub fn save_shielded_spends(&mut self, transaction: &Transaction) {
+    pub fn save_shielded_spends(
+        &mut self,
+        transaction: &Transaction,
+        update_witness_map: bool,
+    ) {
         for ss in transaction
             .sapling_bundle()
             .map_or(&vec![], |x| &x.shielded_spends)
@@ -261,6 +265,9 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
             // note is rendered unusable
             if let Some(note_pos) = self.nf_map.get(&ss.nullifier) {
                 self.spents.insert(*note_pos);
+                if update_witness_map {
+                    self.witness_map.swap_remove(note_pos);
+                }
             }
         }
     }
@@ -357,7 +364,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
         &mut self,
         masp_tx: &Transaction,
     ) -> Result<(), eyre::Error> {
-        self.save_shielded_spends(masp_tx);
+        self.save_shielded_spends(masp_tx, false);
 
         // Save the speculative state for future usage
         self.sync_status = ContextSyncStatus::Speculative;


### PR DESCRIPTION
## Describe your changes

Avoid updating merkle paths of spent notes. This should optimize the synchronous path of the shielded sync on the ledger client.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
