### PR TITLE
Offline signatures from SDK

### DIFF
--- a/.changelog/unreleased/SDK/4234-offline-sigs-in-sdk.md
+++ b/.changelog/unreleased/SDK/4234-offline-sigs-in-sdk.md
@@ -1,0 +1,2 @@
+- Moved the signature generation logic for offline signing to the SDK.
+  ([\#4234](https://github.com/anoma/namada/pull/4234))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -296,7 +296,6 @@ pub mod cmds {
                 .subcommand(QueryEffNativeSupply::def().display_order(5))
                 .subcommand(QueryStakingRewardsRate::def().display_order(5))
                 // Actions
-                .subcommand(SignTx::def().display_order(6))
                 .subcommand(ShieldedSync::def().display_order(6))
                 .subcommand(GenIbcShieldingTransfer::def().display_order(6))
                 // Utils
@@ -1916,25 +1915,6 @@ pub mod cmds {
             App::new(Self::CMD)
                 .about(wrap!("Query PoS bonded stake."))
                 .add_args::<args::QueryBondedStake<args::CliTypes>>()
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct SignTx(pub args::SignTx<args::CliTypes>);
-
-    impl SubCmd for SignTx {
-        const CMD: &'static str = "sign-tx";
-
-        fn parse(matches: &ArgMatches) -> Option<Self> {
-            matches
-                .subcommand_matches(Self::CMD)
-                .map(|matches| SignTx(args::SignTx::parse(matches)))
-        }
-
-        fn def() -> App {
-            App::new(Self::CMD)
-                .about(wrap!("Sign a transaction offline."))
-                .add_args::<args::SignTx<args::CliTypes>>()
         }
     }
 
@@ -6758,47 +6738,6 @@ pub mod args {
                     .def()
                     .help(wrap!("The address of the validator to reactivate.")),
             )
-        }
-    }
-
-    impl CliToSdk<SignTx<SdkTypes>> for SignTx<CliTypes> {
-        type Error = std::io::Error;
-
-        fn to_sdk(
-            self,
-            ctx: &mut Context,
-        ) -> Result<SignTx<SdkTypes>, Self::Error> {
-            let tx = self.tx.to_sdk(ctx)?;
-            let tx_data = std::fs::read(self.tx_data)?;
-
-            Ok(SignTx::<SdkTypes> {
-                tx,
-                tx_data,
-                owner: ctx.borrow_chain_or_exit().get(&self.owner),
-            })
-        }
-    }
-
-    impl Args for SignTx<CliTypes> {
-        fn parse(matches: &ArgMatches) -> Self {
-            let tx = Tx::parse(matches);
-            let tx_path = TX_PATH.parse(matches);
-            let owner = OWNER.parse(matches);
-            Self {
-                tx,
-                tx_data: tx_path,
-                owner,
-            }
-        }
-
-        fn def(app: App) -> App {
-            app.add_args::<Tx<CliTypes>>()
-                .arg(TX_PATH.def().help(wrap!(
-                    "The path to the tx file with the serialized tx."
-                )))
-                .arg(
-                    OWNER.def().help(wrap!("The address of the account owner")),
-                )
         }
     }
 

--- a/crates/apps_lib/src/client/utils.rs
+++ b/crates/apps_lib/src/client/utils.rs
@@ -1052,19 +1052,21 @@ pub async fn sign_offline(
         safe_exit(1)
     };
 
-    let mut tx =
-        if let Ok(transaction) = Tx::try_from_json_bytes(tx_data.as_ref()) {
-            transaction
-        } else {
-            eprintln!("Couldn't decode the transaction.");
-            safe_exit(1)
-        };
+    let tx = if let Ok(transaction) = Tx::try_from_json_bytes(tx_data.as_ref())
+    {
+        transaction
+    } else {
+        eprintln!("Couldn't decode the transaction.");
+        safe_exit(1)
+    };
+    let raw_header_hash = tx.raw_header_hash();
+    let header_hash = tx.header_hash();
 
     let OfflineSignatures {
         signatures,
         wrapper_signature,
     } = match namada_sdk::signing::generate_tx_signatures(
-        &mut tx,
+        tx,
         secret_keys,
         owner,
         wrapper_signer,
@@ -1081,7 +1083,7 @@ pub async fn sign_offline(
     for signature in &signatures {
         let filename = format!(
             "offline_signature_{}_{}.sig",
-            tx.raw_header_hash().to_string().to_lowercase(),
+            raw_header_hash.to_string().to_lowercase(),
             signature.pubkey,
         );
 
@@ -1106,7 +1108,7 @@ pub async fn sign_offline(
     if let Some(wrapper_signature) = wrapper_signature {
         let filename = format!(
             "offline_wrapper_signature_{}.sig",
-            tx.header_hash().to_string().to_lowercase()
+            header_hash.to_string().to_lowercase()
         );
         let signature_path = match output_folder_path {
             Some(ref path) => path.join(filename).to_string_lossy().to_string(),

--- a/crates/apps_lib/src/client/utils.rs
+++ b/crates/apps_lib/src/client/utils.rs
@@ -1063,7 +1063,7 @@ pub async fn sign_offline(
     let OfflineSignatures {
         signatures,
         wrapper_signature,
-    } = match namada_sdk::signing::sign_offline(
+    } = match namada_sdk::signing::generate_tx_signatures(
         &mut tx,
         secret_keys,
         owner,

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -2142,17 +2142,6 @@ impl TxReactivateValidator {
 }
 
 #[derive(Clone, Debug)]
-/// Sign a transaction offline
-pub struct SignTx<C: NamadaTypes = SdkTypes> {
-    /// Common tx arguments
-    pub tx: Tx<C>,
-    /// Transaction data
-    pub tx_data: C::Data,
-    /// The account address
-    pub owner: C::Address,
-}
-
-#[derive(Clone, Debug)]
 /// Sync notes from MASP owned by the provided spending /
 /// viewing keys. Syncing can be told to stop at a given
 /// block height.

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -446,8 +446,13 @@ pub struct OfflineSignatures {
 /// Generates the transaction's signatures for offline signing purposes. This
 /// allows to sign both the inner transactions of the batch as well as the
 /// wrapper transaction and it supports multisignatures.
+///
+/// This function might need to modify the transaction by attaching the inner tx
+/// signatures to correctly produce the wrapper signature: since this change is
+/// only needed for the sake of this function and should not be propagated to
+/// the caller, this function consumes the actual tx.
 pub async fn generate_tx_signatures(
-    tx: &mut Tx,
+    mut tx: Tx,
     secret_keys: Vec<namada_core::key::common::SecretKey>,
     owner: Option<Address>,
     wrapper_signer: Option<namada_core::key::common::SecretKey>,

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -435,19 +435,18 @@ pub async fn aux_signing_data(
     })
 }
 
-/// The offline transaction's signatures produced via the offline signing
-/// procedure
+/// The transaction's signatures produced via the offline signing procedure
 pub struct OfflineSignatures {
     /// Inner txs' signatures
     pub signatures: Vec<SignatureIndex>,
-    /// Wrapper signature
+    /// Optional wrapper signature
     pub wrapper_signature: Option<Authorization>,
 }
 
-/// Sign a transaction offline. This allows to sign both the inner transactions
-/// of the batch as well as the wrapper transaction. It also supports
-/// multisignature.
-pub async fn sign_offline(
+/// Generates the transaction's signatures for offline signing purposes. This
+/// allows to sign both the inner transactions of the batch as well as the
+/// wrapper transaction and it supports multisignatures.
+pub async fn generate_tx_signatures(
     tx: &mut Tx,
     secret_keys: Vec<namada_core::key::common::SecretKey>,
     owner: Option<Address>,
@@ -457,8 +456,6 @@ pub async fn sign_offline(
         secret_keys.iter().map(|sk| sk.to_public()),
     );
 
-    // FIXME: does this work with the hardware wallet? It does not. Should it?
-    // yes absolutely
     let signatures = tx.compute_section_signature(
         &secret_keys,
         &account_public_keys_map,


### PR DESCRIPTION
## Describe your changes

This PR moves the offline signing logic from the client to the SDK.
Also removes some remaining traces of  `SignTx` which is a duplicated of `OfflineSign` (I had already started removing it in #4120 but forgot to remove everything).

I've also opened #4235 with some followup tasks on this topic.

cc: @jurevans

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
