### PR TITLE
Typo Update README.md

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,7 +1,7 @@
 # Fuzz testing
 
 - Uses [cargo-fuzz](https://rust-fuzz.github.io/book/cargo-fuzz.html) which depends on LLVM libFuzzer
-- When ran, a target generates arbitrary input setup for the test. This can be structured data with derived or manually implemented [`trait Arbitrary`](https://crates.io/crates/arbitrary)
+- When run, a target generates arbitrary input setup for the test. This can be structured data with derived or manually implemented [`trait Arbitrary`](https://crates.io/crates/arbitrary)
 - To ensure that the fuzzer explored all interesting branches fuzz testing is used together with code coverage reports
 
 ## How to run
@@ -12,7 +12,7 @@
 - Run e.g. `make fuzz-txs-mempool` (uses nightly)
 - If there is any crash, the fuzzer has found an issue. Read the stack trace for details. It will also print instructions on how to re-run the same case.
 - When there are no panics you'll see it printing statistics. E.g. `cov: 26771 ft: 111572 corp: 2688/1423Kb lim: 2369 exec/s: 39 rss: 647Mb L: 2232/2335 MS: 5`
-- The important stat you'll want to look watch is the very first one - `cov` - "Total number of code blocks or edges covered by executing the current corpus." (more details at <https://llvm.org/docs/LibFuzzer.html#output>)
+- The important stat you'll want to watch is the very first one - `cov` - "Total number of code blocks or edges covered by executing the current corpus." (more details at <https://llvm.org/docs/LibFuzzer.html#output>)
 - After the number in `cov` seems to have settled and is no longer increasing, the fuzzer has most likely explored all possible branches. We're going to check that next with coverage.
 - To generate raw coverage data, run e.g. `cargo +$(cat rust-nightly-version) fuzz coverage txs_mempool --dev`. This will create `fuzz/coverage/txs_mempool/coverage.profdata` (the path gets printed at the end).
 - To turn the raw coverage data into a report:


### PR DESCRIPTION
# Title: Typo update in `README.md`

## Description:

This pull request addresses a couple of minor grammatical issues in the `README.md` file:

1. **Fixed the phrase "When ran" to "When run"** to correct the grammatical issue.
2. **Improved sentence clarity** by changing "look watch" to simply "watch" to make the sentence flow better.

## Changes:
- Corrected the phrase "When ran" to "When run" in the fuzz testing explanation.
- Adjusted "look watch" to "watch" to improve readability and sentence flow.

## Checklist before merging:
- [x] If this PR has some consensus-breaking changes, I added the corresponding `breaking::` labels
  - This will require 2 reviewers to approve the changes.
- [x] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
  - Relevant PR if applies: [link to the documentation PR]
- [x] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
  - Relevant PR if applies: [link to the services PR]


