### PR TITLE
More multisig tests

### DIFF
--- a/.changelog/unreleased/testing/4289-multisig-tests.md
+++ b/.changelog/unreleased/testing/4289-multisig-tests.md
@@ -1,0 +1,2 @@
+- Added more test cases for multisig verification
+  ([\#4289](https://github.com/anoma/namada/pull/4289))


### PR DESCRIPTION
## Describe your changes

Adds a few more cases to the multisig unit test aimed at covering some possible misbehaviors by one of the participants in the multisig account.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
