### PR TITLE
Do not exchange balance amounts when querying non-native token balances.

### DIFF
--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -508,7 +508,7 @@ async fn query_shielded_balance(
         display_line!(context.io(), "{token_alias}: 0");
     };
 
-    let balance = if no_conversions {
+    let balance = if no_conversions || token != context.native_token() {
         let Some(bal) = shielded
             .compute_shielded_balance(&viewing_key)
             .await


### PR DESCRIPTION
## Describe your changes
When querying the shielded balance of a non-native token, the Namada client currently applies conversions before displaying the result. This is unnecessary because applying conversions should only impact the native token balance, and never the balance of non-native tokens. Therefore this PR skips the balance exchanging step in the case of non-native tokens.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
