### PR TITLE
dump tx output for reveal_pk transactions when requested

### DIFF
--- a/.changelog/unreleased/bug-fixes/4061-dump-reveal-pk.md
+++ b/.changelog/unreleased/bug-fixes/4061-dump-reveal-pk.md
@@ -1,0 +1,4 @@
+- fix the cli command 'namada client reveal_pk' to respect the
+  '--dump-tx' and '--dump-wrapper-tx' flags when present. this
+  allows offline accounts to reveal their public keys to the network
+  ([\#4061](https://github.com/anoma/namada/pull/4061))

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -1153,12 +1153,19 @@ pub async fn submit_reveal_pk<N: Namada>(
 where
     <N::Client as namada_sdk::io::Client>::Error: std::fmt::Display,
 {
-    let tx_data =
-        submit_reveal_aux(namada, &args.tx, &(&args.public_key).into()).await?;
+    if args.tx.dump_tx || args.tx.dump_wrapper_tx {
+        let tx_data =
+            tx::build_reveal_pk(namada, &args.tx, &args.public_key).await?;
+        tx::dump_tx(namada.io(), &args.tx, tx_data.0.clone())?;
+    } else {
+        let tx_data =
+            submit_reveal_aux(namada, &args.tx, &(&args.public_key).into())
+                .await?;
 
-    if let Some((mut tx, signing_data)) = tx_data {
-        sign(namada, &mut tx, &args.tx, signing_data).await?;
-        namada.submit(tx, &args.tx).await?;
+        if let Some((mut tx, signing_data)) = tx_data {
+            sign(namada, &mut tx, &args.tx, signing_data).await?;
+            namada.submit(tx, &args.tx).await?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Describe your changes
It is currently not possible to generate the `reveal_pk` transaction offline. This PR will dump the transaction when requested. 


## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
