### PR TITLE
Fix shielded sync scanned progress bar limit

### DIFF
--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -557,7 +557,7 @@ where
 
         self.config
             .scanned_tracker
-            .set_upper_limit(self.cache.fetched.len() as u64);
+            .set_upper_limit(self.cache.fetched.shielded_outputs() as u64);
         self.config.applied_tracker.set_upper_limit(
             self.cache.trial_decrypted.successful_decryptions() as u64,
         );
@@ -667,9 +667,9 @@ where
                 self.cache.fetched.extend(tx_batch);
 
                 self.config.fetched_tracker.increment_by(to.0 - from.0 + 1);
-                self.config
-                    .scanned_tracker
-                    .set_upper_limit(self.cache.fetched.len() as u64);
+                self.config.scanned_tracker.set_upper_limit(
+                    self.cache.fetched.shielded_outputs() as u64,
+                );
             }
             Message::FetchTxs(Err(TaskError {
                 error,

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -134,9 +134,16 @@ impl Fetched {
         self.txs.is_empty()
     }
 
-    /// Check the length of the fetched cache
-    pub fn len(&self) -> usize {
-        self.txs.len()
+    /// Return the number of shielded outputs in the cache
+    pub fn shielded_outputs(&self) -> usize {
+        self.txs
+            .values()
+            .map(|shielded| {
+                shielded
+                    .sapling_bundle()
+                    .map_or(0, |x| x.shielded_outputs.len())
+            })
+            .sum::<usize>()
     }
 }
 


### PR DESCRIPTION
## Describe your changes

Fixes the limit of the scanned progress bar in shielded sync being lower than the current value.

### Example

```
Scanned 0 0
ShieldedBalanceChart.tsx:27 Scanned 1 3
ShieldedBalanceChart.tsx:27 Scanned 2 3
ShieldedBalanceChart.tsx:27 Scanned 3 3
ShieldedBalanceChart.tsx:27 Scanned 4 3
ShieldedBalanceChart.tsx:27 Scanned 5 3
ShieldedBalanceChart.tsx:27 Scanned 6 3
ShieldedBalanceChart.tsx:27 Scanned 7 5
ShieldedBalanceChart.tsx:27 Scanned 8 5
ShieldedBalanceChart.tsx:27 Scanned 9 5
ShieldedBalanceChart.tsx:27 Scanned 10 5
ShieldedBalanceChart.tsx:27 Scanned 11 7
ShieldedBalanceChart.tsx:27 Scanned 12 7
ShieldedBalanceChart.tsx:27 Scanned 13 7
ShieldedBalanceChart.tsx:27 Scanned 14 8
ShieldedBalanceChart.tsx:27 Scanned 15 8
ShieldedBalanceChart.tsx:27 Scanned 16 8
ShieldedBalanceChart.tsx:27 Scanned 17 10
ShieldedBalanceChart.tsx:27 Scanned 18 10
ShieldedBalanceChart.tsx:27 Scanned 19 10
```

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
