### PR TITLE
Avoid duplicated signatures when building transactions

### DIFF
--- a/.changelog/unreleased/improvements/4230-remove-duplicated-sigs.md
+++ b/.changelog/unreleased/improvements/4230-remove-duplicated-sigs.md
@@ -1,0 +1,2 @@
+- Improved the transaction building process to avoid duplicated sections.
+  ([\#4230](https://github.com/anoma/namada/pull/4230))

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -83,22 +83,42 @@ pub struct SigningTxData {
 
 impl PartialEq for SigningTxData {
     fn eq(&self, other: &Self) -> bool {
-        if !(self.owner == other.owner
-            && self.threshold == other.threshold
-            && self.account_public_keys_map == other.account_public_keys_map
-            && self.fee_payer == other.fee_payer)
+        // Deconstruct the two instances to ensure we don't forget any new
+        // field
+        let SigningTxData {
+            owner,
+            public_keys,
+            threshold,
+            account_public_keys_map,
+            fee_payer,
+            shielded_hash,
+        } = self;
+        let SigningTxData {
+            owner: other_owner,
+            public_keys: other_public_keys,
+            threshold: other_threshold,
+            account_public_keys_map: other_account_public_keys_map,
+            fee_payer: other_fee_payer,
+            shielded_hash: other_shielded_hash,
+        } = other;
+
+        if !(owner == other_owner
+            && threshold == other_threshold
+            && account_public_keys_map == other_account_public_keys_map
+            && fee_payer == other_fee_payer
+            && shielded_hash == other_shielded_hash)
         {
             return false;
         }
 
         // Check equivalence of the public keys ignoring the specific ordering
-        if self.public_keys.len() != other.public_keys.len() {
+        if public_keys.len() != other_public_keys.len() {
             return false;
         }
 
-        self.public_keys
+        public_keys
             .iter()
-            .all(|pubkey| other.public_keys.contains(pubkey))
+            .all(|pubkey| other_public_keys.contains(pubkey))
     }
 }
 

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -333,6 +333,10 @@ where
         }
     }
 
+    // Before signing the wrapper tx prune all the possible duplicated sections
+    // (including duplicated raw signatures)
+    tx.prune_duplicated_sections();
+
     // Then try signing the wrapper header (fee payer). Check if there's a
     // provided wrapper signature, otherwise sign with the software wallet or
     // use the fallback

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -83,8 +83,7 @@ pub struct SigningTxData {
 
 impl PartialEq for SigningTxData {
     fn eq(&self, other: &Self) -> bool {
-        // Deconstruct the two instances to ensure we don't forget any new
-        // field
+        // Deconstruct the two instances to ensure we don't forget any new field
         let SigningTxData {
             owner,
             public_keys,
@@ -112,13 +111,17 @@ impl PartialEq for SigningTxData {
         }
 
         // Check equivalence of the public keys ignoring the specific ordering
-        if public_keys.len() != other_public_keys.len() {
-            return false;
-        }
+        // and duplicates (the PartialEq implementation of IndexSet ignores the
+        // order)
+        let unique_public_keys = HashSet::<
+            &namada_account::common::CommonPublicKey,
+        >::from_iter(public_keys.iter());
+        let unique_other_public_keys =
+            HashSet::<&namada_account::common::CommonPublicKey>::from_iter(
+                other_public_keys.iter(),
+            );
 
-        public_keys
-            .iter()
-            .all(|pubkey| other_public_keys.contains(pubkey))
+        unique_public_keys == unique_other_public_keys
     }
 }
 

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -201,6 +201,10 @@ pub fn dump_tx<IO: Io>(io: &IO, args: &args::Tx, mut tx: Tx) -> Result<()> {
         ));
     }
 
+    // Remove duplicated sections before dumping. This is useful in case the
+    // dumped tx needed to be signed offline
+    tx.prune_duplicated_sections();
+
     match args.output_folder.clone() {
         Some(path) => {
             let tx_path = path.join(format!(

--- a/crates/tx/src/section.rs
+++ b/crates/tx/src/section.rs
@@ -443,8 +443,7 @@ pub struct Authorization {
 
 impl PartialEq for Authorization {
     fn eq(&self, other: &Self) -> bool {
-        // Deconstruct the two instances to ensure we don't forget any new
-        // field
+        // Deconstruct the two instances to ensure we don't forget any new field
         let Authorization {
             targets,
             signer: _,
@@ -457,15 +456,18 @@ impl PartialEq for Authorization {
         } = other;
 
         // Two authorizations are equal when they are computed over the same
-        // target(s) and the signatures match ,regardless of how the signer is
+        // target(s) and the signatures match, regardless of how the signer is
         // expressed
 
-        // Check equivalence of the targets ignoring the specific ordering
-        if targets.len() != other_targets.len() {
-            return false;
-        }
+        // Check equivalence of the targets ignoring the specific ordering and
+        // duplicates (the PartialEq implementation of IndexSet ignores the
+        // order)
+        let unique_targets =
+            HashSet::<&namada_account::Hash>::from_iter(targets.iter());
+        let unique_other_targets =
+            HashSet::<&namada_account::Hash>::from_iter(other_targets.iter());
 
-        if !targets.iter().all(|pubkey| other_targets.contains(pubkey)) {
+        if unique_targets != unique_other_targets {
             return false;
         }
 

--- a/crates/tx/src/section.rs
+++ b/crates/tx/src/section.rs
@@ -431,7 +431,6 @@ pub enum Signer {
     BorshSchema,
     Serialize,
     Deserialize,
-    PartialEq,
 )]
 pub struct Authorization {
     /// The hash of the section being signed
@@ -440,6 +439,39 @@ pub struct Authorization {
     pub signer: Signer,
     /// The signature over the above hash
     pub signatures: BTreeMap<u8, common::Signature>,
+}
+
+impl PartialEq for Authorization {
+    fn eq(&self, other: &Self) -> bool {
+        // Deconstruct the two instances to ensure we don't forget any new
+        // field
+        let Authorization {
+            targets,
+            signer: _,
+            signatures,
+        } = self;
+        let Authorization {
+            targets: other_targets,
+            signer: _,
+            signatures: other_signatures,
+        } = other;
+
+        // Two authorizations are equal when they are computed over the same
+        // target(s) and the signatures match ,regardless of how the signer is
+        // expressed
+
+        // Check equivalence of the targets ignoring the specific ordering
+        if targets.len() != other_targets.len() {
+            return false;
+        }
+
+        if !targets.iter().all(|pubkey| other_targets.contains(pubkey)) {
+            return false;
+        }
+
+        // Check equivalence of the signatures
+        signatures == other_signatures
+    }
 }
 
 impl Authorization {

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -188,6 +188,17 @@ impl Tx {
         self.header.batch.insert(cmt)
     }
 
+    /// Remove duplicated sections from the transaction
+    pub fn prune_duplicated_sections(&mut self) {
+        let sections = std::mem::take(&mut self.sections);
+        let mut unique_sections = HashMap::with_capacity(sections.len());
+        for section in sections {
+            unique_sections.insert(section.get_hash(), section);
+        }
+
+        self.sections = unique_sections.into_values().collect();
+    }
+
     /// Get the transaction header
     pub fn header(&self) -> Header {
         self.header.clone()


### PR DESCRIPTION
## Describe your changes

Closes #4203.

This PR modifies adds a new method on the `Tx` type to remove duplicated sections. This function is then called in the signing function before producing the wrapper signature (which is computed on all the sections) and the `dump_tx` function (in case the dumped tx needed to be signed offline).

To support this logic the `PartialEq` implementation for the `Authorization` type is now manually provided and ignores the way the signer is specified, focusing instead on the targets and the actual signature.

As a side note, also the `PartialEq` implementation for `SigningTxData` has been updated to account for the shielded hash.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
