### PR TITLE
IBC Packet Forward Middleware

### DIFF
--- a/.changelog/unreleased/features/4082-ibc-pfm.md
+++ b/.changelog/unreleased/features/4082-ibc-pfm.md
@@ -1,0 +1,3 @@
+- Implement compatibility with Strangelove's Packet Forward Middleware
+  in Namada, to allow forwarding ICS-20 packets over multiple chains.
+  ([\#4082](https://github.com/anoma/namada/pull/4082))

--- a/.github/workflows/scripts/e2e.json
+++ b/.github/workflows/scripts/e2e.json
@@ -6,6 +6,8 @@
     "e2e::ibc_tests::fee_payment_with_ibc_token": 357,
     "e2e::ibc_tests::ibc_token_inflation": 840,
     "e2e::ibc_tests::ibc_rate_limit": 485,
+    "e2e::ibc_tests::ibc_pfm_happy_flows": 485,
+    "e2e::ibc_tests::ibc_pfm_unhappy_flows": 485,
     "e2e::ibc_tests::ibc_upgrade_client": 280,
     "e2e::eth_bridge_tests::test_add_to_bridge_pool": 10,
     "e2e::ledger_tests::double_signing_gets_slashed": 12,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,6 +1893,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "dur"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5b6c91b5e394b75cd96c36393fc938496c030220207a0ccf34d6cd313d3b49"
+dependencies = [
+ "nom",
+ "rust_decimal",
+]
+
+[[package]]
 name = "duration-str"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,7 +3350,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -3353,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -3363,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
@@ -3385,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -3395,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3414,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -3423,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -3440,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -3457,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -3471,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -3480,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3496,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -3511,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3535,7 +3545,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -3548,7 +3558,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3564,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3585,7 +3595,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3605,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -3619,7 +3629,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3641,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3656,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3681,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3699,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3722,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3738,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3752,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -3771,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.8.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3779,9 +3789,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ibc-middleware-packet-forward"
+version = "0.6.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.6.0#ca824cfbe550c529d30bf27a97026dd0a058cfdf"
+dependencies = [
+ "borsh",
+ "dur",
+ "either",
+ "ibc-app-transfer-types",
+ "ibc-core-channel",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ibc-primitives"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3822,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3833,7 +3862,7 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "basecoin-store",
  "derive_more",
@@ -5162,8 +5191,10 @@ dependencies = [
  "assert_matches",
  "borsh",
  "data-encoding",
+ "dur",
  "ibc",
  "ibc-derive",
+ "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "konst",
@@ -5593,12 +5624,14 @@ dependencies = [
  "concat-idents",
  "data-encoding",
  "derivative",
+ "dur",
  "escargot",
  "expectrl",
  "eyre",
  "flate2",
  "fs_extra",
  "hyper 0.14.27",
+ "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "itertools 0.12.1",
@@ -7284,12 +7317,18 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arrayvec",
+ "borsh",
+ "bytes",
  "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -7679,11 +7718,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ derivation-path = "0.2.0"
 derivative = "2.2.0"
 directories = "4.0.1"
 drain_filter_polyfill = "0.1.3"
+dur = "0.5.3"
 duration-str = "0.10.0"
 ed25519-consensus = "2.1.0"
 either = "1.12.0"
@@ -117,10 +118,11 @@ flume = "0.11.1"
 fs_extra = "1.2.0"
 futures = "0.3"
 git2 = { version = "0.18.1", default-features = false }
-# branch yuji/derive-arbitrary
-ibc = { git = "https://github.com/heliaxdev/cosmos-ibc-rs", rev = "38bd2a32f35117d4d9165a3c68c64ccd87ad56dd", features = ["serde"] }
-ibc-derive = { git = "https://github.com/heliaxdev/cosmos-ibc-rs", rev = "38bd2a32f35117d4d9165a3c68c64ccd87ad56dd" }
-ibc-testkit = { git = "https://github.com/heliaxdev/cosmos-ibc-rs", rev = "38bd2a32f35117d4d9165a3c68c64ccd87ad56dd", default-features = false }
+# branch tiago/optional-ack
+ibc = { git = "https://github.com/heliaxdev/cosmos-ibc-rs", rev = "aa229566e6bb688cc2626dab276c3849abc0c583", features = ["serde"] }
+ibc-derive = { git = "https://github.com/heliaxdev/cosmos-ibc-rs", rev = "aa229566e6bb688cc2626dab276c3849abc0c583" }
+ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "pfm/v0.6.0", features = ["borsh"] }
+ibc-testkit = { git = "https://github.com/heliaxdev/cosmos-ibc-rs", rev = "aa229566e6bb688cc2626dab276c3849abc0c583", default-features = false }
 ics23 = "0.12.0"
 usize-set = { version = "0.10.3", features = ["serialize-borsh", "serialize-serde"] }
 indexmap = { package = "nam-indexmap", version = "2.7.1-nam.0", features = ["borsh-schema", "serde"] }
@@ -168,7 +170,7 @@ rpassword = "5.0.1"
 rustversion = "1.0"
 serde = {version = "1.0.125", features = ["derive"]}
 serde_bytes = "0.11.5"
-serde_json = "1.0.62"
+serde_json = "1.0.133"
 serde_tuple = "0.5.0"
 sha2 = "0.9.3"
 sha2-const = "0.1.2"

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -24,6 +24,7 @@ use namada_apps_lib::governance::pgf::storage::steward::StewardDetail;
 use namada_apps_lib::governance::storage::proposal::ProposalType;
 use namada_apps_lib::governance::storage::vote::ProposalVote;
 use namada_apps_lib::governance::{InitProposalData, VoteProposalData};
+use namada_apps_lib::ibc::context::pfm_mod::PfmTransferModule;
 use namada_apps_lib::ibc::core::channel::types::channel::Order;
 use namada_apps_lib::ibc::core::channel::types::msgs::MsgChannelOpenInit;
 use namada_apps_lib::ibc::core::channel::types::Version as ChannelVersion;
@@ -35,9 +36,7 @@ use namada_apps_lib::ibc::core::host::types::identifiers::{
     ClientId, ConnectionId, PortId,
 };
 use namada_apps_lib::ibc::primitives::ToProto;
-use namada_apps_lib::ibc::{
-    IbcActions, NftTransferModule, TransferModule, COMMITMENT_PREFIX,
-};
+use namada_apps_lib::ibc::{IbcActions, NftTransferModule, COMMITMENT_PREFIX};
 use namada_apps_lib::masp_primitives::merkle_tree::CommitmentTree;
 use namada_apps_lib::masp_primitives::transaction::Transaction;
 use namada_apps_lib::masp_proofs::sapling::SaplingVerificationContextInner;
@@ -1725,7 +1724,10 @@ fn ibc_vp_validate_action(c: &mut Criterion) {
             );
         actions.set_validation_params(ibc.validation_params().unwrap());
 
-        let module = TransferModule::new(ctx.clone(), verifiers);
+        let module = PfmTransferModule::<_, parameters::Store<_>>::wrap(
+            ctx.clone(),
+            verifiers,
+        );
         actions.add_transfer_module(module);
         let module = NftTransferModule::<_, token::Store<()>>::new(ctx);
         actions.add_transfer_module(module);
@@ -1786,7 +1788,10 @@ fn ibc_vp_execute_action(c: &mut Criterion) {
             );
         actions.set_validation_params(ibc.validation_params().unwrap());
 
-        let module = TransferModule::new(ctx.clone(), verifiers);
+        let module = PfmTransferModule::<_, parameters::Store<_>>::wrap(
+            ctx.clone(),
+            verifiers,
+        );
         actions.add_transfer_module(module);
         let module = NftTransferModule::<_, token::Store<()>>::new(ctx);
         actions.add_transfer_module(module);

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -40,10 +40,12 @@ namada_vp = { path = "../vp" }
 arbitrary = { workspace = true, optional = true }
 borsh.workspace = true
 data-encoding.workspace = true
+dur.workspace = true
 konst.workspace = true
 linkme = {workspace = true, optional = true}
 ibc.workspace = true
 ibc-derive.workspace = true
+ibc-middleware-packet-forward.workspace = true
 ibc-testkit = {workspace = true, optional = true}
 ics23.workspace = true
 masp_primitives.workspace = true

--- a/crates/ibc/src/context/common.rs
+++ b/crates/ibc/src/context/common.rs
@@ -576,14 +576,11 @@ pub trait IbcCommonContext: IbcStorageContext {
         port_id: &PortId,
         channel_id: &ChannelId,
         sequence: Sequence,
-    ) -> Result<AcknowledgementCommitment> {
+    ) -> Result<Option<AcknowledgementCommitment>> {
         let key = storage::ack_key(port_id, channel_id, sequence);
         match self.storage().read_bytes(&key)? {
-            Some(value) => Ok(value.into()),
-            None => {
-                Err(PacketError::PacketAcknowledgementNotFound { sequence }
-                    .into())
-            }
+            Some(value) => Ok(Some(value.into())),
+            None => Ok(None),
         }
     }
 

--- a/crates/ibc/src/context/mod.rs
+++ b/crates/ibc/src/context/mod.rs
@@ -5,6 +5,7 @@ pub mod common;
 pub mod execution;
 pub mod nft_transfer;
 pub mod nft_transfer_mod;
+pub mod pfm_mod;
 pub mod router;
 pub mod storage;
 pub mod token_transfer;

--- a/crates/ibc/src/context/nft_transfer_mod.rs
+++ b/crates/ibc/src/context/nft_transfer_mod.rs
@@ -261,7 +261,7 @@ where
         &mut self,
         packet: &Packet,
         _relayer: &Signer,
-    ) -> (ModuleExtras, Acknowledgement) {
+    ) -> (ModuleExtras, Option<Acknowledgement>) {
         on_recv_packet_execute(&mut self.ctx, packet)
     }
 
@@ -482,10 +482,10 @@ pub mod testing {
             &mut self,
             _packet: &Packet,
             _relayer: &Signer,
-        ) -> (ModuleExtras, Acknowledgement) {
+        ) -> (ModuleExtras, Option<Acknowledgement>) {
             (
                 ModuleExtras::empty(),
-                AcknowledgementStatus::success(ack_success_b64()).into(),
+                Some(AcknowledgementStatus::success(ack_success_b64()).into()),
             )
         }
 

--- a/crates/ibc/src/context/pfm_mod.rs
+++ b/crates/ibc/src/context/pfm_mod.rs
@@ -1,0 +1,529 @@
+//! Implementation of Packet Forward Middleware on top of the ICS-20
+//! [`TransferModule`].
+
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use ibc::apps::transfer::context::TokenTransferExecutionContext;
+use ibc::apps::transfer::handler::{
+    refund_packet_token_execute, send_transfer_execute,
+};
+use ibc::apps::transfer::types::msgs::transfer::MsgTransfer;
+use ibc::apps::transfer::types::packet::PacketData;
+use ibc::apps::transfer::types::{is_receiver_chain_source, TracePrefix};
+use ibc::core::channel::handler::{
+    commit_packet_acknowledgment, emit_packet_acknowledgement_event,
+};
+use ibc::core::channel::types::acknowledgement::Acknowledgement;
+use ibc::core::channel::types::channel::{Counterparty, Order};
+use ibc::core::channel::types::error::{ChannelError, PacketError};
+use ibc::core::channel::types::packet::Packet;
+use ibc::core::channel::types::timeout::TimeoutTimestamp;
+use ibc::core::channel::types::Version;
+use ibc::core::host::types::identifiers::{
+    ChannelId, ConnectionId, PortId, Sequence,
+};
+use ibc::core::router::module::Module;
+use ibc::core::router::types::module::{ModuleExtras, ModuleId};
+use ibc::primitives::Signer;
+use ibc_middleware_packet_forward::{
+    InFlightPacket, InFlightPacketKey, PacketForwardMiddleware, PfmContext,
+};
+use namada_core::address::{Address, IBC as IBC_ADDRESS, MULTITOKEN};
+use namada_core::storage::{self, KeySeg};
+use namada_state::{StorageRead, StorageWrite};
+
+use crate::context::transfer_mod::TransferModule;
+use crate::context::IbcContext;
+use crate::{
+    Error, IbcCommonContext, IbcStorageContext, ModuleWrapper,
+    TokenTransferContext,
+};
+
+const MIDDLEWARES_SUBKEY: &str = "middleware";
+const PFM_SUBKEY: &str = "pfm";
+
+/// Get the Namada storage key associated to the provided `InFlightPacketKey`.
+pub fn get_inflight_packet_key(
+    inflight_packet_key: &InFlightPacketKey,
+) -> storage::Key {
+    let key: storage::Key = IBC_ADDRESS.to_db_key().into();
+    key.with_segment(MIDDLEWARES_SUBKEY.to_string())
+        .with_segment(PFM_SUBKEY.to_string())
+        .with_segment(inflight_packet_key.port.to_string())
+        .with_segment(inflight_packet_key.channel.to_string())
+        .with_segment(inflight_packet_key.sequence.to_string())
+}
+
+/// A wrapper around an IBC transfer module necessary to
+/// build execution contexts. This allows us to implement
+/// packet forward middleware on this struct.
+pub struct PfmTransferModule<C, Params>
+where
+    C: IbcCommonContext + Debug,
+{
+    /// The main module
+    pub transfer_module: TransferModule<C>,
+    #[allow(missing_docs)]
+    pub _phantom: PhantomData<Params>,
+}
+
+impl<C, Params> PfmTransferModule<C, Params>
+where
+    C: IbcCommonContext + Debug,
+{
+    /// Create a new [`PfmTransferModule`]
+    pub fn wrap(
+        ctx: Rc<RefCell<C>>,
+        verifiers: Rc<RefCell<BTreeSet<Address>>>,
+    ) -> PacketForwardMiddleware<Self> {
+        PacketForwardMiddleware::next(Self {
+            transfer_module: TransferModule::new(ctx, verifiers),
+            _phantom: Default::default(),
+        })
+    }
+}
+
+impl<C: IbcCommonContext + Debug, Params> Debug
+    for PfmTransferModule<C, Params>
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(stringify!(PfmTransferModule))
+            .field("transfer_module", &self.transfer_module)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<C, Params> Module for PfmTransferModule<C, Params>
+where
+    C: IbcCommonContext + Debug,
+{
+    fn on_chan_open_init_validate(
+        &self,
+        order: Order,
+        connection_hops: &[ConnectionId],
+        port_id: &PortId,
+        channel_id: &ChannelId,
+        counterparty: &Counterparty,
+        version: &Version,
+    ) -> Result<Version, ChannelError> {
+        self.transfer_module.on_chan_open_init_validate(
+            order,
+            connection_hops,
+            port_id,
+            channel_id,
+            counterparty,
+            version,
+        )
+    }
+
+    fn on_chan_open_init_execute(
+        &mut self,
+        order: Order,
+        connection_hops: &[ConnectionId],
+        port_id: &PortId,
+        channel_id: &ChannelId,
+        counterparty: &Counterparty,
+        version: &Version,
+    ) -> Result<(ModuleExtras, Version), ChannelError> {
+        self.transfer_module.on_chan_open_init_execute(
+            order,
+            connection_hops,
+            port_id,
+            channel_id,
+            counterparty,
+            version,
+        )
+    }
+
+    fn on_chan_open_try_validate(
+        &self,
+        order: Order,
+        connection_hops: &[ConnectionId],
+        port_id: &PortId,
+        channel_id: &ChannelId,
+        counterparty: &Counterparty,
+        counterparty_version: &Version,
+    ) -> Result<Version, ChannelError> {
+        self.transfer_module.on_chan_open_try_validate(
+            order,
+            connection_hops,
+            port_id,
+            channel_id,
+            counterparty,
+            counterparty_version,
+        )
+    }
+
+    fn on_chan_open_try_execute(
+        &mut self,
+        order: Order,
+        connection_hops: &[ConnectionId],
+        port_id: &PortId,
+        channel_id: &ChannelId,
+        counterparty: &Counterparty,
+        counterparty_version: &Version,
+    ) -> Result<(ModuleExtras, Version), ChannelError> {
+        self.transfer_module.on_chan_open_try_execute(
+            order,
+            connection_hops,
+            port_id,
+            channel_id,
+            counterparty,
+            counterparty_version,
+        )
+    }
+
+    fn on_chan_open_ack_validate(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+        counterparty_version: &Version,
+    ) -> Result<(), ChannelError> {
+        self.transfer_module.on_chan_open_ack_validate(
+            port_id,
+            channel_id,
+            counterparty_version,
+        )
+    }
+
+    fn on_chan_open_ack_execute(
+        &mut self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+        counterparty_version: &Version,
+    ) -> Result<ModuleExtras, ChannelError> {
+        self.transfer_module.on_chan_open_ack_execute(
+            port_id,
+            channel_id,
+            counterparty_version,
+        )
+    }
+
+    fn on_chan_open_confirm_validate(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<(), ChannelError> {
+        self.transfer_module
+            .on_chan_open_confirm_validate(port_id, channel_id)
+    }
+
+    fn on_chan_open_confirm_execute(
+        &mut self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<ModuleExtras, ChannelError> {
+        self.transfer_module
+            .on_chan_open_confirm_execute(port_id, channel_id)
+    }
+
+    fn on_chan_close_init_validate(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<(), ChannelError> {
+        self.transfer_module
+            .on_chan_close_init_validate(port_id, channel_id)
+    }
+
+    fn on_chan_close_init_execute(
+        &mut self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<ModuleExtras, ChannelError> {
+        self.transfer_module
+            .on_chan_close_init_execute(port_id, channel_id)
+    }
+
+    fn on_chan_close_confirm_validate(
+        &self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<(), ChannelError> {
+        self.transfer_module
+            .on_chan_close_confirm_validate(port_id, channel_id)
+    }
+
+    fn on_chan_close_confirm_execute(
+        &mut self,
+        port_id: &PortId,
+        channel_id: &ChannelId,
+    ) -> Result<ModuleExtras, ChannelError> {
+        self.transfer_module
+            .on_chan_close_confirm_execute(port_id, channel_id)
+    }
+
+    fn on_recv_packet_execute(
+        &mut self,
+        packet: &Packet,
+        relayer: &Signer,
+    ) -> (ModuleExtras, Option<Acknowledgement>) {
+        self.transfer_module.on_recv_packet_execute(packet, relayer)
+    }
+
+    fn on_acknowledgement_packet_validate(
+        &self,
+        packet: &Packet,
+        acknowledgement: &Acknowledgement,
+        relayer: &Signer,
+    ) -> Result<(), PacketError> {
+        self.transfer_module.on_acknowledgement_packet_validate(
+            packet,
+            acknowledgement,
+            relayer,
+        )
+    }
+
+    fn on_acknowledgement_packet_execute(
+        &mut self,
+        packet: &Packet,
+        acknowledgement: &Acknowledgement,
+        relayer: &Signer,
+    ) -> (ModuleExtras, Result<(), PacketError>) {
+        self.transfer_module.on_acknowledgement_packet_execute(
+            packet,
+            acknowledgement,
+            relayer,
+        )
+    }
+
+    fn on_timeout_packet_validate(
+        &self,
+        packet: &Packet,
+        relayer: &Signer,
+    ) -> Result<(), PacketError> {
+        self.transfer_module
+            .on_timeout_packet_validate(packet, relayer)
+    }
+
+    fn on_timeout_packet_execute(
+        &mut self,
+        packet: &Packet,
+        relayer: &Signer,
+    ) -> (ModuleExtras, Result<(), PacketError>) {
+        self.transfer_module
+            .on_timeout_packet_execute(packet, relayer)
+    }
+}
+
+impl<C, Params> PfmContext for PfmTransferModule<C, Params>
+where
+    C: IbcCommonContext + Debug,
+    Params: namada_systems::parameters::Read<<C as IbcStorageContext>::Storage>,
+{
+    type Error = crate::Error;
+
+    fn send_transfer_execute(
+        &mut self,
+        msg: MsgTransfer,
+    ) -> Result<Sequence, Self::Error> {
+        let seq = self
+            .transfer_module
+            .ctx
+            .inner
+            .borrow()
+            .get_next_sequence_send(&msg.port_id_on_a, &msg.chan_id_on_a)
+            .map_err(|e| Error::Context(Box::new(e)))?;
+        tracing::debug!(?seq, ?msg, "PFM send_transfer_execute");
+
+        let mut ctx = IbcContext::<C, Params>::new(
+            self.transfer_module.ctx.inner.clone(),
+        );
+        let mut token_transfer_ctx = TokenTransferContext::new(
+            self.transfer_module.ctx.inner.clone(),
+            Default::default(),
+        );
+
+        self.transfer_module.ctx.insert_verifier(&MULTITOKEN);
+
+        send_transfer_execute(&mut ctx, &mut token_transfer_ctx, msg)
+            .map_err(Error::TokenTransfer)?;
+
+        Ok(seq)
+    }
+
+    fn receive_refund_execute(
+        &mut self,
+        packet: &Packet,
+        data: PacketData,
+    ) -> Result<(), Self::Error> {
+        tracing::debug!(?packet, ?data, "PFM receive_refund_execute");
+        let mut token_transfer_ctx = TokenTransferContext::new(
+            self.transfer_module.ctx.inner.clone(),
+            self.transfer_module.ctx.verifiers.clone(),
+        );
+        self.transfer_module.ctx.insert_verifier(&MULTITOKEN);
+        refund_packet_token_execute(&mut token_transfer_ctx, packet, &data)
+            .map_err(Error::TokenTransfer)
+    }
+
+    fn send_refund_execute(
+        &mut self,
+        msg: &InFlightPacket,
+    ) -> Result<(), Self::Error> {
+        tracing::debug!(?msg, "PFM send_refund_execute");
+
+        let packet_data: PacketData = serde_json::from_slice(&msg.packet_data)
+            .expect(
+                "The in-flight packet data should have belonged to an ICS-20 \
+                 packet",
+            );
+
+        let mut token_transfer_ctx = TokenTransferContext::new(
+            self.transfer_module.ctx.inner.clone(),
+            self.transfer_module.ctx.verifiers.clone(),
+        );
+
+        self.transfer_module.ctx.insert_verifier(&MULTITOKEN);
+
+        if is_receiver_chain_source(
+            msg.packet_src_port_id.clone(),
+            msg.packet_src_channel_id.clone(),
+            &packet_data.token.denom,
+        ) {
+            let coin = {
+                let mut c = packet_data.token;
+                c.denom.remove_trace_prefix(&TracePrefix::new(
+                    msg.packet_src_port_id.clone(),
+                    msg.packet_src_channel_id.clone(),
+                ));
+                c
+            };
+
+            token_transfer_ctx
+                .escrow_coins_execute(
+                    &IBC_ADDRESS,
+                    &msg.refund_port_id,
+                    &msg.refund_channel_id,
+                    &coin,
+                    &String::new().into(),
+                )
+                .map_err(Error::TokenTransfer)
+        } else {
+            let coin = {
+                let mut c = packet_data.token;
+                c.denom.add_trace_prefix(TracePrefix::new(
+                    msg.refund_port_id.clone(),
+                    msg.refund_channel_id.clone(),
+                ));
+                c
+            };
+
+            token_transfer_ctx
+                .burn_coins_execute(&IBC_ADDRESS, &coin, &String::new().into())
+                .map_err(Error::TokenTransfer)
+        }
+    }
+
+    fn write_ack_and_events(
+        &mut self,
+        packet: &Packet,
+        acknowledgement: &Acknowledgement,
+    ) -> Result<(), Self::Error> {
+        tracing::debug!(?packet, ?acknowledgement, "PFM write_ack_and_events");
+        let mut ctx = IbcContext::<C, Params>::new(
+            self.transfer_module.ctx.inner.clone(),
+        );
+        commit_packet_acknowledgment(&mut ctx, packet, acknowledgement)
+            .map_err(|e| Error::Context(Box::new(e)))?;
+        emit_packet_acknowledgement_event(
+            &mut ctx,
+            packet.clone(),
+            acknowledgement.clone(),
+        )
+        .map_err(|e| Error::Context(Box::new(e)))
+    }
+
+    fn override_receiver(
+        &self,
+        _channel: &ChannelId,
+        _original_sender: &Signer,
+    ) -> Result<Signer, Self::Error> {
+        Ok(IBC_ADDRESS.to_string().into())
+    }
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn timeout_timestamp(
+        &self,
+        timeout_duration: dur::Duration,
+    ) -> Result<TimeoutTimestamp, Self::Error> {
+        let timestamp = self
+            .transfer_module
+            .ctx
+            .inner
+            .borrow()
+            .host_timestamp()
+            .map_err(|e| Error::Other(e.to_string()))?
+            + timeout_duration.try_to_std().ok_or_else(|| {
+                Error::Other(format!(
+                    "Packet timeout duration is too large: {timeout_duration}"
+                ))
+            })?;
+        let ts = timestamp
+            .map(TimeoutTimestamp::At)
+            .map_err(|e| Error::Other(e.to_string()))?;
+        tracing::debug!(timeout_timestamp = ?ts, "PFM timeout_timestamp");
+        Ok(ts)
+    }
+
+    fn store_inflight_packet(
+        &mut self,
+        key: InFlightPacketKey,
+        inflight_packet: InFlightPacket,
+    ) -> Result<(), Self::Error> {
+        tracing::debug!(?key, ?inflight_packet, "PFM store_inflight_packet");
+        let mut ctx = self.transfer_module.ctx.inner.borrow_mut();
+        let key = get_inflight_packet_key(&key);
+        ctx.storage_mut()
+            .write(&key, inflight_packet)
+            .map_err(Error::Storage)
+    }
+
+    fn retrieve_inflight_packet(
+        &self,
+        key: &InFlightPacketKey,
+    ) -> Result<Option<InFlightPacket>, Self::Error> {
+        let mut ctx = self.transfer_module.ctx.inner.borrow_mut();
+        let key = get_inflight_packet_key(key);
+        let packet = ctx.storage_mut().read(&key).map_err(Error::Storage);
+
+        tracing::debug!(?key, ?packet, "PFM retrieve_inflight_packet");
+
+        packet
+    }
+
+    fn delete_inflight_packet(
+        &mut self,
+        key: &InFlightPacketKey,
+    ) -> Result<(), Self::Error> {
+        tracing::debug!(?key, "PFM delete_inflight_packet");
+        let mut ctx = self.transfer_module.ctx.inner.borrow_mut();
+        let key = get_inflight_packet_key(key);
+        ctx.storage_mut().delete(&key).map_err(Error::Storage)
+    }
+}
+
+impl<T> ModuleWrapper for PacketForwardMiddleware<T>
+where
+    T: Module + PfmContext,
+{
+    fn as_module(&self) -> &dyn Module {
+        self
+    }
+
+    fn as_module_mut(&mut self) -> &mut dyn Module {
+        self
+    }
+
+    fn module_id(&self) -> ModuleId {
+        ModuleId::new(ibc::apps::transfer::types::MODULE_ID_STR.to_string())
+    }
+
+    fn port_id(&self) -> PortId {
+        PortId::transfer()
+    }
+}

--- a/crates/ibc/src/context/token_transfer.rs
+++ b/crates/ibc/src/context/token_transfer.rs
@@ -25,8 +25,8 @@ pub struct TokenTransferContext<C>
 where
     C: IbcCommonContext,
 {
-    inner: Rc<RefCell<C>>,
-    verifiers: Rc<RefCell<BTreeSet<Address>>>,
+    pub(crate) inner: Rc<RefCell<C>>,
+    pub(crate) verifiers: Rc<RefCell<BTreeSet<Address>>>,
     is_shielded: bool,
 }
 
@@ -47,7 +47,7 @@ where
     }
 
     /// Insert a verifier address whose VP will verify the tx.
-    fn insert_verifier(&mut self, addr: &Address) {
+    pub(crate) fn insert_verifier(&mut self, addr: &Address) {
         self.verifiers.borrow_mut().insert(addr.clone());
     }
 

--- a/crates/ibc/src/context/transfer_mod.rs
+++ b/crates/ibc/src/context/transfer_mod.rs
@@ -276,7 +276,7 @@ where
         &mut self,
         packet: &Packet,
         _relayer: &Signer,
-    ) -> (ModuleExtras, Acknowledgement) {
+    ) -> (ModuleExtras, Option<Acknowledgement>) {
         on_recv_packet_execute(&mut self.ctx, packet)
     }
 
@@ -497,10 +497,10 @@ pub mod testing {
             &mut self,
             _packet: &Packet,
             _relayer: &Signer,
-        ) -> (ModuleExtras, Acknowledgement) {
+        ) -> (ModuleExtras, Option<Acknowledgement>) {
             (
                 ModuleExtras::empty(),
-                AcknowledgementStatus::success(ack_success_b64()).into(),
+                Some(AcknowledgementStatus::success(ack_success_b64()).into()),
             )
         }
 

--- a/crates/ibc/src/context/validation.rs
+++ b/crates/ibc/src/context/validation.rs
@@ -5,6 +5,7 @@ use ibc::core::channel::types::channel::ChannelEnd;
 use ibc::core::channel::types::commitment::{
     AcknowledgementCommitment, PacketCommitment,
 };
+use ibc::core::channel::types::error::PacketError;
 use ibc::core::channel::types::packet::Receipt;
 use ibc::core::client::context::{
     ClientValidationContext, ExtClientValidationContext,
@@ -253,11 +254,18 @@ where
         &self,
         path: &AckPath,
     ) -> Result<AcknowledgementCommitment, ContextError> {
-        self.inner.borrow().packet_ack(
+        let maybe_ack = self.inner.borrow().packet_ack(
             &path.port_id,
             &path.channel_id,
             path.sequence,
-        )
+        )?;
+
+        maybe_ack.ok_or_else(|| {
+            PacketError::PacketAcknowledgementNotFound {
+                sequence: path.sequence,
+            }
+            .into()
+        })
     }
 
     fn channel_counter(&self) -> Result<u64, ContextError> {

--- a/crates/ibc/src/vp/mod.rs
+++ b/crates/ibc/src/vp/mod.rs
@@ -27,6 +27,7 @@ use namada_vp::native_vp::{Ctx, CtxPreStorageRead, NativeVp, VpEvaluator};
 use namada_vp::VpEnv;
 use thiserror::Error;
 
+use crate::context::pfm_mod::PfmTransferModule;
 use crate::core::host::types::identifiers::ChainId as IbcChainId;
 use crate::core::host::types::path::UPGRADED_IBC_STATE;
 use crate::event::IbcEvent;
@@ -36,8 +37,8 @@ use crate::storage::{
 };
 use crate::trace::calc_hash;
 use crate::{
-    Error as ActionError, IbcActions, NftTransferModule, TransferModule,
-    ValidationParams, COMMITMENT_PREFIX,
+    Error as ActionError, IbcActions, NftTransferModule, ValidationParams,
+    COMMITMENT_PREFIX,
 };
 
 #[allow(missing_docs)]
@@ -246,7 +247,8 @@ where
             ctx.clone(),
             verifiers.clone(),
         );
-        let module = TransferModule::new(ctx.clone(), verifiers);
+        let module =
+            PfmTransferModule::<_, ParamsPseudo>::wrap(ctx.clone(), verifiers);
         actions.add_transfer_module(module);
         let module = NftTransferModule::<_, Token>::new(ctx.clone());
         actions.add_transfer_module(module);
@@ -301,7 +303,8 @@ where
             IbcActions::<_, Params, Token>::new(ctx.clone(), verifiers.clone());
         actions.set_validation_params(self.validation_params()?);
 
-        let module = TransferModule::new(ctx.clone(), verifiers);
+        let module =
+            PfmTransferModule::<_, Params>::wrap(ctx.clone(), verifiers);
         actions.add_transfer_module(module);
         let module = NftTransferModule::<_, Token>::new(ctx);
         actions.add_transfer_module(module);

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -38,7 +38,9 @@ namada_vm = {path = "../vm", features = ["testing"]}
 
 concat-idents.workspace = true
 derivative.workspace = true
+dur.workspace = true
 hyper = {version = "0.14.20", features = ["full"]}
+ibc-middleware-packet-forward.workspace = true
 ibc-testkit.workspace = true
 ics23.workspace = true
 itertools.workspace = true

--- a/crates/tx_prelude/src/ibc.rs
+++ b/crates/tx_prelude/src/ibc.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use namada_core::address::Address;
 use namada_core::token::Amount;
+use namada_ibc::context::pfm_mod::PfmTransferModule;
 pub use namada_ibc::event::{IbcEvent, IbcEventType};
 pub use namada_ibc::storage::{
     burn_tokens, client_state_key, is_ibc_key, mint_limit_key, mint_tokens,
@@ -19,7 +20,7 @@ pub use namada_ibc::{
 };
 use namada_tx_env::TxEnv;
 
-use crate::{token, Ctx, Result};
+use crate::{parameters, token, Ctx, Result};
 
 /// IBC actions to handle an IBC message. The `verifiers` inserted into the set
 /// must be inserted into the tx context with `Ctx::insert_verifier` after tx
@@ -30,7 +31,10 @@ pub fn ibc_actions(
     let ctx = Rc::new(RefCell::new(ctx.clone()));
     let verifiers = Rc::new(RefCell::new(BTreeSet::<Address>::new()));
     let mut actions = IbcActions::new(ctx.clone(), verifiers.clone());
-    let module = TransferModule::new(ctx.clone(), verifiers);
+    let module = PfmTransferModule::<_, parameters::Store<Ctx>>::wrap(
+        ctx.clone(),
+        verifiers,
+    );
     actions.add_transfer_module(module);
     let module = NftTransferModule::<Ctx, token::Store<Ctx>>::new(ctx);
     actions.add_transfer_module(module);

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1395,6 +1395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "dur"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5b6c91b5e394b75cd96c36393fc938496c030220207a0ccf34d6cd313d3b49"
+dependencies = [
+ "nom",
+ "rust_decimal",
+]
+
+[[package]]
 name = "duration-str"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2649,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2659,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2680,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2690,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2708,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2717,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2734,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2751,7 +2761,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -2765,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2774,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2790,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2805,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2828,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2841,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2857,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2877,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2896,7 +2906,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2910,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2931,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2946,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2970,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2988,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3011,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -3026,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -3040,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -3059,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.8.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3067,9 +3077,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ibc-middleware-packet-forward"
+version = "0.6.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.6.0#ca824cfbe550c529d30bf27a97026dd0a058cfdf"
+dependencies = [
+ "borsh",
+ "dur",
+ "either",
+ "ibc-app-transfer-types",
+ "ibc-core-channel",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ibc-primitives"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -3109,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3120,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "basecoin-store",
  "derive_more",
@@ -3649,6 +3678,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,8 +3988,10 @@ version = "0.46.1"
 dependencies = [
  "borsh",
  "data-encoding",
+ "dur",
  "ibc",
  "ibc-derive",
+ "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "konst",
@@ -4238,7 +4275,9 @@ version = "0.46.1"
 dependencies = [
  "concat-idents",
  "derivative",
+ "dur",
  "hyper 0.14.27",
+ "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "itertools 0.12.1",
@@ -4506,6 +4545,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -5591,12 +5640,18 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arrayvec",
+ "borsh",
+ "bytes",
  "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5959,11 +6014,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -24,6 +24,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +390,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +765,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "dur"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5b6c91b5e394b75cd96c36393fc938496c030220207a0ccf34d6cd313d3b49"
+dependencies = [
+ "nom",
+ "rust_decimal",
 ]
 
 [[package]]
@@ -1137,6 +1180,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -1228,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1241,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -1251,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1272,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1282,7 +1334,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1300,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -1309,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -1326,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1343,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -1357,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1366,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1382,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1397,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1420,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1433,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1449,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1469,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1488,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -1502,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1523,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1538,7 +1590,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1562,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1580,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1603,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1618,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -1632,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1651,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.8.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1659,9 +1711,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ibc-middleware-packet-forward"
+version = "0.6.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.6.0#ca824cfbe550c529d30bf27a97026dd0a058cfdf"
+dependencies = [
+ "borsh",
+ "dur",
+ "either",
+ "ibc-app-transfer-types",
+ "ibc-core-channel",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ibc-primitives"
 version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=aa229566e6bb688cc2626dab276c3849abc0c583#aa229566e6bb688cc2626dab276c3849abc0c583"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2069,6 +2140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,8 +2360,10 @@ version = "0.46.1"
 dependencies = [
  "borsh",
  "data-encoding",
+ "dur",
  "ibc",
  "ibc-derive",
+ "ibc-middleware-packet-forward",
  "ics23",
  "konst",
  "masp_primitives",
@@ -2618,6 +2697,16 @@ dependencies = [
  "namada_vm_env",
  "namada_vp_env",
  "sha2 0.9.9",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3087,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -3109,6 +3198,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
 dependencies = [
  "prost 0.13.2",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3226,6 +3335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,6 +3360,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3264,6 +3411,22 @@ dependencies = [
  "const-default",
  "libc",
  "svgbobdoc",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3370,6 +3533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,11 +3628,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -3538,6 +3708,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -4181,6 +4357,12 @@ dependencies = [
  "borsh",
  "serde",
 ]
+
+[[package]]
+name = "uuid"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 
 [[package]]
 name = "version_check"


### PR DESCRIPTION
## Describe your changes

Integrate with the [Packet Forward Middleware] code. Requires an [`ibc-rs` fork], in order to support asynchronous IBC packet acknowledgements.

**NOTE:** The code in the links above should also be reviewed.

[Packet Forward Middleware]: https://github.com/heliaxdev/ibc-middleware/tree/pfm/v0.6.0/crates/packet-forward
[`ibc-rs` fork]: https://github.com/heliaxdev/cosmos-ibc-rs/tree/aa229566e6bb688cc2626dab276c3849abc0c583

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
