### PR TITLE
Fix Typos in release.sh and merge_pr.sh Scripts

### DIFF
--- a/scripts/A helper to merge e.g. a PR
+++ b/scripts/A helper to merge e.g. a PR
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# A helper to merge e.g. a PR from draft to an RC branch where any neccessary
-# conflicts resolutions are expected to have been trained with rerere.
+# A helper to merge e.g. a PR from draft to an RC branch where any necessary
+# conflict resolutions are expected to have been trained with rerere.
 #
 # It merges PRs from "origin" remote which should be set to "git@github.com:anoma/namada.git".
 # Make sure to fetch latest before running with e.g. `git fetch origin`.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,7 +26,7 @@ cargo release version --execute $VERSION
 git commit -am "Namada $VERSION"
 HASH_AFTER=$(git rev-parse HEAD)
 
-# update the wasm workspace crate versions (1 fixup)
+# update the wasm workspace crate versions (1 commit)
 cd $REPO_ROOT/wasm
 cargo release version --execute $VERSION
 cargo update -w


### PR DESCRIPTION
## Describe your changes

Two typos found in the comments of `scripts/release.sh` and `scripts/merge_pr.sh` to improve clarity and accuracy.  

### Changes:  

1. **`scripts/release.sh`:**  
   - **Comment Update:**  
     - **Before:** `# update the wasm workspace crate versions (1 fixup)`  
     - **After:** `# update the wasm workspace crate versions (1 commit)`  
   - **Reason:** The term "fixup" does not accurately describe the action performed in this context. The script explicitly commits the changes as a separate commit rather than using the "fixup" strategy. This clarification prevents potential misunderstandings for developers reading the script.  

2. **`scripts/merge_pr.sh`:**  
   - **Comment Update:**  
     - **Before:** `# A helper to merge e.g. a PR from draft to an RC branch where any neccessary conflicts resolutions are expected to have been trained with rerere.`  
     - **After:** `# A helper to merge e.g. a PR from draft to an RC branch where any necessary conflict resolutions are expected to have been trained with rerere.`  
   - **Reason:** Corrects a misspelling of "necessary" (was "neccessary") and adjusts "conflicts resolutions" to "conflict resolutions" for grammatical correctness.  

### Importance:  

- **Improved Clarity:** Developers rely on accurate and precise comments for understanding scripts quickly. Typos or misleading terms can cause confusion.  
- **Professionalism:** Ensuring comments are grammatically correct and meaningful reflects attention to detail and improves the codebase's readability.  

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [x] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo

**Thank you for reviewing this PR! Love Namada!** :)
