### PR TITLE
Fix typo in  README.md

### DIFF
--- a/crates/tests/fixtures/README.md
+++ b/crates/tests/fixtures/README.md
@@ -1,6 +1,6 @@
 # Test fixtures
 
-Folder contaning tests fixture.
+Folder containing tests fixture.
 
 ## txs.json
 


### PR DESCRIPTION
# Fix typo in `README.md`

## Description
This PR fixes a typo in the `README.md` file located in the `crates/tests/fixtures` directory. The word "contaning" was incorrectly spelled and has been corrected to "containing."

Thank you for reviewing this pull request! Let me know if any further