### PR TITLE
Upgrade ibc-rs to v0.57

### DIFF
--- a/.changelog/unreleased/improvements/4247-bump-ibc-rs.md
+++ b/.changelog/unreleased/improvements/4247-bump-ibc-rs.md
@@ -1,0 +1,1 @@
+- bump ibc-rs to v0.57.0 ([\#4247](https://github.com/anoma/namada/issues/4247))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3404,10 +3404,10 @@ source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43
 dependencies = [
  "ibc-apps",
  "ibc-clients",
- "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core",
  "ibc-core-host-cosmos",
- "ibc-derive 0.10.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-derive",
+ "ibc-primitives",
 ]
 
 [[package]]
@@ -3416,7 +3416,7 @@ version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-app-nft-transfer-types",
- "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core",
  "serde-json-wasm",
 ]
 
@@ -3431,9 +3431,9 @@ dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
  "http 1.1.0",
- "ibc-app-transfer-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-app-transfer-types",
+ "ibc-core",
+ "ibc-proto",
  "mime",
  "parity-scale-codec",
  "scale-info",
@@ -3447,39 +3447,9 @@ name = "ibc-app-transfer"
 version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
- "ibc-app-transfer-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-app-transfer-types",
+ "ibc-core",
  "serde-json-wasm",
-]
-
-[[package]]
-name = "ibc-app-transfer-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "borsh",
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core 0.54.0",
- "ibc-proto 0.47.1",
- "primitive-types 0.12.2",
- "serde",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "ibc-app-transfer-types"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "borsh",
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-proto 0.51.1",
- "primitive-types 0.13.1",
- "serde",
- "uint 0.10.0",
 ]
 
 [[package]]
@@ -3491,8 +3461,8 @@ dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core",
+ "ibc-proto",
  "parity-scale-codec",
  "primitive-types 0.13.1",
  "scale-info",
@@ -3517,11 +3487,11 @@ source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
- "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client",
+ "ibc-core-commitment-types",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-primitives",
  "serde",
  "tendermint 0.40.1",
  "tendermint-light-client-verifier",
@@ -3533,11 +3503,11 @@ version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "displaydoc",
- "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
  "serde",
  "tendermint 0.40.1",
  "tendermint-light-client-verifier",
@@ -3551,10 +3521,10 @@ source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
- "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core-client",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
  "serde",
 ]
 
@@ -3569,80 +3539,18 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "ibc-core-channel 0.54.0",
- "ibc-core-client 0.54.0",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-connection 0.54.0",
- "ibc-core-handler 0.54.0",
- "ibc-core-host 0.54.0",
- "ibc-core-router 0.54.0",
- "ibc-derive 0.8.0",
- "ibc-primitives 0.54.0",
-]
-
-[[package]]
-name = "ibc-core"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "ibc-core-channel 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-client 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-connection 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-handler 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-derive 0.10.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
-]
-
-[[package]]
-name = "ibc-core"
 version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
- "ibc-core-channel 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-connection 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-handler 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-router 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-derive 0.10.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
-]
-
-[[package]]
-name = "ibc-core-channel"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "ibc-core-channel-types 0.54.0",
- "ibc-core-client 0.54.0",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-connection 0.54.0",
- "ibc-core-handler-types 0.54.0",
- "ibc-core-host 0.54.0",
- "ibc-core-router 0.54.0",
- "ibc-primitives 0.54.0",
-]
-
-[[package]]
-name = "ibc-core-channel"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-client 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-connection 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-channel",
+ "ibc-core-client",
+ "ibc-core-commitment-types",
+ "ibc-core-connection",
+ "ibc-core-handler",
+ "ibc-core-host",
+ "ibc-core-router",
+ "ibc-derive",
+ "ibc-primitives",
 ]
 
 [[package]]
@@ -3650,54 +3558,14 @@ name = "ibc-core-channel"
 version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
- "ibc-core-channel-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-connection 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-router 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
-]
-
-[[package]]
-name = "ibc-core-channel-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "borsh",
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core-client-types 0.54.0",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-connection-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-primitives 0.54.0",
- "ibc-proto 0.47.1",
- "serde",
- "sha2 0.10.8",
- "subtle-encoding",
- "tendermint 0.38.1",
-]
-
-[[package]]
-name = "ibc-core-channel-types"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "borsh",
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-connection-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-proto 0.51.1",
- "serde",
- "sha2 0.10.8",
- "subtle-encoding",
- "tendermint 0.40.1",
+ "ibc-core-channel-types",
+ "ibc-core-client",
+ "ibc-core-commitment-types",
+ "ibc-core-connection",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-core-router",
+ "ibc-primitives",
 ]
 
 [[package]]
@@ -3709,12 +3577,12 @@ dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-connection-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -3726,73 +3594,15 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "ibc-core-client-context 0.54.0",
- "ibc-core-client-types 0.54.0",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-handler-types 0.54.0",
- "ibc-core-host 0.54.0",
- "ibc-primitives 0.54.0",
-]
-
-[[package]]
-name = "ibc-core-client"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "ibc-core-client-context 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
-]
-
-[[package]]
-name = "ibc-core-client"
 version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
- "ibc-core-client-context 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
-]
-
-[[package]]
-name = "ibc-core-client-context"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core-client-types 0.54.0",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-handler-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-primitives 0.54.0",
- "subtle-encoding",
- "tendermint 0.38.1",
-]
-
-[[package]]
-name = "ibc-core-client-context"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "subtle-encoding",
- "tendermint 0.40.1",
+ "ibc-core-client-context",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-primitives",
 ]
 
 [[package]]
@@ -3802,45 +3612,11 @@ source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "subtle-encoding",
- "tendermint 0.40.1",
-]
-
-[[package]]
-name = "ibc-core-client-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "borsh",
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-primitives 0.54.0",
- "ibc-proto 0.47.1",
- "serde",
- "subtle-encoding",
- "tendermint 0.38.1",
-]
-
-[[package]]
-name = "ibc-core-client-types"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "borsh",
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-proto 0.51.1",
- "serde",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-handler-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
  "subtle-encoding",
  "tendermint 0.40.1",
 ]
@@ -3854,48 +3630,16 @@ dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core-commitment-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
  "serde",
  "subtle-encoding",
  "tendermint 0.40.1",
-]
-
-[[package]]
-name = "ibc-core-commitment-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "borsh",
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core-host-types 0.54.0",
- "ibc-primitives 0.54.0",
- "ibc-proto 0.47.1",
- "ics23",
- "serde",
- "subtle-encoding",
-]
-
-[[package]]
-name = "ibc-core-commitment-types"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "borsh",
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-proto 0.51.1",
- "ics23",
- "serde",
- "subtle-encoding",
 ]
 
 [[package]]
@@ -3907,39 +3651,15 @@ dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
  "ics23",
  "parity-scale-codec",
  "scale-info",
  "schemars",
  "serde",
  "subtle-encoding",
-]
-
-[[package]]
-name = "ibc-core-connection"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "ibc-core-client 0.54.0",
- "ibc-core-connection-types 0.54.0",
- "ibc-core-handler-types 0.54.0",
- "ibc-core-host 0.54.0",
- "ibc-primitives 0.54.0",
-]
-
-[[package]]
-name = "ibc-core-connection"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "ibc-core-client 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-connection-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
 ]
 
 [[package]]
@@ -3948,52 +3668,16 @@ version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-client-wasm-types",
- "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client",
+ "ibc-core-connection-types",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-primitives",
  "prost 0.13.2",
 ]
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "borsh",
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core-client-types 0.54.0",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-primitives 0.54.0",
- "ibc-proto 0.47.1",
- "serde",
- "subtle-encoding",
- "tendermint 0.38.1",
-]
-
-[[package]]
-name = "ibc-core-connection-types"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "borsh",
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-proto 0.51.1",
- "serde",
- "subtle-encoding",
- "tendermint 0.40.1",
-]
-
-[[package]]
-name = "ibc-core-connection-types"
 version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
@@ -4001,11 +3685,11 @@ dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -4016,89 +3700,17 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "ibc-core-channel 0.54.0",
- "ibc-core-client 0.54.0",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-connection 0.54.0",
- "ibc-core-handler-types 0.54.0",
- "ibc-core-host 0.54.0",
- "ibc-core-router 0.54.0",
- "ibc-primitives 0.54.0",
-]
-
-[[package]]
-name = "ibc-core-handler"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "ibc-core-channel 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-client 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-connection 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
-]
-
-[[package]]
-name = "ibc-core-handler"
 version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
- "ibc-core-channel 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-connection 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-router 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
-]
-
-[[package]]
-name = "ibc-core-handler-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "borsh",
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core-channel-types 0.54.0",
- "ibc-core-client-types 0.54.0",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-connection-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-core-router-types 0.54.0",
- "ibc-primitives 0.54.0",
- "ibc-proto 0.47.1",
- "serde",
- "subtle-encoding",
- "tendermint 0.38.1",
-]
-
-[[package]]
-name = "ibc-core-handler-types"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "borsh",
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-connection-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-router-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-proto 0.51.1",
- "serde",
- "subtle-encoding",
- "tendermint 0.40.1",
+ "ibc-core-channel",
+ "ibc-core-client",
+ "ibc-core-commitment-types",
+ "ibc-core-connection",
+ "ibc-core-handler-types",
+ "ibc-core-host",
+ "ibc-core-router",
+ "ibc-primitives",
 ]
 
 [[package]]
@@ -4110,14 +3722,14 @@ dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-channel-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-router-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core-channel-types",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-connection-types",
+ "ibc-core-host-types",
+ "ibc-core-router-types",
+ "ibc-primitives",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -4128,55 +3740,19 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core-channel-types 0.54.0",
- "ibc-core-client-context 0.54.0",
- "ibc-core-client-types 0.54.0",
- "ibc-core-commitment-types 0.54.0",
- "ibc-core-connection-types 0.54.0",
- "ibc-core-handler-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-primitives 0.54.0",
- "subtle-encoding",
-]
-
-[[package]]
-name = "ibc-core-host"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-client-context 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-connection-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "subtle-encoding",
-]
-
-[[package]]
-name = "ibc-core-host"
 version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-channel-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-client-context 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-channel-types",
+ "ibc-core-client-context",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-connection-types",
+ "ibc-core-handler-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
  "subtle-encoding",
 ]
 
@@ -4187,16 +3763,16 @@ source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-app-transfer-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-app-transfer-types",
  "ibc-client-tendermint",
- "ibc-core-client-context 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core-client-context",
+ "ibc-core-client-types",
+ "ibc-core-commitment-types",
+ "ibc-core-connection-types",
+ "ibc-core-handler-types",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
@@ -4205,32 +3781,6 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "borsh",
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-primitives 0.54.0",
- "serde",
-]
-
-[[package]]
-name = "ibc-core-host-types"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "base64 0.22.1",
- "borsh",
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "prost 0.13.2",
- "serde",
-]
-
-[[package]]
-name = "ibc-core-host-types"
 version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
@@ -4239,7 +3789,7 @@ dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives",
  "parity-scale-codec",
  "prost 0.13.2",
  "scale-info",
@@ -4249,76 +3799,16 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core-channel-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-core-router-types 0.54.0",
- "ibc-primitives 0.54.0",
- "subtle-encoding",
-]
-
-[[package]]
-name = "ibc-core-router"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-router-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "subtle-encoding",
-]
-
-[[package]]
-name = "ibc-core-router"
 version = "0.56.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-channel-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-core-router-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router-types",
+ "ibc-primitives",
  "subtle-encoding",
-]
-
-[[package]]
-name = "ibc-core-router-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "borsh",
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-core-host-types 0.54.0",
- "ibc-primitives 0.54.0",
- "ibc-proto 0.47.1",
- "serde",
- "subtle-encoding",
- "tendermint 0.38.1",
-]
-
-[[package]]
-name = "ibc-core-router-types"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "borsh",
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-proto 0.51.1",
- "serde",
- "subtle-encoding",
- "tendermint 0.40.1",
 ]
 
 [[package]]
@@ -4329,9 +3819,9 @@ dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-proto 0.51.1",
+ "ibc-core-host-types",
+ "ibc-primitives",
+ "ibc-proto",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -4342,26 +3832,6 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.8.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "ibc-derive"
-version = "0.10.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "ibc-derive"
 version = "0.10.0"
 source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
@@ -4373,61 +3843,19 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.1.0#3d3b436f7c58000c7498d68e88c15a955433a619"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
- "ibc-core-channel-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-core-router 0.54.0",
- "ibc-core-router-types 0.54.0",
- "ibc-primitives 0.54.0",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
-dependencies = [
- "ibc-core-channel-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-core-router 0.54.0",
- "ibc-core-router-types 0.54.0",
- "ibc-primitives 0.54.0",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
-dependencies = [
- "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-router-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
 ]
 
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.1.0#3d3b436f7c58000c7498d68e88c15a955433a619"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4436,16 +3864,16 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-overflow-receive"
 version = "0.4.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
- "ibc-app-transfer-types 0.54.0",
- "ibc-core-channel-types 0.54.0",
- "ibc-core-host-types 0.54.0",
- "ibc-core-router 0.54.0",
- "ibc-core-router-types 0.54.0",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0)",
- "ibc-primitives 0.54.0",
+ "ibc-app-transfer-types",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
+ "ibc-primitives",
  "serde",
  "serde_json",
 ]
@@ -4453,51 +3881,22 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
  "borsh",
  "dur",
  "either",
- "ibc-app-transfer-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-channel 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-core-router-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs)",
- "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-app-transfer-types",
+ "ibc-core-channel",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
+ "ibc-primitives",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ibc-primitives"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
-dependencies = [
- "borsh",
- "derive_more 0.99.18",
- "displaydoc",
- "ibc-proto 0.47.1",
- "prost 0.13.2",
- "serde",
- "tendermint 0.38.1",
- "time",
-]
-
-[[package]]
-name = "ibc-primitives"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
-dependencies = [
- "borsh",
- "derive_more 1.0.0",
- "displaydoc",
- "ibc-proto 0.51.1",
- "prost 0.13.2",
- "serde",
- "time",
 ]
 
 [[package]]
@@ -4509,31 +3908,13 @@ dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-proto 0.51.1",
+ "ibc-proto",
  "parity-scale-codec",
  "prost 0.13.2",
  "scale-info",
  "schemars",
  "serde",
  "time",
-]
-
-[[package]]
-name = "ibc-proto"
-version = "0.47.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c852d22b782d2d793f4a646f968de419be635e02bc8798d5d74a6e44eef27733"
-dependencies = [
- "base64 0.22.1",
- "borsh",
- "bytes",
- "flex-error",
- "ics23",
- "informalsystems-pbjson",
- "prost 0.13.2",
- "serde",
- "subtle-encoding",
- "tendermint-proto 0.38.1",
 ]
 
 [[package]]
@@ -4563,7 +3944,7 @@ source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43
 dependencies = [
  "displaydoc",
  "ibc",
- "ibc-proto 0.51.1",
+ "ibc-proto",
  "tonic",
 ]
 
@@ -4577,7 +3958,7 @@ dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
  "ibc",
- "ibc-proto 0.51.1",
+ "ibc-proto",
  "ibc-query",
  "parking_lot",
  "subtle-encoding",
@@ -5901,9 +5282,9 @@ dependencies = [
  "data-encoding",
  "dur",
  "ibc",
- "ibc-derive 0.10.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.1.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.1.0)",
+ "ibc-derive",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ibc-testkit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,31 +3870,8 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64aa34a2890898b88c6f1e0b505b7d092b569492885cdc145ac5e23e816cc308"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -3905,26 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
 version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.2.0#3dca5354609af33e0aaba3f582a28447410d637f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73055ad46ad031f010ac66ac185fd2e4cee456d5e0e8bec21ea6caf55de7d63a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3933,15 +3893,16 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-overflow-receive"
 version = "0.5.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33fe36be073b32abe9b262134cc2a2fbbd689f9a532f6700533324ff279af8b"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core-channel-types",
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -3950,7 +3911,8 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.10.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9da9cb134fa631c50659f58fb6f5356c724709048107b976548daad8860e7361"
 dependencies = [
  "borsh",
  "dur",
@@ -3961,8 +3923,8 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -5355,8 +5317,8 @@ dependencies = [
  "dur",
  "ibc",
  "ibc-derive",
- "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0)",
- "ibc-middleware-module-macros 0.2.0",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ibc-testkit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,8 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50aebe83b772ecd2020ad1654b09abfb387f5ddc07db01ed23defb04a9a7fde8"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -3412,8 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95bbdca1dab5e007633af6d9ee070a2f35749336239804c42ff7fad444c10b2e"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -3422,8 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e654dd72dc2df2dd1f232b0599331ff1519fc2c0d346f12e5e319a97c33b330c"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
@@ -3444,8 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cad93b5e1074c1f7b8dcea6099640b5a725a8a1dde957b00e89685eb2c0151"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -3454,8 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364c7eb9dc122a279cafb5cd9eb1c459a1902a3c9a1e107f8d3037ca97ab4a5c"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3473,8 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-apps"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5ecc814492ac9349b27d7f119f0b0f3b9f94ffd156df35eaf6adb53b7831f3"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -3482,8 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11225e842c5e3bf0787a36cf10d16b954dafbef357533fa2a87c7ac1bb2739f7"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -3499,8 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa16efb7dc6d7b73d483e55553e6c69eeaf0b82384b464514c52fe813d3c55d2"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -3516,8 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-wasm-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e897b268e2f496e4a66c068a6146576a8b5a8243c5d3f1ab157505a715f22dc8"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -3530,8 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-clients"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464b3c5061092ea25298443d3554c405f78d31e4928060167a216bb8cdc02708"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -3539,8 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f37c8c56ee649ba0ddf64268d4b8b35287937d4aaaf69877f922a4adc2eb29e"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3555,8 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111523dd75048898dcf3806484b2615a97d186725f1df8fe2de2862c6849034e"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -3570,8 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681d986a6943683ef16fbaab8295125bf795ab4e15a1909eccb8574bb4567f10"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3594,8 +3607,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e95616bda7fa163c1ed5e96aa2a5c902d07b31fddbcd756ebaca7a004bc078e8"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -3607,8 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-context"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540ce861ac8fe7ce6ff14de043d8a3e8e239875c058f0b5baa9fe9b0a31ac94"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3623,8 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f741122f7504846a6099d41244687e5db3235b7ce5f651de8a552489c1f5c9a"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3644,8 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-commitment-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba35d2bde395cff6ddbf550d604c3098903e661430588995b1e5f8db1f2e1d1"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3664,8 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debe3ecdf3a0d59b011c963164974d6d924fb7e5580ce8262b1e64e2a0088cd7"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -3678,8 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2eed5ea03d3900f89b3b498c7f2ff83ca50c2f4f76cebc339bfa5ecb2f0ffc1"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3700,8 +3719,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26219873baa090be293308e45be9eb09a4ad5eb27b9cedbca3fa9552e90e6163"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3715,8 +3735,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "426cdb98d683cf8f65b1ebb7638fd4e8a35e1718aa143bcf895636ee34c68385"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3740,8 +3761,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff10f831f430b02462e71852bcbc947dde972762ee26dce1202f861003366f2"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3758,8 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-cosmos"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06697cc443a9ad99a6063e10ae08bf0aa78a72ba9e4e46fd6db8ee1c511b66f"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3781,8 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5879fb43b0789f42919b7965a93f8a18a08eaa39bf624fbaf837d8673ef1ecdc"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
@@ -3799,8 +3823,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d50640473900acca78039d01246bbfec827153eb7d7f294dc08dee58ca2be4f"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3813,8 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cdfb5f8f7986ac50941f556c16d46e81cdf3529b257be1ab3beca8281f953e"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3832,8 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.10.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e93e76ce4da46027a59a5f2c3152e6d4adc4a9d541c782ff69b89e7fa2ccb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3843,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -3855,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3864,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-overflow-receive"
 version = "0.4.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core-channel-types",
@@ -3881,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "borsh",
  "dur",
@@ -3901,8 +3928,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-primitives"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ff3dab00855e9ab99fa7276814bd29b0350f2da70b3e9f67f1d86f4e269655b"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3939,8 +3967,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-query"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d4180842b5fcfb2742cb070b7bde35ee46ccfa7b8ea6c3ac9f209351aae9ba"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3950,8 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-testkit"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78d1c298f8bae59d39734c457ca0200a3830b56986d353fc5074b8f48bb262e"
 dependencies = [
  "basecoin-store",
  "bon",
@@ -6927,7 +6957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,8 +3869,32 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-middleware-module"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-middleware-module"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -3882,7 +3906,25 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "ibc-middleware-module-macros"
+version = "0.1.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "ibc-middleware-module-macros"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.2.0#3dca5354609af33e0aaba3f582a28447410d637f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3890,16 +3932,16 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-overflow-receive"
-version = "0.4.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+version = "0.5.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core-channel-types",
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module",
- "ibc-middleware-module-macros",
+ "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
+ "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -3907,8 +3949,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-packet-forward"
-version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
 dependencies = [
  "borsh",
  "dur",
@@ -3919,8 +3961,8 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module",
- "ibc-middleware-module-macros",
+ "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
+ "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -5313,8 +5355,8 @@ dependencies = [
  "dur",
  "ibc",
  "ibc-derive",
- "ibc-middleware-module",
- "ibc-middleware-module-macros",
+ "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0)",
+ "ibc-middleware-module-macros 0.2.0",
  "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ibc-testkit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -481,7 +481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "tendermint",
+ "tendermint 0.38.1",
  "tracing",
 ]
 
@@ -693,6 +693,31 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "bon"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7acc34ff59877422326db7d6f2d845a582b16396b6b08194942bf34c6528ab"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4159dd617a7fbc9be6a692fe69dc2954f8e6bb6bb5e4d7578467441390d77fd0"
+dependencies = [
+ "darling 0.20.10",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1291,6 +1316,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmos-sdk-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "462e1f6a8e005acc8835d32d60cbd7973ed65ea2a8d8473830e675f050956427"
+dependencies = [
+ "informalsystems-pbjson",
+ "prost 0.13.2",
+ "serde",
+ "tendermint-proto 0.40.1",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,12 +1620,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -1607,14 +1644,18 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
+=======
+ "strsim 0.11.1",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "syn 2.0.96",
 ]
 
@@ -1631,11 +1672,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.10",
  "quote",
  "syn 2.0.96",
 ]
@@ -1714,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1763,6 +1804,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+<<<<<<< HEAD
+=======
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "unicode-xid",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -1891,16 +1956,6 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
-
-[[package]]
-name = "dur"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5b6c91b5e394b75cd96c36393fc938496c030220207a0ccf34d6cd313d3b49"
-dependencies = [
- "nom",
- "rust_decimal",
-]
 
 [[package]]
 name = "duration-str"
@@ -2131,7 +2186,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -2200,8 +2255,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+<<<<<<< HEAD
  "thiserror 1.0.50",
  "uint",
+=======
+ "thiserror",
+ "uint 0.9.5",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -2212,9 +2272,9 @@ checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "tiny-keccak",
 ]
@@ -2272,12 +2332,12 @@ checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
- "primitive-types",
+ "impl-serde 0.4.0",
+ "primitive-types 0.12.2",
  "scale-info",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -3143,15 +3203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e806677ce663d0a199541030c816847b36e8dc095f70dae4a4f4ad63da5383"
 
 [[package]]
-name = "home"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,8 +3400,8 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -3362,8 +3413,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -3372,13 +3423,13 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "http 1.1.0",
  "ibc-app-transfer-types",
@@ -3394,8 +3445,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -3404,27 +3455,27 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "arbitrary",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core",
  "ibc-proto",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.13.1",
  "scale-info",
  "schemars",
  "serde",
- "uint",
+ "uint 0.10.0",
 ]
 
 [[package]]
 name = "ibc-apps"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -3432,10 +3483,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "ibc-client-tendermint-types",
  "ibc-core-client",
  "ibc-core-commitment-types",
@@ -3443,14 +3494,14 @@ dependencies = [
  "ibc-core-host",
  "ibc-primitives",
  "serde",
- "tendermint",
+ "tendermint 0.40.1",
  "tendermint-light-client-verifier",
 ]
 
 [[package]]
 name = "ibc-client-tendermint-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -3459,15 +3510,15 @@ dependencies = [
  "ibc-primitives",
  "ibc-proto",
  "serde",
- "tendermint",
+ "tendermint 0.40.1",
  "tendermint-light-client-verifier",
- "tendermint-proto",
+ "tendermint-proto 0.40.1",
 ]
 
 [[package]]
 name = "ibc-client-wasm-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -3480,8 +3531,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-clients"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -3489,8 +3540,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3505,8 +3556,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -3520,12 +3571,12 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "arbitrary",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -3539,13 +3590,13 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-client"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -3557,10 +3608,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-context"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -3568,17 +3619,17 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-primitives",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-client-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "arbitrary",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
@@ -3589,17 +3640,17 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-commitment-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "arbitrary",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
@@ -3614,8 +3665,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -3628,12 +3679,12 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "arbitrary",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -3645,13 +3696,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3665,12 +3716,12 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "arbitrary",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-channel-types",
  "ibc-core-client-types",
@@ -3685,15 +3736,15 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-host"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-channel-types",
  "ibc-core-client-context",
@@ -3708,10 +3759,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-cosmos"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-app-transfer-types",
  "ibc-client-tendermint",
@@ -3726,20 +3777,22 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "arbitrary",
+ "base64 0.22.1",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-primitives",
  "parity-scale-codec",
+ "prost 0.13.2",
  "scale-info",
  "schemars",
  "serde",
@@ -3747,10 +3800,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -3761,11 +3814,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
@@ -3775,17 +3828,18 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-derive"
-version = "0.8.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+<<<<<<< HEAD
 ]
 
 [[package]]
@@ -3887,16 +3941,18 @@ dependencies = [
  "ibc-primitives",
  "serde",
  "serde_json",
+=======
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
 name = "ibc-primitives"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "arbitrary",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-proto",
  "parity-scale-codec",
@@ -3904,36 +3960,33 @@ dependencies = [
  "scale-info",
  "schemars",
  "serde",
- "tendermint",
  "time",
 ]
 
 [[package]]
 name = "ibc-proto"
-version = "0.47.1"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c852d22b782d2d793f4a646f968de419be635e02bc8798d5d74a6e44eef27733"
+checksum = "9b70f517162e74e2d35875b8b94bf4d1e45f2c69ef3de452dc855944455d33ca"
 dependencies = [
  "base64 0.22.1",
- "borsh",
  "bytes",
+ "cosmos-sdk-proto",
  "flex-error",
  "ics23",
  "informalsystems-pbjson",
- "parity-scale-codec",
  "prost 0.13.2",
- "scale-info",
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.40.1",
  "tonic",
 ]
 
 [[package]]
 name = "ibc-query"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3943,20 +3996,20 @@ dependencies = [
 
 [[package]]
 name = "ibc-testkit"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
 dependencies = [
  "basecoin-store",
- "derive_more",
+ "bon",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc",
  "ibc-proto",
  "ibc-query",
  "parking_lot",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
  "tendermint-testgen",
- "typed-builder",
 ]
 
 [[package]]
@@ -4004,14 +4057,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67aa010c1e3da95bf151bd8b4c059b2ed7e75387cdb969b4f8f2723a43f9941"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "impl-num-traits"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951641f13f873bff03d4bf19ae8bec531935ac0ac2cc775f84d7edfdcfed3f17"
 dependencies = [
  "integer-sqrt",
+<<<<<<< HEAD
  "num-traits",
  "uint",
+=======
+ "num-traits 0.2.17",
+ "uint 0.9.5",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -4028,6 +4095,15 @@ name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
 dependencies = [
  "serde",
 ]
@@ -5084,8 +5160,13 @@ dependencies = [
  "num-rational",
  "num-traits",
  "num256",
+<<<<<<< HEAD
  "num_enum",
  "primitive-types",
+=======
+ "num_enum 0.7.1",
+ "primitive-types 0.13.1",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "proptest",
  "prost-types 0.13.2",
  "rand",
@@ -5096,14 +5177,21 @@ dependencies = [
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
+<<<<<<< HEAD
  "tendermint",
  "tendermint-proto",
  "thiserror 1.0.50",
+=======
+ "sparse-merkle-tree",
+ "tendermint 0.40.1",
+ "tendermint-proto 0.40.1",
+ "thiserror",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "tiny-keccak",
  "tokio",
  "toml 0.5.11",
  "tracing",
- "uint",
+ "uint 0.9.5",
  "usize-set",
  "wasmtimer",
  "zeroize",
@@ -5273,13 +5361,15 @@ dependencies = [
  "assert_matches",
  "borsh",
  "data-encoding",
- "dur",
  "ibc",
  "ibc-derive",
+<<<<<<< HEAD
  "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.1.0)",
  "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.1.0)",
  "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
+=======
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "ibc-testkit",
  "ics23",
  "konst",
@@ -5299,7 +5389,7 @@ dependencies = [
  "namada_tx",
  "namada_vm",
  "namada_vp",
- "primitive-types",
+ "primitive-types 0.13.1",
  "proptest",
  "prost 0.13.2",
  "serde",
@@ -5710,14 +5800,12 @@ dependencies = [
  "concat-idents",
  "data-encoding",
  "derivative",
- "dur",
  "escargot",
  "expectrl",
  "eyre",
  "flate2",
  "fs_extra",
  "hyper 0.14.27",
- "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "itertools 0.12.1",
@@ -6224,7 +6312,22 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
 dependencies = [
+<<<<<<< HEAD
  "num_enum_derive",
+=======
+ "num_enum_derive 0.7.1",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -6788,11 +6891,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
- "uint",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.7.0",
+ "impl-serde 0.5.0",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -6893,16 +7008,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
-dependencies = [
- "bytes",
- "prost-derive 0.12.3",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
@@ -6913,24 +7018,28 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
+checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
+<<<<<<< HEAD
  "heck 0.4.1",
  "itertools 0.11.0",
+=======
+ "heck",
+ "itertools 0.12.1",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
  "regex",
  "syn 2.0.96",
  "tempfile",
- "which",
 ]
 
 [[package]]
@@ -6948,6 +7057,7 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
+<<<<<<< HEAD
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
@@ -6961,6 +7071,8 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
+=======
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
@@ -6979,15 +7091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost 0.11.9",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
-dependencies = [
- "prost 0.12.3",
 ]
 
 [[package]]
@@ -7403,11 +7506,12 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.36.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
  "arrayvec",
+<<<<<<< HEAD
  "borsh",
  "bytes",
  "num-traits",
@@ -7415,6 +7519,9 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
+=======
+ "num-traits 0.2.17",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -7558,7 +7665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
  "scale-info-derive",
 ]
@@ -7804,12 +7911,17 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
+<<<<<<< HEAD
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+=======
+version = "1.0.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 dependencies = [
  "itoa",
- "memchr",
  "ryu",
  "serde",
 ]
@@ -8213,6 +8325,7 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.96",
+<<<<<<< HEAD
 ]
 
 [[package]]
@@ -8226,6 +8339,8 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.96",
+=======
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -8375,6 +8490,33 @@ dependencies = [
  "bytes",
  "digest 0.10.7",
  "ed25519",
+ "flex-error",
+ "futures",
+ "num-traits 0.2.17",
+ "once_cell",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.38.1",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9703e34d940c2a293804752555107f8dbe2b84ec4c6dd5203831235868105d2"
+dependencies = [
+ "bytes",
+ "digest 0.10.7",
+ "ed25519",
  "ed25519-consensus",
  "flex-error",
  "futures",
@@ -8382,7 +8524,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "prost 0.13.2",
- "prost-types 0.13.2",
  "ripemd",
  "serde",
  "serde_bytes",
@@ -8392,34 +8533,34 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.40.1",
  "time",
  "zeroize",
 ]
 
 [[package]]
 name = "tendermint-config"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de111ea653b2adaef627ac2452b463c77aa615c256eaaddf279ec5a1cf9775f"
+checksum = "89cc3ea9a39b7ee34eefcff771cc067ecaa0c988c1c5ac08defd878471a06f76"
 dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint",
+ "tendermint 0.40.1",
  "toml 0.8.2",
  "url",
 ]
 
 [[package]]
 name = "tendermint-light-client"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e5abb448c65e8abdfe0e17a3a189e005a71b4169b89f36aaa2053ff239577"
+checksum = "a803ff14b11827772f696ba3a1873a5f24598121872c924a764011fc58fc22a0"
 dependencies = [
  "contracts",
  "crossbeam-channel",
- "derive_more",
+ "derive_more 0.99.18",
  "flex-error",
  "futures",
  "regex",
@@ -8428,7 +8569,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "static_assertions",
- "tendermint",
+ "tendermint 0.40.1",
  "tendermint-light-client-verifier",
  "tendermint-rpc",
  "time",
@@ -8438,14 +8579,14 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2674adbf0dc51aa0c8eaf8462c7d6692ec79502713e50ed5432a442002be90"
+checksum = "f0cda4a449fc70985a95f892a67286f13afa4e048d90b8d04a2bf6341e88d1c2"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "flex-error",
  "serde",
- "tendermint",
+ "tendermint 0.40.1",
  "time",
 ]
 
@@ -8466,10 +8607,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-rpc"
-version = "0.38.1"
+name = "tendermint-proto"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f96a2b8a0d3d0b59e4024b1a6bdc1589efc6af4709d08a480a20cc4ba90f63"
+checksum = "9ae9e1705aa0fa5ecb2c6aa7fb78c2313c4a31158ea5f02048bf318f849352eb"
+dependencies = [
+ "borsh",
+ "bytes",
+ "flex-error",
+ "parity-scale-codec",
+ "prost 0.13.2",
+ "scale-info",
+ "schemars",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835a52aa504c63ec05519e31348d3f4ba2fe79493c588e2cad5323d5e81b161a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -8486,10 +8646,15 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
  "tendermint-config",
+<<<<<<< HEAD
  "tendermint-proto",
  "thiserror 1.0.50",
+=======
+ "tendermint-proto 0.40.1",
+ "thiserror",
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "time",
  "tokio",
  "tracing",
@@ -8500,9 +8665,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-testgen"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae007e2918414ae96e4835426aace7538d23b8ddf96d71e23d241f58f386e877"
+checksum = "3fbbef28bac7b5b68f44416ef16d072ee8ea4af829aaf2fa259eee1c09237c36"
 dependencies = [
  "ed25519-consensus",
  "gumdrop",
@@ -8510,7 +8675,7 @@ dependencies = [
  "serde_json",
  "simple-error",
  "tempfile",
- "tendermint",
+ "tendermint 0.40.1",
  "time",
 ]
 
@@ -8611,6 +8776,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+<<<<<<< HEAD
 ]
 
 [[package]]
@@ -8642,6 +8808,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+=======
+>>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -8797,9 +8965,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8940,9 +9108,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -8970,13 +9138,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types 0.13.2",
  "quote",
  "syn 2.0.96",
 ]
@@ -9004,16 +9173,16 @@ dependencies = [
 
 [[package]]
 name = "tower-abci"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c31da2537c5f13b67d3f6aa9e5552a1a81a681debbcb3ce9ac6a34876cbcb2"
+checksum = "4f3458c29aae68bfc21edc8482ee7ecce8e5dfbb0d07a8034f96fa304525391f"
 dependencies = [
  "bytes",
  "futures",
  "pin-project",
  "prost 0.13.2",
- "tendermint",
- "tendermint-proto",
+ "tendermint 0.40.1",
+ "tendermint-proto 0.40.1",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -9217,6 +9386,18 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -9837,18 +10018,6 @@ name = "webpki-roots"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,10 +1652,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
-=======
  "strsim 0.11.1",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "syn 2.0.96",
 ]
 
@@ -1804,8 +1801,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-<<<<<<< HEAD
-=======
 ]
 
 [[package]]
@@ -1827,7 +1822,6 @@ dependencies = [
  "quote",
  "syn 2.0.96",
  "unicode-xid",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -1956,6 +1950,16 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "dur"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5b6c91b5e394b75cd96c36393fc938496c030220207a0ccf34d6cd313d3b49"
+dependencies = [
+ "nom",
+ "rust_decimal",
+]
 
 [[package]]
 name = "duration-str"
@@ -2255,13 +2259,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
-<<<<<<< HEAD
  "thiserror 1.0.50",
- "uint",
-=======
- "thiserror",
  "uint 0.9.5",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -2720,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "frost-core"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5afd375261c34d31ff24dad068382f4bc3c95010c919d4fb8d483dc3d85c023"
+checksum = "1858230cabb6792a5020daf4b0074f57b7d1e2a520ac544c77f102babee62ff4"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
@@ -2730,12 +2729,12 @@ dependencies = [
  "derive-getters",
  "document-features",
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "postcard",
  "rand_core",
  "serde",
  "serdect",
- "thiserror 1.0.50",
+ "thiserror 2.0.11",
  "thiserror-nostd-notrait",
  "visibility",
  "zeroize",
@@ -2743,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "frost-rerandomized"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9d77595060546b53543d96b83dbeacaf3907e40a89763a8bb22124812b0cb6"
+checksum = "e8a3b10d9c1e9f298522510940b5b8c3d55040420517ec8d2bb86c4c2d1ae3ee"
 dependencies = [
  "derive-getters",
  "document-features",
@@ -3401,30 +3400,30 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
- "ibc-core",
+ "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "ibc-core-host-cosmos",
- "ibc-derive",
- "ibc-primitives",
+ "ibc-derive 0.10.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
 ]
 
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-app-nft-transfer-types",
- "ibc-core",
+ "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "serde-json-wasm",
 ]
 
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
@@ -3432,9 +3431,9 @@ dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
  "http 1.1.0",
- "ibc-app-transfer-types",
- "ibc-core",
- "ibc-proto",
+ "ibc-app-transfer-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "mime",
  "parity-scale-codec",
  "scale-info",
@@ -3446,24 +3445,54 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
- "ibc-app-transfer-types",
- "ibc-core",
+ "ibc-app-transfer-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "serde-json-wasm",
 ]
 
 [[package]]
 name = "ibc-app-transfer-types"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "borsh",
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core 0.54.0",
+ "ibc-proto 0.47.1",
+ "primitive-types 0.12.2",
+ "serde",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "ibc-app-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-proto 0.51.1",
+ "primitive-types 0.13.1",
+ "serde",
+ "uint 0.10.0",
+]
+
+[[package]]
+name = "ibc-app-transfer-types"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "arbitrary",
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core",
- "ibc-proto",
+ "ibc-core 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "parity-scale-codec",
  "primitive-types 0.13.1",
  "scale-info",
@@ -3475,7 +3504,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -3484,15 +3513,15 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
- "ibc-core-client",
- "ibc-core-commitment-types",
- "ibc-core-handler-types",
- "ibc-core-host",
- "ibc-primitives",
+ "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "serde",
  "tendermint 0.40.1",
  "tendermint-light-client-verifier",
@@ -3501,14 +3530,14 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "displaydoc",
- "ibc-core-client-types",
- "ibc-core-commitment-types",
- "ibc-core-host-types",
- "ibc-primitives",
- "ibc-proto",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "serde",
  "tendermint 0.40.1",
  "tendermint-light-client-verifier",
@@ -3518,21 +3547,21 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
- "ibc-core-client",
- "ibc-core-host-types",
- "ibc-primitives",
- "ibc-proto",
+ "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "serde",
 ]
 
 [[package]]
 name = "ibc-clients"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -3540,50 +3569,152 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
 dependencies = [
- "ibc-core-channel",
- "ibc-core-client",
- "ibc-core-commitment-types",
- "ibc-core-connection",
- "ibc-core-handler",
- "ibc-core-host",
- "ibc-core-router",
- "ibc-derive",
- "ibc-primitives",
+ "ibc-core-channel 0.54.0",
+ "ibc-core-client 0.54.0",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-connection 0.54.0",
+ "ibc-core-handler 0.54.0",
+ "ibc-core-host 0.54.0",
+ "ibc-core-router 0.54.0",
+ "ibc-derive 0.8.0",
+ "ibc-primitives 0.54.0",
+]
+
+[[package]]
+name = "ibc-core"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "ibc-core-channel 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-client 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-connection 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-handler 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-derive 0.10.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+]
+
+[[package]]
+name = "ibc-core"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+dependencies = [
+ "ibc-core-channel 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-connection 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-handler 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-router 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-derive 0.10.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+]
+
+[[package]]
+name = "ibc-core-channel"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "ibc-core-channel-types 0.54.0",
+ "ibc-core-client 0.54.0",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-connection 0.54.0",
+ "ibc-core-handler-types 0.54.0",
+ "ibc-core-host 0.54.0",
+ "ibc-core-router 0.54.0",
+ "ibc-primitives 0.54.0",
 ]
 
 [[package]]
 name = "ibc-core-channel"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
- "ibc-core-channel-types",
- "ibc-core-client",
- "ibc-core-commitment-types",
- "ibc-core-connection",
- "ibc-core-handler-types",
- "ibc-core-host",
- "ibc-core-router",
- "ibc-primitives",
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-client 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-connection 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+]
+
+[[package]]
+name = "ibc-core-channel"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+dependencies = [
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-connection 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-router 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+]
+
+[[package]]
+name = "ibc-core-channel-types"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "borsh",
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core-client-types 0.54.0",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-connection-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-primitives 0.54.0",
+ "ibc-proto 0.47.1",
+ "serde",
+ "sha2 0.10.8",
+ "subtle-encoding",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-connection-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-proto 0.51.1",
+ "serde",
+ "sha2 0.10.8",
+ "subtle-encoding",
+ "tendermint 0.40.1",
+]
+
+[[package]]
+name = "ibc-core-channel-types"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "arbitrary",
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-client-types",
- "ibc-core-commitment-types",
- "ibc-core-connection-types",
- "ibc-core-host-types",
- "ibc-primitives",
- "ibc-proto",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -3595,29 +3726,121 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
 dependencies = [
- "ibc-core-client-context",
- "ibc-core-client-types",
- "ibc-core-commitment-types",
- "ibc-core-handler-types",
- "ibc-core-host",
- "ibc-primitives",
+ "ibc-core-client-context 0.54.0",
+ "ibc-core-client-types 0.54.0",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-handler-types 0.54.0",
+ "ibc-core-host 0.54.0",
+ "ibc-primitives 0.54.0",
+]
+
+[[package]]
+name = "ibc-core-client"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "ibc-core-client-context 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+]
+
+[[package]]
+name = "ibc-core-client"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+dependencies = [
+ "ibc-core-client-context 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+]
+
+[[package]]
+name = "ibc-core-client-context"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core-client-types 0.54.0",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-handler-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-primitives 0.54.0",
+ "subtle-encoding",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-core-client-context"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-client-types",
- "ibc-core-commitment-types",
- "ibc-core-handler-types",
- "ibc-core-host-types",
- "ibc-primitives",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "subtle-encoding",
+ "tendermint 0.40.1",
+]
+
+[[package]]
+name = "ibc-core-client-context"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+dependencies = [
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "subtle-encoding",
+ "tendermint 0.40.1",
+]
+
+[[package]]
+name = "ibc-core-client-types"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "borsh",
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-primitives 0.54.0",
+ "ibc-proto 0.47.1",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.38.1",
+]
+
+[[package]]
+name = "ibc-core-client-types"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-proto 0.51.1",
+ "serde",
  "subtle-encoding",
  "tendermint 0.40.1",
 ]
@@ -3625,16 +3848,16 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "arbitrary",
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-commitment-types",
- "ibc-core-host-types",
- "ibc-primitives",
- "ibc-proto",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -3645,16 +3868,48 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-commitment-types"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "borsh",
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core-host-types 0.54.0",
+ "ibc-primitives 0.54.0",
+ "ibc-proto 0.47.1",
+ "ics23",
+ "serde",
+ "subtle-encoding",
+]
+
+[[package]]
+name = "ibc-core-commitment-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-proto 0.51.1",
+ "ics23",
+ "serde",
+ "subtle-encoding",
+]
+
+[[package]]
+name = "ibc-core-commitment-types"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "arbitrary",
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-host-types",
- "ibc-primitives",
- "ibc-proto",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "ics23",
  "parity-scale-codec",
  "scale-info",
@@ -3665,32 +3920,92 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "ibc-core-client 0.54.0",
+ "ibc-core-connection-types 0.54.0",
+ "ibc-core-handler-types 0.54.0",
+ "ibc-core-host 0.54.0",
+ "ibc-primitives 0.54.0",
+]
+
+[[package]]
+name = "ibc-core-connection"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "ibc-core-client 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-connection-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+]
+
+[[package]]
+name = "ibc-core-connection"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-client-wasm-types",
- "ibc-core-client",
- "ibc-core-connection-types",
- "ibc-core-handler-types",
- "ibc-core-host",
- "ibc-primitives",
+ "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "prost 0.13.2",
 ]
 
 [[package]]
 name = "ibc-core-connection-types"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "borsh",
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core-client-types 0.54.0",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-primitives 0.54.0",
+ "ibc-proto 0.47.1",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.38.1",
+]
+
+[[package]]
+name = "ibc-core-connection-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-proto 0.51.1",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.40.1",
+]
+
+[[package]]
+name = "ibc-core-connection-types"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "arbitrary",
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-client-types",
- "ibc-core-commitment-types",
- "ibc-core-host-types",
- "ibc-primitives",
- "ibc-proto",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -3701,36 +4016,108 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
 dependencies = [
- "ibc-core-channel",
- "ibc-core-client",
- "ibc-core-commitment-types",
- "ibc-core-connection",
- "ibc-core-handler-types",
- "ibc-core-host",
- "ibc-core-router",
- "ibc-primitives",
+ "ibc-core-channel 0.54.0",
+ "ibc-core-client 0.54.0",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-connection 0.54.0",
+ "ibc-core-handler-types 0.54.0",
+ "ibc-core-host 0.54.0",
+ "ibc-core-router 0.54.0",
+ "ibc-primitives 0.54.0",
+]
+
+[[package]]
+name = "ibc-core-handler"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "ibc-core-channel 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-client 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-connection 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+]
+
+[[package]]
+name = "ibc-core-handler"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+dependencies = [
+ "ibc-core-channel 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-connection 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-router 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+]
+
+[[package]]
+name = "ibc-core-handler-types"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "borsh",
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core-channel-types 0.54.0",
+ "ibc-core-client-types 0.54.0",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-connection-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-core-router-types 0.54.0",
+ "ibc-primitives 0.54.0",
+ "ibc-proto 0.47.1",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-connection-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-router-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-proto 0.51.1",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.40.1",
+]
+
+[[package]]
+name = "ibc-core-handler-types"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "arbitrary",
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-channel-types",
- "ibc-core-client-types",
- "ibc-core-commitment-types",
- "ibc-core-connection-types",
- "ibc-core-host-types",
- "ibc-core-router-types",
- "ibc-primitives",
- "ibc-proto",
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-router-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -3741,39 +4128,75 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core-channel-types 0.54.0",
+ "ibc-core-client-context 0.54.0",
+ "ibc-core-client-types 0.54.0",
+ "ibc-core-commitment-types 0.54.0",
+ "ibc-core-connection-types 0.54.0",
+ "ibc-core-handler-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-primitives 0.54.0",
+ "subtle-encoding",
+]
+
+[[package]]
+name = "ibc-core-host"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-channel-types",
- "ibc-core-client-context",
- "ibc-core-client-types",
- "ibc-core-commitment-types",
- "ibc-core-connection-types",
- "ibc-core-handler-types",
- "ibc-core-host-types",
- "ibc-primitives",
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-client-context 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-connection-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "subtle-encoding",
+]
+
+[[package]]
+name = "ibc-core-host"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+dependencies = [
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client-context 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "subtle-encoding",
 ]
 
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-app-transfer-types",
+ "ibc-app-transfer-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "ibc-client-tendermint",
- "ibc-core-client-context",
- "ibc-core-client-types",
- "ibc-core-commitment-types",
- "ibc-core-connection-types",
- "ibc-core-handler-types",
- "ibc-core-host-types",
- "ibc-primitives",
- "ibc-proto",
+ "ibc-core-client-context 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-client-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-commitment-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-connection-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-handler-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
@@ -3782,15 +4205,41 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-types"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "borsh",
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-primitives 0.54.0",
+ "serde",
+]
+
+[[package]]
+name = "ibc-core-host-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "base64 0.22.1",
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "prost 0.13.2",
+ "serde",
+]
+
+[[package]]
+name = "ibc-core-host-types"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "arbitrary",
  "base64 0.22.1",
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-primitives",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "parity-scale-codec",
  "prost 0.13.2",
  "scale-info",
@@ -3800,29 +4249,89 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core-channel-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-core-router-types 0.54.0",
+ "ibc-primitives 0.54.0",
+ "subtle-encoding",
+]
+
+[[package]]
+name = "ibc-core-router"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router-types",
- "ibc-primitives",
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-router-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "subtle-encoding",
+]
+
+[[package]]
+name = "ibc-core-router"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+dependencies = [
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-core-router-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "subtle-encoding",
 ]
 
 [[package]]
 name = "ibc-core-router-types"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "borsh",
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-core-host-types 0.54.0",
+ "ibc-primitives 0.54.0",
+ "ibc-proto 0.47.1",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.38.1",
+]
+
+[[package]]
+name = "ibc-core-router-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-core-host-types",
- "ibc-primitives",
- "ibc-proto",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-proto 0.51.1",
+ "serde",
+ "subtle-encoding",
+ "tendermint 0.40.1",
+]
+
+[[package]]
+name = "ibc-core-router-types"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-primitives 0.56.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
+ "ibc-proto 0.51.1",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -3833,13 +4342,32 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.10.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+version = "0.8.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-<<<<<<< HEAD
+]
+
+[[package]]
+name = "ibc-derive"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "ibc-derive"
+version = "0.10.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3847,11 +4375,11 @@ name = "ibc-middleware-module"
 version = "0.1.0"
 source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.1.0#3d3b436f7c58000c7498d68e88c15a955433a619"
 dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
+ "ibc-core-channel-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-core-router 0.54.0",
+ "ibc-core-router-types 0.54.0",
+ "ibc-primitives 0.54.0",
 ]
 
 [[package]]
@@ -3859,23 +4387,23 @@ name = "ibc-middleware-module"
 version = "0.1.0"
 source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
 dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
+ "ibc-core-channel-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-core-router 0.54.0",
+ "ibc-core-router-types 0.54.0",
+ "ibc-primitives 0.54.0",
 ]
 
 [[package]]
 name = "ibc-middleware-module"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0#3d3b436f7c58000c7498d68e88c15a955433a619"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
 dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-router-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
 ]
 
 [[package]]
@@ -3899,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0#3d3b436f7c58000c7498d68e88c15a955433a619"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3910,14 +4438,14 @@ name = "ibc-middleware-overflow-receive"
 version = "0.4.0"
 source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
 dependencies = [
- "ibc-app-transfer-types",
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
+ "ibc-app-transfer-types 0.54.0",
+ "ibc-core-channel-types 0.54.0",
+ "ibc-core-host-types 0.54.0",
+ "ibc-core-router 0.54.0",
+ "ibc-core-router-types 0.54.0",
  "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0)",
  "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0)",
- "ibc-primitives",
+ "ibc-primitives 0.54.0",
  "serde",
  "serde_json",
 ]
@@ -3925,42 +4453,87 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0#3d3b436f7c58000c7498d68e88c15a955433a619"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
 dependencies = [
  "borsh",
  "dur",
  "either",
- "ibc-app-transfer-types",
- "ibc-core-channel",
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0)",
- "ibc-primitives",
+ "ibc-app-transfer-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-channel 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-channel-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-host-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-router 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-core-router-types 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
+ "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs)",
+ "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs)",
+ "ibc-primitives 0.56.0 (git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500)",
  "serde",
  "serde_json",
-=======
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
+]
+
+[[package]]
+name = "ibc-primitives"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+dependencies = [
+ "borsh",
+ "derive_more 0.99.18",
+ "displaydoc",
+ "ibc-proto 0.47.1",
+ "prost 0.13.2",
+ "serde",
+ "tendermint 0.38.1",
+ "time",
 ]
 
 [[package]]
 name = "ibc-primitives"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+dependencies = [
+ "borsh",
+ "derive_more 1.0.0",
+ "displaydoc",
+ "ibc-proto 0.51.1",
+ "prost 0.13.2",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "ibc-primitives"
+version = "0.56.0"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "arbitrary",
  "borsh",
  "derive_more 1.0.0",
  "displaydoc",
- "ibc-proto",
+ "ibc-proto 0.51.1",
  "parity-scale-codec",
  "prost 0.13.2",
  "scale-info",
  "schemars",
  "serde",
  "time",
+]
+
+[[package]]
+name = "ibc-proto"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c852d22b782d2d793f4a646f968de419be635e02bc8798d5d74a6e44eef27733"
+dependencies = [
+ "base64 0.22.1",
+ "borsh",
+ "bytes",
+ "flex-error",
+ "ics23",
+ "informalsystems-pbjson",
+ "prost 0.13.2",
+ "serde",
+ "subtle-encoding",
+ "tendermint-proto 0.38.1",
 ]
 
 [[package]]
@@ -3986,25 +4559,25 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "displaydoc",
  "ibc",
- "ibc-proto",
+ "ibc-proto 0.51.1",
  "tonic",
 ]
 
 [[package]]
 name = "ibc-testkit"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#b388e853718859fb004cdb5684758d68d4ce42a1"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "basecoin-store",
  "bon",
  "derive_more 1.0.0",
  "displaydoc",
  "ibc",
- "ibc-proto",
+ "ibc-proto 0.51.1",
  "ibc-query",
  "parking_lot",
  "subtle-encoding",
@@ -4072,13 +4645,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951641f13f873bff03d4bf19ae8bec531935ac0ac2cc775f84d7edfdcfed3f17"
 dependencies = [
  "integer-sqrt",
-<<<<<<< HEAD
  "num-traits",
- "uint",
-=======
- "num-traits 0.2.17",
  "uint 0.9.5",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -4236,27 +4804,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -5160,13 +5710,8 @@ dependencies = [
  "num-rational",
  "num-traits",
  "num256",
-<<<<<<< HEAD
  "num_enum",
- "primitive-types",
-=======
- "num_enum 0.7.1",
  "primitive-types 0.13.1",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "proptest",
  "prost-types 0.13.2",
  "rand",
@@ -5177,16 +5722,9 @@ dependencies = [
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
-<<<<<<< HEAD
- "tendermint",
- "tendermint-proto",
- "thiserror 1.0.50",
-=======
- "sparse-merkle-tree",
  "tendermint 0.40.1",
  "tendermint-proto 0.40.1",
- "thiserror",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
+ "thiserror 1.0.50",
  "tiny-keccak",
  "tokio",
  "toml 0.5.11",
@@ -5361,15 +5899,13 @@ dependencies = [
  "assert_matches",
  "borsh",
  "data-encoding",
+ "dur",
  "ibc",
- "ibc-derive",
-<<<<<<< HEAD
+ "ibc-derive 0.10.0 (git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4)",
  "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.1.0)",
  "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.1.0)",
  "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
-=======
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "ibc-testkit",
  "ics23",
  "konst",
@@ -5800,12 +6336,14 @@ dependencies = [
  "concat-idents",
  "data-encoding",
  "derivative",
+ "dur",
  "escargot",
  "expectrl",
  "eyre",
  "flate2",
  "fs_extra",
  "hyper 0.14.27",
+ "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "itertools 0.12.1",
@@ -6204,9 +6742,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.6"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
@@ -6251,9 +6789,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -6312,22 +6850,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
 dependencies = [
-<<<<<<< HEAD
  "num_enum_derive",
-=======
- "num_enum_derive 0.7.1",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -7023,13 +7546,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
-<<<<<<< HEAD
  "heck 0.4.1",
- "itertools 0.11.0",
-=======
- "heck",
  "itertools 0.12.1",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
  "log",
  "multimap",
  "once_cell",
@@ -7057,28 +7575,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-<<<<<<< HEAD
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "prost-derive"
-=======
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -7506,12 +8008,11 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arrayvec",
-<<<<<<< HEAD
  "borsh",
  "bytes",
  "num-traits",
@@ -7519,9 +8020,6 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
-=======
- "num-traits 0.2.17",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -7911,17 +8409,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-<<<<<<< HEAD
-version = "1.0.137"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
-=======
-version = "1.0.108"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -8325,7 +8818,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.96",
-<<<<<<< HEAD
 ]
 
 [[package]]
@@ -8339,8 +8831,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.96",
-=======
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]
@@ -8492,7 +8982,7 @@ dependencies = [
  "ed25519",
  "flex-error",
  "futures",
- "num-traits 0.2.17",
+ "num-traits",
  "once_cell",
  "prost 0.13.2",
  "prost-types 0.13.2",
@@ -8648,13 +9138,8 @@ dependencies = [
  "subtle-encoding",
  "tendermint 0.40.1",
  "tendermint-config",
-<<<<<<< HEAD
- "tendermint-proto",
- "thiserror 1.0.50",
-=======
  "tendermint-proto 0.40.1",
- "thiserror",
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
+ "thiserror 1.0.50",
  "time",
  "tokio",
  "tracing",
@@ -8776,7 +9261,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-<<<<<<< HEAD
 ]
 
 [[package]]
@@ -8808,8 +9292,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-=======
->>>>>>> b73473752 (WIP: upgrade ibc-rs)
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,10 +120,10 @@ futures = "0.3"
 git2 = { version = "0.18.1", default-features = false }
 ibc = { version = "0.57.0", features = ["serde"] }
 ibc-derive = "0.10.1"
-ibc-middleware-module = { git = "https://github.com/heliaxdev/ibc-middleware", rev = "e723d8465d9ed8185ea08debc01cd4d18af140bc" }
-ibc-middleware-module-macros = { git = "https://github.com/heliaxdev/ibc-middleware", rev = "e723d8465d9ed8185ea08debc01cd4d18af140bc" }
-ibc-middleware-overflow-receive = { git = "https://github.com/heliaxdev/ibc-middleware", rev = "e723d8465d9ed8185ea08debc01cd4d18af140bc" }
-ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", rev = "e723d8465d9ed8185ea08debc01cd4d18af140bc", features = ["borsh"] }
+ibc-middleware-module = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module/v0.2.0" }
+ibc-middleware-module-macros = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module-macros/v0.2.0" }
+ibc-middleware-overflow-receive = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "orm/v0.5.0" }
+ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "pfm/v0.10.0", features = ["borsh"] }
 ibc-testkit = { version = "0.57.0", default-features = false }
 ics23 = "0.12.0"
 usize-set = { version = "0.10.3", features = ["serialize-borsh", "serialize-serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ ibc-derive = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db
 ibc-middleware-module = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module/v0.1.0" }
 ibc-middleware-module-macros = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module-macros/v0.1.0" }
 ibc-middleware-overflow-receive = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "orm/v0.4.0" }
-ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "pfm/v0.9.0", features = ["borsh"] }
+ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", branch = "yuji/upgrade-ibc-rs", features = ["borsh"] }
 ibc-testkit = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4", default-features = false }
 ics23 = "0.12.0"
 usize-set = { version = "0.10.3", features = ["serialize-borsh", "serialize-serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,10 +120,10 @@ futures = "0.3"
 git2 = { version = "0.18.1", default-features = false }
 ibc = { version = "0.57.0", features = ["serde"] }
 ibc-derive = "0.10.1"
-ibc-middleware-module = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module/v0.2.0" }
-ibc-middleware-module-macros = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module-macros/v0.2.0" }
-ibc-middleware-overflow-receive = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "orm/v0.5.0" }
-ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "pfm/v0.10.0", features = ["borsh"] }
+ibc-middleware-module = { version = "0.2.0" }
+ibc-middleware-module-macros = { version = "0.2.0" }
+ibc-middleware-overflow-receive = { version = "0.5.0" }
+ibc-middleware-packet-forward = { version = "0.10.0", features = ["borsh"] }
 ibc-testkit = { version = "0.57.0", default-features = false }
 ics23 = "0.12.0"
 usize-set = { version = "0.10.3", features = ["serialize-borsh", "serialize-serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,9 +120,9 @@ futures = "0.3"
 git2 = { version = "0.18.1", default-features = false }
 ibc = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4", features = ["serde"] }
 ibc-derive = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4" }
-ibc-middleware-module = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module/v0.1.0" }
-ibc-middleware-module-macros = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module-macros/v0.1.0" }
-ibc-middleware-overflow-receive = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "orm/v0.4.0" }
+ibc-middleware-module = { git = "https://github.com/heliaxdev/ibc-middleware", branch = "yuji/upgrade-ibc-rs" }
+ibc-middleware-module-macros = { git = "https://github.com/heliaxdev/ibc-middleware", branch = "yuji/upgrade-ibc-rs" }
+ibc-middleware-overflow-receive = { git = "https://github.com/heliaxdev/ibc-middleware", branch = "yuji/upgrade-ibc-rs" }
 ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", branch = "yuji/upgrade-ibc-rs", features = ["borsh"] }
 ibc-testkit = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4", default-features = false }
 ics23 = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ repository = "https://github.com/anoma/namada"
 version = "0.47.0"
 
 [workspace.dependencies]
-arbitrary = {version = "1.3", features = ["derive"]}
+arbitrary = {version = "1.4", features = ["derive"]}
 ark-bls12-381 = {version = "0.3"}
 ark-serialize = {version = "0.3"}
 ark-std = "0.3.0"
@@ -118,14 +118,13 @@ flume = "0.11.1"
 fs_extra = "1.2.0"
 futures = "0.3"
 git2 = { version = "0.18.1", default-features = false }
-# branch tiago/optional-ack
-ibc = { git = "https://github.com/heliaxdev/cosmos-ibc-rs", rev = "38489943c4e75206eaffeeeec6153c039c2499d1", features = ["serde"] }
-ibc-derive = { git = "https://github.com/heliaxdev/cosmos-ibc-rs", rev = "38489943c4e75206eaffeeeec6153c039c2499d1" }
+ibc = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4", features = ["serde"] }
+ibc-derive = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4" }
 ibc-middleware-module = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module/v0.1.0" }
 ibc-middleware-module-macros = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "module-macros/v0.1.0" }
 ibc-middleware-overflow-receive = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "orm/v0.4.0" }
 ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", tag = "pfm/v0.9.0", features = ["borsh"] }
-ibc-testkit = { git = "https://github.com/heliaxdev/cosmos-ibc-rs", rev = "38489943c4e75206eaffeeeec6153c039c2499d1", default-features = false }
+ibc-testkit = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4", default-features = false }
 ics23 = "0.12.0"
 usize-set = { version = "0.10.3", features = ["serialize-borsh", "serialize-serde"] }
 indexmap = { package = "nam-indexmap", version = "2.7.1-nam.0", features = ["borsh-schema", "serde"] }
@@ -156,7 +155,7 @@ owo-colors = "3.5.0"
 paste = "1.0.9"
 patricia_tree = "0.8.0"
 pretty_assertions = "1.4.0"
-primitive-types = "0.12.1"
+primitive-types = "0.13.1"
 proptest = "1.4.0"
 proptest-state-machine = "0.3.0"
 prost = "0.13.1"
@@ -184,11 +183,11 @@ smooth-operator = "0.7.2"
 sysinfo = {version = "0.27.8", default-features = false}
 tar = "0.4.37"
 tempfile = {version = "3.2.0"}
-tendermint = {version = "0.38.0", features = ["secp256k1"]}
-tendermint-config = "0.38.0"
-tendermint-light-client = "0.38.0"
-tendermint-proto = "0.38.0"
-tendermint-rpc = {version = "0.38.0", default-features = false}
+tendermint = {version = "0.40.1", features = ["secp256k1"]}
+tendermint-config = "0.40.1"
+tendermint-light-client = "0.40.1"
+tendermint-proto = "0.40.1"
+tendermint-rpc = {version = "0.40.1", default-features = false}
 test-log = {version = "0.2.14", default-features = false, features = ["trace"]}
 tiny-bip39 = {version = "2.0"}
 tiny-hderive = {package = "nam-tiny-hderive", version = "0.3.1-nam.0"}
@@ -197,10 +196,10 @@ thiserror = "1.0.38"
 tokio = {version = "1.8.2", default-features = false}
 tokio-test = "0.4.2"
 toml = "0.5.8"
-tonic = "0.8.3"
-tonic-build = "0.11.0"
+tonic = "0.12.3"
+tonic-build = "0.12.3"
 tower = "0.4"
-tower-abci = "0.16.0"
+tower-abci = "0.18.0"
 tracing = "0.1.30"
 tracing-appender = "0.2.2"
 tracing-log = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,13 +118,13 @@ flume = "0.11.1"
 fs_extra = "1.2.0"
 futures = "0.3"
 git2 = { version = "0.18.1", default-features = false }
-ibc = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4", features = ["serde"] }
-ibc-derive = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4" }
-ibc-middleware-module = { git = "https://github.com/heliaxdev/ibc-middleware", branch = "yuji/upgrade-ibc-rs" }
-ibc-middleware-module-macros = { git = "https://github.com/heliaxdev/ibc-middleware", branch = "yuji/upgrade-ibc-rs" }
-ibc-middleware-overflow-receive = { git = "https://github.com/heliaxdev/ibc-middleware", branch = "yuji/upgrade-ibc-rs" }
-ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", branch = "yuji/upgrade-ibc-rs", features = ["borsh"] }
-ibc-testkit = { git = "https://github.com/cosmos/ibc-rs", rev = "a5f9fbf236cb26db3a76cde20ba43382de2d1ba4", default-features = false }
+ibc = { version = "0.57.0", features = ["serde"] }
+ibc-derive = "0.10.1"
+ibc-middleware-module = { git = "https://github.com/heliaxdev/ibc-middleware", rev = "e723d8465d9ed8185ea08debc01cd4d18af140bc" }
+ibc-middleware-module-macros = { git = "https://github.com/heliaxdev/ibc-middleware", rev = "e723d8465d9ed8185ea08debc01cd4d18af140bc" }
+ibc-middleware-overflow-receive = { git = "https://github.com/heliaxdev/ibc-middleware", rev = "e723d8465d9ed8185ea08debc01cd4d18af140bc" }
+ibc-middleware-packet-forward = { git = "https://github.com/heliaxdev/ibc-middleware", rev = "e723d8465d9ed8185ea08debc01cd4d18af140bc", features = ["borsh"] }
+ibc-testkit = { version = "0.57.0", default-features = false }
 ics23 = "0.12.0"
 usize-set = { version = "0.10.3", features = ["serialize-borsh", "serialize-serde"] }
 indexmap = { package = "nam-indexmap", version = "2.7.1-nam.0", features = ["borsh-schema", "serde"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -8,7 +8,7 @@ disallowed-methods = [
   { path = "chrono::Utc::now", reason = "Do not use current date/time in code that must be deterministic" },
   { path = "namada_core::time::DateTimeUtc::now", reason = "Do not use current date/time in code that must be deterministic" },
   { path = "wasmtimer::std::Instant", reason = "Do not use current date/time in code that must be deterministic" },
-  { path = "std::result::Result::unwrap_or_default", reason = "Do not silently ignore an error that could be caused by gas" },
+  #{ path = "std::result::Result::unwrap_or_default", reason = "Do not silently ignore an error that could be caused by gas" },
 ]
 allow-dbg-in-tests = true
 allow-print-in-tests = true

--- a/crates/ibc/src/actions.rs
+++ b/crates/ibc/src/actions.rs
@@ -11,6 +11,7 @@ use ibc::apps::transfer::types::msgs::transfer::MsgTransfer as IbcMsgTransfer;
 use ibc::apps::transfer::types::packet::PacketData;
 use ibc::apps::transfer::types::PrefixedCoin;
 use ibc::core::channel::types::timeout::{TimeoutHeight, TimeoutTimestamp};
+use ibc::primitives::IntoTimestamp;
 use namada_core::address::Address;
 use namada_core::borsh::{BorshSerialize, BorshSerializeExt};
 use namada_core::chain::ChainId;
@@ -232,7 +233,7 @@ where
     let timeout_timestamp =
         TmTime::try_from(timeout_timestamp).into_storage_result()?;
     let timeout_timestamp = TimeoutTimestamp::At(
-        timeout_timestamp.try_into().into_storage_result()?,
+        timeout_timestamp.into_timestamp().into_storage_result()?,
     );
     let message = IbcMsgTransfer {
         port_id_on_a: target.port_id.clone(),

--- a/crates/ibc/src/context/common.rs
+++ b/crates/ibc/src/context/common.rs
@@ -552,12 +552,7 @@ pub trait IbcCommonContext: IbcStorageContext {
         let key = storage::receipt_key(port_id, channel_id, sequence);
         match self.storage().read_bytes(&key)? {
             Some(_) => Ok(Receipt::Ok),
-            None => Err(HostError::FailedToRetrieve {
-                description: format!(
-                    "No packet receipt: port {port_id}, channel {channel_id}, \
-                     sequence {sequence}"
-                ),
-            }),
+            None => Ok(Receipt::None),
         }
     }
 

--- a/crates/ibc/src/context/middlewares/pfm_mod.rs
+++ b/crates/ibc/src/context/middlewares/pfm_mod.rs
@@ -16,7 +16,7 @@ use ibc::core::channel::handler::{
 };
 use ibc::core::channel::types::acknowledgement::Acknowledgement;
 use ibc::core::channel::types::channel::{Counterparty, Order};
-use ibc::core::channel::types::error::{ChannelError, PacketError};
+use ibc::core::channel::types::error::ChannelError;
 use ibc::core::channel::types::packet::Packet;
 use ibc::core::channel::types::timeout::TimeoutTimestamp;
 use ibc::core::channel::types::Version;
@@ -124,7 +124,7 @@ where
             .inner
             .borrow()
             .get_next_sequence_send(&msg.port_id_on_a, &msg.chan_id_on_a)
-            .map_err(|e| Error::Context(Box::new(e)))?;
+            .map_err(|e| Error::TokenTransfer(e.into()))?;
         tracing::debug!(?seq, ?msg, "PFM send_transfer_execute");
 
         let mut ctx = IbcContext::<C, Params>::new(
@@ -199,7 +199,7 @@ where
                     &coin,
                     &String::new().into(),
                 )
-                .map_err(Error::TokenTransfer)
+                .map_err(|e| Error::TokenTransfer(e.into()))
         } else {
             let coin = {
                 let mut c = packet_data.token;
@@ -212,7 +212,7 @@ where
 
             token_transfer_ctx
                 .burn_coins_execute(&IBC_ADDRESS, &coin, &String::new().into())
-                .map_err(Error::TokenTransfer)
+                .map_err(|e| Error::TokenTransfer(e.into()))
         }
     }
 
@@ -226,13 +226,13 @@ where
             self.transfer_module.ctx.inner.clone(),
         );
         commit_packet_acknowledgment(&mut ctx, packet, acknowledgement)
-            .map_err(|e| Error::Context(Box::new(e)))?;
+            .map_err(|e| Error::TokenTransfer(e.into()))?;
         emit_packet_acknowledgement_event(
             &mut ctx,
             packet.clone(),
             acknowledgement.clone(),
         )
-        .map_err(|e| Error::Context(Box::new(e)))
+        .map_err(|e| Error::TokenTransfer(e.into()))
     }
 
     fn override_receiver(

--- a/crates/ibc/src/context/middlewares/shielded_recv.rs
+++ b/crates/ibc/src/context/middlewares/shielded_recv.rs
@@ -13,13 +13,14 @@ use std::fmt::{Debug, Formatter};
 use std::rc::Rc;
 
 use ibc::apps::transfer::context::TokenTransferExecutionContext;
+use ibc::apps::transfer::types::error::TokenTransferError;
 use ibc::apps::transfer::types::packet::PacketData;
 use ibc::apps::transfer::types::{Coin, PrefixedDenom};
 use ibc::core::channel::types::acknowledgement::{
     Acknowledgement, AcknowledgementStatus, StatusValue as AckStatusValue,
 };
 use ibc::core::channel::types::channel::{Counterparty, Order};
-use ibc::core::channel::types::error::{ChannelError, PacketError};
+use ibc::core::channel::types::error::ChannelError;
 use ibc::core::channel::types::packet::Packet;
 use ibc::core::channel::types::Version;
 use ibc::core::host::types::identifiers::{ChannelId, ConnectionId, PortId};
@@ -192,7 +193,7 @@ where
             TokenTransferContext::new(ctx, verifiers);
         token_transfer_context
             .mint_coins_execute(receiver, coin)
-            .map_err(Error::TokenTransfer)
+            .map_err(|e| Error::TokenTransfer(TokenTransferError::Host(e)))
     }
 
     fn unescrow_coins_execute(
@@ -208,6 +209,6 @@ where
             TokenTransferContext::new(ctx, verifiers);
         token_transfer_context
             .unescrow_coins_execute(receiver, port, channel, coin)
-            .map_err(Error::TokenTransfer)
+            .map_err(|e| Error::TokenTransfer(TokenTransferError::Host(e)))
     }
 }

--- a/crates/ibc/src/context/nft_transfer.rs
+++ b/crates/ibc/src/context/nft_transfer.rs
@@ -13,6 +13,7 @@ use ibc::apps::nft_transfer::types::{
 };
 use ibc::core::host::types::error::HostError;
 use ibc::core::host::types::identifiers::{ChannelId, PortId};
+use ibc::core::primitives::Signer;
 use namada_core::address::{Address, MASP};
 use namada_core::token::Amount;
 use namada_systems::trans_token;
@@ -126,6 +127,28 @@ where
     type AccountId = Address;
     type Nft = NftMetadata;
     type NftClass = NftClass;
+
+    fn sender_account(
+        &self,
+        signer: &Signer,
+    ) -> Result<Self::AccountId, HostError> {
+        Address::decode(signer.as_ref()).map_err(|e| HostError::Other {
+            description: format!(
+                "Decoding the signer failed: {signer}, error {e}"
+            ),
+        })
+    }
+
+    fn receiver_account(
+        &self,
+        signer: &Signer,
+    ) -> Result<Self::AccountId, HostError> {
+        Address::try_from(signer).map_err(|e| HostError::Other {
+            description: format!(
+                "Decoding the signer failed: {signer}, error {e}"
+            ),
+        })
+    }
 
     fn get_port(&self) -> Result<PortId, HostError> {
         Ok(PORT_ID_STR.parse().expect("the ID should be parsable"))

--- a/crates/ibc/src/context/nft_transfer_mod.rs
+++ b/crates/ibc/src/context/nft_transfer_mod.rs
@@ -262,7 +262,8 @@ where
         packet: &Packet,
         _relayer: &Signer,
     ) -> (ModuleExtras, Option<Acknowledgement>) {
-        on_recv_packet_execute(&mut self.ctx, packet)
+        let (extras, ack) = on_recv_packet_execute(&mut self.ctx, packet);
+        (extras, Some(ack))
     }
 
     fn on_acknowledgement_packet_validate(

--- a/crates/ibc/src/context/nft_transfer_mod.rs
+++ b/crates/ibc/src/context/nft_transfer_mod.rs
@@ -20,7 +20,7 @@ use ibc::apps::nft_transfer::types::error::NftTransferError;
 use ibc::apps::nft_transfer::types::MODULE_ID_STR;
 use ibc::core::channel::types::acknowledgement::Acknowledgement;
 use ibc::core::channel::types::channel::{Counterparty, Order};
-use ibc::core::channel::types::error::{ChannelError, PacketError};
+use ibc::core::channel::types::error::ChannelError;
 use ibc::core::channel::types::packet::Packet;
 use ibc::core::channel::types::Version;
 use ibc::core::host::types::identifiers::{ChannelId, ConnectionId, PortId};
@@ -270,14 +270,14 @@ where
         packet: &Packet,
         acknowledgement: &Acknowledgement,
         relayer: &Signer,
-    ) -> Result<(), PacketError> {
+    ) -> Result<(), ChannelError> {
         on_acknowledgement_packet_validate(
             &self.ctx,
             packet,
             acknowledgement,
             relayer,
         )
-        .map_err(into_packet_error)
+        .map_err(into_channel_error)
     }
 
     fn on_acknowledgement_packet_execute(
@@ -285,44 +285,38 @@ where
         packet: &Packet,
         acknowledgement: &Acknowledgement,
         relayer: &Signer,
-    ) -> (ModuleExtras, Result<(), PacketError>) {
+    ) -> (ModuleExtras, Result<(), ChannelError>) {
         let (extras, result) = on_acknowledgement_packet_execute(
             &mut self.ctx,
             packet,
             acknowledgement,
             relayer,
         );
-        (extras, result.map_err(into_packet_error))
+        (extras, result.map_err(into_channel_error))
     }
 
     fn on_timeout_packet_validate(
         &self,
         packet: &Packet,
         relayer: &Signer,
-    ) -> Result<(), PacketError> {
+    ) -> Result<(), ChannelError> {
         on_timeout_packet_validate(&self.ctx, packet, relayer)
-            .map_err(into_packet_error)
+            .map_err(into_channel_error)
     }
 
     fn on_timeout_packet_execute(
         &mut self,
         packet: &Packet,
         relayer: &Signer,
-    ) -> (ModuleExtras, Result<(), PacketError>) {
+    ) -> (ModuleExtras, Result<(), ChannelError>) {
         let (extras, result) =
             on_timeout_packet_execute(&mut self.ctx, packet, relayer);
-        (extras, result.map_err(into_packet_error))
+        (extras, result.map_err(into_channel_error))
     }
 }
 
 fn into_channel_error(error: NftTransferError) -> ChannelError {
-    ChannelError::AppModule {
-        description: error.to_string(),
-    }
-}
-
-fn into_packet_error(error: NftTransferError) -> PacketError {
-    PacketError::AppModule {
+    ChannelError::AppSpecific {
         description: error.to_string(),
     }
 }
@@ -494,7 +488,7 @@ pub mod testing {
             _packet: &Packet,
             _acknowledgement: &Acknowledgement,
             _relayer: &Signer,
-        ) -> Result<(), PacketError> {
+        ) -> Result<(), ChannelError> {
             Ok(())
         }
 
@@ -503,7 +497,7 @@ pub mod testing {
             _packet: &Packet,
             _acknowledgement: &Acknowledgement,
             _relayer: &Signer,
-        ) -> (ModuleExtras, Result<(), PacketError>) {
+        ) -> (ModuleExtras, Result<(), ChannelError>) {
             (ModuleExtras::empty(), Ok(()))
         }
 
@@ -511,7 +505,7 @@ pub mod testing {
             &self,
             _packet: &Packet,
             _relayer: &Signer,
-        ) -> Result<(), PacketError> {
+        ) -> Result<(), ChannelError> {
             Ok(())
         }
 
@@ -519,7 +513,7 @@ pub mod testing {
             &mut self,
             _packet: &Packet,
             _relayer: &Signer,
-        ) -> (ModuleExtras, Result<(), PacketError>) {
+        ) -> (ModuleExtras, Result<(), ChannelError>) {
             (ModuleExtras::empty(), Ok(()))
         }
     }

--- a/crates/ibc/src/context/token_transfer.rs
+++ b/crates/ibc/src/context/token_transfer.rs
@@ -183,21 +183,29 @@ where
 {
     type AccountId = Address;
 
-    fn sender_account_from_signer(
+    fn sender_account(
         &self,
         signer: &Signer,
-    ) -> Option<Self::AccountId> {
-        Address::decode(signer.as_ref()).ok()
+    ) -> Result<Self::AccountId, HostError> {
+        Address::decode(signer.as_ref()).map_err(|e| HostError::Other {
+            description: format!(
+                "Decoding the signer failed: {signer}, error {e}"
+            ),
+        })
     }
 
-    fn receiver_account_from_signer(
+    fn receiver_account(
         &self,
         signer: &Signer,
-    ) -> Option<Self::AccountId> {
+    ) -> Result<Self::AccountId, HostError> {
         if self.parse_addr_as_governance {
-            Some(namada_core::address::GOV)
+            Ok(namada_core::address::GOV)
         } else {
-            Address::try_from(signer).ok()
+            Address::try_from(signer).map_err(|e| HostError::Other {
+                description: format!(
+                    "Decoding the signer failed: {signer}, error {e}"
+                ),
+            })
         }
     }
 

--- a/crates/ibc/src/context/transfer_mod.rs
+++ b/crates/ibc/src/context/transfer_mod.rs
@@ -277,7 +277,8 @@ where
         packet: &Packet,
         _relayer: &Signer,
     ) -> (ModuleExtras, Option<Acknowledgement>) {
-        on_recv_packet_execute(&mut self.ctx, packet)
+        let (extras, ack) = on_recv_packet_execute(&mut self.ctx, packet);
+        (extras, Some(ack))
     }
 
     fn on_acknowledgement_packet_validate(

--- a/crates/ibc/src/context/transfer_mod.rs
+++ b/crates/ibc/src/context/transfer_mod.rs
@@ -21,7 +21,7 @@ use ibc::apps::transfer::types::error::TokenTransferError;
 use ibc::apps::transfer::types::MODULE_ID_STR;
 use ibc::core::channel::types::acknowledgement::Acknowledgement;
 use ibc::core::channel::types::channel::{Counterparty, Order};
-use ibc::core::channel::types::error::{ChannelError, PacketError};
+use ibc::core::channel::types::error::ChannelError;
 use ibc::core::channel::types::packet::Packet;
 use ibc::core::channel::types::Version;
 use ibc::core::host::types::identifiers::{ChannelId, ConnectionId, PortId};
@@ -285,14 +285,14 @@ where
         packet: &Packet,
         acknowledgement: &Acknowledgement,
         relayer: &Signer,
-    ) -> Result<(), PacketError> {
+    ) -> Result<(), ChannelError> {
         on_acknowledgement_packet_validate(
             &self.ctx,
             packet,
             acknowledgement,
             relayer,
         )
-        .map_err(into_packet_error)
+        .map_err(into_channel_error)
     }
 
     fn on_acknowledgement_packet_execute(
@@ -300,44 +300,38 @@ where
         packet: &Packet,
         acknowledgement: &Acknowledgement,
         relayer: &Signer,
-    ) -> (ModuleExtras, Result<(), PacketError>) {
+    ) -> (ModuleExtras, Result<(), ChannelError>) {
         let (extras, result) = on_acknowledgement_packet_execute(
             &mut self.ctx,
             packet,
             acknowledgement,
             relayer,
         );
-        (extras, result.map_err(into_packet_error))
+        (extras, result.map_err(into_channel_error))
     }
 
     fn on_timeout_packet_validate(
         &self,
         packet: &Packet,
         relayer: &Signer,
-    ) -> Result<(), PacketError> {
+    ) -> Result<(), ChannelError> {
         on_timeout_packet_validate(&self.ctx, packet, relayer)
-            .map_err(into_packet_error)
+            .map_err(into_channel_error)
     }
 
     fn on_timeout_packet_execute(
         &mut self,
         packet: &Packet,
         relayer: &Signer,
-    ) -> (ModuleExtras, Result<(), PacketError>) {
+    ) -> (ModuleExtras, Result<(), ChannelError>) {
         let (extras, result) =
             on_timeout_packet_execute(&mut self.ctx, packet, relayer);
-        (extras, result.map_err(into_packet_error))
+        (extras, result.map_err(into_channel_error))
     }
 }
 
 fn into_channel_error(error: TokenTransferError) -> ChannelError {
-    ChannelError::AppModule {
-        description: error.to_string(),
-    }
-}
-
-fn into_packet_error(error: TokenTransferError) -> PacketError {
-    PacketError::AppModule {
+    ChannelError::AppSpecific {
         description: error.to_string(),
     }
 }
@@ -509,7 +503,7 @@ pub mod testing {
             _packet: &Packet,
             _acknowledgement: &Acknowledgement,
             _relayer: &Signer,
-        ) -> Result<(), PacketError> {
+        ) -> Result<(), ChannelError> {
             Ok(())
         }
 
@@ -518,7 +512,7 @@ pub mod testing {
             _packet: &Packet,
             _acknowledgement: &Acknowledgement,
             _relayer: &Signer,
-        ) -> (ModuleExtras, Result<(), PacketError>) {
+        ) -> (ModuleExtras, Result<(), ChannelError>) {
             (ModuleExtras::empty(), Ok(()))
         }
 
@@ -526,7 +520,7 @@ pub mod testing {
             &self,
             _packet: &Packet,
             _relayer: &Signer,
-        ) -> Result<(), PacketError> {
+        ) -> Result<(), ChannelError> {
             Ok(())
         }
 
@@ -534,7 +528,7 @@ pub mod testing {
             &mut self,
             _packet: &Packet,
             _relayer: &Signer,
-        ) -> (ModuleExtras, Result<(), PacketError>) {
+        ) -> (ModuleExtras, Result<(), ChannelError>) {
             (ModuleExtras::empty(), Ok(()))
         }
     }

--- a/crates/ibc/src/context/validation.rs
+++ b/crates/ibc/src/context/validation.rs
@@ -5,7 +5,6 @@ use ibc::core::channel::types::channel::ChannelEnd;
 use ibc::core::channel::types::commitment::{
     AcknowledgementCommitment, PacketCommitment,
 };
-use ibc::core::channel::types::error::PacketError;
 use ibc::core::channel::types::packet::Receipt;
 use ibc::core::client::context::{
     ClientValidationContext, ExtClientValidationContext,
@@ -267,10 +266,11 @@ where
             path.sequence,
         )?;
 
-        maybe_ack.ok_or_else(|| {
-            HostError::Other {
-                description: format!("No packet acknowledgement: port {}, channel {}, sequence {}" path.port_id, path.channel_id, path.sequence)
-            }
+        maybe_ack.ok_or_else(|| HostError::Other {
+            description: format!(
+                "No packet acknowledgement: port {}, channel {}, sequence {}",
+                path.port_id, path.channel_id, path.sequence
+            ),
         })
     }
 

--- a/crates/ibc/src/nft.rs
+++ b/crates/ibc/src/nft.rs
@@ -1,9 +1,9 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use ibc::apps::nft_transfer::context::{NftClassContext, NftContext};
-use ibc::apps::nft_transfer::types::error::NftTransferError;
 use ibc::apps::nft_transfer::types::{
     ClassData, ClassId, ClassUri, PrefixedClassId, TokenData, TokenId, TokenUri,
 };
+use ibc::core::host::types::error::DecodingError;
 
 /// NFT class
 #[derive(Clone, Debug)]
@@ -45,14 +45,14 @@ impl BorshDeserialize for NftClass {
     ) -> std::io::Result<Self> {
         use std::io::{Error, ErrorKind};
         let class_id: String = BorshDeserialize::deserialize_reader(reader)?;
-        let class_id = class_id.parse().map_err(|e: NftTransferError| {
+        let class_id = class_id.parse().map_err(|e: DecodingError| {
             Error::new(ErrorKind::InvalidData, e.to_string())
         })?;
 
         let is_uri: bool = BorshDeserialize::deserialize_reader(reader)?;
         let class_uri = if is_uri {
             let uri_str: String = BorshDeserialize::deserialize_reader(reader)?;
-            Some(uri_str.parse().map_err(|e: NftTransferError| {
+            Some(uri_str.parse().map_err(|e: DecodingError| {
                 Error::new(ErrorKind::InvalidData, e.to_string())
             })?)
         } else {
@@ -63,7 +63,7 @@ impl BorshDeserialize for NftClass {
         let class_data = if is_data {
             let data_str: String =
                 BorshDeserialize::deserialize_reader(reader)?;
-            Some(data_str.parse().map_err(|e: NftTransferError| {
+            Some(data_str.parse().map_err(|e: DecodingError| {
                 Error::new(ErrorKind::InvalidData, e.to_string())
             })?)
         } else {
@@ -135,19 +135,19 @@ impl BorshDeserialize for NftMetadata {
     ) -> std::io::Result<Self> {
         use std::io::{Error, ErrorKind};
         let class_id: String = BorshDeserialize::deserialize_reader(reader)?;
-        let class_id = class_id.parse().map_err(|e: NftTransferError| {
+        let class_id = class_id.parse().map_err(|e: DecodingError| {
             Error::new(ErrorKind::InvalidData, e.to_string())
         })?;
 
         let token_id: String = BorshDeserialize::deserialize_reader(reader)?;
-        let token_id = token_id.parse().map_err(|e: NftTransferError| {
+        let token_id = token_id.parse().map_err(|e: DecodingError| {
             Error::new(ErrorKind::InvalidData, e.to_string())
         })?;
 
         let is_uri: bool = BorshDeserialize::deserialize_reader(reader)?;
         let token_uri = if is_uri {
             let uri_str: String = BorshDeserialize::deserialize_reader(reader)?;
-            Some(uri_str.parse().map_err(|e: NftTransferError| {
+            Some(uri_str.parse().map_err(|e: DecodingError| {
                 Error::new(ErrorKind::InvalidData, e.to_string())
             })?)
         } else {
@@ -158,7 +158,7 @@ impl BorshDeserialize for NftMetadata {
         let token_data = if is_data {
             let data_str: String =
                 BorshDeserialize::deserialize_reader(reader)?;
-            Some(data_str.parse().map_err(|e: NftTransferError| {
+            Some(data_str.parse().map_err(|e: DecodingError| {
                 Error::new(ErrorKind::InvalidData, e.to_string())
             })?)
         } else {

--- a/crates/ibc/src/vp/mod.rs
+++ b/crates/ibc/src/vp/mod.rs
@@ -464,6 +464,7 @@ mod tests {
 
     use assert_matches::assert_matches;
     use ibc::core::channel::types::timeout::TimeoutTimestamp;
+    use ibc::primitives::IntoTimestamp;
     use ibc_testkit::testapp::ibc::clients::mock::client_state::{
         client_type, MockClientState, MOCK_CLIENT_TYPE,
     };
@@ -1156,7 +1157,7 @@ mod tests {
         let time = (TmTime::now() - std::time::Duration::new(100, 0)).unwrap();
         let header = MockHeader {
             height,
-            timestamp: time.try_into().unwrap(),
+            timestamp: time.into_timestamp().unwrap(),
         };
         let msg = MsgUpdateClient {
             client_id: client_id.clone(),

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -68,7 +68,7 @@ use namada_sdk::ibc::core::host::types::path::{
     ClientConsensusStatePath, ClientStatePath, Path as IbcPath,
 };
 use namada_sdk::ibc::primitives::proto::{Any, Protobuf};
-use namada_sdk::ibc::primitives::Timestamp as IbcTimestamp;
+use namada_sdk::ibc::primitives::{IntoTimestamp, Timestamp as IbcTimestamp};
 use namada_sdk::ibc::storage::{
     channel_key, connection_key, mint_limit_key, port_key, throughput_limit_key,
 };
@@ -239,7 +239,7 @@ impl BenchShellInner {
         #[allow(clippy::disallowed_methods)]
         let now: namada_sdk::tendermint::Time =
             DateTimeUtc::now().try_into().unwrap();
-        let now: IbcTimestamp = now.try_into().unwrap();
+        let now: IbcTimestamp = now.into_timestamp().unwrap();
         let timeout_timestamp =
             (now + std::time::Duration::new(3600, 0)).unwrap();
 
@@ -1327,7 +1327,7 @@ impl BenchShieldedCtx {
         #[allow(clippy::disallowed_methods)]
         let now: namada_sdk::tendermint::Time =
             DateTimeUtc::now().try_into().unwrap();
-        let now: IbcTimestamp = now.try_into().unwrap();
+        let now: IbcTimestamp = now.into_timestamp().unwrap();
         let timeout_timestamp =
             (now + std::time::Duration::new(3600, 0)).unwrap();
         let msg = IbcMsgTransfer {

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -16,10 +16,12 @@ use namada_account::{AccountPublicKeysMap, InitAccount, UpdateAccount};
 use namada_core::address::{Address, ImplicitAddress, InternalAddress, MASP};
 use namada_core::arith::checked;
 use namada_core::collections::{HashMap, HashSet};
+use namada_core::ibc::primitives::IntoHostTime;
 use namada_core::key::*;
 use namada_core::masp::{
     AssetData, ExtendedViewingKey, MaspTxId, PaymentAddress,
 };
+use namada_core::tendermint::Time as TmTime;
 use namada_core::time::DateTimeUtc;
 use namada_core::token::{Amount, DenominatedAmount};
 use namada_governance::storage::proposal::{
@@ -1109,7 +1111,9 @@ fn format_timeout_timestamp(timestamp: &TimeoutTimestamp) -> String {
     match timestamp {
         TimeoutTimestamp::Never => "no timestamp".to_string(),
         TimeoutTimestamp::At(timestamp) => {
-            timestamp.into_tm_time().to_rfc3339()
+            let tm_time: TmTime =
+                timestamp.into_host_time().expect("invalid timestamp");
+            tm_time.to_rfc3339()
         }
     }
 }

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -39,7 +39,7 @@ use namada_core::ibc::core::channel::types::timeout::{
 };
 use namada_core::ibc::core::client::types::Height as IbcHeight;
 use namada_core::ibc::core::host::types::identifiers::{ChannelId, PortId};
-use namada_core::ibc::primitives::Timestamp as IbcTimestamp;
+use namada_core::ibc::primitives::{IntoTimestamp, Timestamp as IbcTimestamp};
 use namada_core::key::{self, *};
 use namada_core::masp::{AssetData, MaspEpoch, TransferSource, TransferTarget};
 use namada_core::storage;
@@ -2742,7 +2742,7 @@ pub async fn build_ibc_transfer(
     }
     .try_into();
     let now = now.map_err(|e| Error::Other(e.to_string()))?;
-    let now: IbcTimestamp = now.try_into().map_err(|e| {
+    let now: IbcTimestamp = now.into_timestamp().map_err(|e| {
         Error::Other(format!("Timestamp conversion failed: {e}"))
     })?;
     let timeout_timestamp = if let Some(offset) = args.timeout_sec_offset {

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -148,17 +148,14 @@ impl<T> OptionExt<T> for Option<T> {
     }
 }
 
-/// Convert `namada_storage::Error` into IBC `ContextError`.
-/// It always returns `ClientError::Other` though the storage error could happen
+/// Convert `namada_storage::Error` into IBC `HandlerError`.
+/// It always returns `HostError::Other` though the storage error could happen
 /// in any storage access.
-impl From<Error>
-    for namada_core::ibc::core::handler::types::error::ContextError
-{
+impl From<Error> for namada_core::ibc::core::host::types::error::HostError {
     fn from(error: Error) -> Self {
-        namada_core::ibc::core::client::types::error::ClientError::Other {
+        namada_core::ibc::core::host::types::error::HostError::Other {
             description: format!("Storage error: {error}"),
         }
-        .into()
     }
 }
 

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -2488,7 +2488,7 @@ fn try_invalid_transfers(
         &"channel-42".parse().unwrap(),
         None,
         None,
-        Some("IBC token transfer error: context error: `ICS04 Channel error"),
+        Some("No channel end: port transfer, channel channel-42"),
         None,
         false,
     )?;

--- a/crates/tests/src/e2e/setup.rs
+++ b/crates/tests/src/e2e/setup.rs
@@ -1140,7 +1140,7 @@ where
     // Root cargo workspace manifest path
     let (bin_name, log_level) = match bin {
         Bin::Namada => ("namada", "info"),
-        Bin::Node => ("namadan", "debug"),
+        Bin::Node => ("namadan", "info"),
         Bin::Client => (
             "namadac",
             if is_shielded_sync {

--- a/crates/tests/src/e2e/setup.rs
+++ b/crates/tests/src/e2e/setup.rs
@@ -1140,7 +1140,7 @@ where
     // Root cargo workspace manifest path
     let (bin_name, log_level) = match bin {
         Bin::Namada => ("namada", "info"),
-        Bin::Node => ("namadan", "info"),
+        Bin::Node => ("namadan", "debug"),
         Bin::Client => (
             "namadac",
             if is_shielded_sync {

--- a/crates/tests/src/vm_host_env/ibc.rs
+++ b/crates/tests/src/vm_host_env/ibc.rs
@@ -735,7 +735,7 @@ pub fn balance_key_with_ibc_prefix(denom: String, owner: &Address) -> Key {
 pub fn transfer_ack_with_error() -> AcknowledgementStatus {
     AcknowledgementStatus::error(
         StatusValue::new(
-            TokenTransferError::PacketDataDeserialization.to_string(),
+            TokenTransferError::FailedToDeserializePacketData.to_string(),
         )
         .expect("Empty message"),
     )

--- a/crates/tests/src/vm_host_env/mod.rs
+++ b/crates/tests/src/vm_host_env/mod.rs
@@ -1112,7 +1112,7 @@ mod tests {
             result
                 .expect_err("validation succeeded unexpectedly")
                 .downcast_ref::<IbcActionError>(),
-            Some(IbcActionError::Context(_)),
+            Some(IbcActionError::Handler(_)),
         ));
     }
 

--- a/crates/tx/build.rs
+++ b/crates/tx/build.rs
@@ -17,6 +17,6 @@ fn main() {
     tonic_build::configure()
         .out_dir("src/proto/generated")
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile(&[format!("{}/types.proto", PROTO_SRC)], &[PROTO_SRC])
+        .compile_protos(&[format!("{}/types.proto", PROTO_SRC)], &[PROTO_SRC])
         .unwrap();
 }

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -1422,6 +1422,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "dur"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5b6c91b5e394b75cd96c36393fc938496c030220207a0ccf34d6cd313d3b49"
+dependencies = [
+ "nom",
+ "rust_decimal",
+]
+
+[[package]]
 name = "duration-str"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2613,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2623,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2644,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2654,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2672,7 +2682,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2681,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -2698,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2715,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -2729,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2738,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2754,7 +2764,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2769,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2792,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2805,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -2821,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2841,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2860,7 +2870,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2874,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2895,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2910,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2934,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -2952,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -2975,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2992,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3006,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3025,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.10.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3033,9 +3043,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ibc-middleware-module"
+version = "0.1.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
+dependencies = [
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-middleware-module-macros"
+version = "0.1.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "ibc-middleware-packet-forward"
+version = "0.9.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
+dependencies = [
+ "borsh",
+ "dur",
+ "either",
+ "ibc-app-transfer-types",
+ "ibc-core-channel",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
+ "ibc-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ibc-primitives"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3072,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3083,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "basecoin-store",
  "bon",
@@ -3633,6 +3685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,8 +3889,10 @@ version = "0.47.0"
 dependencies = [
  "borsh",
  "data-encoding",
+ "dur",
  "ibc",
  "ibc-derive",
+ "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "konst",
@@ -4116,7 +4176,9 @@ version = "0.47.0"
 dependencies = [
  "concat-idents",
  "derivative",
+ "dur",
  "hyper 0.14.27",
+ "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "itertools 0.12.1",
@@ -4384,6 +4446,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -5118,9 +5190,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -5512,12 +5584,18 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arrayvec",
+ "borsh",
+ "bytes",
  "num-traits 0.2.17",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5880,11 +5958,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -54,7 +54,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -116,7 +116,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "num-traits 0.2.17",
+ "num-traits",
  "zeroize",
 ]
 
@@ -132,7 +132,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits",
  "paste",
  "rustc_version 0.3.3",
  "zeroize",
@@ -155,7 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -176,8 +176,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "num-traits 0.2.17",
- "rand 0.8.5",
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -234,6 +234,15 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -398,7 +407,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -417,9 +426,9 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "pbkdf2 0.12.2",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "unicode-normalization",
  "zeroize",
@@ -536,19 +545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "bls12_381"
-version = "0.8.0"
-source = "git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838#d3ebe9dd6488fac1923db120a7498079e55dd838"
-dependencies = [
- "ff",
- "group",
- "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -698,7 +695,7 @@ dependencies = [
  "semver 1.0.20",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -764,7 +761,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.17",
+ "num-traits",
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
@@ -821,6 +818,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "coins-bip32"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,11 +832,11 @@ dependencies = [
  "bs58",
  "coins-core",
  "digest 0.10.7",
- "hmac 0.12.1",
+ "hmac",
  "k256",
  "serde",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -844,12 +847,12 @@ checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
 dependencies = [
  "bitvec",
  "coins-bip32",
- "hmac 0.12.1",
+ "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -869,7 +872,7 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.8",
  "sha3",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -881,6 +884,12 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
+
+[[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-default"
@@ -934,6 +943,15 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "corosensei"
@@ -1062,6 +1080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,7 +1137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1126,16 +1150,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -1161,7 +1175,7 @@ checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle-ng",
  "zeroize",
 ]
@@ -1256,6 +1270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
+name = "debugless-unwrap"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1309,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1377,22 +1408,23 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "4.0.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1440,7 +1472,7 @@ dependencies = [
  "chrono",
  "rust_decimal",
  "serde",
- "thiserror",
+ "thiserror 1.0.50",
  "time",
  "winnow 0.6.8",
 ]
@@ -1510,10 +1542,10 @@ checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2 0.9.9",
- "thiserror",
+ "thiserror 1.0.50",
  "zeroize",
 ]
 
@@ -1536,12 +1568,24 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "serdect",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -1563,7 +1607,7 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand 0.8.5",
+ "rand",
  "rlp",
  "serde",
  "sha3",
@@ -1637,15 +1681,15 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "pbkdf2 0.11.0",
- "rand 0.8.5",
+ "rand",
  "scrypt",
  "serde",
  "serde_json",
  "sha2 0.10.8",
  "sha3",
- "thiserror",
+ "thiserror 1.0.50",
  "uuid 0.8.2",
 ]
 
@@ -1662,7 +1706,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "thiserror",
+ "thiserror 1.0.50",
  "uint 0.9.5",
 ]
 
@@ -1775,7 +1819,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -1834,14 +1878,14 @@ dependencies = [
  "num_enum",
  "once_cell",
  "open-fastrlp",
- "rand 0.8.5",
+ "rand",
  "rlp",
  "serde",
  "serde_json",
  "strum 0.25.0",
  "syn 2.0.96",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.50",
  "tiny-keccak",
  "unicode-xid",
 ]
@@ -1858,7 +1902,7 @@ dependencies = [
  "semver 1.0.20",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -1881,7 +1925,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.50",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -1913,7 +1957,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.50",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -1937,9 +1981,9 @@ dependencies = [
  "elliptic-curve",
  "eth-keystore",
  "ethers-core",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -1983,7 +2027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "bitvec",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2006,7 +2050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2089,7 +2133,43 @@ dependencies = [
  "libm",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits",
+]
+
+[[package]]
+name = "frost-core"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1858230cabb6792a5020daf4b0074f57b7d1e2a520ac544c77f102babee62ff4"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "debugless-unwrap",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core",
+ "serde",
+ "serdect",
+ "thiserror 2.0.11",
+ "thiserror-nostd-notrait",
+ "visibility",
+ "zeroize",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3b10d9c1e9f298522510940b5b8c3d55040420517ec8d2bb86c4c2d1ae3ee"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core",
 ]
 
 [[package]]
@@ -2229,19 +2309,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
@@ -2249,7 +2316,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2290,7 +2357,7 @@ checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "memuse",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -2359,6 +2426,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,12 +2450,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "hashers"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.0",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2399,16 +2495,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
 
 [[package]]
 name = "hmac"
@@ -2610,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2623,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2633,7 +2719,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2654,7 +2740,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2664,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2682,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2691,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -2708,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2725,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -2739,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2748,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2764,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2779,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2802,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2815,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -2831,7 +2917,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2851,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2870,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2884,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2905,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2920,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2944,7 +3030,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -2962,7 +3048,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -2985,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -3002,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3016,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3035,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.10.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3045,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -3057,16 +3143,33 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
+name = "ibc-middleware-overflow-receive"
+version = "0.4.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+dependencies = [
+ "ibc-app-transfer-types",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
+ "ibc-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#89e394130f7c4bfba6c067f5ab89d1297b7fabc9"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
  "borsh",
  "dur",
@@ -3087,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3124,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "ibc-query"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3135,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "ibc-testkit"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "basecoin-store",
  "bon",
@@ -3210,7 +3313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951641f13f873bff03d4bf19ae8bec531935ac0ac2cc775f84d7edfdcfed3f17"
 dependencies = [
  "integer-sqrt",
- "num-traits 0.2.17",
+ "num-traits",
  "uint 0.9.5",
 ]
 
@@ -3280,17 +3383,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.4"
-source = "git+https://github.com/heliaxdev/indexmap?tag=2.2.4-heliax-1#b5b5b547bd6ab04bbb16e060326a50ddaeb6c909"
-dependencies = [
- "borsh",
- "equivalent",
- "hashbrown 0.14.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
@@ -3343,7 +3435,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -3354,18 +3446,18 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3406,23 +3498,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
 dependencies = [
  "bitvec",
- "bls12_381 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bls12_381",
  "ff",
  "group",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "jubjub"
-version = "0.10.0"
-source = "git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c#a373686962f4e9d0edb3b4716f86ff6bbd9aa86c"
-dependencies = [
- "bitvec",
- "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
- "ff",
- "group",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -3554,28 +3633,29 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
 dependencies = [
  "borsh",
  "chacha20",
  "chacha20poly1305",
  "cipher",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "masp_primitives"
-version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
 dependencies = [
  "aes",
  "bip0039",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
- "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "borsh",
  "byteorder",
  "ff",
@@ -3583,15 +3663,16 @@ dependencies = [
  "group",
  "hex",
  "incrementalmerkletree",
- "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_note_encryption",
  "memuse",
- "nonempty",
- "num-traits 0.2.19",
+ "nam-bls12_381",
+ "nam-jubjub",
+ "nam-num-traits",
+ "nonempty 0.11.0",
  "proptest",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "sha2 0.10.8",
  "subtle",
  "zcash_encoding",
@@ -3599,22 +3680,23 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
 dependencies = [
  "bellman",
  "blake2b_simd",
- "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "directories",
- "getrandom 0.2.15",
+ "getrandom",
  "group",
- "itertools 0.11.0",
- "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
+ "itertools 0.14.0",
  "lazy_static",
  "masp_primitives",
  "minreq",
- "rand_core 0.6.4",
- "redjubjub",
+ "nam-bls12_381",
+ "nam-jubjub",
+ "nam-redjubjub",
+ "rand_core",
  "tracing",
 ]
 
@@ -3720,7 +3802,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -3735,6 +3817,112 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nam-bls12_381"
+version = "0.8.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e768b0e2383163f2f4bbce1112d6454b2cb515950b0a9177733f0d71254d2c68"
+dependencies = [
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "nam-indexmap"
+version = "2.7.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b40876708764895b63bb5a1e9f102d3813cb16baeb9f12932b7c8f2df4248e"
+dependencies = [
+ "borsh",
+ "equivalent",
+ "hashbrown 0.15.2",
+ "serde",
+]
+
+[[package]]
+name = "nam-jubjub"
+version = "0.10.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdced0f5975d8f80cb82a84d464481acb7b586d22f447dda86947d6a572997b9"
+dependencies = [
+ "bitvec",
+ "ff",
+ "group",
+ "nam-bls12_381",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "nam-num-traits"
+version = "0.2.20-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687832a07242b76ab2760bc95180240954bf77e06bf8d9e825473c373146dc4a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nam-reddsa"
+version = "0.5.2-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d102b4311bf60c03405350e976d17f5df155d2cb588f6401995a29ae8c1565"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "frost-rerandomized",
+ "group",
+ "hex",
+ "jubjub",
+ "pasta_curves",
+ "rand_core",
+ "serde",
+ "thiserror 2.0.11",
+ "zeroize",
+]
+
+[[package]]
+name = "nam-redjubjub"
+version = "0.7.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e457988762db7daad8d79f8a837a07295f5cc178d9236ba77db7339072ffb61e"
+dependencies = [
+ "nam-reddsa",
+ "rand_core",
+ "serde",
+ "thiserror 1.0.50",
+ "zeroize",
+]
+
+[[package]]
+name = "nam-sparse-merkle-tree"
+version = "0.3.2-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fae108a0f6aabf789e34d6d447c1184608d1c70c087f957b720042226a47ab63"
+dependencies = [
+ "borsh",
+ "cfg-if",
+ "ics23",
+ "itertools 0.14.0",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "nam-tiny-hderive"
+version = "0.3.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfd77f274636f722e966c394b381a70233ed4c25150864a4c53d398028a6818"
+dependencies = [
+ "base58",
+ "hmac",
+ "k256",
+ "memzero",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "namada_account"
@@ -3754,7 +3942,7 @@ version = "0.47.0"
 dependencies = [
  "namada_core",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -3772,31 +3960,31 @@ dependencies = [
  "ibc",
  "ics23",
  "impl-num-traits",
- "indexmap 2.2.4",
  "k256",
  "lazy_static",
  "masp_primitives",
+ "nam-indexmap",
+ "nam-sparse-merkle-tree",
  "namada_macros",
  "num-integer",
  "num-rational",
- "num-traits 0.2.17",
+ "num-traits",
  "num256",
  "num_enum",
  "primitive-types 0.13.1",
  "proptest",
  "prost-types",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "rayon",
  "ripemd",
  "serde",
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
- "sparse-merkle-tree",
  "tendermint 0.40.1",
  "tendermint-proto 0.40.1",
- "thiserror",
+ "thiserror 1.0.50",
  "tiny-keccak",
  "tokio",
  "tracing",
@@ -3831,7 +4019,7 @@ dependencies = [
  "namada_vp_env",
  "serde",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -3844,7 +4032,7 @@ dependencies = [
  "namada_macros",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -3857,7 +4045,7 @@ dependencies = [
  "namada_events",
  "namada_macros",
  "serde",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -3879,7 +4067,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -3892,6 +4080,9 @@ dependencies = [
  "dur",
  "ibc",
  "ibc-derive",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
+ "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
@@ -3912,7 +4103,7 @@ dependencies = [
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -3924,7 +4115,7 @@ dependencies = [
  "kdam",
  "namada_core",
  "tendermint-rpc",
- "thiserror",
+ "thiserror 1.0.50",
  "tokio",
 ]
 
@@ -3946,11 +4137,11 @@ dependencies = [
  "borsh",
  "eyre",
  "ics23",
+ "nam-sparse-merkle-tree",
  "namada_core",
  "namada_macros",
  "prost",
- "sparse-merkle-tree",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -3964,7 +4155,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -3987,7 +4178,7 @@ dependencies = [
  "proptest",
  "serde",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -4003,6 +4194,7 @@ name = "namada_sdk"
 version = "0.47.0"
 dependencies = [
  "async-trait",
+ "bech32 0.8.1",
  "bimap",
  "borsh",
  "circular-queue",
@@ -4017,10 +4209,10 @@ dependencies = [
  "futures",
  "init-once",
  "itertools 0.12.1",
- "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
+ "nam-jubjub",
  "namada_account",
  "namada_core",
  "namada_ethereum_bridge",
@@ -4040,15 +4232,15 @@ dependencies = [
  "namada_vote_ext",
  "namada_vp",
  "namada_wallet",
- "num-traits 0.2.17",
+ "num-traits",
  "num256",
  "owo-colors",
  "paste",
  "patricia_tree",
  "proptest",
  "prost",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "rayon",
  "regex",
  "reqwest",
@@ -4059,7 +4251,7 @@ dependencies = [
  "smooth-operator",
  "tempfile",
  "tendermint-rpc",
- "thiserror",
+ "thiserror 1.0.50",
  "tiny-bip39",
  "tokio",
  "toml 0.5.11",
@@ -4094,8 +4286,8 @@ dependencies = [
  "namada_vp_env",
  "namada_wallet",
  "proptest",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "rayon",
  "ripemd",
  "serde",
@@ -4103,7 +4295,7 @@ dependencies = [
  "sha2 0.9.9",
  "smooth-operator",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
  "typed-builder",
  "xorf",
@@ -4128,7 +4320,7 @@ dependencies = [
  "patricia_tree",
  "proptest",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -4146,7 +4338,7 @@ dependencies = [
  "regex",
  "serde",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -4234,7 +4426,7 @@ dependencies = [
  "namada_tx",
  "namada_tx_env",
  "namada_vp_env",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -4255,15 +4447,15 @@ dependencies = [
  "namada_gas",
  "namada_macros",
  "num-derive 0.4.2",
- "num-traits 0.2.17",
+ "num-traits",
  "proptest",
  "prost",
  "prost-types",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "thiserror",
+ "thiserror 1.0.50",
  "tonic-build",
 ]
 
@@ -4316,7 +4508,7 @@ dependencies = [
  "rayon",
  "smooth-operator",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
  "wasm-instrument",
  "wasmer",
@@ -4355,7 +4547,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -4406,18 +4598,18 @@ dependencies = [
  "fd-lock",
  "itertools 0.12.1",
  "masp_primitives",
+ "nam-tiny-hderive",
  "namada_core",
  "namada_ibc",
  "namada_macros",
  "orion",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "serde",
  "slip10_ed25519",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tiny-bip39",
- "tiny-hderive",
  "toml 0.5.11",
  "zeroize",
 ]
@@ -4428,7 +4620,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
 ]
 
 [[package]]
@@ -4465,6 +4657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
+name = "nonempty"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4475,7 +4673,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -4486,7 +4684,7 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -4495,7 +4693,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -4533,7 +4731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -4544,7 +4742,7 @@ checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -4556,25 +4754,17 @@ dependencies = [
  "autocfg",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
-dependencies = [
- "autocfg",
- "libm",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.19"
-source = "git+https://github.com/heliaxdev/num-traits?rev=3f3657caa34b8e116fdf3f8a3519c4ac29f012fe#3f3657caa34b8e116fdf3f8a3519c4ac29f012fe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4586,7 +4776,7 @@ dependencies = [
  "lazy_static",
  "num",
  "num-derive 0.3.3",
- "num-traits 0.2.17",
+ "num-traits",
  "serde",
  "serde_derive",
 ]
@@ -4703,13 +4893,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orion"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6624905ddd92e460ff0685567539ed1ac985b2dee4c92c7edcd64fce905b00c"
 dependencies = [
  "ct-codecs",
- "getrandom 0.2.15",
+ "getrandom",
  "subtle",
  "zeroize",
 ]
@@ -4791,7 +4987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -4803,7 +4999,7 @@ checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
 dependencies = [
  "ff",
  "group",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
  "subtle",
 ]
@@ -4825,15 +5021,6 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
-dependencies = [
- "crypto-mac",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
@@ -4848,7 +5035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac 0.12.1",
+ "hmac",
  "password-hash",
 ]
 
@@ -4901,7 +5088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.50",
  "ucd-trie",
 ]
 
@@ -4989,6 +5176,19 @@ name = "portable-atomic"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+
+[[package]]
+name = "postcard"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "powerfmt"
@@ -5099,9 +5299,9 @@ dependencies = [
  "bit-vec",
  "bitflags 2.5.0",
  "lazy_static",
- "num-traits 0.2.17",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "num-traits",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.2",
  "rusty-fork",
@@ -5205,36 +5405,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -5244,16 +5421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -5262,16 +5430,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -5280,7 +5439,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -5306,37 +5465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reddsa"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "group",
- "hex",
- "jubjub 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pasta_curves",
- "rand_core 0.6.4",
- "serde",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "redjubjub"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a60db2c3bc9c6fd1e8631fee75abc008841d27144be744951d6b9b75f9b569c"
-dependencies = [
- "rand_core 0.6.4",
- "reddsa",
- "serde",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5351,9 +5479,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -5477,7 +5605,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -5503,7 +5631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
- "getrandom 0.2.15",
+ "getrandom",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -5591,8 +5719,8 @@ dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
- "num-traits 0.2.17",
- "rand 0.8.5",
+ "num-traits",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",
@@ -5781,7 +5909,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
  "sha2 0.10.8",
@@ -6113,7 +6241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -6135,8 +6263,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.17",
- "thiserror",
+ "num-traits",
+ "thiserror 1.0.50",
  "time",
 ]
 
@@ -6208,18 +6336,6 @@ checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "sparse-merkle-tree"
-version = "0.3.1-pre"
-source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=a93c55ccd47840ee0967eee237e47d9245478594#a93c55ccd47840ee0967eee237e47d9245478594"
-dependencies = [
- "borsh",
- "cfg-if",
- "ics23",
- "itertools 0.12.1",
- "sha2 0.9.9",
 ]
 
 [[package]]
@@ -6463,7 +6579,7 @@ dependencies = [
  "ed25519",
  "flex-error",
  "futures",
- "num-traits 0.2.17",
+ "num-traits",
  "once_cell",
  "prost",
  "prost-types",
@@ -6492,7 +6608,7 @@ dependencies = [
  "flex-error",
  "futures",
  "k256",
- "num-traits 0.2.17",
+ "num-traits",
  "once_cell",
  "prost",
  "ripemd",
@@ -6580,10 +6696,10 @@ dependencies = [
  "async-trait",
  "bytes",
  "flex-error",
- "getrandom 0.2.15",
+ "getrandom",
  "peg",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "semver 1.0.20",
  "serde",
  "serde_bytes",
@@ -6593,7 +6709,7 @@ dependencies = [
  "tendermint 0.40.1",
  "tendermint-config",
  "tendermint-proto 0.40.1",
- "thiserror",
+ "thiserror 1.0.50",
  "time",
  "url",
  "uuid 1.8.0",
@@ -6653,7 +6769,16 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.50",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -6661,6 +6786,37 @@ name = "thiserror-impl"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8444e638022c44d2a9337031dee8acb732bcc7fbf52ac654edc236b26408b61"
+dependencies = [
+ "thiserror-nostd-notrait-impl",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6710,32 +6866,19 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.8.2"
-source = "git+https://github.com/anoma/tiny-bip39.git?rev=bf0f6d8713589b83af7a917366ec31f5275c0e57#bf0f6d8713589b83af7a917366ec31f5275c0e57"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
- "anyhow",
- "hmac 0.8.1",
  "once_cell",
- "pbkdf2 0.4.0",
- "rand 0.7.3",
+ "pbkdf2 0.12.2",
+ "rand",
  "rustc-hash",
- "sha2 0.9.9",
- "thiserror",
+ "sha2 0.10.8",
+ "thiserror 1.0.50",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
-]
-
-[[package]]
-name = "tiny-hderive"
-version = "0.3.0"
-source = "git+https://github.com/heliaxdev/tiny-hderive.git?rev=173ae03abed0cd25d88a5a13efac00af96b75b87#173ae03abed0cd25d88a5a13efac00af96b75b87"
-dependencies = [
- "base58",
- "hmac 0.12.1",
- "k256",
- "memzero",
- "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6960,7 +7103,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -7047,7 +7190,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 name = "tx_become_validator"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7056,7 +7199,7 @@ dependencies = [
 name = "tx_bond"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7072,7 +7215,7 @@ dependencies = [
 name = "tx_bridge_pool"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7081,7 +7224,7 @@ dependencies = [
 name = "tx_change_consensus_key"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7090,7 +7233,7 @@ dependencies = [
 name = "tx_change_validator_commission"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7106,7 +7249,7 @@ dependencies = [
 name = "tx_change_validator_metadata"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7115,7 +7258,7 @@ dependencies = [
 name = "tx_claim_rewards"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7124,7 +7267,7 @@ dependencies = [
 name = "tx_deactivate_validator"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7133,7 +7276,7 @@ dependencies = [
 name = "tx_ibc"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7142,7 +7285,7 @@ dependencies = [
 name = "tx_init_account"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7151,7 +7294,7 @@ dependencies = [
 name = "tx_init_proposal"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7160,7 +7303,7 @@ dependencies = [
 name = "tx_reactivate_validator"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7169,7 +7312,7 @@ dependencies = [
 name = "tx_redelegate"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7185,7 +7328,7 @@ dependencies = [
 name = "tx_resign_steward"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7194,7 +7337,7 @@ dependencies = [
 name = "tx_reveal_pk"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7203,7 +7346,7 @@ dependencies = [
 name = "tx_transfer"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7212,7 +7355,7 @@ dependencies = [
 name = "tx_unbond"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7228,7 +7371,7 @@ dependencies = [
 name = "tx_unjail_validator"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7237,7 +7380,7 @@ dependencies = [
 name = "tx_update_account"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7246,7 +7389,7 @@ dependencies = [
 name = "tx_update_steward_commission"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7255,7 +7398,7 @@ dependencies = [
 name = "tx_vote_proposal"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7264,7 +7407,7 @@ dependencies = [
 name = "tx_withdraw"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7442,7 +7585,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "serde",
 ]
 
@@ -7465,10 +7608,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "vp_implicit"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7484,7 +7638,7 @@ dependencies = [
 name = "vp_user"
 version = "0.47.0"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7523,12 +7677,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -7637,7 +7785,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "shared-buffer",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
  "wasm-bindgen",
  "wasmer-compiler",
@@ -7657,7 +7805,7 @@ checksum = "79fd0889f8844b7c70b8ee8fbf1d1f6ccff99399c6f3d3627048cde04b1ac493"
 dependencies = [
  "blake3",
  "hex",
- "thiserror",
+ "thiserror 1.0.50",
  "wasmer",
 ]
 
@@ -7682,7 +7830,7 @@ dependencies = [
  "self_cell",
  "shared-buffer",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.50",
  "wasmer-types",
  "wasmer-vm",
  "wasmparser 0.121.2",
@@ -7745,7 +7893,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.50",
  "toml 0.8.2",
  "url",
 ]
@@ -7771,14 +7919,14 @@ dependencies = [
  "bytecheck",
  "enum-iterator",
  "enumset",
- "getrandom 0.2.15",
+ "getrandom",
  "hex",
  "indexmap 1.9.3",
  "more-asserts",
  "rkyv",
  "sha2 0.10.8",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.50",
  "webc",
  "xxhash-rust",
 ]
@@ -7806,7 +7954,7 @@ dependencies = [
  "more-asserts",
  "region",
  "scopeguard",
- "thiserror",
+ "thiserror 1.0.50",
  "wasmer-types",
  "winapi",
 ]
@@ -7900,7 +8048,7 @@ dependencies = [
  "shared-buffer",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.50",
  "toml 0.7.8",
  "url",
  "wasmer-config",
@@ -8168,7 +8316,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.0",
  "send_wrapper 0.6.0",
- "thiserror",
+ "thiserror 1.0.50",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -8201,7 +8349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf24c008fe464f5d8f58b8d16a1ab7e930bd73b2a6933ff8704c414b2bed7f92"
 dependencies = [
  "libm",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -8213,11 +8361,12 @@ checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
 
 [[package]]
 name = "zcash_encoding"
-version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash?rev=bd7f9d7#bd7f9d7c3ce5cfd14af169ffe0e1c5c903162f46"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3654116ae23ab67dd1f849b01f8821a8a156f884807ff665eac109bf28306c4d"
 dependencies = [
- "byteorder",
- "nonempty",
+ "core2",
+ "nonempty 0.7.0",
 ]
 
 [[package]]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3158,31 +3158,8 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64aa34a2890898b88c6f1e0b505b7d092b569492885cdc145ac5e23e816cc308"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -3193,26 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
 version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.2.0#3dca5354609af33e0aaba3f582a28447410d637f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73055ad46ad031f010ac66ac185fd2e4cee456d5e0e8bec21ea6caf55de7d63a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3221,15 +3181,16 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-overflow-receive"
 version = "0.5.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33fe36be073b32abe9b262134cc2a2fbbd689f9a532f6700533324ff279af8b"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core-channel-types",
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -3238,7 +3199,8 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.10.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9da9cb134fa631c50659f58fb6f5356c724709048107b976548daad8860e7361"
 dependencies = [
  "borsh",
  "dur",
@@ -3249,8 +3211,8 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -4152,8 +4114,8 @@ dependencies = [
  "dur",
  "ibc",
  "ibc-derive",
- "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0)",
- "ibc-middleware-module-macros 0.2.0",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ibc-testkit",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -2695,8 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50aebe83b772ecd2020ad1654b09abfb387f5ddc07db01ed23defb04a9a7fde8"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2708,8 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95bbdca1dab5e007633af6d9ee070a2f35749336239804c42ff7fad444c10b2e"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2718,8 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e654dd72dc2df2dd1f232b0599331ff1519fc2c0d346f12e5e319a97c33b330c"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2739,8 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cad93b5e1074c1f7b8dcea6099640b5a725a8a1dde957b00e89685eb2c0151"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2749,8 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364c7eb9dc122a279cafb5cd9eb1c459a1902a3c9a1e107f8d3037ca97ab4a5c"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2767,8 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-apps"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5ecc814492ac9349b27d7f119f0b0f3b9f94ffd156df35eaf6adb53b7831f3"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2776,8 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11225e842c5e3bf0787a36cf10d16b954dafbef357533fa2a87c7ac1bb2739f7"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -2793,8 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa16efb7dc6d7b73d483e55553e6c69eeaf0b82384b464514c52fe813d3c55d2"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2810,8 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-wasm-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e897b268e2f496e4a66c068a6146576a8b5a8243c5d3f1ab157505a715f22dc8"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -2824,8 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-clients"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464b3c5061092ea25298443d3554c405f78d31e4928060167a216bb8cdc02708"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2833,8 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f37c8c56ee649ba0ddf64268d4b8b35287937d4aaaf69877f922a4adc2eb29e"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2849,8 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111523dd75048898dcf3806484b2615a97d186725f1df8fe2de2862c6849034e"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2864,8 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681d986a6943683ef16fbaab8295125bf795ab4e15a1909eccb8574bb4567f10"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2887,8 +2900,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e95616bda7fa163c1ed5e96aa2a5c902d07b31fddbcd756ebaca7a004bc078e8"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2900,8 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-context"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540ce861ac8fe7ce6ff14de043d8a3e8e239875c058f0b5baa9fe9b0a31ac94"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -2916,8 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f741122f7504846a6099d41244687e5db3235b7ce5f651de8a552489c1f5c9a"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2936,8 +2952,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-commitment-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba35d2bde395cff6ddbf550d604c3098903e661430588995b1e5f8db1f2e1d1"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2955,8 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debe3ecdf3a0d59b011c963164974d6d924fb7e5580ce8262b1e64e2a0088cd7"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2969,8 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2eed5ea03d3900f89b3b498c7f2ff83ca50c2f4f76cebc339bfa5ecb2f0ffc1"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -2990,8 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26219873baa090be293308e45be9eb09a4ad5eb27b9cedbca3fa9552e90e6163"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -3005,8 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "426cdb98d683cf8f65b1ebb7638fd4e8a35e1718aa143bcf895636ee34c68385"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3029,8 +3050,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff10f831f430b02462e71852bcbc947dde972762ee26dce1202f861003366f2"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3047,8 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-cosmos"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06697cc443a9ad99a6063e10ae08bf0aa78a72ba9e4e46fd6db8ee1c511b66f"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3070,8 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5879fb43b0789f42919b7965a93f8a18a08eaa39bf624fbaf837d8673ef1ecdc"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -3087,8 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d50640473900acca78039d01246bbfec827153eb7d7f294dc08dee58ca2be4f"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -3101,8 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cdfb5f8f7986ac50941f556c16d46e81cdf3529b257be1ab3beca8281f953e"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3120,8 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.10.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e93e76ce4da46027a59a5f2c3152e6d4adc4a9d541c782ff69b89e7fa2ccb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3131,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -3143,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3152,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-overflow-receive"
 version = "0.4.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core-channel-types",
@@ -3169,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "borsh",
  "dur",
@@ -3189,8 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-primitives"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ff3dab00855e9ab99fa7276814bd29b0350f2da70b3e9f67f1d86f4e269655b"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -3226,8 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-query"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d4180842b5fcfb2742cb070b7bde35ee46ccfa7b8ea6c3ac9f209351aae9ba"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3237,8 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-testkit"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78d1c298f8bae59d39734c457ca0200a3830b56986d353fc5074b8f48bb262e"
 dependencies = [
  "basecoin-store",
  "bon",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -3157,8 +3157,32 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-middleware-module"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-middleware-module"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -3170,7 +3194,25 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "ibc-middleware-module-macros"
+version = "0.1.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "ibc-middleware-module-macros"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.2.0#3dca5354609af33e0aaba3f582a28447410d637f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3178,16 +3220,16 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-overflow-receive"
-version = "0.4.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+version = "0.5.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core-channel-types",
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module",
- "ibc-middleware-module-macros",
+ "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
+ "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -3195,8 +3237,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-packet-forward"
-version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
 dependencies = [
  "borsh",
  "dur",
@@ -3207,8 +3249,8 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module",
- "ibc-middleware-module-macros",
+ "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
+ "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -4110,8 +4152,8 @@ dependencies = [
  "dur",
  "ibc",
  "ibc-derive",
- "ibc-middleware-module",
- "ibc-middleware-module-macros",
+ "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0)",
+ "ibc-middleware-module-macros 0.2.0",
  "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ibc-testkit",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -54,7 +54,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -116,7 +116,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "num-traits",
+ "num-traits 0.2.17",
  "zeroize",
 ]
 
@@ -132,7 +132,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "num-bigint",
- "num-traits",
+ "num-traits 0.2.17",
  "paste",
  "rustc_version 0.3.3",
  "zeroize",
@@ -155,7 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint",
- "num-traits",
+ "num-traits 0.2.17",
  "quote",
  "syn 1.0.109",
 ]
@@ -176,8 +176,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "num-traits",
- "rand",
+ "num-traits 0.2.17",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -234,15 +234,6 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.0",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -375,11 +366,11 @@ checksum = "dd18cd9983aad2c7dbe0552c597c1a2a8373c6e88ba327dce73860975554b3db"
 dependencies = [
  "displaydoc",
  "ics23",
- "prost 0.13.1",
+ "prost",
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "tendermint",
+ "tendermint 0.38.1",
  "tracing",
 ]
 
@@ -407,7 +398,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -426,9 +417,9 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "unicode-normalization",
  "zeroize",
@@ -545,8 +536,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838#d3ebe9dd6488fac1923db120a7498079e55dd838"
+dependencies = [
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "bon"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7acc34ff59877422326db7d6f2d845a582b16396b6b08194942bf34c6528ab"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4159dd617a7fbc9be6a692fe69dc2954f8e6bb6bb5e4d7578467441390d77fd0"
+dependencies = [
+ "darling 0.20.10",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -670,7 +698,7 @@ dependencies = [
  "semver 1.0.20",
  "serde",
  "serde_json",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -736,7 +764,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits",
+ "num-traits 0.2.17",
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
@@ -793,12 +821,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
-name = "cobs"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
-
-[[package]]
 name = "coins-bip32"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,11 +829,11 @@ dependencies = [
  "bs58",
  "coins-core",
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
  "k256",
  "serde",
  "sha2 0.10.8",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -822,12 +844,12 @@ checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
 dependencies = [
  "bitvec",
  "coins-bip32",
- "hmac",
+ "hmac 0.12.1",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -847,7 +869,7 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.8",
  "sha3",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -859,12 +881,6 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
-
-[[package]]
-name = "const-crc32-nostd"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-default"
@@ -920,15 +936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "core2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "corosensei"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +946,18 @@ dependencies = [
  "libc",
  "scopeguard",
  "windows-sys 0.33.0",
+]
+
+[[package]]
+name = "cosmos-sdk-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "462e1f6a8e005acc8835d32d60cbd7973ed65ea2a8d8473830e675f050956427"
+dependencies = [
+ "informalsystems-pbjson",
+ "prost",
+ "serde",
+ "tendermint-proto 0.40.1",
 ]
 
 [[package]]
@@ -1043,12 +1062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,7 +1113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1113,6 +1126,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1138,7 +1161,7 @@ checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle-ng",
  "zeroize",
 ]
@@ -1155,12 +1178,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -1173,20 +1196,21 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim 0.11.1",
  "syn 2.0.96",
 ]
 
@@ -1203,11 +1227,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.10",
  "quote",
  "syn 2.0.96",
 ]
@@ -1230,12 +1254,6 @@ name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
-
-[[package]]
-name = "debugless-unwrap"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
 
 [[package]]
 name = "der"
@@ -1271,17 +1289,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive-getters"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -1327,6 +1334,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,23 +1377,22 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "5.0.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "winapi",
 ]
 
 [[package]]
@@ -1395,16 +1422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
-name = "dur"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5b6c91b5e394b75cd96c36393fc938496c030220207a0ccf34d6cd313d3b49"
-dependencies = [
- "nom",
- "rust_decimal",
-]
-
-[[package]]
 name = "duration-str"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,7 +1430,7 @@ dependencies = [
  "chrono",
  "rust_decimal",
  "serde",
- "thiserror 1.0.50",
+ "thiserror",
  "time",
  "winnow 0.6.8",
 ]
@@ -1483,10 +1500,10 @@ checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror 1.0.50",
+ "thiserror",
  "zeroize",
 ]
 
@@ -1509,24 +1526,12 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serdect",
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -1548,7 +1553,7 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "sha3",
@@ -1590,7 +1595,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -1622,15 +1627,15 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2 0.11.0",
- "rand",
+ "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
  "sha2 0.10.8",
  "sha3",
- "thiserror 1.0.50",
+ "thiserror",
  "uuid 0.8.2",
 ]
 
@@ -1647,8 +1652,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "thiserror 1.0.50",
- "uint",
+ "thiserror",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -1659,9 +1664,9 @@ checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "tiny-keccak",
 ]
@@ -1709,12 +1714,12 @@ checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
- "primitive-types",
+ "impl-serde 0.4.0",
+ "primitive-types 0.12.2",
  "scale-info",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -1760,7 +1765,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -1819,14 +1824,14 @@ dependencies = [
  "num_enum",
  "once_cell",
  "open-fastrlp",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
  "strum 0.25.0",
  "syn 2.0.96",
  "tempfile",
- "thiserror 1.0.50",
+ "thiserror",
  "tiny-keccak",
  "unicode-xid",
 ]
@@ -1843,7 +1848,7 @@ dependencies = [
  "semver 1.0.20",
  "serde",
  "serde_json",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -1866,7 +1871,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.50",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -1898,7 +1903,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.50",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -1922,9 +1927,9 @@ dependencies = [
  "elliptic-curve",
  "eth-keystore",
  "ethers-core",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -1968,7 +1973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1991,7 +1996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2074,43 +2079,7 @@ dependencies = [
  "libm",
  "num-bigint",
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "frost-core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5afd375261c34d31ff24dad068382f4bc3c95010c919d4fb8d483dc3d85c023"
-dependencies = [
- "byteorder",
- "const-crc32-nostd",
- "debugless-unwrap",
- "derive-getters",
- "document-features",
- "hex",
- "itertools 0.13.0",
- "postcard",
- "rand_core",
- "serde",
- "serdect",
- "thiserror 1.0.50",
- "thiserror-nostd-notrait",
- "visibility",
- "zeroize",
-]
-
-[[package]]
-name = "frost-rerandomized"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9d77595060546b53543d96b83dbeacaf3907e40a89763a8bb22124812b0cb6"
-dependencies = [
- "derive-getters",
- "document-features",
- "frost-core",
- "hex",
- "rand_core",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -2250,6 +2219,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
@@ -2257,7 +2239,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2298,7 +2280,7 @@ checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "memuse",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2367,15 +2349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,32 +2364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
 name = "hashers"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version 0.4.0",
- "serde",
- "spin 0.9.8",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -2439,6 +2392,16 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
@@ -2451,15 +2414,6 @@ name = "hmac-sha512"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e806677ce663d0a199541030c816847b36e8dc095f70dae4a4f4ad63da5383"
-
-[[package]]
-name = "home"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
-dependencies = [
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "http"
@@ -2645,8 +2599,8 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -2658,8 +2612,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2668,12 +2622,12 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "base64 0.22.1",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "http 1.1.0",
  "ibc-app-transfer-types",
@@ -2689,8 +2643,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2699,26 +2653,26 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core",
  "ibc-proto",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.13.1",
  "scale-info",
  "schemars",
  "serde",
- "uint",
+ "uint 0.10.0",
 ]
 
 [[package]]
 name = "ibc-apps"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2726,10 +2680,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "ibc-client-tendermint-types",
  "ibc-core-client",
  "ibc-core-commitment-types",
@@ -2737,14 +2691,14 @@ dependencies = [
  "ibc-core-host",
  "ibc-primitives",
  "serde",
- "tendermint",
+ "tendermint 0.40.1",
  "tendermint-light-client-verifier",
 ]
 
 [[package]]
 name = "ibc-client-tendermint-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2753,15 +2707,15 @@ dependencies = [
  "ibc-primitives",
  "ibc-proto",
  "serde",
- "tendermint",
+ "tendermint 0.40.1",
  "tendermint-light-client-verifier",
- "tendermint-proto",
+ "tendermint-proto 0.40.1",
 ]
 
 [[package]]
 name = "ibc-client-wasm-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -2774,8 +2728,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-clients"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2783,8 +2737,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2799,8 +2753,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2814,11 +2768,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -2832,13 +2786,13 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-client"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2850,10 +2804,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-context"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -2861,16 +2815,16 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-primitives",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-client-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
@@ -2881,16 +2835,16 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-commitment-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
@@ -2905,8 +2859,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2914,16 +2868,16 @@ dependencies = [
  "ibc-core-handler-types",
  "ibc-core-host",
  "ibc-primitives",
- "prost 0.13.1",
+ "prost",
 ]
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -2935,13 +2889,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2955,11 +2909,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-channel-types",
  "ibc-core-client-types",
@@ -2974,15 +2928,15 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-host"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-channel-types",
  "ibc-core-client-context",
@@ -2997,10 +2951,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-cosmos"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-app-transfer-types",
  "ibc-client-tendermint",
@@ -3015,19 +2969,21 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
+ "base64 0.22.1",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-primitives",
  "parity-scale-codec",
+ "prost",
  "scale-info",
  "schemars",
  "serde",
@@ -3035,10 +2991,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -3049,11 +3005,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
@@ -3063,13 +3019,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
 ]
 
 [[package]]
 name = "ibc-derive"
-version = "0.8.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3077,150 +3033,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.1.0#3d3b436f7c58000c7498d68e88c15a955433a619"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0#3d3b436f7c58000c7498d68e88c15a955433a619"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.1.0#3d3b436f7c58000c7498d68e88c15a955433a619"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0#3d3b436f7c58000c7498d68e88c15a955433a619"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-overflow-receive"
-version = "0.4.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
-dependencies = [
- "ibc-app-transfer-types",
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0)",
- "ibc-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ibc-middleware-packet-forward"
-version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0#3d3b436f7c58000c7498d68e88c15a955433a619"
-dependencies = [
- "borsh",
- "dur",
- "either",
- "ibc-app-transfer-types",
- "ibc-core-channel",
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0)",
- "ibc-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "ibc-primitives"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-proto",
  "parity-scale-codec",
- "prost 0.13.1",
+ "prost",
  "scale-info",
  "schemars",
  "serde",
- "tendermint",
  "time",
 ]
 
 [[package]]
 name = "ibc-proto"
-version = "0.47.0"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1678333cf68c9094ca66aaf9a271269f1f6bf5c26881161def8bd88cee831a23"
+checksum = "9b70f517162e74e2d35875b8b94bf4d1e45f2c69ef3de452dc855944455d33ca"
 dependencies = [
  "base64 0.22.1",
- "borsh",
  "bytes",
+ "cosmos-sdk-proto",
  "flex-error",
  "ics23",
  "informalsystems-pbjson",
- "parity-scale-codec",
- "prost 0.13.1",
- "scale-info",
+ "prost",
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.40.1",
  "tonic",
 ]
 
 [[package]]
 name = "ibc-query"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "displaydoc",
  "ibc",
@@ -3230,20 +3082,20 @@ dependencies = [
 
 [[package]]
 name = "ibc-testkit"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?branch=tiago/optional-ack-rebased#2bfea0b1e400808a15ad0d9223e89665d0fad205"
 dependencies = [
  "basecoin-store",
- "derive_more",
+ "bon",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc",
  "ibc-proto",
  "ibc-query",
  "parking_lot",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
  "tendermint-testgen",
- "typed-builder",
 ]
 
 [[package]]
@@ -3258,7 +3110,7 @@ dependencies = [
  "bytes",
  "hex",
  "informalsystems-pbjson",
- "prost 0.13.1",
+ "prost",
  "ripemd",
  "serde",
  "sha2 0.10.8",
@@ -3291,14 +3143,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67aa010c1e3da95bf151bd8b4c059b2ed7e75387cdb969b4f8f2723a43f9941"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "impl-num-traits"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951641f13f873bff03d4bf19ae8bec531935ac0ac2cc775f84d7edfdcfed3f17"
 dependencies = [
  "integer-sqrt",
- "num-traits",
- "uint",
+ "num-traits 0.2.17",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -3315,6 +3176,15 @@ name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
 dependencies = [
  "serde",
 ]
@@ -3353,6 +3223,17 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.4"
+source = "git+https://github.com/heliaxdev/indexmap?tag=2.2.4-heliax-1#b5b5b547bd6ab04bbb16e060326a50ddaeb6c909"
+dependencies = [
+ "borsh",
+ "equivalent",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -3410,7 +3291,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -3433,24 +3314,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3491,10 +3354,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
 dependencies = [
  "bitvec",
- "bls12_381",
+ "bls12_381 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "jubjub"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c#a373686962f4e9d0edb3b4716f86ff6bbd9aa86c"
+dependencies = [
+ "bitvec",
+ "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
+ "ff",
+ "group",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3626,29 +3502,28 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+version = "1.0.0"
+source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
 dependencies = [
  "borsh",
  "chacha20",
  "chacha20poly1305",
  "cipher",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+version = "1.0.0"
+source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
 dependencies = [
  "aes",
  "bip0039",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
+ "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "borsh",
  "byteorder",
  "ff",
@@ -3656,16 +3531,15 @@ dependencies = [
  "group",
  "hex",
  "incrementalmerkletree",
+ "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_note_encryption",
  "memuse",
- "nam-bls12_381",
- "nam-jubjub",
- "nam-num-traits",
- "nonempty 0.11.0",
+ "nonempty",
+ "num-traits 0.2.19",
  "proptest",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "subtle",
  "zcash_encoding",
@@ -3673,23 +3547,22 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+version = "1.0.0"
+source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
 dependencies = [
  "bellman",
  "blake2b_simd",
+ "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "directories",
- "getrandom",
+ "getrandom 0.2.15",
  "group",
- "itertools 0.14.0",
+ "itertools 0.11.0",
+ "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_primitives",
  "minreq",
- "nam-bls12_381",
- "nam-jubjub",
- "nam-redjubjub",
- "rand_core",
+ "rand_core 0.6.4",
+ "redjubjub",
  "tracing",
 ]
 
@@ -3760,12 +3633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3795,7 +3662,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -3810,112 +3677,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "nam-bls12_381"
-version = "0.8.1-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e768b0e2383163f2f4bbce1112d6454b2cb515950b0a9177733f0d71254d2c68"
-dependencies = [
- "ff",
- "group",
- "pairing",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "nam-indexmap"
-version = "2.7.1-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b40876708764895b63bb5a1e9f102d3813cb16baeb9f12932b7c8f2df4248e"
-dependencies = [
- "borsh",
- "equivalent",
- "hashbrown 0.15.2",
- "serde",
-]
-
-[[package]]
-name = "nam-jubjub"
-version = "0.10.1-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdced0f5975d8f80cb82a84d464481acb7b586d22f447dda86947d6a572997b9"
-dependencies = [
- "bitvec",
- "ff",
- "group",
- "nam-bls12_381",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "nam-num-traits"
-version = "0.2.20-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687832a07242b76ab2760bc95180240954bf77e06bf8d9e825473c373146dc4a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "nam-reddsa"
-version = "0.5.2-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d102b4311bf60c03405350e976d17f5df155d2cb588f6401995a29ae8c1565"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "frost-rerandomized",
- "group",
- "hex",
- "jubjub",
- "pasta_curves",
- "rand_core",
- "serde",
- "thiserror 2.0.11",
- "zeroize",
-]
-
-[[package]]
-name = "nam-redjubjub"
-version = "0.7.1-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e457988762db7daad8d79f8a837a07295f5cc178d9236ba77db7339072ffb61e"
-dependencies = [
- "nam-reddsa",
- "rand_core",
- "serde",
- "thiserror 1.0.50",
- "zeroize",
-]
-
-[[package]]
-name = "nam-sparse-merkle-tree"
-version = "0.3.2-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae108a0f6aabf789e34d6d447c1184608d1c70c087f957b720042226a47ab63"
-dependencies = [
- "borsh",
- "cfg-if",
- "ics23",
- "itertools 0.14.0",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "nam-tiny-hderive"
-version = "0.3.1-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfd77f274636f722e966c394b381a70233ed4c25150864a4c53d398028a6818"
-dependencies = [
- "base58",
- "hmac",
- "k256",
- "memzero",
- "sha2 0.10.8",
-]
 
 [[package]]
 name = "namada_account"
@@ -3935,7 +3696,7 @@ version = "0.47.0"
 dependencies = [
  "namada_core",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -3953,35 +3714,35 @@ dependencies = [
  "ibc",
  "ics23",
  "impl-num-traits",
+ "indexmap 2.2.4",
  "k256",
  "lazy_static",
  "masp_primitives",
- "nam-indexmap",
- "nam-sparse-merkle-tree",
  "namada_macros",
  "num-integer",
  "num-rational",
- "num-traits",
+ "num-traits 0.2.17",
  "num256",
  "num_enum",
- "primitive-types",
+ "primitive-types 0.13.1",
  "proptest",
- "prost-types 0.13.1",
- "rand",
- "rand_core",
+ "prost-types",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "ripemd",
  "serde",
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
- "tendermint",
- "tendermint-proto",
- "thiserror 1.0.50",
+ "sparse-merkle-tree",
+ "tendermint 0.40.1",
+ "tendermint-proto 0.40.1",
+ "thiserror",
  "tiny-keccak",
  "tokio",
  "tracing",
- "uint",
+ "uint 0.9.5",
  "usize-set",
  "wasmtimer",
  "zeroize",
@@ -4012,7 +3773,7 @@ dependencies = [
  "namada_vp_env",
  "serde",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -4025,7 +3786,7 @@ dependencies = [
  "namada_macros",
  "serde",
  "serde_json",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -4038,7 +3799,7 @@ dependencies = [
  "namada_events",
  "namada_macros",
  "serde",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -4060,7 +3821,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -4070,13 +3831,8 @@ version = "0.47.0"
 dependencies = [
  "borsh",
  "data-encoding",
- "dur",
  "ibc",
  "ibc-derive",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.1.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.1.0)",
- "ibc-middleware-overflow-receive",
- "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "konst",
@@ -4089,14 +3845,14 @@ dependencies = [
  "namada_systems",
  "namada_tx",
  "namada_vp",
- "primitive-types",
+ "primitive-types 0.13.1",
  "proptest",
- "prost 0.13.1",
+ "prost",
  "serde",
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -4108,7 +3864,7 @@ dependencies = [
  "kdam",
  "namada_core",
  "tendermint-rpc",
- "thiserror 1.0.50",
+ "thiserror",
  "tokio",
 ]
 
@@ -4130,11 +3886,11 @@ dependencies = [
  "borsh",
  "eyre",
  "ics23",
- "nam-sparse-merkle-tree",
  "namada_core",
  "namada_macros",
- "prost 0.13.1",
- "thiserror 1.0.50",
+ "prost",
+ "sparse-merkle-tree",
+ "thiserror",
 ]
 
 [[package]]
@@ -4148,7 +3904,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -4171,7 +3927,7 @@ dependencies = [
  "proptest",
  "serde",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -4187,7 +3943,6 @@ name = "namada_sdk"
 version = "0.47.0"
 dependencies = [
  "async-trait",
- "bech32 0.8.1",
  "bimap",
  "borsh",
  "circular-queue",
@@ -4202,10 +3957,10 @@ dependencies = [
  "futures",
  "init-once",
  "itertools 0.12.1",
+ "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
- "nam-jubjub",
  "namada_account",
  "namada_core",
  "namada_ethereum_bridge",
@@ -4225,15 +3980,15 @@ dependencies = [
  "namada_vote_ext",
  "namada_vp",
  "namada_wallet",
- "num-traits",
+ "num-traits 0.2.17",
  "num256",
  "owo-colors",
  "paste",
  "patricia_tree",
  "proptest",
- "prost 0.13.1",
- "rand",
- "rand_core",
+ "prost",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "regex",
  "reqwest",
@@ -4244,7 +3999,7 @@ dependencies = [
  "smooth-operator",
  "tempfile",
  "tendermint-rpc",
- "thiserror 1.0.50",
+ "thiserror",
  "tiny-bip39",
  "tokio",
  "toml 0.5.11",
@@ -4279,8 +4034,8 @@ dependencies = [
  "namada_vp_env",
  "namada_wallet",
  "proptest",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rayon",
  "ripemd",
  "serde",
@@ -4288,7 +4043,7 @@ dependencies = [
  "sha2 0.9.9",
  "smooth-operator",
  "tempfile",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
  "typed-builder",
  "xorf",
@@ -4313,7 +4068,7 @@ dependencies = [
  "patricia_tree",
  "proptest",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -4331,7 +4086,7 @@ dependencies = [
  "regex",
  "serde",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -4351,7 +4106,7 @@ dependencies = [
  "borsh",
  "namada_core",
  "namada_state",
- "prost 0.13.1",
+ "prost",
  "strum 0.24.1",
 ]
 
@@ -4361,9 +4116,7 @@ version = "0.47.0"
 dependencies = [
  "concat-idents",
  "derivative",
- "dur",
  "hyper 0.14.27",
- "ibc-middleware-packet-forward",
  "ibc-testkit",
  "ics23",
  "itertools 0.12.1",
@@ -4376,7 +4129,7 @@ dependencies = [
  "namada_vp",
  "namada_vp_prelude",
  "proptest",
- "prost 0.13.1",
+ "prost",
  "regex",
  "serde",
  "serde_json",
@@ -4419,7 +4172,7 @@ dependencies = [
  "namada_tx",
  "namada_tx_env",
  "namada_vp_env",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -4440,15 +4193,15 @@ dependencies = [
  "namada_gas",
  "namada_macros",
  "num-derive 0.4.2",
- "num-traits",
+ "num-traits 0.2.17",
  "proptest",
- "prost 0.13.1",
- "prost-types 0.13.1",
- "rand_core",
+ "prost",
+ "prost-types",
+ "rand_core 0.6.4",
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "thiserror 1.0.50",
+ "thiserror",
  "tonic-build",
 ]
 
@@ -4501,7 +4254,7 @@ dependencies = [
  "rayon",
  "smooth-operator",
  "tempfile",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
  "wasm-instrument",
  "wasmer",
@@ -4540,7 +4293,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -4591,18 +4344,18 @@ dependencies = [
  "fd-lock",
  "itertools 0.12.1",
  "masp_primitives",
- "nam-tiny-hderive",
  "namada_core",
  "namada_ibc",
  "namada_macros",
  "orion",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "slip10_ed25519",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tiny-bip39",
+ "tiny-hderive",
  "toml 0.5.11",
  "zeroize",
 ]
@@ -4613,7 +4366,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -4634,26 +4387,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "nonempty"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
-
-[[package]]
-name = "nonempty"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
 
 [[package]]
 name = "num"
@@ -4666,7 +4403,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -4677,7 +4414,7 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -4686,7 +4423,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -4724,7 +4461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -4735,7 +4472,7 @@ checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -4747,17 +4484,25 @@ dependencies = [
  "autocfg",
  "num-bigint",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.17",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+source = "git+https://github.com/heliaxdev/num-traits?rev=3f3657caa34b8e116fdf3f8a3519c4ac29f012fe#3f3657caa34b8e116fdf3f8a3519c4ac29f012fe"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -4769,7 +4514,7 @@ dependencies = [
  "lazy_static",
  "num",
  "num-derive 0.3.3",
- "num-traits",
+ "num-traits 0.2.17",
  "serde",
  "serde_derive",
 ]
@@ -4886,19 +4631,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "orion"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6624905ddd92e460ff0685567539ed1ac985b2dee4c92c7edcd64fce905b00c"
 dependencies = [
  "ct-codecs",
- "getrandom",
+ "getrandom 0.2.15",
  "subtle",
  "zeroize",
 ]
@@ -4980,7 +4719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -4992,7 +4731,7 @@ checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
 dependencies = [
  "ff",
  "group",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "subtle",
 ]
@@ -5014,6 +4753,15 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+dependencies = [
+ "crypto-mac",
+]
+
+[[package]]
+name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
@@ -5028,7 +4776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
  "password-hash",
 ]
 
@@ -5081,7 +4829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
- "thiserror 1.0.50",
+ "thiserror",
  "ucd-trie",
 ]
 
@@ -5171,19 +4919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
-name = "postcard"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5212,11 +4947,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
- "uint",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.7.0",
+ "impl-serde 0.5.0",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -5280,9 +5027,9 @@ dependencies = [
  "bit-vec",
  "bitflags 2.5.0",
  "lazy_static",
- "num-traits",
- "rand",
- "rand_chacha",
+ "num-traits 0.2.17",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.2",
  "rusty-fork",
@@ -5292,79 +5039,46 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
-dependencies = [
- "bytes",
- "prost-derive 0.13.1",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
+checksum = "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.96",
  "tempfile",
- "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
-dependencies = [
- "anyhow",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
-dependencies = [
- "prost 0.12.3",
 ]
 
 [[package]]
@@ -5373,7 +5087,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
 dependencies = [
- "prost 0.13.1",
+ "prost",
 ]
 
 [[package]]
@@ -5404,9 +5118,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -5419,13 +5133,36 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5435,7 +5172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -5444,7 +5190,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5453,7 +5208,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5479,6 +5234,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "reddsa"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "group",
+ "hex",
+ "jubjub 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pasta_curves",
+ "rand_core 0.6.4",
+ "serde",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "redjubjub"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a60db2c3bc9c6fd1e8631fee75abc008841d27144be744951d6b9b75f9b569c"
+dependencies = [
+ "rand_core 0.6.4",
+ "reddsa",
+ "serde",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5493,9 +5279,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -5619,7 +5405,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -5645,7 +5431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -5726,18 +5512,12 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.36.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
  "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand",
- "rkyv",
- "serde",
- "serde_json",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -5860,7 +5640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
  "scale-info-derive",
 ]
@@ -5923,7 +5703,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "salsa20",
  "sha2 0.10.8",
@@ -6100,12 +5880,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
- "memchr",
  "ryu",
  "serde",
 ]
@@ -6255,7 +6034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6277,8 +6056,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
- "num-traits",
- "thiserror 1.0.50",
+ "num-traits 0.2.17",
+ "thiserror",
  "time",
 ]
 
@@ -6353,6 +6132,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sparse-merkle-tree"
+version = "0.3.1-pre"
+source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=a93c55ccd47840ee0967eee237e47d9245478594#a93c55ccd47840ee0967eee237e47d9245478594"
+dependencies = [
+ "borsh",
+ "cfg-if",
+ "ics23",
+ "itertools 0.12.1",
+ "sha2 0.9.9",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6394,6 +6185,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -6585,14 +6382,40 @@ dependencies = [
  "bytes",
  "digest 0.10.7",
  "ed25519",
+ "flex-error",
+ "futures",
+ "num-traits 0.2.17",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.38.1",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9703e34d940c2a293804752555107f8dbe2b84ec4c6dd5203831235868105d2"
+dependencies = [
+ "bytes",
+ "digest 0.10.7",
+ "ed25519",
  "ed25519-consensus",
  "flex-error",
  "futures",
  "k256",
- "num-traits",
+ "num-traits 0.2.17",
  "once_cell",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
  "ripemd",
  "serde",
  "serde_bytes",
@@ -6602,35 +6425,35 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.40.1",
  "time",
  "zeroize",
 ]
 
 [[package]]
 name = "tendermint-config"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de111ea653b2adaef627ac2452b463c77aa615c256eaaddf279ec5a1cf9775f"
+checksum = "89cc3ea9a39b7ee34eefcff771cc067ecaa0c988c1c5ac08defd878471a06f76"
 dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint",
+ "tendermint 0.40.1",
  "toml 0.8.2",
  "url",
 ]
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2674adbf0dc51aa0c8eaf8462c7d6692ec79502713e50ed5432a442002be90"
+checksum = "f0cda4a449fc70985a95f892a67286f13afa4e048d90b8d04a2bf6341e88d1c2"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "flex-error",
  "serde",
- "tendermint",
+ "tendermint 0.40.1",
  "time",
 ]
 
@@ -6642,8 +6465,27 @@ checksum = "8ed14abe3b0502a3afe21ca74ca5cdd6c7e8d326d982c26f98a394445eb31d6e"
 dependencies = [
  "bytes",
  "flex-error",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9e1705aa0fa5ecb2c6aa7fb78c2313c4a31158ea5f02048bf318f849352eb"
+dependencies = [
+ "borsh",
+ "bytes",
+ "flex-error",
+ "parity-scale-codec",
+ "prost",
+ "scale-info",
+ "schemars",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -6652,27 +6494,27 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f96a2b8a0d3d0b59e4024b1a6bdc1589efc6af4709d08a480a20cc4ba90f63"
+checksum = "835a52aa504c63ec05519e31348d3f4ba2fe79493c588e2cad5323d5e81b161a"
 dependencies = [
  "async-trait",
  "bytes",
  "flex-error",
- "getrandom",
+ "getrandom 0.2.15",
  "peg",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "semver 1.0.20",
  "serde",
  "serde_bytes",
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.1",
  "tendermint-config",
- "tendermint-proto",
- "thiserror 1.0.50",
+ "tendermint-proto 0.40.1",
+ "thiserror",
  "time",
  "url",
  "uuid 1.8.0",
@@ -6681,9 +6523,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-testgen"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae007e2918414ae96e4835426aace7538d23b8ddf96d71e23d241f58f386e877"
+checksum = "3fbbef28bac7b5b68f44416ef16d072ee8ea4af829aaf2fa259eee1c09237c36"
 dependencies = [
  "ed25519-consensus",
  "gumdrop",
@@ -6691,7 +6533,7 @@ dependencies = [
  "serde_json",
  "simple-error",
  "tempfile",
- "tendermint",
+ "tendermint 0.40.1",
  "time",
 ]
 
@@ -6732,16 +6574,7 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
- "thiserror-impl 1.0.50",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -6749,37 +6582,6 @@ name = "thiserror-impl"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "thiserror-nostd-notrait"
-version = "1.0.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8444e638022c44d2a9337031dee8acb732bcc7fbf52ac654edc236b26408b61"
-dependencies = [
- "thiserror-nostd-notrait-impl",
-]
-
-[[package]]
-name = "thiserror-nostd-notrait-impl"
-version = "1.0.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6829,19 +6631,32 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
+version = "0.8.2"
+source = "git+https://github.com/anoma/tiny-bip39.git?rev=bf0f6d8713589b83af7a917366ec31f5275c0e57#bf0f6d8713589b83af7a917366ec31f5275c0e57"
 dependencies = [
+ "anyhow",
+ "hmac 0.8.1",
  "once_cell",
- "pbkdf2 0.12.2",
- "rand",
+ "pbkdf2 0.4.0",
+ "rand 0.7.3",
  "rustc-hash",
- "sha2 0.10.8",
- "thiserror 1.0.50",
+ "sha2 0.9.9",
+ "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "tiny-hderive"
+version = "0.3.0"
+source = "git+https://github.com/heliaxdev/tiny-hderive.git?rev=173ae03abed0cd25d88a5a13efac00af96b75b87#173ae03abed0cd25d88a5a13efac00af96b75b87"
+dependencies = [
+ "base58",
+ "hmac 0.12.1",
+ "k256",
+ "memzero",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -6909,9 +6724,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7013,9 +6828,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7031,7 +6846,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.1",
+ "prost",
  "socket2 0.5.5",
  "tokio",
  "tokio-stream",
@@ -7043,13 +6858,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types",
  "quote",
  "syn 2.0.96",
 ]
@@ -7065,7 +6881,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -7152,7 +6968,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 name = "tx_become_validator"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7161,7 +6977,7 @@ dependencies = [
 name = "tx_bond"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7177,7 +6993,7 @@ dependencies = [
 name = "tx_bridge_pool"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7186,7 +7002,7 @@ dependencies = [
 name = "tx_change_consensus_key"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7195,7 +7011,7 @@ dependencies = [
 name = "tx_change_validator_commission"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7211,7 +7027,7 @@ dependencies = [
 name = "tx_change_validator_metadata"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7220,7 +7036,7 @@ dependencies = [
 name = "tx_claim_rewards"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7229,7 +7045,7 @@ dependencies = [
 name = "tx_deactivate_validator"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7238,7 +7054,7 @@ dependencies = [
 name = "tx_ibc"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7247,7 +7063,7 @@ dependencies = [
 name = "tx_init_account"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7256,7 +7072,7 @@ dependencies = [
 name = "tx_init_proposal"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7265,7 +7081,7 @@ dependencies = [
 name = "tx_reactivate_validator"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7274,7 +7090,7 @@ dependencies = [
 name = "tx_redelegate"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7290,7 +7106,7 @@ dependencies = [
 name = "tx_resign_steward"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7299,7 +7115,7 @@ dependencies = [
 name = "tx_reveal_pk"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7308,7 +7124,7 @@ dependencies = [
 name = "tx_transfer"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7317,7 +7133,7 @@ dependencies = [
 name = "tx_unbond"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7333,7 +7149,7 @@ dependencies = [
 name = "tx_unjail_validator"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7342,7 +7158,7 @@ dependencies = [
 name = "tx_update_account"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7351,7 +7167,7 @@ dependencies = [
 name = "tx_update_steward_commission"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7360,7 +7176,7 @@ dependencies = [
 name = "tx_vote_proposal"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_tx_prelude",
  "rlsf",
 ]
@@ -7369,7 +7185,7 @@ dependencies = [
 name = "tx_withdraw"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7433,6 +7249,18 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -7535,7 +7363,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -7558,21 +7386,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "visibility"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "vp_implicit"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7588,7 +7405,7 @@ dependencies = [
 name = "vp_user"
 version = "0.47.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "namada_test_utils",
  "namada_tests",
  "namada_tx_prelude",
@@ -7627,6 +7444,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -7735,7 +7558,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "shared-buffer",
  "target-lexicon",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
  "wasm-bindgen",
  "wasmer-compiler",
@@ -7755,7 +7578,7 @@ checksum = "79fd0889f8844b7c70b8ee8fbf1d1f6ccff99399c6f3d3627048cde04b1ac493"
 dependencies = [
  "blake3",
  "hex",
- "thiserror 1.0.50",
+ "thiserror",
  "wasmer",
 ]
 
@@ -7780,7 +7603,7 @@ dependencies = [
  "self_cell",
  "shared-buffer",
  "smallvec",
- "thiserror 1.0.50",
+ "thiserror",
  "wasmer-types",
  "wasmer-vm",
  "wasmparser 0.121.2",
@@ -7843,7 +7666,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.50",
+ "thiserror",
  "toml 0.8.2",
  "url",
 ]
@@ -7869,14 +7692,14 @@ dependencies = [
  "bytecheck",
  "enum-iterator",
  "enumset",
- "getrandom",
+ "getrandom 0.2.15",
  "hex",
  "indexmap 1.9.3",
  "more-asserts",
  "rkyv",
  "sha2 0.10.8",
  "target-lexicon",
- "thiserror 1.0.50",
+ "thiserror",
  "webc",
  "xxhash-rust",
 ]
@@ -7904,7 +7727,7 @@ dependencies = [
  "more-asserts",
  "region",
  "scopeguard",
- "thiserror 1.0.50",
+ "thiserror",
  "wasmer-types",
  "winapi",
 ]
@@ -7998,7 +7821,7 @@ dependencies = [
  "shared-buffer",
  "tar",
  "tempfile",
- "thiserror 1.0.50",
+ "thiserror",
  "toml 0.7.8",
  "url",
  "wasmer-config",
@@ -8009,18 +7832,6 @@ name = "webpki-roots"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "winapi"
@@ -8278,7 +8089,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.0",
  "send_wrapper 0.6.0",
- "thiserror 1.0.50",
+ "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -8311,7 +8122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf24c008fe464f5d8f58b8d16a1ab7e930bd73b2a6933ff8704c414b2bed7f92"
 dependencies = [
  "libm",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -8323,12 +8134,11 @@ checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
 
 [[package]]
 name = "zcash_encoding"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3654116ae23ab67dd1f849b01f8821a8a156f884807ff665eac109bf28306c4d"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash?rev=bd7f9d7#bd7f9d7c3ce5cfd14af169ffe0e1c5c903162f46"
 dependencies = [
- "core2",
- "nonempty 0.7.0",
+ "byteorder",
+ "nonempty",
 ]
 
 [[package]]

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "num-traits 0.2.17",
+ "num-traits",
  "zeroize",
 ]
 
@@ -101,9 +101,9 @@ dependencies = [
  "ark-std",
  "derivative",
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits",
  "paste",
- "rustc_version",
+ "rustc_version 0.3.3",
  "zeroize",
 ]
 
@@ -124,7 +124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.17",
+ "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -145,7 +145,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits",
  "rand",
 ]
 
@@ -170,6 +170,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -345,18 +354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bls12_381"
-version = "0.8.0"
-source = "git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838#d3ebe9dd6488fac1923db120a7498079e55dd838"
-dependencies = [
- "ff",
- "group",
- "pairing",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "borsh"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,7 +488,7 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "num-traits 0.2.17",
+ "num-traits",
  "windows-targets 0.48.5",
 ]
 
@@ -511,6 +508,18 @@ name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
+
+[[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-default"
@@ -543,6 +552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "core2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cosmos-sdk-proto"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +580,12 @@ checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -636,6 +660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
+name = "debugless-unwrap"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
+
+[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +693,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -720,22 +761,23 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "4.0.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -747,6 +789,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -801,7 +852,7 @@ dependencies = [
  "rand_core",
  "serde",
  "sha2 0.9.9",
- "thiserror",
+ "thiserror 1.0.50",
  "zeroize",
 ]
 
@@ -832,6 +883,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,7 +923,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "thiserror",
+ "thiserror 1.0.50",
  "uint 0.9.5",
 ]
 
@@ -971,7 +1034,43 @@ dependencies = [
  "libm",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits",
+]
+
+[[package]]
+name = "frost-core"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1858230cabb6792a5020daf4b0074f57b7d1e2a520ac544c77f102babee62ff4"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "debugless-unwrap",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core",
+ "serde",
+ "serdect",
+ "thiserror 2.0.11",
+ "thiserror-nostd-notrait",
+ "visibility",
+ "zeroize",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3b10d9c1e9f298522510940b5b8c3d55040420517ec8d2bb86c4c2d1ae3ee"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core",
 ]
 
 [[package]]
@@ -1104,6 +1203,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1225,26 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1176,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1189,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -1199,7 +1327,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1220,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1230,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1248,7 +1376,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -1257,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -1274,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1291,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -1305,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1314,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1330,7 +1458,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1345,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1368,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1381,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1397,7 +1525,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1417,7 +1545,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1436,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -1450,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1471,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1486,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1510,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1528,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1551,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1568,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1582,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1601,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.10.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1611,6 +1739,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.1.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -1622,14 +1751,33 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
+name = "ibc-middleware-overflow-receive"
+version = "0.4.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+dependencies = [
+ "ibc-app-transfer-types",
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
+ "ibc-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.9.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
 dependencies = [
  "borsh",
  "dur",
@@ -1650,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.56.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
+source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1727,7 +1875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951641f13f873bff03d4bf19ae8bec531935ac0ac2cc775f84d7edfdcfed3f17"
 dependencies = [
  "integer-sqrt",
- "num-traits 0.2.17",
+ "num-traits",
  "uint 0.9.5",
 ]
 
@@ -1786,17 +1934,6 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.2.4"
-source = "git+https://github.com/heliaxdev/indexmap?tag=2.2.4-heliax-1#b5b5b547bd6ab04bbb16e060326a50ddaeb6c909"
-dependencies = [
- "borsh",
- "equivalent",
- "hashbrown 0.14.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
@@ -1830,16 +1967,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
- "num-traits 0.2.17",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
+ "num-traits",
 ]
 
 [[package]]
@@ -1847,6 +1975,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1873,20 +2010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
 dependencies = [
  "bitvec",
- "bls12_381 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff",
- "group",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "jubjub"
-version = "0.10.0"
-source = "git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c#a373686962f4e9d0edb3b4716f86ff6bbd9aa86c"
-dependencies = [
- "bitvec",
- "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
+ "bls12_381",
  "ff",
  "group",
  "rand_core",
@@ -1972,6 +2096,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,8 +2119,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
 dependencies = [
  "borsh",
  "chacha20",
@@ -1992,15 +2133,15 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
 dependencies = [
  "aes",
  "bip0039",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
- "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "borsh",
  "byteorder",
  "ff",
@@ -2008,12 +2149,13 @@ dependencies = [
  "group",
  "hex",
  "incrementalmerkletree",
- "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_note_encryption",
  "memuse",
- "nonempty",
- "num-traits 0.2.19",
+ "nam-bls12_381",
+ "nam-jubjub",
+ "nam-num-traits",
+ "nonempty 0.11.0",
  "rand",
  "rand_core",
  "sha2 0.10.8",
@@ -2023,21 +2165,22 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
 dependencies = [
  "bellman",
  "blake2b_simd",
- "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "directories",
  "getrandom",
  "group",
- "itertools 0.11.0",
- "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
+ "itertools 0.14.0",
  "lazy_static",
  "masp_primitives",
+ "nam-bls12_381",
+ "nam-jubjub",
+ "nam-redjubjub",
  "rand_core",
- "redjubjub",
  "tracing",
 ]
 
@@ -2072,6 +2215,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nam-bls12_381"
+version = "0.8.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e768b0e2383163f2f4bbce1112d6454b2cb515950b0a9177733f0d71254d2c68"
+dependencies = [
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "nam-indexmap"
+version = "2.7.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b40876708764895b63bb5a1e9f102d3813cb16baeb9f12932b7c8f2df4248e"
+dependencies = [
+ "borsh",
+ "equivalent",
+ "hashbrown 0.15.2",
+ "serde",
+]
+
+[[package]]
+name = "nam-jubjub"
+version = "0.10.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdced0f5975d8f80cb82a84d464481acb7b586d22f447dda86947d6a572997b9"
+dependencies = [
+ "bitvec",
+ "ff",
+ "group",
+ "nam-bls12_381",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "nam-num-traits"
+version = "0.2.20-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687832a07242b76ab2760bc95180240954bf77e06bf8d9e825473c373146dc4a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nam-reddsa"
+version = "0.5.2-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d102b4311bf60c03405350e976d17f5df155d2cb588f6401995a29ae8c1565"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "frost-rerandomized",
+ "group",
+ "hex",
+ "jubjub",
+ "pasta_curves",
+ "rand_core",
+ "serde",
+ "thiserror 2.0.11",
+ "zeroize",
+]
+
+[[package]]
+name = "nam-redjubjub"
+version = "0.7.1-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e457988762db7daad8d79f8a837a07295f5cc178d9236ba77db7339072ffb61e"
+dependencies = [
+ "nam-reddsa",
+ "rand_core",
+ "serde",
+ "thiserror 1.0.50",
+ "zeroize",
+]
+
+[[package]]
+name = "nam-sparse-merkle-tree"
+version = "0.3.2-nam.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fae108a0f6aabf789e34d6d447c1184608d1c70c087f957b720042226a47ab63"
+dependencies = [
+ "borsh",
+ "cfg-if",
+ "ics23",
+ "itertools 0.14.0",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "namada_account"
 version = "0.47.0"
 dependencies = [
@@ -2088,7 +2324,7 @@ version = "0.47.0"
 dependencies = [
  "namada_core",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -2106,13 +2342,14 @@ dependencies = [
  "ibc",
  "ics23",
  "impl-num-traits",
- "indexmap 2.2.4",
  "k256",
  "masp_primitives",
+ "nam-indexmap",
+ "nam-sparse-merkle-tree",
  "namada_macros",
  "num-integer",
  "num-rational",
- "num-traits 0.2.17",
+ "num-traits",
  "num256",
  "num_enum",
  "primitive-types 0.13.1",
@@ -2123,10 +2360,9 @@ dependencies = [
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
- "sparse-merkle-tree",
  "tendermint",
  "tendermint-proto",
- "thiserror",
+ "thiserror 1.0.50",
  "tiny-keccak",
  "tracing",
  "uint 0.9.5",
@@ -2143,7 +2379,7 @@ dependencies = [
  "namada_macros",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -2156,7 +2392,7 @@ dependencies = [
  "namada_events",
  "namada_macros",
  "serde",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -2177,7 +2413,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -2190,6 +2426,9 @@ dependencies = [
  "dur",
  "ibc",
  "ibc-derive",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
+ "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ics23",
  "konst",
@@ -2208,7 +2447,7 @@ dependencies = [
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -2230,11 +2469,11 @@ dependencies = [
  "borsh",
  "eyre",
  "ics23",
+ "nam-sparse-merkle-tree",
  "namada_core",
  "namada_macros",
  "prost",
- "sparse-merkle-tree",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -2248,7 +2487,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -2270,7 +2509,7 @@ dependencies = [
  "once_cell",
  "serde",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -2311,7 +2550,7 @@ dependencies = [
  "sha2 0.9.9",
  "smooth-operator",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
  "typed-builder",
  "xorf",
@@ -2335,7 +2574,7 @@ dependencies = [
  "namada_tx",
  "patricia_tree",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -2353,7 +2592,7 @@ dependencies = [
  "regex",
  "serde",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -2406,7 +2645,7 @@ dependencies = [
  "namada_tx",
  "namada_tx_env",
  "namada_vp_env",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -2427,14 +2666,14 @@ dependencies = [
  "namada_gas",
  "namada_macros",
  "num-derive 0.4.2",
- "num-traits 0.2.17",
+ "num-traits",
  "prost",
  "prost-types",
  "rand_core",
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "thiserror",
+ "thiserror 1.0.50",
  "tonic-build",
 ]
 
@@ -2486,7 +2725,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror",
+ "thiserror 1.0.50",
  "tracing",
 ]
 
@@ -2543,6 +2782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
+name = "nonempty"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2553,7 +2798,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -2564,7 +2809,7 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -2573,7 +2818,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -2611,7 +2856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -2622,7 +2867,7 @@ checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.17",
+ "num-traits",
 ]
 
 [[package]]
@@ -2634,22 +2879,14 @@ dependencies = [
  "autocfg",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.17",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
-dependencies = [
- "autocfg",
+ "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.19"
-source = "git+https://github.com/heliaxdev/num-traits?rev=3f3657caa34b8e116fdf3f8a3519c4ac29f012fe#3f3657caa34b8e116fdf3f8a3519c4ac29f012fe"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -2663,7 +2900,7 @@ dependencies = [
  "lazy_static",
  "num",
  "num-derive 0.3.3",
- "num-traits 0.2.17",
+ "num-traits",
  "serde",
  "serde_derive",
 ]
@@ -2700,6 +2937,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pairing"
@@ -2792,7 +3035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.50",
  "ucd-trie",
 ]
 
@@ -2803,7 +3046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap",
 ]
 
 [[package]]
@@ -2837,6 +3080,19 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -3075,37 +3331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reddsa"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "group",
- "hex",
- "jubjub 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pasta_curves",
- "rand_core",
- "serde",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
-name = "redjubjub"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a60db2c3bc9c6fd1e8631fee75abc008841d27144be744951d6b9b75f9b569c"
-dependencies = [
- "rand_core",
- "reddsa",
- "serde",
- "thiserror",
- "zeroize",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,7 +3347,7 @@ checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -3242,7 +3467,7 @@ dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
- "num-traits 0.2.17",
+ "num-traits",
  "rand",
  "rkyv",
  "serde",
@@ -3261,7 +3486,16 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.25",
 ]
 
 [[package]]
@@ -3338,6 +3572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3366,6 +3606,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "semver-parser"
@@ -3544,15 +3790,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "sparse-merkle-tree"
-version = "0.3.1-pre"
-source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=a93c55ccd47840ee0967eee237e47d9245478594#a93c55ccd47840ee0967eee237e47d9245478594"
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
- "borsh",
- "cfg-if",
- "ics23",
- "itertools 0.12.1",
- "sha2 0.9.9",
+ "lock_api",
 ]
 
 [[package]]
@@ -3564,6 +3807,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -3693,7 +3942,7 @@ dependencies = [
  "flex-error",
  "futures",
  "k256",
- "num-traits 0.2.17",
+ "num-traits",
  "once_cell",
  "prost",
  "ripemd",
@@ -3748,7 +3997,16 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.50",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -3756,6 +4014,37 @@ name = "thiserror-impl"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8444e638022c44d2a9337031dee8acb732bcc7fbf52ac654edc236b26408b61"
+dependencies = [
+ "thiserror-nostd-notrait-impl",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3828,7 +4117,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -3839,7 +4128,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -4148,6 +4437,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "vp_always_false"
 version = "0.47.0"
 dependencies = [
@@ -4280,28 +4580,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4475,11 +4753,12 @@ dependencies = [
 
 [[package]]
 name = "zcash_encoding"
-version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash?rev=bd7f9d7#bd7f9d7c3ce5cfd14af169ffe0e1c5c903162f46"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3654116ae23ab67dd1f849b01f8821a8a156f884807ff665eac109bf28306c4d"
 dependencies = [
- "byteorder",
- "nonempty",
+ "core2",
+ "nonempty 0.7.0",
 ]
 
 [[package]]

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -1303,8 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50aebe83b772ecd2020ad1654b09abfb387f5ddc07db01ed23defb04a9a7fde8"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1316,8 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95bbdca1dab5e007633af6d9ee070a2f35749336239804c42ff7fad444c10b2e"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -1326,8 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e654dd72dc2df2dd1f232b0599331ff1519fc2c0d346f12e5e319a97c33b330c"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1347,8 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cad93b5e1074c1f7b8dcea6099640b5a725a8a1dde957b00e89685eb2c0151"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1357,8 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "364c7eb9dc122a279cafb5cd9eb1c459a1902a3c9a1e107f8d3037ca97ab4a5c"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1375,8 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-apps"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5ecc814492ac9349b27d7f119f0b0f3b9f94ffd156df35eaf6adb53b7831f3"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -1384,8 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11225e842c5e3bf0787a36cf10d16b954dafbef357533fa2a87c7ac1bb2739f7"
 dependencies = [
  "derive_more 1.0.0",
  "ibc-client-tendermint-types",
@@ -1401,8 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa16efb7dc6d7b73d483e55553e6c69eeaf0b82384b464514c52fe813d3c55d2"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1418,8 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-wasm-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e897b268e2f496e4a66c068a6146576a8b5a8243c5d3f1ab157505a715f22dc8"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -1432,8 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-clients"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464b3c5061092ea25298443d3554c405f78d31e4928060167a216bb8cdc02708"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1441,8 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f37c8c56ee649ba0ddf64268d4b8b35287937d4aaaf69877f922a4adc2eb29e"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1457,8 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111523dd75048898dcf3806484b2615a97d186725f1df8fe2de2862c6849034e"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1472,8 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681d986a6943683ef16fbaab8295125bf795ab4e15a1909eccb8574bb4567f10"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1495,8 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e95616bda7fa163c1ed5e96aa2a5c902d07b31fddbcd756ebaca7a004bc078e8"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1508,8 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-context"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540ce861ac8fe7ce6ff14de043d8a3e8e239875c058f0b5baa9fe9b0a31ac94"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1524,8 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f741122f7504846a6099d41244687e5db3235b7ce5f651de8a552489c1f5c9a"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1544,8 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-commitment-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba35d2bde395cff6ddbf550d604c3098903e661430588995b1e5f8db1f2e1d1"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1563,8 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debe3ecdf3a0d59b011c963164974d6d924fb7e5580ce8262b1e64e2a0088cd7"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -1577,8 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2eed5ea03d3900f89b3b498c7f2ff83ca50c2f4f76cebc339bfa5ecb2f0ffc1"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1598,8 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26219873baa090be293308e45be9eb09a4ad5eb27b9cedbca3fa9552e90e6163"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1613,8 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "426cdb98d683cf8f65b1ebb7638fd4e8a35e1718aa143bcf895636ee34c68385"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1637,8 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff10f831f430b02462e71852bcbc947dde972762ee26dce1202f861003366f2"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1655,8 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-cosmos"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06697cc443a9ad99a6063e10ae08bf0aa78a72ba9e4e46fd6db8ee1c511b66f"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1678,8 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5879fb43b0789f42919b7965a93f8a18a08eaa39bf624fbaf837d8673ef1ecdc"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1695,8 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d50640473900acca78039d01246bbfec827153eb7d7f294dc08dee58ca2be4f"
 dependencies = [
  "derive_more 1.0.0",
  "displaydoc",
@@ -1709,8 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router-types"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cdfb5f8f7986ac50941f556c16d46e81cdf3529b257be1ab3beca8281f953e"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",
@@ -1728,8 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.10.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27e93e76ce4da46027a59a5f2c3152e6d4adc4a9d541c782ff69b89e7fa2ccb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1739,7 +1766,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -1751,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1760,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-overflow-receive"
 version = "0.4.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core-channel-types",
@@ -1777,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?branch=yuji/upgrade-ibc-rs#2c979856e6a242fad41697a66642645a67c78ddc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
 dependencies = [
  "borsh",
  "dur",
@@ -1797,8 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-primitives"
-version = "0.56.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=a5f9fbf236cb26db3a76cde20ba43382de2d1ba4#a5f9fbf236cb26db3a76cde20ba43382de2d1ba4"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ff3dab00855e9ab99fa7276814bd29b0350f2da70b3e9f67f1d86f4e269655b"
 dependencies = [
  "borsh",
  "derive_more 1.0.0",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -1766,31 +1766,8 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64aa34a2890898b88c6f1e0b505b7d092b569492885cdc145ac5e23e816cc308"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -1801,26 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
 version = "0.2.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.2.0#3dca5354609af33e0aaba3f582a28447410d637f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73055ad46ad031f010ac66ac185fd2e4cee456d5e0e8bec21ea6caf55de7d63a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1829,15 +1789,16 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-overflow-receive"
 version = "0.5.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33fe36be073b32abe9b262134cc2a2fbbd689f9a532f6700533324ff279af8b"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core-channel-types",
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -1846,7 +1807,8 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.10.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9da9cb134fa631c50659f58fb6f5356c724709048107b976548daad8860e7361"
 dependencies = [
  "borsh",
  "dur",
@@ -1857,8 +1819,8 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -2496,8 +2458,8 @@ dependencies = [
  "dur",
  "ibc",
  "ibc-derive",
- "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0)",
- "ibc-middleware-module-macros 0.2.0",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ics23",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "num-traits",
+ "num-traits 0.2.17",
  "zeroize",
 ]
 
@@ -101,9 +101,9 @@ dependencies = [
  "ark-std",
  "derivative",
  "num-bigint",
- "num-traits",
+ "num-traits 0.2.17",
  "paste",
- "rustc_version 0.3.3",
+ "rustc_version",
  "zeroize",
 ]
 
@@ -124,7 +124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint",
- "num-traits",
+ "num-traits 0.2.17",
  "quote",
  "syn 1.0.109",
 ]
@@ -145,7 +145,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.17",
  "rand",
 ]
 
@@ -170,15 +170,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -354,6 +345,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838#d3ebe9dd6488fac1923db120a7498079e55dd838"
+dependencies = [
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "borsh"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,7 +491,7 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "num-traits",
+ "num-traits 0.2.17",
  "windows-targets 0.48.5",
 ]
 
@@ -508,18 +511,6 @@ name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
-
-[[package]]
-name = "cobs"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
-
-[[package]]
-name = "const-crc32-nostd"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-default"
@@ -552,12 +543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "core2"
-version = "0.3.3"
+name = "cosmos-sdk-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+checksum = "462e1f6a8e005acc8835d32d60cbd7973ed65ea2a8d8473830e675f050956427"
 dependencies = [
- "memchr",
+ "informalsystems-pbjson",
+ "prost",
+ "serde",
+ "tendermint-proto",
 ]
 
 [[package]]
@@ -568,12 +562,6 @@ checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -648,12 +636,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
-name = "debugless-unwrap"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
-
-[[package]]
 name = "der"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,17 +666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-getters"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +674,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -728,23 +720,22 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "5.0.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "winapi",
 ]
 
 [[package]]
@@ -756,15 +747,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
-dependencies = [
- "litrs",
 ]
 
 [[package]]
@@ -819,7 +801,7 @@ dependencies = [
  "rand_core",
  "serde",
  "sha2 0.9.9",
- "thiserror 1.0.50",
+ "thiserror",
  "zeroize",
 ]
 
@@ -850,18 +832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,8 +860,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "thiserror 1.0.50",
- "uint",
+ "thiserror",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -903,7 +873,7 @@ dependencies = [
  "crunchy",
  "fixed-hash",
  "impl-rlp",
- "impl-serde",
+ "impl-serde 0.4.0",
  "tiny-keccak",
 ]
 
@@ -925,9 +895,9 @@ dependencies = [
  "ethbloom",
  "fixed-hash",
  "impl-rlp",
- "impl-serde",
- "primitive-types",
- "uint",
+ "impl-serde 0.4.0",
+ "primitive-types 0.12.2",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -1001,43 +971,7 @@ dependencies = [
  "libm",
  "num-bigint",
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "frost-core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5afd375261c34d31ff24dad068382f4bc3c95010c919d4fb8d483dc3d85c023"
-dependencies = [
- "byteorder",
- "const-crc32-nostd",
- "debugless-unwrap",
- "derive-getters",
- "document-features",
- "hex",
- "itertools 0.13.0",
- "postcard",
- "rand_core",
- "serde",
- "serdect",
- "thiserror 1.0.50",
- "thiserror-nostd-notrait",
- "visibility",
- "zeroize",
-]
-
-[[package]]
-name = "frost-rerandomized"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9d77595060546b53543d96b83dbeacaf3907e40a89763a8bb22124812b0cb6"
-dependencies = [
- "derive-getters",
- "document-features",
- "frost-core",
- "hex",
- "rand_core",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -1170,15 +1104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,26 +1117,6 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version 0.4.1",
- "serde",
- "spin",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "heck"
@@ -1232,15 +1137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
-dependencies = [
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1279,8 +1175,8 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1292,8 +1188,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -1302,12 +1198,12 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "base64 0.22.1",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "http",
  "ibc-app-transfer-types",
@@ -1323,8 +1219,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1333,26 +1229,26 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core",
  "ibc-proto",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.13.1",
  "scale-info",
  "schemars",
  "serde",
- "uint",
+ "uint 0.10.0",
 ]
 
 [[package]]
 name = "ibc-apps"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -1360,10 +1256,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "ibc-client-tendermint-types",
  "ibc-core-client",
  "ibc-core-commitment-types",
@@ -1377,8 +1273,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -1394,8 +1290,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-wasm-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -1408,8 +1304,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-clients"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -1417,8 +1313,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1433,8 +1329,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -1448,11 +1344,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -1471,8 +1367,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -1484,10 +1380,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-context"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -1500,11 +1396,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-commitment-types",
  "ibc-core-host-types",
@@ -1520,11 +1416,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-commitment-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
@@ -1539,8 +1435,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -1548,16 +1444,16 @@ dependencies = [
  "ibc-core-handler-types",
  "ibc-core-host",
  "ibc-primitives",
- "prost 0.13.2",
+ "prost",
 ]
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-client-types",
  "ibc-core-commitment-types",
@@ -1574,8 +1470,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -1589,11 +1485,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-channel-types",
  "ibc-core-client-types",
@@ -1613,10 +1509,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-channel-types",
  "ibc-core-client-context",
@@ -1631,10 +1527,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-cosmos"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-app-transfer-types",
  "ibc-client-tendermint",
@@ -1654,14 +1550,16 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
+ "base64 0.22.1",
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-primitives",
  "parity-scale-codec",
+ "prost",
  "scale-info",
  "schemars",
  "serde",
@@ -1669,10 +1567,10 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -1683,11 +1581,11 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router-types"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-core-host-types",
  "ibc-primitives",
@@ -1702,8 +1600,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-derive"
-version = "0.8.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1713,31 +1611,6 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.1.0#3d3b436f7c58000c7498d68e88c15a955433a619"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
-dependencies = [
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-primitives",
-]
-
-[[package]]
-name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0#3d3b436f7c58000c7498d68e88c15a955433a619"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -1749,51 +1622,14 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.1.0#3d3b436f7c58000c7498d68e88c15a955433a619"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-module-macros"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0#3d3b436f7c58000c7498d68e88c15a955433a619"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "ibc-middleware-overflow-receive"
-version = "0.4.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0#8d341de14ff5e2a637699796cffbf0fbbaee001f"
-dependencies = [
- "ibc-app-transfer-types",
- "ibc-core-channel-types",
- "ibc-core-host-types",
- "ibc-core-router",
- "ibc-core-router-types",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.4.0)",
- "ibc-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "ibc-middleware-packet-forward"
 version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0#3d3b436f7c58000c7498d68e88c15a955433a619"
 dependencies = [
  "borsh",
  "dur",
@@ -1804,8 +1640,8 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.9.0)",
+ "ibc-middleware-module",
+ "ibc-middleware-module-macros",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -1813,37 +1649,34 @@ dependencies = [
 
 [[package]]
 name = "ibc-primitives"
-version = "0.54.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38489943c4e75206eaffeeeec6153c039c2499d1#38489943c4e75206eaffeeeec6153c039c2499d1"
+version = "0.56.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=12ffb4bd01e962b86e2db00b10ef60921a9b8500#12ffb4bd01e962b86e2db00b10ef60921a9b8500"
 dependencies = [
  "borsh",
- "derive_more",
+ "derive_more 1.0.0",
  "displaydoc",
  "ibc-proto",
  "parity-scale-codec",
- "prost 0.13.2",
+ "prost",
  "scale-info",
  "schemars",
  "serde",
- "tendermint",
  "time",
 ]
 
 [[package]]
 name = "ibc-proto"
-version = "0.47.1"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c852d22b782d2d793f4a646f968de419be635e02bc8798d5d74a6e44eef27733"
+checksum = "9b70f517162e74e2d35875b8b94bf4d1e45f2c69ef3de452dc855944455d33ca"
 dependencies = [
  "base64 0.22.1",
- "borsh",
  "bytes",
+ "cosmos-sdk-proto",
  "flex-error",
  "ics23",
  "informalsystems-pbjson",
- "parity-scale-codec",
- "prost 0.13.2",
- "scale-info",
+ "prost",
  "schemars",
  "serde",
  "subtle-encoding",
@@ -1862,7 +1695,7 @@ dependencies = [
  "bytes",
  "hex",
  "informalsystems-pbjson",
- "prost 0.13.2",
+ "prost",
  "ripemd",
  "serde",
  "sha2 0.10.8",
@@ -1879,14 +1712,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67aa010c1e3da95bf151bd8b4c059b2ed7e75387cdb969b4f8f2723a43f9941"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "impl-num-traits"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951641f13f873bff03d4bf19ae8bec531935ac0ac2cc775f84d7edfdcfed3f17"
 dependencies = [
  "integer-sqrt",
- "num-traits",
- "uint",
+ "num-traits 0.2.17",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -1903,6 +1745,15 @@ name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
 dependencies = [
  "serde",
 ]
@@ -1932,6 +1783,17 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "2.2.4"
+source = "git+https://github.com/heliaxdev/indexmap?tag=2.2.4-heliax-1#b5b5b547bd6ab04bbb16e060326a50ddaeb6c909"
+dependencies = [
+ "borsh",
+ "equivalent",
+ "hashbrown 0.14.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -1968,7 +1830,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -1985,24 +1847,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2029,7 +1873,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
 dependencies = [
  "bitvec",
- "bls12_381",
+ "bls12_381 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff",
+ "group",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "jubjub"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c#a373686962f4e9d0edb3b4716f86ff6bbd9aa86c"
+dependencies = [
+ "bitvec",
+ "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "ff",
  "group",
  "rand_core",
@@ -2115,22 +1972,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
-name = "litrs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,9 +1979,8 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+version = "1.0.0"
+source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
 dependencies = [
  "borsh",
  "chacha20",
@@ -2152,15 +1992,15 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+version = "1.0.0"
+source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
 dependencies = [
  "aes",
  "bip0039",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
+ "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "borsh",
  "byteorder",
  "ff",
@@ -2168,13 +2008,12 @@ dependencies = [
  "group",
  "hex",
  "incrementalmerkletree",
+ "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_note_encryption",
  "memuse",
- "nam-bls12_381",
- "nam-jubjub",
- "nam-num-traits",
- "nonempty 0.11.0",
+ "nonempty",
+ "num-traits 0.2.19",
  "rand",
  "rand_core",
  "sha2 0.10.8",
@@ -2184,22 +2023,21 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+version = "1.0.0"
+source = "git+https://github.com/anoma/masp?rev=0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe#0d0da3507a6f9ad135f00fd8201dc54c2f1d9efe"
 dependencies = [
  "bellman",
  "blake2b_simd",
+ "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "directories",
  "getrandom",
  "group",
- "itertools 0.14.0",
+ "itertools 0.11.0",
+ "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_primitives",
- "nam-bls12_381",
- "nam-jubjub",
- "nam-redjubjub",
  "rand_core",
+ "redjubjub",
  "tracing",
 ]
 
@@ -2234,99 +2072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "nam-bls12_381"
-version = "0.8.1-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e768b0e2383163f2f4bbce1112d6454b2cb515950b0a9177733f0d71254d2c68"
-dependencies = [
- "ff",
- "group",
- "pairing",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "nam-indexmap"
-version = "2.7.1-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b40876708764895b63bb5a1e9f102d3813cb16baeb9f12932b7c8f2df4248e"
-dependencies = [
- "borsh",
- "equivalent",
- "hashbrown 0.15.2",
- "serde",
-]
-
-[[package]]
-name = "nam-jubjub"
-version = "0.10.1-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdced0f5975d8f80cb82a84d464481acb7b586d22f447dda86947d6a572997b9"
-dependencies = [
- "bitvec",
- "ff",
- "group",
- "nam-bls12_381",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "nam-num-traits"
-version = "0.2.20-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687832a07242b76ab2760bc95180240954bf77e06bf8d9e825473c373146dc4a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "nam-reddsa"
-version = "0.5.2-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d102b4311bf60c03405350e976d17f5df155d2cb588f6401995a29ae8c1565"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "frost-rerandomized",
- "group",
- "hex",
- "jubjub",
- "pasta_curves",
- "rand_core",
- "serde",
- "thiserror 2.0.11",
- "zeroize",
-]
-
-[[package]]
-name = "nam-redjubjub"
-version = "0.7.1-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e457988762db7daad8d79f8a837a07295f5cc178d9236ba77db7339072ffb61e"
-dependencies = [
- "nam-reddsa",
- "rand_core",
- "serde",
- "thiserror 1.0.50",
- "zeroize",
-]
-
-[[package]]
-name = "nam-sparse-merkle-tree"
-version = "0.3.2-nam.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae108a0f6aabf789e34d6d447c1184608d1c70c087f957b720042226a47ab63"
-dependencies = [
- "borsh",
- "cfg-if",
- "ics23",
- "itertools 0.14.0",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "namada_account"
 version = "0.47.0"
 dependencies = [
@@ -2343,7 +2088,7 @@ version = "0.47.0"
 dependencies = [
  "namada_core",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -2361,30 +2106,30 @@ dependencies = [
  "ibc",
  "ics23",
  "impl-num-traits",
+ "indexmap 2.2.4",
  "k256",
  "masp_primitives",
- "nam-indexmap",
- "nam-sparse-merkle-tree",
  "namada_macros",
  "num-integer",
  "num-rational",
- "num-traits",
+ "num-traits 0.2.17",
  "num256",
  "num_enum",
- "primitive-types",
- "prost-types 0.13.2",
+ "primitive-types 0.13.1",
+ "prost-types",
  "rayon",
  "ripemd",
  "serde",
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
+ "sparse-merkle-tree",
  "tendermint",
  "tendermint-proto",
- "thiserror 1.0.50",
+ "thiserror",
  "tiny-keccak",
  "tracing",
- "uint",
+ "uint 0.9.5",
  "usize-set",
  "zeroize",
 ]
@@ -2398,7 +2143,7 @@ dependencies = [
  "namada_macros",
  "serde",
  "serde_json",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -2411,7 +2156,7 @@ dependencies = [
  "namada_events",
  "namada_macros",
  "serde",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -2432,7 +2177,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -2445,9 +2190,6 @@ dependencies = [
  "dur",
  "ibc",
  "ibc-derive",
- "ibc-middleware-module 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.1.0)",
- "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.1.0)",
- "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ics23",
  "konst",
@@ -2460,13 +2202,13 @@ dependencies = [
  "namada_systems",
  "namada_tx",
  "namada_vp",
- "primitive-types",
- "prost 0.13.2",
+ "primitive-types 0.13.1",
+ "prost",
  "serde",
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -2488,11 +2230,11 @@ dependencies = [
  "borsh",
  "eyre",
  "ics23",
- "nam-sparse-merkle-tree",
  "namada_core",
  "namada_macros",
- "prost 0.13.2",
- "thiserror 1.0.50",
+ "prost",
+ "sparse-merkle-tree",
+ "thiserror",
 ]
 
 [[package]]
@@ -2506,7 +2248,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -2528,7 +2270,7 @@ dependencies = [
  "once_cell",
  "serde",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -2569,7 +2311,7 @@ dependencies = [
  "sha2 0.9.9",
  "smooth-operator",
  "tempfile",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
  "typed-builder",
  "xorf",
@@ -2593,7 +2335,7 @@ dependencies = [
  "namada_tx",
  "patricia_tree",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -2611,7 +2353,7 @@ dependencies = [
  "regex",
  "serde",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -2631,7 +2373,7 @@ dependencies = [
  "borsh",
  "namada_core",
  "namada_state",
- "prost 0.13.2",
+ "prost",
  "strum",
 ]
 
@@ -2664,7 +2406,7 @@ dependencies = [
  "namada_tx",
  "namada_tx_env",
  "namada_vp_env",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -2685,14 +2427,14 @@ dependencies = [
  "namada_gas",
  "namada_macros",
  "num-derive 0.4.2",
- "num-traits",
- "prost 0.13.2",
- "prost-types 0.13.2",
+ "num-traits 0.2.17",
+ "prost",
+ "prost-types",
  "rand_core",
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "thiserror 1.0.50",
+ "thiserror",
  "tonic-build",
 ]
 
@@ -2744,7 +2486,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
 ]
 
@@ -2801,12 +2543,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
-name = "nonempty"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
-
-[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,7 +2553,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -2828,7 +2564,7 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -2837,7 +2573,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -2875,7 +2611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -2886,7 +2622,7 @@ checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -2898,14 +2634,22 @@ dependencies = [
  "autocfg",
  "num-bigint",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.17",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+source = "git+https://github.com/heliaxdev/num-traits?rev=3f3657caa34b8e116fdf3f8a3519c4ac29f012fe#3f3657caa34b8e116fdf3f8a3519c4ac29f012fe"
 dependencies = [
  "autocfg",
 ]
@@ -2919,7 +2663,7 @@ dependencies = [
  "lazy_static",
  "num",
  "num-derive 0.3.3",
- "num-traits",
+ "num-traits 0.2.17",
  "serde",
  "serde_derive",
 ]
@@ -2956,12 +2700,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pairing"
@@ -3054,7 +2792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
- "thiserror 1.0.50",
+ "thiserror",
  "ucd-trie",
 ]
 
@@ -3065,7 +2803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -3102,19 +2840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postcard"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3143,10 +2868,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.6.0",
  "impl-rlp",
- "impl-serde",
- "uint",
+ "impl-serde 0.4.0",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.7.0",
+ "impl-serde 0.5.0",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -3201,57 +2938,33 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
-dependencies = [
- "bytes",
- "prost-derive 0.12.3",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
 dependencies = [
  "bytes",
- "prost-derive 0.13.2",
+ "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
+checksum = "f8650aabb6c35b860610e9cff5dc1af886c9e25073b7b1712a68972af4281302"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.96",
  "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -3261,19 +2974,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
-dependencies = [
- "prost 0.12.3",
 ]
 
 [[package]]
@@ -3282,7 +2986,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
 dependencies = [
- "prost 0.13.2",
+ "prost",
 ]
 
 [[package]]
@@ -3371,6 +3075,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "reddsa"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "group",
+ "hex",
+ "jubjub 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pasta_curves",
+ "rand_core",
+ "serde",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "redjubjub"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a60db2c3bc9c6fd1e8631fee75abc008841d27144be744951d6b9b75f9b569c"
+dependencies = [
+ "rand_core",
+ "reddsa",
+ "serde",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,7 +3122,7 @@ checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.50",
+ "thiserror",
 ]
 
 [[package]]
@@ -3507,7 +3242,7 @@ dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
- "num-traits",
+ "num-traits 0.2.17",
  "rand",
  "rkyv",
  "serde",
@@ -3526,16 +3261,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver 1.0.24",
+ "semver",
 ]
 
 [[package]]
@@ -3570,7 +3296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
  "scale-info-derive",
 ]
@@ -3612,12 +3338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,12 +3368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
-
-[[package]]
 name = "semver-parser"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -3691,9 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3713,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -3830,12 +3544,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+name = "sparse-merkle-tree"
+version = "0.3.1-pre"
+source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=a93c55ccd47840ee0967eee237e47d9245478594#a93c55ccd47840ee0967eee237e47d9245478594"
 dependencies = [
- "lock_api",
+ "borsh",
+ "cfg-if",
+ "ics23",
+ "itertools 0.12.1",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -3847,12 +3564,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -3971,9 +3682,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d9d6ffeb83b1de47c307c6e0d2dff56c6256989299010ad03cd80a8491e97"
+checksum = "d9703e34d940c2a293804752555107f8dbe2b84ec4c6dd5203831235868105d2"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -3982,10 +3693,9 @@ dependencies = [
  "flex-error",
  "futures",
  "k256",
- "num-traits",
+ "num-traits 0.2.17",
  "once_cell",
- "prost 0.13.2",
- "prost-types 0.13.2",
+ "prost",
  "ripemd",
  "serde",
  "serde_bytes",
@@ -4002,11 +3712,11 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2674adbf0dc51aa0c8eaf8462c7d6692ec79502713e50ed5432a442002be90"
+checksum = "f0cda4a449fc70985a95f892a67286f13afa4e048d90b8d04a2bf6341e88d1c2"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "flex-error",
  "serde",
  "tendermint",
@@ -4015,14 +3725,17 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.38.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed14abe3b0502a3afe21ca74ca5cdd6c7e8d326d982c26f98a394445eb31d6e"
+checksum = "9ae9e1705aa0fa5ecb2c6aa7fb78c2313c4a31158ea5f02048bf318f849352eb"
 dependencies = [
+ "borsh",
  "bytes",
  "flex-error",
- "prost 0.13.2",
- "prost-types 0.13.2",
+ "parity-scale-codec",
+ "prost",
+ "scale-info",
+ "schemars",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -4035,16 +3748,7 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
- "thiserror-impl 1.0.50",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4052,37 +3756,6 @@ name = "thiserror-impl"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "thiserror-nostd-notrait"
-version = "1.0.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8444e638022c44d2a9337031dee8acb732bcc7fbf52ac654edc236b26408b61"
-dependencies = [
- "thiserror-nostd-notrait-impl",
-]
-
-[[package]]
-name = "thiserror-nostd-notrait-impl"
-version = "1.0.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4155,7 +3828,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
@@ -4166,20 +3839,21 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types",
  "quote",
  "syn 2.0.96",
 ]
@@ -4403,6 +4077,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,6 +4108,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -4445,26 +4137,15 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 
 [[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "visibility"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
 
 [[package]]
 name = "vp_always_false"
@@ -4601,16 +4282,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
-name = "which"
-version = "4.4.2"
+name = "winapi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4784,12 +4475,11 @@ dependencies = [
 
 [[package]]
 name = "zcash_encoding"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3654116ae23ab67dd1f849b01f8821a8a156f884807ff665eac109bf28306c4d"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash?rev=bd7f9d7#bd7f9d7c3ce5cfd14af169ffe0e1c5c903162f46"
 dependencies = [
- "core2",
- "nonempty 0.7.0",
+ "byteorder",
+ "nonempty",
 ]
 
 [[package]]

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -1765,8 +1765,32 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-module"
-version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-middleware-module"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "ibc-core-channel-types",
+ "ibc-core-host-types",
+ "ibc-core-router",
+ "ibc-core-router-types",
+ "ibc-primitives",
+]
+
+[[package]]
+name = "ibc-middleware-module"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-host-types",
@@ -1778,7 +1802,25 @@ dependencies = [
 [[package]]
 name = "ibc-middleware-module-macros"
 version = "0.1.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "ibc-middleware-module-macros"
+version = "0.1.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "ibc-middleware-module-macros"
+version = "0.2.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=module-macros/v0.2.0#3dca5354609af33e0aaba3f582a28447410d637f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1786,16 +1828,16 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-overflow-receive"
-version = "0.4.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+version = "0.5.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core-channel-types",
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module",
- "ibc-middleware-module-macros",
+ "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
+ "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=orm/v0.5.0)",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -1803,8 +1845,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-middleware-packet-forward"
-version = "0.9.0"
-source = "git+https://github.com/heliaxdev/ibc-middleware?rev=e723d8465d9ed8185ea08debc01cd4d18af140bc#e723d8465d9ed8185ea08debc01cd4d18af140bc"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0#bd89960566b52d8e141308c72bb4f95e69f2c643"
 dependencies = [
  "borsh",
  "dur",
@@ -1815,8 +1857,8 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-core-router",
  "ibc-core-router-types",
- "ibc-middleware-module",
- "ibc-middleware-module-macros",
+ "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
+ "ibc-middleware-module-macros 0.1.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=pfm/v0.10.0)",
  "ibc-primitives",
  "serde",
  "serde_json",
@@ -2454,8 +2496,8 @@ dependencies = [
  "dur",
  "ibc",
  "ibc-derive",
- "ibc-middleware-module",
- "ibc-middleware-module-macros",
+ "ibc-middleware-module 0.2.0 (git+https://github.com/heliaxdev/ibc-middleware?tag=module/v0.2.0)",
+ "ibc-middleware-module-macros 0.2.0",
  "ibc-middleware-overflow-receive",
  "ibc-middleware-packet-forward",
  "ics23",


### PR DESCRIPTION
## Describe your changes
NOTE: Need to update ibc-middleware with the release version

Mainly updated error types of `ibc-rs`. No logic should be changed.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
