### PR TITLE
docs: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Namada
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE)
-![CI Status](https://github.com/anoma/namada/actions/workflows/ci.yml/badge.svg?branch=main)
+[![CI Status](https://github.com/anoma/namada/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/anoma/namada/actions/workflows/ci.yml)
 
 ## Overview
 


### PR DESCRIPTION
I added a link that was missing in the documentation

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
