### PR TITLE
Fix Typographical Errors in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To change the log level, set `NAMADA_LOG` environment variable to one of:
 * `debug`
 * `trace`
 
-The default is set to `info` for all the modules, expect for CometBFT ABCI, which has a lot of `debug` logging.
+The default is set to `info` for all the modules, except for CometBFT ABCI, which has a lot of `debug` logging.
 
 For more fine-grained logging levels settings, please refer to the [tracing subscriber docs](https://docs.rs/tracing-subscriber/0.2.18/tracing_subscriber/struct.EnvFilter.html#directives) for more information.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,5 +13,5 @@ This example is run as follows:
 cargo run --example generate-txs -- <vectors.json> <debugs.txt>
 ```
 where `<vectors.json>` is the path where the JSON test vectors will be stored
-and `<debugs.txt>` is where rust `Debug` representations oof this data will be
+and `<debugs.txt>` is where rust `Debug` representations of this data will be
 stored.


### PR DESCRIPTION
## Describe your changes

**Changes Made**

1. **README.md**:
   - **Section**: Logging
   - **Issue**: The word "expect" was used instead of "except" in the sentence:  
     "The default is set to info for all the modules, expect for CometBFT ABCI, which has a lot of debug logging."
   - **Correction**: Changed "expect" to "except."  
     The corrected sentence now reads:  
     "The default is set to info for all the modules, except for CometBFT ABCI, which has a lot of debug logging."

   - **Importance**: This correction clarifies the intended default logging behavior, especially for users configuring logging levels. The typo could mislead users to think there's a specific expectation for CometBFT ABCI rather than an exception.

2. **examples/README.md**:
   - **Section**: Usage
   - **Issue**: The word "oof" was used instead of "of" in the sentence describing the storage of debug data.
   - **Correction**: Changed "oof" to "of" to ensure accurate communication of file storage details.

   - **Importance**: This correction ensures clarity in file naming conventions and debug data storage, reducing potential confusion for developers using this example.

**These corrections improve the readability and accuracy of the documentation, enhancing the user experience and reducing potential misunderstandings for contributors and users alike.**

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [x] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
