### PR TITLE
client: print last stake ration and improve msg on zero inflation

### DIFF
--- a/.changelog/unreleased/improvements/4241-client-staking-rewards-query.md
+++ b/.changelog/unreleased/improvements/4241-client-staking-rewards-query.md
@@ -1,0 +1,2 @@
+- Improved the staking rewards query to print last staked ratio.
+  ([\#4241](https://github.com/anoma/namada/pull/4241))


### PR DESCRIPTION
## Describe your changes

When the PoS inflation is 0 the client printed `PoS inflation and rewards are not currently enabled.` assuming it's not enabled. This PR adds additional query to print last staked ratio which may cause the inflation to go to 0 when its over the `target_staked_ratio` and changes the message to `No PoS inflation and rewards tokens were minted.` that can apply to either case.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
