### PR TITLE
fix make-package.sh to work on windows

### DIFF
--- a/scripts/make-package.sh
+++ b/scripts/make-package.sh
@@ -16,6 +16,6 @@ ln ${BIN} ../../${PACKAGE_NAME} && \
 cd ../.. && \
 ln wasm/*.*.wasm wasm/checksums.json ${PACKAGE_NAME}/wasm && \
 ln LICENSE ${PACKAGE_NAME} && \
-cargo about generate about.hbs > ${PACKAGE_NAME}/LICENSE.thirdparty && \
+cargo about generate about.hbs --output-fle ${PACKAGE_NAME}/LICENSE.thirdparty && \
 tar -c -z -f ${PACKAGE_NAME}.tar.gz ${PACKAGE_NAME} && \
 rm -rf ${PACKAGE_NAME}


### PR DESCRIPTION
## Describe your changes

fixes `[ERROR] cargo-about should not redirect its output in powershell, please use the -o, --output-file option to redirect to a file to avoid powershell encoding issues`

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
