### PR TITLE
code-Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install -y \
     clang-tools-14 \
     git \
     libssl-dev \
-    pkg-config \
-    protobuf-compiler \
     libudev-dev \
+    pkg-config \
+    protobuf-compiler
     && apt-get clean
 
 COPY --from=planner /app/recipe.json recipe.json


### PR DESCRIPTION

# Fix: Sorted package names alphanumerically in Dockerfile

## Changes
- Sorted package names in the `RUN apt-get install` command to maintain consistency and adhere to best practices.

  - **Before**:
    ```dockerfile
    RUN apt-get update && apt-get install -y \
        build-essential \
        clang-tools-14 \
        git \
        libssl-dev \
        pkg-config \
        protobuf-compiler \
        libudev-dev
    ```

  - **After**:
    ```dockerfile
    RUN apt-get update && apt-get install -y \
        build-essential \
        clang-tools-14 \
        git \
        libssl-dev \
        libudev-dev \
        pkg-config \
        protobuf-compiler
    ```

## Purpose
- Ensured consistency by sorting package names alphanumerically.
- Improved readability and maintainability of the Dockerfile.
