### PR TITLE
Increase `MAX_PGF_ACTIONS`

### DIFF
--- a/crates/governance/src/vp/mod.rs
+++ b/crates/governance/src/vp/mod.rs
@@ -28,7 +28,7 @@ use crate::ProposalVote;
 pub const ADDRESS: Address = Address::Internal(InternalAddress::Governance);
 
 /// The maximum number of item in a pgf proposal
-pub const MAX_PGF_ACTIONS: usize = 20;
+pub const MAX_PGF_ACTIONS: usize = 1000;
 
 #[allow(missing_docs)]
 #[derive(Error, Debug)]
@@ -505,8 +505,9 @@ where
 
                 if !is_total_fundings_valid {
                     return Err(Error::new_alloc(format!(
-                        "Maximum number of funding actions \
-                         ({MAX_PGF_ACTIONS}) exceeded ({})",
+                        "Maximum number of funding targets \
+                         ({MAX_PGF_ACTIONS}) exceeded by the provided amount \
+                         of ({})",
                         fundings.len()
                     )));
                 }


### PR DESCRIPTION
## Describe your changes
Increase `MAX_PGF_ACTIONS` from 20 to 1000. This will be helpful for the donor drop idea.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
