### PR TITLE
2776-update-rocksdb.md

### DIFF
--- a/.changelog/v0.31.9/improvements/2776-update-rocksdb.md
+++ b/.changelog/v0.31.9/improvements/2776-update-rocksdb.md
@@ -1,2 +1,2 @@
-- Updated RocksDB dependency. For a shared libary users make sure to link
+- Updated RocksDB dependency. For a shared library users make sure to link
   against version v8.10.0. ([\#2776](https://github.com/anoma/namada/pull/2776))


### PR DESCRIPTION
- **Change:** Replaced "libary" with "library" in the sentence: "For a shared libary users make sure to link against version v8.10.0."