### PR TITLE
Add rewards query to SDK

### DIFF
--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -1482,9 +1482,7 @@ pub async fn query_rewards<C: Client + Sync>(
     source: &Option<Address>,
     validator: &Address,
 ) -> token::Amount {
-    unwrap_client_response::<C, token::Amount>(
-        RPC.vp().pos().rewards(client, validator, source).await,
-    )
+    unwrap_sdk_result(rpc::query_rewards(client, source, validator).await)
 }
 
 /// Query token total supply.

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -858,6 +858,17 @@ pub async fn get_validator_state<C: namada_io::Client + Sync>(
     )
 }
 
+/// Query and return the available reward tokens corresponding to the bond
+pub async fn query_rewards<C: namada_io::Client + Sync>(
+    client: &C,
+    source: &Option<Address>,
+    validator: &Address,
+) -> Result<token::Amount, error::Error> {
+    convert_response::<C, token::Amount>(
+        RPC.vp().pos().rewards(client, validator, source).await,
+    )
+}
+
 /// Get the validators to which a delegator is bonded at a certain epoch
 pub async fn get_delegation_validators<C: namada_io::Client + Sync>(
     client: &C,


### PR DESCRIPTION
## Describe your changes
Adds a query for a delegator or validator's rewards to the SDK

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
