### PR TITLE
Prune more Merkle tree snapshots

### DIFF
--- a/.changelog/unreleased/improvements/4043-prune-more-subtree-snapshots.md
+++ b/.changelog/unreleased/improvements/4043-prune-more-subtree-snapshots.md
@@ -1,0 +1,2 @@
+- Prune old Merkle tree snapshots which are saved every block
+  ([\#4043](https://github.com/anoma/namada/issues/4043))

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::ops::{Deref, DerefMut};
 
+use itertools::Either;
 use namada_core::address::Address;
 use namada_core::arith::checked;
 use namada_core::borsh::BorshSerializeExt;
@@ -393,12 +394,35 @@ where
     // commit.
     fn prune_merkle_tree_stores(
         &mut self,
+        is_full_commit: bool,
         batch: &mut D::WriteBatch,
     ) -> Result<()> {
+        if let Some(prev_height) = self.in_mem.block.height.prev_height() {
+            for st in StoreType::iter().filter(|st| st.is_stored_every_block())
+            {
+                match st {
+                    StoreType::Base => continue,
+                    _ => self.0.db.prune_merkle_tree_store(
+                        batch,
+                        st,
+                        Either::Left(prev_height),
+                    )?,
+                }
+            }
+        }
+
+        if !is_full_commit {
+            return Ok(());
+        }
+
         // Prune non-provable stores at the previous epoch
         if let Some(prev_epoch) = self.in_mem.block.epoch.prev() {
             for st in StoreType::iter_non_provable() {
-                self.0.db.prune_merkle_tree_store(batch, st, prev_epoch)?;
+                self.0.db.prune_merkle_tree_store(
+                    batch,
+                    st,
+                    Either::Right(prev_epoch),
+                )?;
             }
         }
         // Prune provable stores
@@ -411,7 +435,11 @@ where
                 self.db.prune_merkle_tree_store(
                     batch,
                     st,
-                    oldest_epoch.prev().unwrap(),
+                    Either::Right(
+                        oldest_epoch
+                            .prev()
+                            .expect("the previous epoch should exist"),
+                    ),
                 )?;
             }
 
@@ -425,7 +453,7 @@ where
                 self.db.prune_merkle_tree_store(
                     batch,
                     &StoreType::BridgePool,
-                    epoch,
+                    Either::Right(epoch),
                 )?;
             }
         }
@@ -637,10 +665,8 @@ where
             time: header.time,
         });
         self.in_mem.last_epoch = self.in_mem.block.epoch;
-        if is_full_commit {
-            // prune old merkle tree stores
-            self.prune_merkle_tree_stores(&mut batch)?;
-        }
+        // prune old merkle tree stores
+        self.prune_merkle_tree_stores(is_full_commit, &mut batch)?;
         // If there's a previous block, prune non-persisted diffs from it
         if let Some(height) = self.in_mem.block.height.prev_height() {
             self.db.prune_non_persisted_diffs(&mut batch, height)?;
@@ -996,15 +1022,14 @@ where
                 None => BlockHeight(1),
             },
         };
+        // Try to read all subtrees, but some subtrees would be stale or empty.
+        // They will be rebuild later. That's why the tree isn't validated here.
         let stores = self
             .db
             .read_merkle_tree_stores(epoch, start_height, store_type)?
             .ok_or(StateError::NoMerkleTree { height })?;
+        let mut tree = MerkleTree::<H>::new_partial(stores);
         let prefix = store_type.and_then(|st| st.provable_prefix());
-        let mut tree = match store_type {
-            Some(_) => MerkleTree::<H>::new_partial(stores),
-            None => MerkleTree::<H>::new(stores).expect("invalid stores"),
-        };
         // Restore the tree state with diffs
         let mut target_height = start_height;
         while target_height < height {

--- a/crates/state/src/wl_state.rs
+++ b/crates/state/src/wl_state.rs
@@ -397,7 +397,13 @@ where
         is_full_commit: bool,
         batch: &mut D::WriteBatch,
     ) -> Result<()> {
-        if let Some(prev_height) = self.in_mem.block.height.prev_height() {
+        if let Some(prev_height) = self
+            .in_mem
+            .block
+            .height
+            .prev_height()
+            .and_then(|h| h.prev_height())
+        {
             for st in StoreType::iter().filter(|st| st.is_stored_every_block())
             {
                 match st {

--- a/crates/storage/src/db.rs
+++ b/crates/storage/src/db.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::num::TryFromIntError;
 
+use itertools::Either;
 use namada_core::address::EstablishedAddressGen;
 use namada_core::chain::{BlockHeader, BlockHeight, Epoch, Epochs};
 use namada_core::hash::{Error as HashError, Hash};
@@ -169,7 +170,7 @@ pub trait DB: Debug {
 
     /// Read the merkle tree stores with the given epoch. If a store_type is
     /// given, it reads only the specified tree. Otherwise, it reads all
-    /// trees.
+    /// trees, but some subtrees could be empty if the stores aren't saved.
     fn read_merkle_tree_stores(
         &self,
         epoch: Epoch,
@@ -258,7 +259,7 @@ pub trait DB: Debug {
         &mut self,
         batch: &mut Self::WriteBatch,
         store_type: &StoreType,
-        pruned_epoch: Epoch,
+        pruned_target: Either<BlockHeight, Epoch>,
     ) -> Result<()>;
 
     /// Read the signed nonce of Bridge Pool

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "vp_verify_signature"
-version = "0.41.0"
+version = "0.45.1"
 dependencies = [
  "getrandom",
  "namada_vp_prelude",


### PR DESCRIPTION
## Describe your changes
The old Merkle tree snapshots for `NoDiff` and `CommitData` don't need to be saved.
The storage space was occupied by `NoDiff` Merkle tree snapshots.

This PR prunes the previous snapshots at every block commit.
- `prune_merkle_tree_stores` prunes subtree snapshots which are saved every block
  - Other snapshots which are saved every epoch are pruned as before
- `read_merkle_tree_stores` returns incomplete Merkle tree if the store type isn't specified i.e. if it is requested to restore all subtrees. (When the store type is specified, it returns an error if the store type snapshot doesn't exist.) `get_merkle_tree` will rebuild the incomplete subtrees.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
