### PR TITLE
Murisi/reverse conversion at source

### DIFF
--- a/.changelog/unreleased/bug-fixes/4287-consolidate-dust.md
+++ b/.changelog/unreleased/bug-fixes/4287-consolidate-dust.md
@@ -1,0 +1,2 @@
+- Fix underestimation of MASP balances
+  ([\#4287](https://github.com/anoma/namada/pull/4287))

--- a/.changelog/unreleased/improvements/4288-reverse-conversion-at-source.md
+++ b/.changelog/unreleased/improvements/4288-reverse-conversion-at-source.md
@@ -1,0 +1,2 @@
+- Simplify exchanging balance amounts to older epochs
+  ([\#4288](https://github.com/anoma/namada/pull/4288))

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -524,7 +524,6 @@ async fn query_shielded_balance(
                 context.client(),
                 context.io(),
                 &viewing_key,
-                masp_epoch,
             )
             .await
             .unwrap()

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -201,24 +201,35 @@ impl AssetData {
 
     /// Give this pre-asset type the given epoch if already has an epoch. Return
     /// the replaced value.
-    pub fn redate(&mut self, to: MaspEpoch) {
+    pub fn redate(self, to: MaspEpoch) -> Self {
         if self.epoch.is_some() {
-            self.epoch = Some(to);
+            Self {
+                epoch: Some(to),
+                ..self
+            }
+        } else {
+            self
         }
     }
 
     /// Update the MaspEpoch to the next one
-    pub fn redate_to_next_epoch(&mut self) {
-        if let Some(ep) = self.epoch.as_mut() {
-            if let Some(next) = ep.next() {
-                *ep = next;
+    pub fn redate_to_next_epoch(self) -> Self {
+        if let Some(next) = self.epoch.as_ref().and_then(MaspEpoch::next) {
+            Self {
+                epoch: Some(next),
+                ..self
             }
+        } else {
+            self
         }
     }
 
     /// Remove the epoch associated with this pre-asset type
-    pub fn undate(&mut self) {
-        self.epoch = None;
+    pub fn undate(self) -> Self {
+        Self {
+            epoch: None,
+            ..self
+        }
     }
 }
 
@@ -1128,23 +1139,23 @@ mod test {
 
     #[test]
     fn test_masp_asset_data_basics() {
-        let mut data = AssetData {
+        let data = AssetData {
             token: address::testing::nam(),
             denom: Denomination(6),
             position: MaspDigitPos::One,
             epoch: None,
         };
 
-        data.undate();
+        let data = data.undate();
         assert!(data.epoch.is_none());
 
         let epoch_0 = MaspEpoch::new(3);
-        data.redate(epoch_0);
+        let mut data = data.redate(epoch_0);
         assert!(data.epoch.is_none());
         data.epoch = Some(epoch_0);
 
         let epoch_1 = MaspEpoch::new(5);
-        data.redate(epoch_1);
+        let data = data.redate(epoch_1);
         assert_eq!(data.epoch, Some(epoch_1));
     }
 

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -297,11 +297,6 @@ pub type MaspAmount = ValueSum<(Option<MaspEpoch>, Address), token::Change>;
 /// transaction
 pub type SpentNotesTracker = HashMap<ViewingKey, HashSet<usize>>;
 
-/// An extension of Option's cloned method for pair types
-fn cloned_pair<T: Clone, U: Clone>((a, b): (&T, &U)) -> (T, U) {
-    (a.clone(), b.clone())
-}
-
 /// Represents the amount used of different conversions
 pub type Conversions =
     BTreeMap<AssetType, (AllowedConversion, MerklePath<Node>, i128)>;

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -2019,18 +2019,18 @@ mod test_shielded_wallet {
                 }
                 .encode()
                 .unwrap(),
-                -1,
+                -2i128.pow(epoch as u32),
             );
             conv += I128Sum::from_pair(
                 AssetData {
                     token: native_token.clone(),
                     denom: native_token_denom,
                     position: MaspDigitPos::Zero,
-                    epoch: Some(MaspEpoch::new(epoch + 1)),
+                    epoch: Some(MaspEpoch::new(5)),
                 }
                 .encode()
                 .unwrap(),
-                2,
+                2i128.pow(5),
             );
             context.add_conversions(
                 AssetData {
@@ -2057,7 +2057,7 @@ mod test_shielded_wallet {
             token: native_token.clone(),
             denom: native_token_denom,
             position: MaspDigitPos::Zero,
-            epoch: Some(MaspEpoch::new(5)),
+            epoch: Some(MaspEpoch::new(1)),
         };
         wallet.add_asset_type(asset_data.clone());
         wallet.add_note(create_note(asset_data.clone(), 10, pa), vk);
@@ -2093,7 +2093,7 @@ mod test_shielded_wallet {
                 }
                 .encode()
                 .unwrap(),
-                5
+                80,
             )
         );
     }


### PR DESCRIPTION
## Describe your changes
Based on the bug fix in #4287. An alternative to #4290 that simplifies the exchanging an amount to some past epoch. If the current epoch is 10 and it is desired to convert an asset from epoch 2 to epoch 6 when only conversions to the latest epoch, 10, are available. Then the following process is now done:
1) Query the conversion from epoch 2 to epoch 10, call it `A`
2) Query the conversion from epoch 6 to epoch 10, call it `B`. (If we were converting to epoch 10, then `B` would equal 0 since that is the conversion from an epoch to itself.)
3) Then return `C=A-B`. Because of the way the conversion tree is constructed, `C` is the conversion from epoch 2 to epoch 6 that would have been returned during epoch 6.

So more generally `query_allowed_conversion` now returns the result of a subtraction `A-B`. And by definition, the second operand of the subtraction is 0 when converting to the latest epoch, which ultimately means the result is simply `A` in that case. Additionally, `compute_exchanged_amount` has been simplified removing the forward and backward conversions.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
