### PR TITLE
PoS: fix and improve chained redelegation error msg

### DIFF
--- a/.changelog/unreleased/bug-fixes/4264-fix-redeleg-err.md
+++ b/.changelog/unreleased/bug-fixes/4264-fix-redeleg-err.md
@@ -1,0 +1,3 @@
+- The the swapped arguments in error message for a chained redelegation. Also
+  added the earliest redelegation epoch to help users determine when they can
+  redelegate again. ([\#4264](https://github.com/anoma/namada/pull/4264))

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -301,9 +301,10 @@ pub enum TxSubmitError {
     /// slashing
     #[error(
         "An incoming redelegation from delegator {0} to validator {1} is \
-         still subject to possible slashing"
+         still subject to possible slashing and cannot redelegated again \
+         before epoch {2}"
     )]
-    IncomingRedelIsStillSlashable(Address, Address),
+    IncomingRedelIsStillSlashable(Address, Address, Epoch),
     /// An empty string was provided as a new email
     #[error("An empty string cannot be provided as a new email")]
     InvalidEmail,


### PR DESCRIPTION
## Describe your changes

closes #4263

The args for `IncomingRedelIsStillSlashable` error were swapped. Also added the earliest redelegation epoch to help users determine when they can redelegate again.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
