### PR TITLE
Fix Typo

### DIFF
--- a/.changelog/v0.8.0/bug-fixes/279-new-merkle-tree.md
+++ b/.changelog/v0.8.0/bug-fixes/279-new-merkle-tree.md
@@ -1,3 +1,3 @@
-- Switch to a alternative sparse merkle tree implementation for IBC sub-tree
+- Switch to an alternative sparse merkle tree implementation for IBC sub-tree
   to be able to support proofs compatible with the current version of ICS23
   ([#279](https://github.com/anoma/namada/pull/279))


### PR DESCRIPTION
This PR corrects a minor grammatical error in the changelog file `.changelog/v0.8.0/bug-fixes/279-new-merkle-tree.md`.  

## Changes Made  

- Updated "a alternative" to "an alternative" to ensure proper article usage before a word starting with a vowel sound.  

## Checklist Before Merging  

- [ ] If this PR has consensus-breaking changes, the corresponding `breaking::` labels have been added.  
    - This will require 2 reviewers to approve the changes.  
- [ ] If this PR requires updates to documentation or specifications, a corresponding PR has been opened in the `namada-docs` repo.  
    - Relevant PR if applicable:  
- [ ] If this PR affects services like `namada-indexer` or `namada-masp-indexer`, a corresponding PR has been opened in that repo.  
    - Relevant PR if applicable:  

---

- **Files Changed:** 1  
- **Commits:** 1  

Let me know if further adjustments are needed.  
**Allow edits by maintainers:** Enabled.  
