### PR TITLE
Improve tx result message

### DIFF
--- a/.changelog/unreleased/improvements/4039-adjust-tx-response-output.md
+++ b/.changelog/unreleased/improvements/4039-adjust-tx-response-output.md
@@ -1,0 +1,2 @@
+- Improved the display of transactions' results.
+  ([\#4039](https://github.com/anoma/namada/pull/4039))

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -658,8 +658,8 @@ pub enum InnerTxResult<'a> {
     Success(&'a BatchedTxResult),
     /// Some VPs rejected the tx
     VpsRejected(&'a BatchedTxResult),
-    /// Transaction failed in some other way
-    OtherFailure,
+    /// Transaction failed in some other way specified in the associated message
+    OtherFailure(String),
 }
 
 impl TryFrom<Event> for TxResponse {
@@ -720,7 +720,7 @@ impl TxResponse {
                             InnerTxResult::VpsRejected(res)
                         }
                     }
-                    Err(_) => InnerTxResult::OtherFailure,
+                    Err(msg) => InnerTxResult::OtherFailure(msg.to_owned()),
                 };
                 result.insert(inner_hash.to_owned(), value);
             }

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -435,7 +435,7 @@ pub fn display_batch_resp(context: &impl Namada, resp: &TxResponse) {
     // Wrapper-level logs
     display_line!(
         context.io(),
-        "Wrapper transaction {} was applied at height {}, consuming {} gas \
+        "Transaction batch {} was applied at height {}, consuming {} gas \
          units.",
         resp.hash,
         resp.height,

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -432,16 +432,28 @@ pub async fn submit_tx(
 
 /// Display a result of a tx batch.
 pub fn display_batch_resp(context: &impl Namada, resp: &TxResponse) {
-    for (inner_hash, result) in resp.batch_result() {
+    // Wrapper-level logs
+    display_line!(
+        context.io(),
+        "Wrapper transaction {} was applied at height {}, consuming {} gas \
+         units.",
+        resp.hash,
+        resp.height,
+        resp.gas_used
+    );
+    let batch_results = resp.batch_result();
+    if !batch_results.is_empty() {
+        display_line!(context.io(), "Batch results:");
+    }
+
+    // Batch-level logs
+    for (inner_hash, result) in batch_results {
         match result {
             InnerTxResult::Success(_) => {
                 display_line!(
                     context.io(),
-                    "Transaction {} was successfully applied at height {}, \
-                     consuming {} gas units.",
+                    "Transaction {} was successfully applied.",
                     inner_hash,
-                    resp.height,
-                    resp.gas_used
                 );
             }
             InnerTxResult::VpsRejected(inner) => {
@@ -464,12 +476,12 @@ pub fn display_batch_resp(context: &impl Namada, resp: &TxResponse) {
                     serde_json::to_string_pretty(&changed_keys).unwrap(),
                 );
             }
-            InnerTxResult::OtherFailure => {
+            InnerTxResult::OtherFailure(msg) => {
                 edisplay_line!(
                     context.io(),
                     "Transaction {} failed.\nDetails: {}",
                     inner_hash,
-                    serde_json::to_string_pretty(&resp).unwrap()
+                    msg
                 );
             }
         }

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -1187,6 +1187,7 @@ fn transfer(
     timeout_sec: Option<Duration>,
     shielding_data_path: Option<PathBuf>,
     expected_err: Option<&str>,
+    // FIXME: seems like this is always false, we can remove it?
     wait_reveal_pk: bool,
 ) -> Result<u32> {
     let rpc = get_actor_rpc(test, Who::Validator(0));
@@ -1260,11 +1261,14 @@ fn transfer(
             Ok(0)
         }
         None => {
+            let height = check_tx_height(test, &mut client)?;
             client.exp_string(TX_APPLIED_SUCCESS)?;
+            // FIXME: do we need this?
             if wait_reveal_pk {
                 client.exp_string(TX_APPLIED_SUCCESS)?;
             }
-            check_tx_height(test, &mut client)
+
+            Ok(height)
         }
     }
 }

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -120,7 +120,6 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         None,
-        false,
     )?;
     wait_for_packet_relay(&port_id_namada, &channel_id_namada, &test)?;
 
@@ -182,7 +181,6 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         None,
-        false,
     )?;
     wait_for_packet_relay(&port_id_namada, &channel_id_namada, &test)?;
 
@@ -252,7 +250,6 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         None,
-        false,
     )?;
     wait_for_packet_relay(&port_id_namada, &channel_id_namada, &test)?;
     check_balance(&test, AB_VIEWING_KEY, &ibc_denom_on_namada, 40)?;
@@ -299,7 +296,6 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         None,
-        false,
     )?;
     wait_for_packet_relay(&port_id_namada, &channel_id_namada, &test)?;
     // The balance should not be changed
@@ -322,7 +318,6 @@ fn ibc_transfers() -> Result<()> {
         Some(Duration::new(10, 0)),
         None,
         None,
-        false,
     )?;
     // wait for the timeout
     sleep(10);
@@ -349,7 +344,6 @@ fn ibc_transfers() -> Result<()> {
         None,
         None,
         None,
-        false,
     )?;
     wait_for_packet_relay(&port_id_namada, &channel_id_namada, &test)?;
     // Check the token has been refunded to the refund target
@@ -374,7 +368,6 @@ fn ibc_transfers() -> Result<()> {
         Some(Duration::new(10, 0)),
         None,
         None,
-        false,
     )?;
     // wait for the timeout
     sleep(10);
@@ -834,7 +827,6 @@ fn ibc_rate_limit() -> Result<()> {
         None,
         None,
         None,
-        false,
     )?;
 
     // Transfer 1 NAM from Namada to Gaia again will fail
@@ -853,7 +845,6 @@ fn ibc_rate_limit() -> Result<()> {
         Some(
             "Transfer exceeding the per-epoch throughput limit is not allowed",
         ),
-        false,
     )?;
 
     // wait for the next epoch
@@ -876,7 +867,6 @@ fn ibc_rate_limit() -> Result<()> {
         None,
         None,
         None,
-        false,
     )?;
 
     // wait for the next epoch
@@ -1116,7 +1106,6 @@ fn try_invalid_transfers(
         None,
         // the IBC denom can't be parsed when using an invalid port
         Some(&format!("Invalid IBC denom: {nam_addr}")),
-        false,
     )?;
 
     // invalid channel
@@ -1132,7 +1121,6 @@ fn try_invalid_transfers(
         None,
         None,
         Some("IBC token transfer error: context error: `ICS04 Channel error"),
-        false,
     )?;
 
     Ok(())
@@ -1187,8 +1175,6 @@ fn transfer(
     timeout_sec: Option<Duration>,
     shielding_data_path: Option<PathBuf>,
     expected_err: Option<&str>,
-    // FIXME: seems like this is always false, we can remove it?
-    wait_reveal_pk: bool,
 ) -> Result<u32> {
     let rpc = get_actor_rpc(test, Who::Validator(0));
 
@@ -1263,10 +1249,6 @@ fn transfer(
         None => {
             let height = check_tx_height(test, &mut client)?;
             client.exp_string(TX_APPLIED_SUCCESS)?;
-            // FIXME: do we need this?
-            if wait_reveal_pk {
-                client.exp_string(TX_APPLIED_SUCCESS)?;
-            }
 
             Ok(height)
         }


### PR DESCRIPTION
## Describe your changes

Closes #4020.

`display_batch_resp` now logs some information at the batch level followed by the results of the single inner txs. In case of `OtherFailure` we only print the error message for that specific failure instead of the entire tx result.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
