### PR TITLE
Murisi/improve native rewards precision

### DIFF
--- a/.changelog/unreleased/improvements/4308-improve-native-rewards-precision.md
+++ b/.changelog/unreleased/improvements/4308-improve-native-rewards-precision.md
@@ -1,0 +1,2 @@
+- Improve the accuracy of shielded rewards for native tokens
+  ([\#4308](https://github.com/anoma/namada/pull/4308))


### PR DESCRIPTION
## Describe your changes
Improve the accuracy of native rewards in line with the recommendation from the audit report. Essentially the precision (or, equivalently, the denominator) used when computing the native rewards is set to equal the current normed inflation. This way the computed reward can be put directly into the allowed conversion without any scaling by `normed_inflation / precision`.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
