### PR TITLE
Add a single CometBFT dummy validator

### DIFF
--- a/.changelog/unreleased/bug-fixes/4116-comet-genesis-validator-set.md
+++ b/.changelog/unreleased/bug-fixes/4116-comet-genesis-validator-set.md
@@ -1,0 +1,2 @@
+- Only write a dummy validator to CometBFT's genesis if the number of validators
+  present is lower than 2. ([\#4116](https://github.com/anoma/namada/pull/4116))

--- a/crates/node/src/tendermint_node.rs
+++ b/crates/node/src/tendermint_node.rs
@@ -370,14 +370,16 @@ async fn write_tm_genesis(
     // validator unless we insert a dummy. If cometbft thinks a node is the
     // only validator, it won't start state sync. These validators are
     // overwritten after init chain is called.
-    const DUMMY_VALIDATOR: [u8; 32] = [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-    ];
-    genesis.validators.push(Info::new(
-        PublicKey::from_raw_ed25519(&DUMMY_VALIDATOR).unwrap(),
-        10u32.into(),
-    ));
+    if genesis.validators.len() < 2 {
+        const DUMMY_VALIDATOR: [u8; 32] = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+            19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        genesis.validators.push(Info::new(
+            PublicKey::from_raw_ed25519(&DUMMY_VALIDATOR).unwrap(),
+            10u32.into(),
+        ));
+    }
     const EVIDENCE_AND_PROTOBUF_OVERHEAD: u64 = 10 * 1024 * 1024;
     let size = block::Size {
         // maximum size of a serialized Tendermint block.


### PR DESCRIPTION
## Describe your changes

Closes #4096

Only writes a dummy validator to CometBFT's genesis if the number of validators present is lower than 2.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
