### PR TITLE
Fixups learned from dry-run

### DIFF
--- a/.changelog/unreleased/improvements/4021-dryrun-fixups.md
+++ b/.changelog/unreleased/improvements/4021-dryrun-fixups.md
@@ -1,0 +1,3 @@
+- Some small fixups learned from the dry-run: namadac
+  staking-rewards-rate, namadac query-proposal, log.
+  ([\#4021](https://github.com/anoma/namada/pull/4021))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -5993,11 +5993,12 @@ pub mod args {
         }
 
         fn def(app: App) -> App {
-            app.add_args::<Query<CliTypes>>().arg(
-                PROPOSAL_ID_OPT
-                    .def()
-                    .help(wrap!("The proposal identifier.")),
-            )
+            app.add_args::<Query<CliTypes>>()
+                .arg(PROPOSAL_ID_OPT.def().help(wrap!(
+                    "The ID number of the proposal. This argument is \
+                     optional. If not provided, then the most recent 10 \
+                     proposals will be displayed."
+                )))
         }
     }
 

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -1403,7 +1403,6 @@ pub async fn query_effective_native_supply<N: Namada>(context: &N) {
 
 /// Query the staking rewards rate estimate
 pub async fn query_staking_rewards_rate<N: Namada>(context: &N) {
-    display_line!(context.io(), "Querying staking rewards rates...");
     let PosRewardsRates {
         staking_rewards_rate,
         inflation_rate,
@@ -1413,13 +1412,20 @@ pub async fn query_staking_rewards_rate<N: Namada>(context: &N) {
             .staking_rewards_rate(context.client())
             .await,
     );
-    display_line!(
-        context.io(),
-        "Current annual staking rewards rate: {}\nCurrent PoS inflation rate: \
-         {}",
-        staking_rewards_rate,
-        inflation_rate
-    );
+    if staking_rewards_rate.is_zero() && inflation_rate.is_zero() {
+        display_line!(
+            context.io(),
+            "PoS inflation and rewards are not currently enabled."
+        );
+    } else {
+        display_line!(
+            context.io(),
+            "Current annual staking rewards rate: {}\nCurrent PoS inflation \
+             rate: {}",
+            staking_rewards_rate,
+            inflation_rate
+        );
+    }
 }
 
 /// Query a validator's state information

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -2142,7 +2142,8 @@ pub async fn build_vote_proposal(
                 context.io(),
                 "NB: voter address {} is a validator, and validators can only \
                  vote on proposals within the first 2/3 of the voting period. \
-                 The voting period specifically for validators has ended.",
+                 Either the voting period has not started, or the voting \
+                 period specifically for validators has ended.",
                 voter_address
             );
         }


### PR DESCRIPTION
## Describe your changes
- Closes #4014.
- Fixes `namadac query-proposal` without `--proposal-id` flag

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
