### PR TITLE
Murisi/non compounding rewards

### DIFF
--- a/.changelog/unreleased/features/4285-non-compounding-rewards.md
+++ b/.changelog/unreleased/features/4285-non-compounding-rewards.md
@@ -1,0 +1,2 @@
+- Disable the compounding of MASP rewards to reduce overminting of NAM.
+  ([\#4285](https://github.com/anoma/namada/pull/4285))

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -491,6 +491,8 @@ async fn query_shielded_balance(
         // Precompute asset types to increase chances of success in decoding
         let token_map = context.wallet().await.get_addresses();
         let mut tokens: BTreeSet<_> = token_map.values().collect();
+        let native_token = context.native_token();
+        tokens.insert(&native_token);
         tokens.insert(&token);
         let _ = shielded
             .precompute_asset_types(context.client(), tokens)

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -263,25 +263,25 @@ pub fn encode_reward_asset_types(
             native_token.clone(),
             NATIVE_MAX_DECIMAL_PLACES.into(),
             MaspDigitPos::Zero,
-            Some(MaspEpoch::zero()),
+            None,
         )?,
         encode_asset_type(
             native_token.clone(),
             NATIVE_MAX_DECIMAL_PLACES.into(),
             MaspDigitPos::One,
-            Some(MaspEpoch::zero()),
+            None,
         )?,
         encode_asset_type(
             native_token.clone(),
             NATIVE_MAX_DECIMAL_PLACES.into(),
             MaspDigitPos::Two,
-            Some(MaspEpoch::zero()),
+            None,
         )?,
         encode_asset_type(
             native_token.clone(),
             NATIVE_MAX_DECIMAL_PLACES.into(),
             MaspDigitPos::Three,
-            Some(MaspEpoch::zero()),
+            None,
         )?,
     ])
 }

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -254,10 +254,7 @@ pub fn encode_asset_type(
 pub fn encode_reward_asset_types(
     native_token: &Address,
 ) -> Result<[AssetType; 4], std::io::Error> {
-    // Construct MASP asset type for rewards. Always deflate and timestamp
-    // reward tokens with the zeroth epoch to minimize the number of convert
-    // notes clients have to use. This trick works under the assumption that
-    // reward tokens will then be reinflated back to the current epoch.
+    // Construct MASP asset types for rewards. These are always undated.
     Ok([
         encode_asset_type(
             native_token.clone(),

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -1,7 +1,7 @@
 //! SDK functions to construct different types of transactions
 
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -3555,7 +3555,9 @@ async fn construct_shielded_parts<N: Namada>(
 ) -> Result<Option<(ShieldedTransfer, HashSet<AssetData>)>> {
     // Precompute asset types to increase chances of success in decoding
     let token_map = context.wallet().await.get_addresses();
-    let tokens = token_map.values().collect();
+    let mut tokens: BTreeSet<_> = token_map.values().collect();
+    let native_token = context.native_token();
+    tokens.insert(&native_token);
 
     let stx_result = {
         let mut shielded = context.shielded_mut().await;
@@ -3941,7 +3943,9 @@ pub async fn gen_ibc_shielding_transfer<N: Namada>(
 
     // Precompute asset types to increase chances of success in decoding
     let token_map = context.wallet().await.get_addresses();
-    let tokens = token_map.values().collect();
+    let mut tokens: BTreeSet<_> = token_map.values().collect();
+    let native_token = context.native_token();
+    tokens.insert(&native_token);
     let _ = context
         .shielded_mut()
         .await

--- a/crates/shielded_token/src/storage.rs
+++ b/crates/shielded_token/src/storage.rs
@@ -65,7 +65,12 @@ where
     let total_rewards_key = masp_total_rewards();
     let mut total_rewards = read_total_rewards(storage)?;
     checked!(total_rewards += amount)?;
-    storage.write(&total_rewards_key, total_rewards)
+    storage.write(&total_rewards_key, total_rewards)?;
+
+    let undated_balance_key = masp_undated_balance_key(&native_token);
+    let mut undated_balance = read_undated_balance(storage, &native_token)?;
+    checked!(undated_balance += amount)?;
+    storage.write(&undated_balance_key, undated_balance)
 }
 
 /// Read the total rewards minted by MASP.

--- a/crates/storage/src/conversion_state.rs
+++ b/crates/storage/src/conversion_state.rs
@@ -36,8 +36,6 @@ pub struct ConversionLeaf {
     Debug, Default, BorshSerialize, BorshDeserialize, BorshDeserializer,
 )]
 pub struct ConversionState {
-    /// The last amount of the native token distributed
-    pub normed_inflation: Option<u128>,
     /// The tree currently containing all the conversions
     pub tree: FrozenCommitmentTree<SaplingNode>,
     /// Map assets to their latest conversion and position in Merkle tree

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -1615,9 +1615,11 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.063"
-    ));
+    assert!(
+        captured.contains(
+            "Estimated native token rewards for the next MASP epoch: 0"
+        )
+    );
 
     // Assert NAM balance at MASP pool is exclusively the
     // rewards from the shielded BTC
@@ -1686,7 +1688,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.18887"));
+    assert!(captured.contains("nam: 0.189"));
 
     // Assert the rewards estimate are 0 since we haven't shielded any more
     // tokens
@@ -1728,7 +1730,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.18887"));
+    assert!(captured.contains("nam: 0.189"));
 
     // Wait till epoch boundary
     node.next_masp_epoch();
@@ -1850,7 +1852,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.750883"));
+    assert!(captured.contains("nam: 0.750887"));
 
     // Assert NAM balance at MASP pool is an accumulation of
     // rewards from both the shielded BTC and shielded ETH
@@ -1870,7 +1872,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 1.383286"));
+    assert!(captured.contains("nam: 1.380887"));
 
     // Wait till epoch boundary
     node.next_masp_epoch();
@@ -1951,7 +1953,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 1.502496"));
+    assert!(captured.contains("nam: 1.501774"));
 
     node.next_masp_epoch();
     // sync the shielded context
@@ -1979,7 +1981,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 3.267817"));
+    assert!(captured.contains("nam: 3.265774"));
 
     // Wait till epoch boundary
     node.next_masp_epoch();
@@ -2052,7 +2054,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 2.268662"));
+    assert!(captured.contains("nam: 2.268"));
 
     // Assert NAM balance at MASP pool is
     // the accumulation of rewards from the shielded assets (BTC and ETH)
@@ -2072,7 +2074,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 3.77117"));
+    assert!(captured.contains("nam: 3.769774"));
 
     // Wait till epoch boundary
     node.next_masp_epoch();
@@ -2102,7 +2104,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 2.268662"));
+    assert!(captured.contains("nam: 2.268"));
 
     // Assert NAM balance at VK(B) is the rewards dispensed earlier
     // (since VK(A) has no shielded assets, no further rewards should
@@ -2123,7 +2125,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 1.502496"));
+    assert!(captured.contains("nam: 1.501774"));
 
     // Assert NAM balance at MASP pool is
     // the accumulation of rewards from the shielded assets (BTC and ETH)
@@ -2143,7 +2145,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 3.77117"));
+    assert!(captured.contains("nam: 3.769774"));
 
     // Wait till epoch boundary to prevent conversion expiry during transaction
     // construction
@@ -2168,7 +2170,7 @@ fn masp_incentives() -> Result<()> {
                 "--token",
                 NAM,
                 "--amount",
-                "1.502496",
+                "1.501774",
                 "--gas-limit",
                 "60000",
                 "--signing-keys",
@@ -2203,7 +2205,7 @@ fn masp_incentives() -> Result<()> {
                 "--token",
                 NAM,
                 "--amount",
-                "2.268662",
+                "2.268",
                 "--signing-keys",
                 ALBERT_KEY,
                 "--node",
@@ -2282,7 +2284,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.000012"));
+    assert!(captured.contains("nam: 0"));
 
     Ok(())
 }
@@ -3814,7 +3816,7 @@ fn dynamic_assets() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.189567"));
+    assert!(captured.contains("nam: 0.189"));
 
     // Unshield the rewards
     let captured = CapturedOutput::of(|| {
@@ -3830,7 +3832,7 @@ fn dynamic_assets() -> Result<()> {
                 "--token",
                 NAM,
                 "--amount",
-                "0.189567",
+                "0.189",
                 "--gas-payer",
                 BERTHA_KEY,
                 "--ledger-address",

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -19,8 +19,6 @@ pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     Debug, Default, BorshSerialize, BorshDeserialize, BorshDeserializer,
 )]
 pub struct NewConversionState {
-    /// The last amount of the native token distributed
-    pub normed_inflation: Option<u128>,
     /// The tree currently containing all the conversions
     pub tree: FrozenCommitmentTree<sapling::Node>,
     /// Map assets to their latest conversion and position in Merkle tree
@@ -31,7 +29,6 @@ pub struct NewConversionState {
 impl From<ConversionState> for NewConversionState {
     fn from(value: ConversionState) -> Self {
         Self {
-            normed_inflation: value.normed_inflation,
             tree: value.tree,
             assets: value.assets,
         }


### PR DESCRIPTION
## Describe your changes
Based on #4303 . Implemented a version of MASP rewards where rewards do not compound. More precisely, the NAM received for locking tokens in the MASP does not itself receive NAM rewards. This version was implemented as an alternative to the compounding version in case the rounding errors become significant. This PR was also made to demonstrate that non-compounding rewards are also possible, and hence leave this possibility on the table.

In order to achieve the goal of non-compounding rewards, the following changes were made:
* MASP rewards are denominated in NAMs that have no timestamps
* The reward deflation step that was used to denominate rewards as NAM in epoch 0 is only required when compounding, so this has been removed
* The special logic for rewarding locking NAM in the MASP is no longer required and is now covered by the same logic that rewards other tokens
* Note: the test failures are due to the fact that the rewards in the integration tests need to be recomputed for the new rewards algorithm

The overall outcome of these changes is that while the PD-controller is untouched and the MASP pool's transparent balance still grows at the same rate, the portion of rewards that would have gone to the reward NAM locked in the MASP has now been redistributed to the non-reward NAM locked in the MASP.

Additionally, this PR reduces the amount of dust created by the rewards algorithm - the issue raised at https://github.com/anoma/namada/issues/4372. To see this, note that the dust left at the MASP address after all shielded tokens are unshielded in https://github.com/anoma/namada/pull/4285/files#diff-78668f42dcc983dea532ff370112f41796cfae99510ea10156df37c4e1e4e0d2R2287 has gone down from `nam: 0.003216` to `nam: 0`.

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
