### PR TITLE
Make sure the CI installs libudev-dev before building Namada.

### DIFF
--- a/.changelog/unreleased/CI/4286-fix-ci-udev-dep.md
+++ b/.changelog/unreleased/CI/4286-fix-ci-udev-dep.md
@@ -1,0 +1,2 @@
+- Ensure the CI installs libudev-dev for the test-ledger-app job
+  ([\#4286](https://github.com/anoma/namada/pull/4286))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,6 +604,7 @@ jobs:
           git checkout "v$LEDGER_APP_VERSION"
           git submodule update --init --recursive
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+          sudo apt-get update
           make deps
       - name: Install rust
         uses: actions-rs/toolchain@v1
@@ -614,7 +615,7 @@ jobs:
           # The path where the Ledger app test suite will locate test vectors
           TESTVEC_PATH="../ledger-namada/tests/testvectors.json"
           TESTDBG_PATH="../ledger-namada/tests/testdebugs.txt"
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler libudev-dev
           cargo run --example generate-txs -- $TESTVEC_PATH $TESTDBG_PATH
       - name: Check test vectors
         run: |


### PR DESCRIPTION
## Describe your changes
Ensure that `libudev-dev` is installed by the CI before trying to generate test vectors in `test-ledger-app`. This addresses the issue that appeared only after merging https://github.com/anoma/namada/pull/4218 . See https://github.com/murisi/namada/actions/runs/13067326899/job/36461810196?pr=2 for a successful run of this fix.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
