### PR TITLE
Updates masp gas limit in genesis files

### DIFF
--- a/genesis/hardware/parameters.toml
+++ b/genesis/hardware/parameters.toml
@@ -21,7 +21,7 @@ masp_epoch_multiplier = 2
 # Max gas for block
 max_block_gas = 3_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 65_000
+masp_fee_payment_gas_limit = 100_000
 # Gas scale
 gas_scale = 50_000
 

--- a/genesis/localnet/parameters.toml
+++ b/genesis/localnet/parameters.toml
@@ -21,7 +21,7 @@ masp_epoch_multiplier = 2
 # Max gas for block
 max_block_gas = 3_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 65_000
+masp_fee_payment_gas_limit = 100_000
 # Gas scale
 gas_scale = 50_000
 

--- a/genesis/starter/parameters.toml
+++ b/genesis/starter/parameters.toml
@@ -21,7 +21,7 @@ masp_epoch_multiplier = 2
 # Max gas for block
 max_block_gas = 3_000_000
 # Masp fee payment gas limit
-masp_fee_payment_gas_limit = 65_000
+masp_fee_payment_gas_limit = 100_000
 # Gas scale
 gas_scale = 50_000
 


### PR DESCRIPTION
## Describe your changes

Updates the `masp_fee_payment_gas_limit` in the genesis files to match the one proposed for mainnet.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
