### PR TITLE
test/ibc: ensure unique token IDs

### DIFF
--- a/crates/ibc/src/lib.rs
+++ b/crates/ibc/src/lib.rs
@@ -1284,8 +1284,8 @@ pub mod testing {
 
     prop_compose! {
         /// Generate an arbitrary IBC token ID vector
-        pub fn arb_ibc_token_ids()(token_ids in collection::vec(arb_ibc_token_id().prop_map(|x| x.to_string()), 1..10)) -> TokenIds {
-            TokenIds::try_from(token_ids).expect("generated invalid IBC token ID vector")
+        pub fn arb_ibc_token_ids()(token_ids in collection::hash_set(arb_ibc_token_id().prop_map(|x| x.to_string()), 1..10)) -> TokenIds {
+            TokenIds::try_from(token_ids.into_iter().collect::<Vec<_>>()).expect("generated invalid IBC token ID vector")
         }
     }
 


### PR DESCRIPTION
## Describe your changes

fixes a panic in strategy when a list of generated token IDs is not unique (as seen in https://github.com/anoma/namada/actions/runs/12213873245/job/34074078139)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
