### PR TITLE
Update README.md

### DIFF
--- a/.changelog/.changelog/real-time-log-example.md
+++ b/.changelog/.changelog/real-time-log-example.md
@@ -1,0 +1,2 @@
+### Added
+- Added an example of real-time log monitoring to the Logging section in README.md.

--- a/.changelog/422b3f15-feature-added.md
+++ b/.changelog/422b3f15-feature-added.md
@@ -1,0 +1,2 @@
+### Added
+- Added a real-time log monitoring example to the Logging section in README.md.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ The default is set to `info` for all the modules, except for CometBFT ABCI, whic
 For more fine-grained logging levels settings, please refer to the [tracing subscriber docs](https://docs.rs/tracing-subscriber/0.2.18/tracing_subscriber/struct.EnvFilter.html#directives) for more information.
 
 To switch on logging in tests that use `#[test]` macro from `test_log::test`, use `RUST_LOG` with e.g. `RUST_LOG=info cargo test -- --nocapture`.
+**Example Usage:**
+```bash
+# Set log level to debug
+export NAMADA_LOG=debug
+namada node run
+
+# Check logs of the running Namada node
+tail -f ~/.namada/logs/namada.log
 
 ## How to contribute
 


### PR DESCRIPTION
-Added real-time logging monitoring example to the logging section-

In the logging section, I added an example of how to use the `tail` command to monitor Namada node logs in real time, placing it in the code line.

This provides users with a practical way to debug and analyze more effectively.

## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
