### PR TITLE
Narrow down shielding retry logic

### DIFF
--- a/.changelog/unreleased/improvements/4071-narrow-shielding-retry-logic.md
+++ b/.changelog/unreleased/improvements/4071-narrow-shielding-retry-logic.md
@@ -1,0 +1,3 @@
+- Improved the client's retry logic on failed shielding transactions
+  to avoid resubmissions on rejections other than the MASP vp ones.
+  ([\#4071](https://github.com/anoma/namada/pull/4071))

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -896,8 +896,20 @@ pub async fn submit_shielding_transfer(
                 ))
             {
                 let rejected_vps = &result.vps_result.rejected_vps;
-                // If the transaction is rejected by the MASP VP only
-                if rejected_vps.len() == 1 && rejected_vps.contains(&MASP) {
+                let vps_errors = &result.vps_result.errors;
+                // If the transaction is rejected by the MASP VP only and
+                // because of an asset's epoch issue
+                if rejected_vps.len() == 1
+                    && (vps_errors.contains(&(
+                        MASP,
+                        "Native VP error: epoch is missing from asset type"
+                            .to_string(),
+                    )) || vps_errors.contains(&(
+                        MASP,
+                        "Native VP error: Unable to decode asset type"
+                            .to_string(),
+                    )))
+                {
                     let submission_masp_epoch =
                         rpc::query_and_print_masp_epoch(namada).await;
                     // And its submission epoch doesn't match construction

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -6,7 +6,7 @@ use borsh_ext::BorshSerializeExt;
 use color_eyre::owo_colors::OwoColorize;
 use ledger_namada_rs::{BIP44Path, NamadaApp};
 use namada_core::masp::MaspTransaction;
-use namada_sdk::address::{Address, ImplicitAddress};
+use namada_sdk::address::{Address, ImplicitAddress, MASP};
 use namada_sdk::args::TxBecomeValidator;
 use namada_sdk::collections::HashSet;
 use namada_sdk::governance::cli::onchain::{
@@ -887,32 +887,42 @@ pub async fn submit_shielding_transfer(
         )
         .await?;
 
+        // FIXME: maybe better and if let here since we are only interested in
+        // one case
         match result {
-                ProcessTxResponse::Applied(resp) if
-                    // If a transaction is rejected by a VP
-                    matches!(
-                        resp.batch_result().get(&compute_inner_tx_hash(
-                            wrapper_hash.as_ref(),
-                            either::Left(&cmt_hash)
-                        )),
-                        Some(InnerTxResult::VpsRejected(_))
-                    ) =>
+            ProcessTxResponse::Applied(resp) => {
+                if let Some(InnerTxResult::VpsRejected(result)) =
+                    resp.batch_result().get(&compute_inner_tx_hash(
+                        wrapper_hash.as_ref(),
+                        either::Left(&cmt_hash),
+                    ))
                 {
-                    let submission_masp_epoch = rpc::query_and_print_masp_epoch(namada).await;
-                    // And its submission epoch doesn't match construction epoch
-                    if tx_epoch != submission_masp_epoch {
-                        // Then we probably straddled an epoch boundary. Let's retry...
-                        edisplay_line!(namada.io(),
-                            "Shielding transaction rejected and this may be due to the \
-                            epoch changing. Attempting to resubmit transaction.",
-                        );
-                        continue;
+                    let rejected_vps = &result.vps_result.rejected_vps;
+                    // If a transaction is rejected by the MASP VP only
+                    if rejected_vps.len() == 1 && rejected_vps.contains(&MASP) {
+                        let submission_masp_epoch =
+                            rpc::query_and_print_masp_epoch(namada).await;
+                        // And its submission epoch doesn't match construction
+                        // epoch
+                        if tx_epoch != submission_masp_epoch {
+                            // Then we probably straddled an epoch boundary.
+                            // Let's retry...
+                            edisplay_line!(
+                                namada.io(),
+                                "Shielding transaction rejected and this may \
+                                 be due to the epoch changing. Attempting to \
+                                 resubmit transaction.",
+                            );
+                            continue;
+                        }
                     }
-                },
-                // Otherwise either the transaction was successful or it will not
-                // benefit from resubmission
-                _ => break,
+                }
+                break;
             }
+            // Otherwise either the transaction was successful or it will not
+            // benefit from resubmission
+            _ => break,
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Describe your changes

Closes #4045.

Ensures that the retry logic for a failed shielding tx hitting an epoch boundary is applied only when the MASP vp is the only one rejecting the tx and the error is among the expected ones.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
