### PR TITLE
fix typo storage_key.rs

### DIFF
--- a/crates/account/src/storage_key.rs
+++ b/crates/account/src/storage_key.rs
@@ -46,7 +46,7 @@ pub fn is_pks_key(key: &storage::Key) -> Option<&Address> {
     }
 }
 
-/// Check if the given storage key is a threshol key.
+/// Check if the given storage key is a threshold key.
 pub fn is_threshold_key(key: &storage::Key) -> Option<&Address> {
     match &key.segments[..] {
         [DbKeySeg::AddressSeg(owner), DbKeySeg::StringSeg(prefix)]


### PR DESCRIPTION
### Title: Fix Typo in `storage_key.rs`

### Description:
This pull request fixes a typo in the `storage_key.rs` file. The word "threshol" has been corrected to "threshold" in the function `is_threshold_key`.

This small change improves the accuracy and readability of the code.
