### PR TITLE
Improve error message on failed fee payment

### DIFF
--- a/.changelog/unreleased/improvements/4271-masp-fee-error-msg.md
+++ b/.changelog/unreleased/improvements/4271-masp-fee-error-msg.md
@@ -1,0 +1,2 @@
+- Improved the error message for a failed masp fee payment.
+  ([\#4271](https://github.com/anoma/namada/pull/4271))

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -794,17 +794,14 @@ where
                 } else {
                     state.write_log_mut().drop_tx();
 
-                    // FIXME: review this part
-                    let mut error_msg = String::new();
-                    if !is_masp_transfer {
-                        error_msg.push_str("Not a MASP transaction.");
-                    }
-                    if !result.is_accepted() {
-                        error_msg = format!(
+                    let error_msg = if !is_masp_transfer {
+                        "Not a MASP transaction.".to_string()
+                    } else {
+                        format!(
                             "Some VPs rejected it: {:#?}",
                             result.vps_result.rejected_vps
-                        );
-                    }
+                        )
+                    };
                     tracing::error!(error_msg);
 
                     return Err(Error::FeeError(error_msg).into());

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -613,10 +613,10 @@ where
                         // process_proposal.
                         tracing::error!(
                             "Transfer of tx fee cannot be applied because of \
-                             {}. This shouldn't happen.",
+                             an eror: {}. This shouldn't happen.",
                             e
                         );
-                        return Err(e);
+                        return Err(e.into());
                     }
                 }
             };
@@ -669,6 +669,45 @@ where
     }
 }
 
+/// Custom error type for masp fee payment. This is needed to enforce that the
+/// error messages we produce are not misleading
+// FIXME: should contain Error
+pub struct MaspFeeError(String);
+
+impl Display for MaspFeeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", Error::from(self))
+    }
+}
+
+impl From<&MaspFeeError> for Error {
+    fn from(value: &MaspFeeError) -> Self {
+        Self::FeeError(format!(
+            "The transparent balance of the fee payer was insufficient to pay \
+             fees. The protocol tried to run the first transaction in the \
+             batch to pay fees via the MASP but it failed: {0}",
+            value.0
+        ))
+    }
+}
+
+impl From<MaspFeeError> for Error {
+    fn from(value: MaspFeeError) -> Self {
+        Self::from(&value)
+    }
+}
+
+impl From<&Error> for MaspFeeError {
+    fn from(value: &Error) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<Error> for MaspFeeError {
+    fn from(value: Error) -> Self {
+        Self::from(&value)
+    }
+}
 fn try_masp_fee_payment<S, D, H, CA>(
     ShellParams {
         tx_gas_meter,
@@ -678,7 +717,7 @@ fn try_masp_fee_payment<S, D, H, CA>(
     }: &mut ShellParams<'_, S, D, H, CA>,
     tx: &Tx,
     tx_index: &TxIndex,
-) -> Result<MaspTxResult>
+) -> std::result::Result<MaspTxResult, MaspFeeError>
 where
     S: 'static
         + State<D = D, H = H>
@@ -690,9 +729,6 @@ where
     H: 'static + StorageHasher + Sync,
     CA: 'static + WasmCacheAccess + Sync,
 {
-    const MASP_FEE_PAYMENT_ERROR: &str =
-        "The first transaction in the batch failed to pay fees via the MASP.";
-
     // The fee payment is subject to a gas limit imposed by a protocol
     // parameter. Here we instantiate a custom gas meter for this step where the
     // gas limit is actually the lowest between the protocol parameter and the
@@ -746,7 +782,7 @@ where
                         Either::Left(true),
                     )?
                     .ok_or_else(|| {
-                        Error::FeeError(
+                        MaspFeeError(
                             "Missing expected masp section reference"
                                 .to_string(),
                         )
@@ -758,27 +794,27 @@ where
                 } else {
                     state.write_log_mut().drop_tx();
 
-                    let mut error_msg = MASP_FEE_PAYMENT_ERROR.to_string();
+                    // FIXME: review this part
+                    let mut error_msg = String::new();
                     if !is_masp_transfer {
-                        error_msg.push_str(" Not a MASP transaction.");
+                        error_msg.push_str("Not a MASP transaction.");
                     }
                     if !result.is_accepted() {
                         error_msg = format!(
-                            "{error_msg} Some VPs rejected it: {:#?}",
+                            "Some VPs rejected it: {:#?}",
                             result.vps_result.rejected_vps
                         );
                     }
                     tracing::error!(error_msg);
 
-                    return Err(Error::FeeError(error_msg));
+                    return Err(MaspFeeError(error_msg));
                 }
             }
             Err(e) => {
                 state.write_log_mut().drop_tx();
-                let error_msg =
-                    format!("{MASP_FEE_PAYMENT_ERROR} Wasm run failed: {}", e);
+                let error_msg = format!("Wasm run failed: {}", e);
                 tracing::error!(error_msg);
-                return Err(Error::FeeError(error_msg));
+                return Err(MaspFeeError(error_msg));
             }
         }
     };
@@ -901,12 +937,13 @@ where
 
                     checked!(balance - fees).map_or_else(
                         |_| {
-                            Err(Error::FeeError(format!(
+                            Err(MaspFeeError(format!(
                                 "Masp fee payment unshielded an insufficient \
-                                 amount: Balance after unshielding: {balance} \
-                                 {}; required {fees}",
+                                 amount. Balance after unshielding: {balance} \
+                                 {}, required {fees}",
                                 wrapper.fee.token
-                            )))
+                            ))
+                            .into())
                         },
                         |_| Ok(Some(valid_batched_tx_result)),
                     )

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -613,7 +613,7 @@ where
                         // process_proposal.
                         tracing::error!(
                             "Transfer of tx fee cannot be applied because of \
-                             an eror: {}. This shouldn't happen.",
+                             an error: {}. This shouldn't happen.",
                             e
                         );
                         return Err(e.into());

--- a/crates/node/src/shell/process_proposal.rs
+++ b/crates/node/src/shell/process_proposal.rs
@@ -1096,9 +1096,10 @@ mod test_process_proposal {
         assert_eq!(response.result.code, u32::from(ResultCode::FeeError));
         assert!(response.result.info.contains(
             "Error trying to apply a transaction: Error while processing \
-             transaction's fees: The first transaction in the batch failed to \
-             pay fees via the MASP. Wasm run failed: Transaction runner \
-             error: Wasm validation error"
+             transaction's fees: The transparent balance of the fee payer was \
+             insufficient to pay fees. The protocol tried to run the first \
+             transaction in the batch to pay fees via the MASP but it failed: \
+             Wasm run failed: Transaction runner error: Wasm validation error"
         ));
     }
 


### PR DESCRIPTION
## Describe your changes

Closes #4262.

This PR tries to improve the error message we emit in case of a failed masp fee payment by better explaining the logic applied by the protocol

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
