### PR TITLE
Fix typo Update gen_localnet.py

### DIFF
--- a/scripts/gen_localnet.py
+++ b/scripts/gen_localnet.py
@@ -483,7 +483,7 @@ def full_nodes_object(s):
 def load_json(s):
     try:
         return json.loads(s)
-    except json.decode.JSONDecodeError:
+    except json.JSONDecodeError:
         # assume we're dealing with a file path
         with open(s, "r") as f:
             return json.load(f)


### PR DESCRIPTION
**Description:**  
Fxes a typo in the exception handling block related to JSON decoding. Previously, the code contained an incorrect reference to the `JSONDecodeError` exception:  

```python  
except json.decode.JSONDecodeError:  
```  

The correct reference is:  

```python  
except json.JSONDecodeError:  
```  

### Why this change is important:  
1. **Prevent runtime errors:** The incorrect attribute `decode` does not exist in the `json` module, which would result in an `AttributeError` being raised instead of handling the intended `JSONDecodeError`.  
2. **Ensure proper error handling:** Without this fix, the intended exception (`JSONDecodeError`) will not be caught, potentially causing the program to crash or behave unexpectedly when encountering invalid JSON.  
3. **Improve code reliability:** Correctly referencing exceptions ensures the code is robust and adheres to Python's standard library specifications.  

### Steps to reproduce the issue:  
1. Use the original code with a block referencing `json.decode.JSONDecodeError`.  
2. Pass an invalid JSON string to a `json.loads` function.  
3. Observe that an `AttributeError` is raised instead of handling the invalid JSON case.  

### Fix implementation:  
The fix replaces the incorrect exception reference with the proper one, ensuring that the intended `JSONDecodeError` is caught:  

```python  
except json.JSONDecodeError:  
```  

### Tests:  
- [x] Verified that the corrected exception handling properly catches `JSONDecodeError` when invalid JSON is provided.  
- [x] Confirmed no `AttributeError` is raised with the updated code.  

## Checklist before merging 
- [x] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo