### PR TITLE
PoS claim rewards - add token transfer event

### DIFF
--- a/.changelog/unreleased/improvements/4283-pos-claim-rewards-events.md
+++ b/.changelog/unreleased/improvements/4283-pos-claim-rewards-events.md
@@ -1,0 +1,2 @@
+- Emit a token transfer emit with `"pos-claim-rewards"` descriptor when claiming
+  staking rewards. ([\#4283](https://github.com/anoma/namada/pull/4283))


### PR DESCRIPTION
## Describe your changes

Emit a token transfer emit with `"pos-claim-rewards"` descriptor when claiming non-zero staking rewards.

An update to a live chain with this change can be applied via a gov proposal replacing the `tx_claim_rewards` wasm

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
