### PR TITLE
ci/test-ledger-app: specify container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,6 +655,8 @@ jobs:
   test-ledger-app:
     timeout-minutes: 30
     runs-on: [self-hosted, 4vcpu-8ram-ubuntu22-namada-x86]
+    container: 
+      image: ghcr.io/heliaxdev/namada-ci:namada-main
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Describe your changes

The image contains `cargo` (as missing here https://github.com/anoma/namada/actions/runs/12213873245/job/34073974397)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
