### PR TITLE
avoid running cometbft as a validator when tendermint_node is set to non-validator

### DIFF
--- a/.changelog/unreleased/bug-fixes/4245-fix-tm-mode.md
+++ b/.changelog/unreleased/bug-fixes/4245-fix-tm-mode.md
@@ -1,0 +1,5 @@
+- Fixed running CometBFT as a validator when the Namada config `tendermint_mode`
+  is set to a non-validator mode. When the `tendermint_mode` changes
+  from a validator to non-validator mode, the node will replace and
+  backup the validator consensus key and state in the CometBFT directory.
+  ([\#4245](https://github.com/anoma/namada/pull/4245))

--- a/crates/apps/src/bin/namada-node/cli.rs
+++ b/crates/apps/src/bin/namada-node/cli.rs
@@ -28,11 +28,7 @@ pub fn main() -> Result<()> {
                     );
                     ScheduledMigration::from_path(p, hash, height).unwrap()
                 });
-                node::run(
-                    chain_ctx.config.ledger,
-                    wasm_dir,
-                    scheduled_migration,
-                );
+                node::run(chain_ctx.config, wasm_dir, scheduled_migration);
             }
             cmds::Ledger::RunUntil(cmds::LedgerRunUntil(args)) => {
                 let mut chain_ctx = ctx.take_chain_or_exit();
@@ -40,7 +36,7 @@ pub fn main() -> Result<()> {
                 sleep_until(args.time);
                 chain_ctx.config.ledger.shell.action_at_height =
                     Some(args.action_at_height);
-                node::run(chain_ctx.config.ledger, wasm_dir, None);
+                node::run(chain_ctx.config, wasm_dir, None);
             }
             cmds::Ledger::Reset(_) => {
                 let chain_ctx = ctx.take_chain_or_exit();

--- a/crates/apps_lib/src/config/mod.rs
+++ b/crates/apps_lib/src/config/mod.rs
@@ -51,7 +51,7 @@ pub struct NodeLocalConfig {
     pub recheck_process_proposal: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TendermintMode {
     Full,
     Validator,
@@ -101,7 +101,6 @@ pub struct Ledger {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Shell {
     pub base_dir: PathBuf,
-    // pub ledger_address: SocketAddr,
     /// RocksDB block cache maximum size in bytes.
     /// When not set, defaults to 1/3 of the available memory.
     pub block_cache_bytes: Option<u64>,
@@ -122,6 +121,8 @@ pub struct Shell {
     pub action_at_height: Option<ActionAtHeight>,
     /// Specify if tendermint is started as validator, fullnode or seednode
     pub tendermint_mode: TendermintMode,
+    /// A `tendermint_mode` set on the last node start-up, if any.
+    pub last_tendermint_mode: Option<TendermintMode>,
     /// When set, indicates after how many blocks a new snapshot
     /// will be taken (counting from the first block)
     pub blocks_between_snapshots: Option<NonZeroU64>,
@@ -155,6 +156,7 @@ impl Ledger {
                 cometbft_dir: COMETBFT_DIR.into(),
                 action_at_height: None,
                 tendermint_mode: mode,
+                last_tendermint_mode: None,
                 blocks_between_snapshots: None,
                 snapshots_to_keep: None,
             },


### PR DESCRIPTION
## Describe your changes

closes #4139

The PR adds a new field in config `last_tendermint_mode` (non-breaking as it's optional) which will be persisted on node start-up. If the mode changes from validator to non-validator, the node will backup and replace the validator key and state in the CometBFT dir.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
