### PR TITLE
Support IBC signing on hardware wallets not supporting MASP

### DIFF
--- a/.changelog/unreleased/bug-fixes/4251-ibc-for-maspless-hw.md
+++ b/.changelog/unreleased/bug-fixes/4251-ibc-for-maspless-hw.md
@@ -1,0 +1,2 @@
+- Support IBC signing on hardware wallets not supporting MASP
+  ([\#4251](https://github.com/anoma/namada/pull/4251))


### PR DESCRIPTION
## Describe your changes
Pure IBC transaction signing currently fails on the Ledger Nano S. This is because it tries to use the hardware wallet to generate MASP build parameters even when they are not needed. This PR modifies the code to ignore MASP build parameter generation failures if they turn out to not be needed for the construction of an IBC transaction.

An alternative approach to this PR could be to determine the precise conditions under which MASP build parameters would be required, and only do generation in those circumstances. This also would work fine, but would involve making sure that the determined conditions do not fall out of sync with the transaction building code that follows its usage.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
