### PR TITLE
Display transaction fees in normal mode

### DIFF
--- a/.changelog/unreleased/improvements/4218-normal-mode-display-tx-fees.md
+++ b/.changelog/unreleased/improvements/4218-normal-mode-display-tx-fees.md
@@ -1,0 +1,2 @@
+- Require the hardware wallet to display transaction fees in normal mode.
+  ([\#4218](https://github.com/anoma/namada/pull/4218))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ env:
   AWS_REGION: us-west-2
   NIGHTLY: nightly-2024-09-08
   NAMADA_MASP_PARAMS_DIR: /masp/.masp-params
-  LEDGER_APP_VERSION: "2.0.3"
+  LEDGER_APP_VERSION: "2.0.4"
   ROLE: arn:aws:iam::375643557360:role/github-runners-ci-shared
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4343,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "ledger-namada-rs"
 version = "0.0.1"
-source = "git+https://github.com/Zondax/ledger-namada?tag=v2.0.2#4eb39abc55b08a6a2b7ae0692913a469356d6642"
+source = "git+https://github.com/Zondax/ledger-namada?tag=v2.0.4#50f3332e091bad2e96ac52e30f03dd85d7daf9e7"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ kdam = "0.5.2"
 konst = { version = "0.3.8", default-features = false }
 lazy_static = "1.4.0"
 ledger-lib = { package="nam-ledger-lib", version = "0.1.1-nam.0", default-features = false, features = ["transport_tcp"] }
-ledger-namada-rs = { git = "https://github.com/Zondax/ledger-namada", tag = "v2.0.2" }
+ledger-namada-rs = { git = "https://github.com/Zondax/ledger-namada", tag = "v2.0.4" }
 ledger-transport = "0.10.0"
 ledger-transport-hid = "0.10.0"
 libc = "0.2.97"

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1037,8 +1037,8 @@ pub mod testing {
     }
 
     prop_compose! {
-        /// Generate an arbitrary wrapper transaction
-        pub fn arb_wrapper_tx()(
+        /// Generate an arbitrary wrapper transaction. Do not check fee validity
+        pub fn arb_unchecked_wrapper_tx()(
             fee in arb_fee(),
             pk in arb_common_pk(),
             gas_limit in arb_gas_limit(),
@@ -1048,6 +1048,18 @@ pub mod testing {
                 pk,
                 gas_limit,
             }
+        }
+    }
+
+    prop_compose! {
+        /// Generate an arbitrary wrapper transaction with valid fees
+        pub fn arb_wrapper_tx()(
+            wrapper in arb_unchecked_wrapper_tx().prop_filter(
+                "wrapper fees overflow",
+                |x| x.get_tx_fee().is_ok(),
+            ),
+        ) -> WrapperTx {
+            wrapper
         }
     }
 

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -2172,6 +2172,11 @@ pub async fn to_ledger_vector(
             let fee_amount_per_gas_unit = to_ledger_decimal_variable_token(
                 wrapper.fee.amount_per_gas_unit,
             );
+            let fee_limit = to_ledger_decimal_variable_token(
+                wrapper
+                    .get_tx_fee()
+                    .map_err(|e| Error::Other(format!("{}", e)))?,
+            );
             tv.output_expert.extend(vec![
                 format!(
                     "Timestamp : {}",
@@ -2181,12 +2186,21 @@ pub async fn to_ledger_vector(
                 format!("Gas limit : {}", u64::from(wrapper.gas_limit)),
             ]);
             if let Some(token) = tokens.get(&wrapper.fee.token) {
+                tv.output.push(format!(
+                    "Fee : {} {}",
+                    token.to_uppercase(),
+                    fee_limit
+                ));
                 tv.output_expert.push(format!(
                     "Fees/gas unit : {} {}",
                     token.to_uppercase(),
                     fee_amount_per_gas_unit,
                 ));
             } else {
+                tv.output.extend(vec![
+                    format!("Fee token : {}", wrapper.fee.token),
+                    format!("Fee : {}", fee_limit),
+                ]);
                 tv.output_expert.extend(vec![
                     format!("Fee token : {}", wrapper.fee.token),
                     format!("Fees/gas unit : {}", fee_amount_per_gas_unit),


### PR DESCRIPTION
## Describe your changes
Updated the test vector generator to require the hardware wallet to display wrapper transaction fees in normal mode. See attached the test vectors (which show what the hardware wallet will be required to display) resulting from this change: [testvecs.json](https://github.com/user-attachments/files/18320129/testvecs.json) . This PR should not be merged before hardware wallet normal mode fee display support is implemented because that would cause the hardware wallet CI tests in this Namada repository to fail.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
