### PR TITLE
Typo Update README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,5 +13,5 @@ This example is run as follows:
 cargo run --example generate-txs -- <vectors.json> <debugs.txt>
 ```
 where `<vectors.json>` is the path where the JSON test vectors will be stored
-and `<debugs.txt>` is where rust `Debug` representations oof this data will be
+and `<debugs.txt>` is where rust `Debug` representations of this data will be
 stored.


### PR DESCRIPTION
## Describe your changes

Fixed a minor but noticeable typo in the `Examples` section of the documentation. Specifically:  

- **Before:**  
  > "and `<debugs.txt>` is where rust `Debug` representations oof this data will be stored."  
- **After:**  
  > "and `<debugs.txt>` is where rust `Debug` representations of this data will be stored."  

**Importance of the Fix:**  
While the typo ("oof" instead of "of") is small, it impacts the readability and professionalism of the documentation. Clear and error-free documentation is crucial for developers, especially when it involves instructions for using tools like `generate-txs`. Fixing this ensures the documentation maintains high-quality standards, reflecting well on the project and providing a seamless experience for contributors and users.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [x] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
