### PR TITLE
build with no jemalloc on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,12 @@ jobs:
         with:
           name: wasm-${{ github.sha }}
           path: wasm
-      - name: Build release package for ${{ matrix.os }}
+      - name: Build release package for ${{ matrix.os }} (non-Windows)
+        if: ${{ !startsWith(runner.os, 'Windows') }}
         run: make package
+      - name: Build release package for ${{ matrix.os }} (Windows)
+        if: ${{ startsWith(runner.os, 'Windows') }}
+        run: make package-no-jemalloc
       - name: Upload binaries package
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,7 +4375,8 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.16.0+8.10.0"
-source = "git+https://github.com/heliaxdev/rust-rocksdb?rev=4dc7f4fdfa17e923d3078d51261e3db66707754d#4dc7f4fdfa17e923d3078d51261e3db66707754d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -7225,7 +7226,8 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.22.0"
-source = "git+https://github.com/heliaxdev/rust-rocksdb?rev=4dc7f4fdfa17e923d3078d51261e3db66707754d#4dc7f4fdfa17e923d3078d51261e3db66707754d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,9 +167,7 @@ regex = "1.10.2"
 reqwest = "0.11.4"
 ripemd = "0.1"
 rlimit = "0.5.4"
-# rocksdb = {version = "0.22.0", features = ['zstd'], default-features = false}
-# TEMP branch "tomas/no-jemalloc-win", replace once upstreamed
-rocksdb = {git = "https://github.com/heliaxdev/rust-rocksdb", rev = "4dc7f4fdfa17e923d3078d51261e3db66707754d", features = ['zstd'], default-features = false}
+rocksdb = {version = "0.22.0", features = ['zstd'], default-features = false}
 rpassword = "5.0.1"
 rustversion = "1.0"
 serde = {version = "1.0.125", features = ["derive"]}

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,12 @@ build-release:
 		--features jemalloc \
 		--features migrations
 
+build-release-no-jemalloc:
+	$(cargo) build $(jobs) --release --timings --package namada_apps \
+		--manifest-path Cargo.toml \
+		--no-default-features \
+		--features migrations
+
 build-debug:
 	$(cargo) build --package namada_apps --manifest-path Cargo.toml
 
@@ -93,6 +99,9 @@ check-release:
 	$(cargo) check --release --package namada_apps
 
 package: build-release
+	scripts/make-package.sh
+
+package-no-jemalloc: build-release-no-jemalloc
 	scripts/make-package.sh
 
 check-wasm = $(cargo) check --target wasm32-unknown-unknown --manifest-path $(wasm)/Cargo.toml


### PR DESCRIPTION
## Describe your changes

Switched back to upstream version of rocksdb and avoids enabling jemalloc feature in windows release build.

Tested in https://github.com/anoma/namada/actions/runs/12812138436 (though I broke `make-package.sh` earlier in unrelated change - fixed in #4243)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
