### PR TITLE
Fix client missing help messages

### DIFF
--- a/.changelog/unreleased/improvements/4047-fix-help-msgs.md
+++ b/.changelog/unreleased/improvements/4047-fix-help-msgs.md
@@ -1,0 +1,2 @@
+- Client now prints help messages on missing arguments.
+  ([\#4047](https://github.com/anoma/namada/pull/4047))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -1324,6 +1324,7 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about(wrap!("Send a transaction with custom WASM code."))
+                .arg_required_else_help(true)
                 .add_args::<args::TxCustom<args::CliTypes>>()
         }
     }
@@ -1475,6 +1476,7 @@ pub mod cmds {
                     "Send a signed transaction to create a new established \
                      account."
                 ))
+                .arg_required_else_help(true)
                 .add_args::<args::TxInitAccount<args::CliTypes>>()
         }
     }
@@ -2179,8 +2181,6 @@ pub mod cmds {
     #[derive(Clone, Debug)]
     pub struct QueryFindValidator(pub args::QueryFindValidator<args::CliTypes>);
 
-    // FIXME: check that all the namadac subcommand (and maybe the wallet and
-    // node too) print information when nothing is provided
     impl SubCmd for QueryFindValidator {
         const CMD: &'static str = "find-validator";
 
@@ -2199,6 +2199,7 @@ pub mod cmds {
                     "Find a PoS validator and its consensus key by its native \
                      address or Tendermint address."
                 ))
+                .arg_required_else_help(true)
                 .add_args::<args::QueryFindValidator<args::CliTypes>>()
         }
     }
@@ -7313,19 +7314,11 @@ pub mod args {
             let validator_addr = VALIDATOR_OPT.parse(matches);
 
             let addr = match (tm_addr, validator_addr) {
-                (Some(_), Some(_)) => unreachable!(
-                    "Cli should prevent the presence of both --{} and --{}",
-                    TM_ADDRESS_OPT.name, VALIDATOR_OPT.name
-                ),
                 (Some(tm_addr), None) => Either::Left(tm_addr),
                 (None, Some(validator_addr)) => Either::Right(validator_addr),
-                (None, None) => {
-                    eprintln!(
-                        "Missing argument: please specify one of --{} or --{}",
-                        TM_ADDRESS_OPT.name, VALIDATOR_OPT.name
-                    );
-                    safe_exit(1)
-                }
+                _ => unreachable!(
+                    "Wrong arguments supplied, CLI should prevent this"
+                ),
             };
             Self { query, addr }
         }

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -7310,7 +7310,6 @@ pub mod args {
             let query = Query::parse(matches);
             let tm_addr = TM_ADDRESS_OPT.parse(matches);
             let validator_addr = VALIDATOR_OPT.parse(matches);
-            // FIXME: maybe I can panic here if both are none
             // FIXME: so to recap, these args are optional but at least one of
             // them must be provided and both of them should never be provided
             // cause it doesn't make sense FIXME: so probably we
@@ -7336,18 +7335,19 @@ pub mod args {
 
         fn def(app: App) -> App {
             app.add_args::<Query<CliTypes>>()
-                // FIXME: here, I believe the issue is that both args are
-                // optional. Is teh validator really optional though? yes
-                // FIXME: pobably these two should confclit with each other
                 .arg(
-                    TM_ADDRESS_OPT.def().help(wrap!(
-                        "The address of the validator in Tendermint."
-                    )),
+                    TM_ADDRESS_OPT
+                        .def()
+                        .help(wrap!(
+                            "The address of the validator in Tendermint."
+                        ))
+                        .conflicts_with(VALIDATOR_OPT.name),
                 )
                 .arg(
                     VALIDATOR_OPT
                         .def()
-                        .help(wrap!("The native address of the validator.")),
+                        .help(wrap!("The native address of the validator."))
+                        .conflicts_with(TM_ADDRESS_OPT.name),
                 )
         }
     }

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -3360,6 +3360,7 @@ pub mod args {
     use std::str::FromStr;
 
     use data_encoding::HEXUPPER;
+    use either::Either;
     use namada_core::masp::{MaspEpoch, PaymentAddress};
     use namada_sdk::address::{Address, EstablishedAddress};
     pub use namada_sdk::args::*;
@@ -7310,27 +7311,23 @@ pub mod args {
             let query = Query::parse(matches);
             let tm_addr = TM_ADDRESS_OPT.parse(matches);
             let validator_addr = VALIDATOR_OPT.parse(matches);
-            // FIXME: so to recap, these args are optional but at least one of
-            // them must be provided and both of them should never be provided
-            // cause it doesn't make sense FIXME: so probably we
-            // should just change the fields of the struct to a single one which
-            // is an Either. If both are provided which one shoudl take
-            // precedence? Maybe we can reject if both are provided, or we can
-            // just accept both and state th precedence in the help message? Use
-            // the same precedence we are using right now, so VALIDATOR opr over
-            // TM_AD
-            if tm_addr.is_none() && validator_addr.is_none() {
-                eprintln!(
-                    "Missing argument: please specify one of --{} or --{}",
+
+            let addr = match (tm_addr, validator_addr) {
+                (Some(_), Some(_)) => unreachable!(
+                    "Cli should prevent the presence of both --{} and --{}",
                     TM_ADDRESS_OPT.name, VALIDATOR_OPT.name
-                );
-                safe_exit(1)
-            }
-            Self {
-                query,
-                tm_addr,
-                validator_addr,
-            }
+                ),
+                (Some(tm_addr), None) => Either::Left(tm_addr),
+                (None, Some(validator_addr)) => Either::Right(validator_addr),
+                (None, None) => {
+                    eprintln!(
+                        "Missing argument: please specify one of --{} or --{}",
+                        TM_ADDRESS_OPT.name, VALIDATOR_OPT.name
+                    );
+                    safe_exit(1)
+                }
+            };
+            Self { query, addr }
         }
 
         fn def(app: App) -> App {
@@ -7361,10 +7358,9 @@ pub mod args {
         ) -> Result<QueryFindValidator<SdkTypes>, Self::Error> {
             Ok(QueryFindValidator::<SdkTypes> {
                 query: self.query.to_sdk(ctx)?,
-                tm_addr: self.tm_addr,
-                validator_addr: self
-                    .validator_addr
-                    .map(|x| ctx.borrow_chain_or_exit().get(&x)),
+                addr: self.addr.map_right(|validator_addr| {
+                    ctx.borrow_chain_or_exit().get(&validator_addr)
+                }),
             })
         }
     }

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -5,6 +5,7 @@ use std::io;
 
 use borsh::BorshDeserialize;
 use data_encoding::HEXLOWER;
+use either::Either;
 use masp_primitives::asset_type::AssetType;
 use masp_primitives::merkle_tree::MerklePath;
 use masp_primitives::sapling::Node;
@@ -1803,67 +1804,64 @@ pub async fn query_find_validator<N: Namada>(
     context: &N,
     args: args::QueryFindValidator,
 ) {
-    let args::QueryFindValidator {
-        query: _,
-        tm_addr,
-        mut validator_addr,
-    } = args;
-    if let Some(tm_addr) = tm_addr {
-        if tm_addr.len() != 40 {
-            edisplay_line!(
-                context.io(),
-                "Expected 40 characters in Tendermint address, got {}",
-                tm_addr.len()
-            );
-            cli::safe_exit(1);
-        }
-        let tm_addr = tm_addr.to_ascii_uppercase();
-        let validator = unwrap_client_response::<N::Client, _>(
-            RPC.vp()
-                .pos()
-                .validator_by_tm_addr(context.client(), &tm_addr)
-                .await,
-        );
-        match validator {
-            Some(address) => {
-                display_line!(
+    let args::QueryFindValidator { query: _, addr } = args;
+    let validator_addr = match addr {
+        Either::Left(comet_addr) => {
+            // Retrieve the native address from the Comet one
+            if comet_addr.len() != 40 {
+                edisplay_line!(
                     context.io(),
-                    "Found validator address \"{address}\"."
+                    "Expected 40 characters in Tendermint address, got {}",
+                    comet_addr.len()
                 );
-                if validator_addr.is_none() {
-                    validator_addr = Some(address);
+                cli::safe_exit(1);
+            }
+            let tm_addr = comet_addr.to_ascii_uppercase();
+            let validator = unwrap_client_response::<N::Client, _>(
+                RPC.vp()
+                    .pos()
+                    .validator_by_tm_addr(context.client(), &tm_addr)
+                    .await,
+            );
+            match validator {
+                Some(address) => {
+                    display_line!(
+                        context.io(),
+                        "Found validator address \"{address}\"."
+                    );
+                    address
+                }
+                None => {
+                    edisplay_line!(
+                        context.io(),
+                        "No validator with Tendermint address {tm_addr} found."
+                    );
+                    cli::safe_exit(1);
                 }
             }
-            None => {
-                display_line!(
-                    context.io(),
-                    "No validator with Tendermint address {tm_addr} found."
-                )
-            }
         }
-    }
-    if let Some(validator_addr) = validator_addr {
-        if let Some(consensus_key) = unwrap_client_response::<N::Client, _>(
-            RPC.vp()
-                .pos()
-                .consensus_key(context.client(), &validator_addr)
-                .await,
-        ) {
-            let pkh: PublicKeyHash = (&consensus_key).into();
-            display_line!(context.io(), "Consensus key: {consensus_key}");
-            display_line!(
-                context.io(),
-                "Tendermint key: {}",
-                tm_consensus_key_raw_hash(&consensus_key)
-            );
-            display_line!(context.io(), "Consensus key hash: {}", pkh);
-        } else {
-            display_line!(
-                context.io(),
-                "Consensus key for validator {validator_addr} could not be \
-                 found."
-            )
-        }
+        Either::Right(validator_addr) => validator_addr,
+    };
+
+    if let Some(consensus_key) = unwrap_client_response::<N::Client, _>(
+        RPC.vp()
+            .pos()
+            .consensus_key(context.client(), &validator_addr)
+            .await,
+    ) {
+        let pkh: PublicKeyHash = (&consensus_key).into();
+        display_line!(context.io(), "Consensus key: {consensus_key}");
+        display_line!(
+            context.io(),
+            "Tendermint key: {}",
+            tm_consensus_key_raw_hash(&consensus_key)
+        );
+        display_line!(context.io(), "Consensus key hash: {}", pkh);
+    } else {
+        display_line!(
+            context.io(),
+            "Consensus key for validator {validator_addr} could not be found."
+        )
     }
 }
 

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration as StdDuration;
 
+use either::Either;
 use namada_core::address::Address;
 use namada_core::chain::{BlockHeight, ChainId, Epoch};
 use namada_core::collections::HashMap;
@@ -2252,10 +2253,8 @@ pub struct QueryStakingRewardsRate<C: NamadaTypes = SdkTypes> {
 pub struct QueryFindValidator<C: NamadaTypes = SdkTypes> {
     /// Common query args
     pub query: Query<C>,
-    /// Tendermint address
-    pub tm_addr: Option<String>,
-    /// Native validator address
-    pub validator_addr: Option<C::Address>,
+    /// Validator address, either Comet or native
+    pub addr: Either<String, C::Address>,
 }
 
 /// Query the raw bytes of given storage key


### PR DESCRIPTION
## Describe your changes

Closes #4022.

Adds a call to `arg_required_else_help` for `TxCustom`, `TxInitAccount` and `QueryFindValidator` to print the command's help message when no arguments are provided.

Modified `QueryFindValidator` to carry a single address instead of two and updated the logic of `query_find_validator` to account for this.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
