### PR TITLE
Fix masp rewards estimate

### DIFF
--- a/.changelog/unreleased/bug-fixes/4146-fix-masp-rewards-estimate.md
+++ b/.changelog/unreleased/bug-fixes/4146-fix-masp-rewards-estimate.md
@@ -1,0 +1,4 @@
+- Fixed a bug in the masp rewards estimation logic that was not correctly
+  accounting for native token rewards and rewards accrued by assets shielded
+  at the current epoch. Updated the API of the function to better suite some UI
+  needs. Improved testing ([\#4146](https://github.com/anoma/namada/pull/4146))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -273,7 +273,9 @@ pub mod cmds {
                 .subcommand(QueryMaspRewardTokens::def().display_order(5))
                 .subcommand(QueryBlock::def().display_order(5))
                 .subcommand(QueryBalance::def().display_order(5))
-                .subcommand(QueryRewardsEstimate::def().display_order(5))
+                .subcommand(
+                    QueryShieldingRewardsEstimate::def().display_order(5),
+                )
                 .subcommand(QueryBonds::def().display_order(5))
                 .subcommand(QueryBondedStake::def().display_order(5))
                 .subcommand(QuerySlashes::def().display_order(5))
@@ -358,7 +360,7 @@ pub mod cmds {
             let query_block = Self::parse_with_ctx(matches, QueryBlock);
             let query_balance = Self::parse_with_ctx(matches, QueryBalance);
             let query_rewards_estimate =
-                Self::parse_with_ctx(matches, QueryRewardsEstimate);
+                Self::parse_with_ctx(matches, QueryShieldingRewardsEstimate);
             let query_bonds = Self::parse_with_ctx(matches, QueryBonds);
             let query_bonded_stake =
                 Self::parse_with_ctx(matches, QueryBondedStake);
@@ -525,7 +527,7 @@ pub mod cmds {
         QueryMaspRewardTokens(QueryMaspRewardTokens),
         QueryBlock(QueryBlock),
         QueryBalance(QueryBalance),
-        QueryRewardsEstimate(QueryRewardsEstimate),
+        QueryShieldingRewardsEstimate(QueryShieldingRewardsEstimate),
         QueryBonds(QueryBonds),
         QueryBondedStake(QueryBondedStake),
         QueryCommissionRate(QueryCommissionRate),
@@ -1880,27 +1882,29 @@ pub mod cmds {
     }
 
     #[derive(Clone, Debug)]
-    pub struct QueryRewardsEstimate(
-        pub args::QueryRewardsEstimate<args::CliTypes>,
+    pub struct QueryShieldingRewardsEstimate(
+        pub args::QueryShieldingRewardsEstimate<args::CliTypes>,
     );
 
-    impl SubCmd for QueryRewardsEstimate {
-        const CMD: &'static str = "estimate-rewards";
+    impl SubCmd for QueryShieldingRewardsEstimate {
+        const CMD: &'static str = "estimate-shielding-rewards";
 
         fn parse(matches: &ArgMatches) -> Option<Self> {
             matches.subcommand_matches(Self::CMD).map(|matches| {
-                QueryRewardsEstimate(args::QueryRewardsEstimate::parse(matches))
+                QueryShieldingRewardsEstimate(
+                    args::QueryShieldingRewardsEstimate::parse(matches),
+                )
             })
         }
 
         fn def() -> App {
             App::new(Self::CMD)
                 .about(wrap!(
-                    "Estimate the amount of MASP rewards accumulated by the \
+                    "Estimate the amount of MASP rewards for the \
                      next MASP epoch. Please run shielded-sync first for best \
                      results."
                 ))
-                .add_args::<args::QueryRewardsEstimate<args::CliTypes>>()
+                .add_args::<args::QueryShieldingRewardsEstimate<args::CliTypes>>()
         }
     }
 
@@ -6355,26 +6359,27 @@ pub mod args {
         }
     }
 
-    impl CliToSdk<QueryRewardsEstimate<SdkTypes>>
-        for QueryRewardsEstimate<CliTypes>
+    impl CliToSdk<QueryShieldingRewardsEstimate<SdkTypes>>
+        for QueryShieldingRewardsEstimate<CliTypes>
     {
         type Error = std::convert::Infallible;
 
         fn to_sdk(
             self,
             ctx: &mut Context,
-        ) -> Result<QueryRewardsEstimate<SdkTypes>, Self::Error> {
+        ) -> Result<QueryShieldingRewardsEstimate<SdkTypes>, Self::Error>
+        {
             let query = self.query.to_sdk(ctx)?;
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
-            Ok(QueryRewardsEstimate::<SdkTypes> {
+            Ok(QueryShieldingRewardsEstimate::<SdkTypes> {
                 query,
                 owner: chain_ctx.get_cached(&self.owner),
             })
         }
     }
 
-    impl Args for QueryRewardsEstimate<CliTypes> {
+    impl Args for QueryShieldingRewardsEstimate<CliTypes> {
         fn parse(matches: &ArgMatches) -> Self {
             let query = Query::parse(matches);
             let owner = VIEWING_KEY.parse(matches);

--- a/crates/apps_lib/src/cli/client.rs
+++ b/crates/apps_lib/src/cli/client.rs
@@ -560,7 +560,9 @@ impl CliApi {
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_balance(&namada, args).await;
                     }
-                    Sub::QueryRewardsEstimate(QueryRewardsEstimate(args)) => {
+                    Sub::QueryShieldingRewardsEstimate(
+                        QueryShieldingRewardsEstimate(args),
+                    ) => {
                         let chain_ctx = ctx.borrow_mut_chain_or_exit();
                         let ledger_address =
                             chain_ctx.get(&args.query.ledger_address);

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -50,9 +50,7 @@ use namada_sdk::rpc::{
 use namada_sdk::storage::BlockResults;
 use namada_sdk::tendermint_rpc::endpoint::status;
 use namada_sdk::time::DateTimeUtc;
-use namada_sdk::token::{
-    DenominatedAmount, MaspDigitPos, NATIVE_MAX_DECIMAL_PLACES,
-};
+use namada_sdk::token::{DenominatedAmount, MaspDigitPos};
 use namada_sdk::tx::display_batch_resp;
 use namada_sdk::wallet::AddressVpType;
 use namada_sdk::{error, state as storage, token, Namada};
@@ -428,7 +426,7 @@ pub async fn query_rewards_estimate(
                 .estimate_next_epoch_rewards(context, &balance)
                 .await
             {
-                Ok(estimate) => estimate.unsigned_abs(),
+                Ok(estimate) => estimate,
                 Err(e) => {
                     edisplay_line!(
                         context.io(),
@@ -440,13 +438,9 @@ pub async fn query_rewards_estimate(
                 }
             }
         }
-        None => 0,
+        None => DenominatedAmount::native(Amount::zero()),
     };
 
-    let rewards_estimate = DenominatedAmount::new(
-        Amount::from_u128(rewards_estimate),
-        NATIVE_MAX_DECIMAL_PLACES.into(),
-    );
     display_line!(
         context.io(),
         "Estimated native token rewards for the next MASP epoch: {}",

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -403,7 +403,7 @@ pub async fn query_proposal_by_id<C: Client + Sync>(
 /// Estimate MASP rewards for next MASP epoch
 pub async fn query_rewards_estimate(
     context: &impl Namada,
-    args: args::QueryRewardsEstimate,
+    args: args::QueryShieldingRewardsEstimate,
 ) {
     let mut shielded = context.shielded_mut().await;
     let _ = shielded.load().await;

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -1607,10 +1607,10 @@ pub struct QueryBalance<C: NamadaTypes = SdkTypes> {
     pub height: Option<C::BlockHeight>,
 }
 
-/// Get an estimate for the MASP rewards accumulated by the next
+/// Get an estimate for the MASP rewards for the next
 /// MASP epoch.
 #[derive(Clone, Debug)]
-pub struct QueryRewardsEstimate<C: NamadaTypes = SdkTypes> {
+pub struct QueryShieldingRewardsEstimate<C: NamadaTypes = SdkTypes> {
     /// Common query args
     pub query: Query<C>,
     /// Viewing key

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -410,7 +410,9 @@ where
                         );
                         normed_inflation
                     });
-                // The conversion is computed such that if consecutive conversions are added together, the intermediate native tokens cancel/telescope out
+                // The conversion is computed such that if consecutive
+                // conversions are added together, the intermediate native
+                // tokens cancel/telescope out
                 let cur_conv = MaspAmount::from_pair(
                     old_asset,
                     i128::try_from(normed_inflation)

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -410,10 +410,7 @@ where
                         );
                         normed_inflation
                     });
-                // The conversion is computed such that if consecutive
-                // conversions are added together, the
-                // intermediate native tokens cancel/
-                // telescope out
+                // The conversion is computed such that if consecutive conversions are added together, the intermediate native tokens cancel/telescope out
                 let cur_conv = MaspAmount::from_pair(
                     old_asset,
                     i128::try_from(normed_inflation)
@@ -465,8 +462,7 @@ where
                 }
             } else {
                 // Express the inflation reward in real terms, that is, with
-                // respect to the native asset in the zeroth
-                // epoch
+                // respect to the native asset in the zeroth epoch
                 let reward_uint = Uint::from(reward);
                 let ref_inflation_uint = Uint::from(ref_inflation);
                 let inflation_uint = Uint::from(normed_inflation);

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -545,7 +545,6 @@ where
         .values_mut()
         .enumerate()
         .collect();
-    // ceil(assets.len() / num_threads)
 
     #[allow(clippy::arithmetic_side_effects)]
     let notes_per_thread_max = (assets.len() + num_threads - 1) / num_threads;

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -713,9 +713,6 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
         }
     }
 
-    // FIXME: check the help message of this command and verify that it states
-    // rewards only for the next epoch FIXME: maybe also change the name of
-    // the command?
     /// We estimate the next epoch rewards accumulated by the assets owned by
     /// the provided viewing key. This is done by assuming the same rewards
     /// rate on each asset as in the latest masp epoch.

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -1450,9 +1450,6 @@ fn masp_incentives() -> Result<()> {
     let validator_one_rpc = "http://127.0.0.1:26567";
     // Download the shielded pool parameters before starting node
     let _ = FsShieldedUtils::new(PathBuf::new());
-    // Lengthen epoch to ensure that a transaction can be constructed and
-    // submitted within the same block. Necessary to ensure that conversion is
-    // not invalidated.
     let (mut node, _services) = setup::setup()?;
     // Wait till epoch boundary
     node.next_masp_epoch();
@@ -1539,7 +1536,7 @@ fn masp_incentives() -> Result<()> {
             &node,
             Bin::Client,
             vec![
-                "estimate-rewards",
+                "estimate-shielding-rewards",
                 "--key",
                 AA_VIEWING_KEY,
                 "--node",
@@ -1603,13 +1600,13 @@ fn masp_incentives() -> Result<()> {
     assert!(captured.result.is_ok());
     assert!(captured.contains("nam: 0.063"));
 
-    // Assert the rewards estimate is a number higher than the actual rewards
+    // Assert the rewards estimate matches the actual rewards
     let captured = CapturedOutput::of(|| {
         run(
             &node,
             Bin::Client,
             vec![
-                "estimate-rewards",
+                "estimate-shielding-rewards",
                 "--key",
                 AA_VIEWING_KEY,
                 "--node",
@@ -1618,9 +1615,8 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    // note that 0.126 = 2 * 0.063 which is expected
     assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.126"
+        "Estimated native token rewards for the next MASP epoch: 0.063"
     ));
 
     // Assert NAM balance at MASP pool is exclusively the
@@ -3277,9 +3273,6 @@ fn dynamic_assets() -> Result<()> {
     let validator_one_rpc = "http://127.0.0.1:26567";
     // Download the shielded pool parameters before starting node
     let _ = FsShieldedUtils::new(PathBuf::new());
-    // Lengthen epoch to ensure that a transaction can be constructed and
-    // submitted within the same block. Necessary to ensure that conversion is
-    // not invalidated.
     let (mut node, _services) = setup::setup()?;
     let btc = BTC.to_lowercase();
     let nam = NAM.to_lowercase();


### PR DESCRIPTION
## Describe your changes

Various adjustments to the masp rewards estimation logic:

- Fixed the logic to correctly account for rewards accrued by the native token and by assets that have been shielded in the current epoch (for which no conversions are available yet but the conversion from the previous epoch can be used as an estimate)
- Fixed the logic to allow estimating rewards for assets that have been shielded before the last epoch
- Changed the API of the estimate function to require a `ValueSum` instead of a viewing key (this is to support a UI view with the possible rewards for different tokens, cc @ChrisHoltDesign, @mateuszjasiuk)
- The function now returns a `DenominatedAmount` instead of an `i128`
- Changed the name of the cli command to `estimate-shielding-rewards`
- Updated and improved tests

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
