### PR TITLE
Improve `namadac next-epoch-info`

### DIFF
--- a/.changelog/unreleased/improvements/4205-improve-next-epoch-info.md
+++ b/.changelog/unreleased/improvements/4205-improve-next-epoch-info.md
@@ -1,0 +1,2 @@
+- Improve namadac next-epoch-info to also estimate how much time is left in the
+  current epoch. ([\#4205](https://github.com/anoma/namada/pull/4205))

--- a/crates/core/src/time.rs
+++ b/crates/core/src/time.rs
@@ -208,7 +208,7 @@ impl DateTimeUtc {
     }
 
     /// Returns the number of seconds in between two `DateTimeUtc` instances.
-    /// Ass
+    /// Assumes that `self` is later than `earlier`.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn time_diff(&self, earlier: DateTimeUtc) -> DurationSecs {
         (self.0 - earlier.0)

--- a/crates/core/src/time.rs
+++ b/crates/core/src/time.rs
@@ -206,6 +206,16 @@ impl DateTimeUtc {
     pub fn next_second(&self) -> Self {
         *self + DurationSecs(1)
     }
+
+    /// Returns the number of seconds in between two `DateTimeUtc` instances.
+    /// Ass
+    #[allow(clippy::arithmetic_side_effects)]
+    pub fn time_diff(&self, earlier: DateTimeUtc) -> DurationSecs {
+        (self.0 - earlier.0)
+            .to_std()
+            .map(DurationSecs::from)
+            .unwrap_or(DurationSecs(0))
+    }
 }
 
 impl FromStr for DateTimeUtc {

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -45,7 +45,7 @@ use namada_proof_of_stake::types::{
     BondsAndUnbondsDetails, CommissionPair, LivenessInfo, ValidatorMetaData,
     WeightedValidator,
 };
-use namada_state::LastBlock;
+use namada_state::{BlockHeader, LastBlock};
 use namada_token::masp::MaspTokenRewardData;
 use namada_tx::data::{BatchedTxResult, DryRunResult, ResultCode, TxResult};
 use namada_tx::event::{Batch as BatchAttr, Code as CodeAttr};
@@ -149,6 +149,14 @@ pub async fn query_epoch<C: namada_io::Client + Sync>(
     client: &C,
 ) -> Result<Epoch, error::Error> {
     convert_response::<C, _>(RPC.shell().epoch(client).await)
+}
+
+/// Query the epoch of the last committed block
+pub async fn query_block_header<C: namada_io::Client + Sync>(
+    client: &C,
+    height: BlockHeight,
+) -> Result<Option<BlockHeader>, error::Error> {
+    convert_response::<C, _>(RPC.shell().block_header(client, &height).await)
 }
 
 /// Query the masp epoch of the last committed block


### PR DESCRIPTION
## Describe your changes
For example, currently on mainnet with `v1.0.0`:
```
Last committed block height: 269035, time: 2024-12-25T09:35:13.291756821+00:00
Current epoch: 87.

First block height of this epoch 87: 268949.
Minimum number of blocks in an epoch: 2700.
Minimum amount of time for an epoch: 21600 seconds.

Earliest height at which epoch 88 can begin is block 271649.
```

And with the changes:
```
Last committed block height: 269044, time: 2024-12-25T09:36:15.592519345+00:00

Current epoch: 87.
First block height of epoch 87: 268949.

Minimum number of blocks in an epoch: 2700.
Minimum amount of time for an epoch: 6h-0m-0.

Next epoch (88) begins in 5h-49m-0s or at block height 271649, whichever occurs later.

```

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
