### PR TITLE
fix apps version fallback

### DIFF
--- a/.changelog/unreleased/bug-fixes/4224-fix-apps-version-fallback.md
+++ b/.changelog/unreleased/bug-fixes/4224-fix-apps-version-fallback.md
@@ -1,0 +1,2 @@
+- Fixed the apps version fallback for a build without git.
+  ([\#4224](https://github.com/anoma/namada/pull/4224))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,6 +4743,7 @@ dependencies = [
  "base64 0.13.1",
  "bit-set",
  "borsh",
+ "cargo_metadata",
  "clap",
  "color-eyre",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ byte-unit = "4.0.13"
 byteorder = "1.4.2"
 borsh = {version = "1.2.0", features = ["unstable__schema", "derive"]}
 borsh-ext = { git = "https://github.com/heliaxdev/borsh-ext", tag = "v1.2.0" }
+cargo_metadata = "0.18.1"
 chrono = {version = "0.4.22", default-features = false, features = ["clock", "std"]}
 circular-queue = "0.2.6"
 clap = "4.5"

--- a/crates/apps_lib/Cargo.toml
+++ b/crates/apps_lib/Cargo.toml
@@ -92,4 +92,5 @@ lazy_static.workspace= true
 pretty_assertions.workspace = true
 
 [build-dependencies]
+cargo_metadata.workspace = true
 git2.workspace = true

--- a/crates/systems/Cargo.toml
+++ b/crates/systems/Cargo.toml
@@ -18,5 +18,5 @@ namada_events = { path = "../events" }
 namada_storage = { path = "../storage" }
 
 [dev-dependencies]
-cargo_metadata = "0.18.1"
+cargo_metadata.workspace = true
 lazy_static.workspace = true


### PR DESCRIPTION
## Describe your changes

When there's no `.git` dir the build script falls back to get the version string from cargo. This should use the metadata of the apps crate, but instead it was using the workspace version, which contains version used for libs.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
