### PR TITLE
Murisi/re enable masp hw support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,7 +4252,7 @@ dependencies = [
 [[package]]
 name = "ledger-namada-rs"
 version = "0.0.1"
-source = "git+https://github.com/Zondax/ledger-namada?rev=f54b76adcc1430db0496e894ad72cd74cfb6eb88#f54b76adcc1430db0496e894ad72cd74cfb6eb88"
+source = "git+https://github.com/Zondax/ledger-namada?tag=v2.0.2#4eb39abc55b08a6a2b7ae0692913a469356d6642"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4756,6 +4756,7 @@ dependencies = [
  "futures",
  "git2",
  "itertools 0.12.1",
+ "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "kdam",
  "lazy_static",
  "ledger-lib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,7 +4252,7 @@ dependencies = [
 [[package]]
 name = "ledger-namada-rs"
 version = "0.0.1"
-source = "git+https://github.com/Zondax/ledger-namada?tag=v1.0.5#731d66fdbae54f10b854d0d985e4fe9b94cd6e84"
+source = "git+https://github.com/Zondax/ledger-namada?rev=f54b76adcc1430db0496e894ad72cd74cfb6eb88#f54b76adcc1430db0496e894ad72cd74cfb6eb88"
 dependencies = [
  "bincode",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ konst = { version = "0.3.8", default-features = false }
 lazy_static = "1.4.0"
 # TODO: upstreamed in https://github.com/ledger-community/rust-ledger/pull/9
 ledger-lib = { git = "https://github.com/heliaxdev/rust-ledger", rev = "f96f4559b3237d09218f7583df01acf36034ea79", default-features = false, features = ["transport_tcp"] }
-ledger-namada-rs = { git = "https://github.com/Zondax/ledger-namada", rev = "f54b76adcc1430db0496e894ad72cd74cfb6eb88" }
+ledger-namada-rs = { git = "https://github.com/Zondax/ledger-namada", tag = "v2.0.2" }
 ledger-transport = "0.10.0"
 ledger-transport-hid = "0.10.0"
 libc = "0.2.97"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ konst = { version = "0.3.8", default-features = false }
 lazy_static = "1.4.0"
 # TODO: upstreamed in https://github.com/ledger-community/rust-ledger/pull/9
 ledger-lib = { git = "https://github.com/heliaxdev/rust-ledger", rev = "f96f4559b3237d09218f7583df01acf36034ea79", default-features = false, features = ["transport_tcp"] }
-ledger-namada-rs = { git = "https://github.com/Zondax/ledger-namada", tag = "v1.0.5" }
+ledger-namada-rs = { git = "https://github.com/Zondax/ledger-namada", rev = "f54b76adcc1430db0496e894ad72cd74cfb6eb88" }
 ledger-transport = "0.10.0"
 ledger-transport-hid = "0.10.0"
 libc = "0.2.97"

--- a/crates/apps_lib/Cargo.toml
+++ b/crates/apps_lib/Cargo.toml
@@ -52,6 +52,7 @@ fd-lock.workspace = true
 flate2.workspace = true
 futures.workspace = true
 itertools.workspace = true
+jubjub.workspace = true
 kdam.workspace = true
 lazy_static = { workspace = true, optional = true }
 linkme = { workspace = true, optional = true }


### PR DESCRIPTION
## Describe your changes
Enable MASP hardware wallet support by reverting the reversion (bec57d6eb3016df8b4e47537076c92570bd7f7f5) enacted in #4127 . Hence this PR is essentially the same as https://github.com/anoma/namada/pull/3797 . For clarity, this PR makes the following changes:
* Allow the outsourcing of generator randomness to the hardware wallet
* Allow the generation of MASP extended full viewing keys using the hardware wallet
* Allow the client to generate proofs using proof generation keys from the hardware wallet
* Now apply signatures generated by the hardware wallet onto client build Transactions
* The following transaction types are supported by MASP hardware wallet signing:
  * Shielding transactions (only randomness parameters are taken from hardware wallet)
  * Shielded, unshielding, and IBC transactions (randomness parameters and proof  generation keys are taken from hardware wallet)
  * Combined hardware wallet and software client signing where the the shielded keys are on the hardware wallet and wrapper signer keys are on the computer, or vice-versa, or both reside on the device is supported

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
