### PR TITLE
Murisi/fix hw tests by unbatching

### DIFF
--- a/.changelog/unreleased/improvements/4228-fix-hw-tests-by-unbatching.md
+++ b/.changelog/unreleased/improvements/4228-fix-hw-tests-by-unbatching.md
@@ -1,0 +1,3 @@
+- Stop batching transactions that need to be signed on
+  the hardware wallet because these are not supported yet.
+  ([\#4228](https://github.com/anoma/namada/pull/4228))

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -146,6 +146,11 @@ where
         )));
     }
     // Get the Ledger to sign using our obtained derivation path
+    println!(
+        "Requesting that hardware wallet sign transaction with transparent \
+         key at {}...",
+        path.path
+    );
     let response = app
         .sign(&path, &tx.serialize_to_vec())
         .await
@@ -961,6 +966,10 @@ async fn augment_masp_hardware_keys(
                 // Then confirm that the viewing key at this path in the
                 // hardware wallet matches the viewing key in this pseudo
                 // spending key
+                println!(
+                    "Requesting viewing key at {} from hardware wallet...",
+                    path.path
+                );
                 let response = app
                     .retrieve_keys(&path, NamadaKeys::ViewKey, true)
                     .await
@@ -1138,6 +1147,11 @@ async fn masp_sign(
             let path = BIP44Path {
                 path: path.to_string(),
             };
+            println!(
+                "Requesting that hardware wallet sign shielded transfer with \
+                 spending key at {}...",
+                path.path
+            );
             app.sign_masp_spends(&path, &tx.serialize_to_vec())
                 .await
                 .map_err(|err| error::Error::Other(err.to_string()))?;

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -1403,7 +1403,7 @@ fn transfer_on_chain(
         &rpc,
     ]);
     tx_args.extend_from_slice(extra_args);
-    let mut client = run!(test, Bin::Client, tx_args, Some(120))?;
+    let mut client = run!(test, Bin::Client, tx_args, Some(240))?;
     client.exp_string(TX_APPLIED_SUCCESS)?;
     client.assert_success();
 

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -2381,12 +2381,12 @@ fn wrap_tx_by_elsewho() -> Result<()> {
         run(
             &node,
             Bin::Wallet,
-            apply_use_device(vec![
+            vec![
                 "gen",
                 "--alias",
                 key_alias,
                 "--unsafe-dont-encrypt",
-            ]),
+            ],
         )
     });
     assert!(captured.result.is_ok());
@@ -2510,7 +2510,7 @@ fn wrap_tx_by_elsewho() -> Result<()> {
         run(
             &node,
             Bin::Client,
-            apply_use_device(vec![
+            vec![
                 "utils",
                 "sign-offline",
                 "--data-path",
@@ -2519,7 +2519,7 @@ fn wrap_tx_by_elsewho() -> Result<()> {
                 &key_alias,
                 "--output-folder-path",
                 &output_folder.to_str().unwrap(),
-            ]),
+            ],
         )
     });
     assert!(captured.result.is_ok());
@@ -2594,12 +2594,12 @@ fn offline_wrap_tx_by_elsewho() -> Result<()> {
         run(
             &node,
             Bin::Wallet,
-            apply_use_device(vec![
+            vec![
                 "gen",
                 "--alias",
                 key_alias,
                 "--unsafe-dont-encrypt",
-            ]),
+            ],
         )
     });
     assert!(captured.result.is_ok());
@@ -2721,7 +2721,7 @@ fn offline_wrap_tx_by_elsewho() -> Result<()> {
         run(
             &node,
             Bin::Client,
-            apply_use_device(vec![
+            vec![
                 "utils",
                 "sign-offline",
                 "--data-path",
@@ -2730,7 +2730,7 @@ fn offline_wrap_tx_by_elsewho() -> Result<()> {
                 &key_alias,
                 "--output-folder-path",
                 &output_folder.to_str().unwrap(),
-            ]),
+            ],
         )
     });
     assert!(captured.result.is_ok());
@@ -2774,7 +2774,7 @@ fn offline_wrap_tx_by_elsewho() -> Result<()> {
         run(
             &node,
             Bin::Client,
-            apply_use_device(vec![
+            vec![
                 "utils",
                 "sign-offline",
                 "--data-path",
@@ -2783,7 +2783,7 @@ fn offline_wrap_tx_by_elsewho() -> Result<()> {
                 CHRISTEL_KEY,
                 "--output-folder-path",
                 &output_folder.to_str().unwrap(),
-            ]),
+            ],
         )
     });
     assert!(captured.result.is_ok());
@@ -2862,12 +2862,12 @@ fn offline_wrapper_tx() -> Result<()> {
         run(
             &node,
             Bin::Wallet,
-            apply_use_device(vec![
+            vec![
                 "gen",
                 "--alias",
                 key_alias,
                 "--unsafe-dont-encrypt",
-            ]),
+            ],
         )
     });
     assert!(captured.result.is_ok());
@@ -2990,7 +2990,7 @@ fn offline_wrapper_tx() -> Result<()> {
         run(
             &node,
             Bin::Client,
-            apply_use_device(vec![
+            vec![
                 "utils",
                 "sign-offline",
                 "--data-path",
@@ -3001,7 +3001,7 @@ fn offline_wrapper_tx() -> Result<()> {
                 CHRISTEL_KEY,
                 "--output-folder-path",
                 &output_folder.to_str().unwrap(),
-            ]),
+            ],
         )
     });
     assert!(captured.result.is_ok());
@@ -3107,11 +3107,11 @@ fn pos_validator_metadata_validation() -> Result<()> {
     assert!(captured.contains(TX_APPLIED_SUCCESS));
 
     // 3. Check that the metadata has changed.
-    let query_args = apply_use_device(vec![
+    let query_args = vec![
         "validator-metadata",
         "--validator",
         "validator-0-validator",
-    ]);
+    ];
     let captured =
         CapturedOutput::of(|| run(&node, Bin::Client, query_args.clone()));
     println!("{:?}", captured.result);

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -2381,12 +2381,7 @@ fn wrap_tx_by_elsewho() -> Result<()> {
         run(
             &node,
             Bin::Wallet,
-            vec![
-                "gen",
-                "--alias",
-                key_alias,
-                "--unsafe-dont-encrypt",
-            ],
+            vec!["gen", "--alias", key_alias, "--unsafe-dont-encrypt"],
         )
     });
     assert!(captured.result.is_ok());
@@ -2594,12 +2589,7 @@ fn offline_wrap_tx_by_elsewho() -> Result<()> {
         run(
             &node,
             Bin::Wallet,
-            vec![
-                "gen",
-                "--alias",
-                key_alias,
-                "--unsafe-dont-encrypt",
-            ],
+            vec!["gen", "--alias", key_alias, "--unsafe-dont-encrypt"],
         )
     });
     assert!(captured.result.is_ok());
@@ -2862,12 +2852,7 @@ fn offline_wrapper_tx() -> Result<()> {
         run(
             &node,
             Bin::Wallet,
-            vec![
-                "gen",
-                "--alias",
-                key_alias,
-                "--unsafe-dont-encrypt",
-            ],
+            vec!["gen", "--alias", key_alias, "--unsafe-dont-encrypt"],
         )
     });
     assert!(captured.result.is_ok());
@@ -3107,11 +3092,8 @@ fn pos_validator_metadata_validation() -> Result<()> {
     assert!(captured.contains(TX_APPLIED_SUCCESS));
 
     // 3. Check that the metadata has changed.
-    let query_args = vec![
-        "validator-metadata",
-        "--validator",
-        "validator-0-validator",
-    ];
+    let query_args =
+        vec!["validator-metadata", "--validator", "validator-0-validator"];
     let captured =
         CapturedOutput::of(|| run(&node, Bin::Client, query_args.clone()));
     println!("{:?}", captured.result);


### PR DESCRIPTION
## Describe your changes
Avoid batching transactions when doing hardware wallet signing because it does not yet support them. Instead sign each transaction separately. Also remove the usage of `--use-device` flags in the test code wherever they are not supported by the CLI. Also resolved https://github.com/anoma/namada/pull/3797#issuecomment-2391356816 regarding informing the user about the requests being made to the hardware wallet.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
