### PR TITLE
updates to publish to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ namada_parameters = { version = "0.47.0", path = "crates/parameters" }
 namada_proof_of_stake = { version = "0.47.0", path = "crates/proof_of_stake" }
 namada_replay_protection = { version = "0.47.0", path = "crates/replay_protection" }
 namada_node = { version = "0.47.0", path = "crates/node" }
-namada_sdk = { version = "0.47.0", path = "crates/sdk" }
+namada_sdk = { version = "0.47.0", path = "crates/sdk", default-features = false }
 namada_shielded_token = { version = "0.47.0", path = "crates/shielded_token" }
 namada_state = { version = "0.47.0", path = "crates/state" }
 namada_storage = { version = "0.47.0", path = "crates/storage" }
@@ -96,7 +96,7 @@ namada_trans_token = { version = "0.47.0", path = "crates/trans_token" }
 namada_tx = { version = "0.47.0", path = "crates/tx" }
 namada_tx_env = { version = "0.47.0", path = "crates/tx_env" }
 namada_tx_prelude = { version = "0.47.0", path = "crates/tx_prelude" }
-namada_vm = { version = "0.47.0", path = "crates/vm" }
+namada_vm = { version = "0.47.0", path = "crates/vm", default-features = false }
 namada_vm_env = { version = "0.47.0", path = "crates/vm_env" }
 namada_vote_ext = { version = "0.47.0", path = "crates/vote_ext" }
 namada_vp = { version = "0.47.0", path = "crates/vp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,45 @@ repository = "https://github.com/anoma/namada"
 version = "0.47.0"
 
 [workspace.dependencies]
+namada_account = { version = "0.47.0", path = "crates/account" }
+namada_apps_lib = { version = "0.47.0", path = "crates/apps_lib" }
+namada_controller = { version = "0.47.0", path = "crates/controller" }
+namada_core = { version = "0.47.0", path = "crates/core" }
+namada_encoding_spec = { version = "0.47.0", path = "crates/encoding_spec" }
+namada_ethereum_bridge = { version = "0.47.0", path = "crates/ethereum_bridge" }
+namada_events = { version = "0.47.0", path = "crates/events" }
+namada_gas = { version = "0.47.0", path = "crates/gas" }
+namada_governance = { version = "0.47.0", path = "crates/governance" }
+namada_ibc = { version = "0.47.0", path = "crates/ibc" }
+namada_io = { version = "0.47.0", path = "crates/io" }
+namada_light_sdk = { version = "0.47.0", path = "crates/light_sdk" }
+namada_macros = { version = "0.47.0", path = "crates/macros" }
+namada_migrations = { version = "0.47.0", path = "crates/migrations" }
+namada_merkle_tree = { version = "0.47.0", path = "crates/merkle_tree" }
+namada_parameters = { version = "0.47.0", path = "crates/parameters" }
+namada_proof_of_stake = { version = "0.47.0", path = "crates/proof_of_stake" }
+namada_replay_protection = { version = "0.47.0", path = "crates/replay_protection" }
+namada_node = { version = "0.47.0", path = "crates/node" }
+namada_sdk = { version = "0.47.0", path = "crates/sdk" }
+namada_shielded_token = { version = "0.47.0", path = "crates/shielded_token" }
+namada_state = { version = "0.47.0", path = "crates/state" }
+namada_storage = { version = "0.47.0", path = "crates/storage" }
+namada_systems = { version = "0.47.0", path = "crates/systems" }
+namada_test_utils = { version = "0.47.0", path = "crates/test_utils" }
+namada_tests = { version = "0.47.0", path = "crates/tests" }
+namada_token = { version = "0.47.0", path = "crates/token" }
+namada_trans_token = { version = "0.47.0", path = "crates/trans_token" }
+namada_tx = { version = "0.47.0", path = "crates/tx" }
+namada_tx_env = { version = "0.47.0", path = "crates/tx_env" }
+namada_tx_prelude = { version = "0.47.0", path = "crates/tx_prelude" }
+namada_vm = { version = "0.47.0", path = "crates/vm" }
+namada_vm_env = { version = "0.47.0", path = "crates/vm_env" }
+namada_vote_ext = { version = "0.47.0", path = "crates/vote_ext" }
+namada_vp = { version = "0.47.0", path = "crates/vp" }
+namada_vp_env = { version = "0.47.0", path = "crates/vp_env" }
+namada_vp_prelude = { version = "0.47.0", path = "crates/vp_prelude" }
+namada_wallet = { version = "0.47.0", path = "crates/wallet" }
+
 arbitrary = {version = "1.4", features = ["derive"]}
 ark-bls12-381 = {version = "0.3"}
 ark-serialize = {version = "0.3"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ blake2b-rs = "0.2.0"
 byte-unit = "4.0.13"
 byteorder = "1.4.2"
 borsh = {version = "1.2.0", features = ["unstable__schema", "derive"]}
-borsh-ext = { git = "https://github.com/heliaxdev/borsh-ext", tag = "v1.2.0" }
 cargo_metadata = "0.18.1"
 chrono = {version = "0.4.22", default-features = false, features = ["clock", "std"]}
 circular-queue = "0.2.6"

--- a/crates/account/Cargo.toml
+++ b/crates/account/Cargo.toml
@@ -19,18 +19,18 @@ arbitrary = ["dep:arbitrary", "namada_core/arbitrary"]
 migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_macros = { path = "../macros" }
-namada_migrations = { path = "../migrations", optional = true }
-namada_storage = { path = "../storage" }
+namada_core.workspace = true
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_storage.workspace = true
 
 arbitrary = { workspace = true, optional = true }
 borsh.workspace = true
-linkme = {workspace = true, optional = true }
+linkme = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 serde.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
+namada_core = { workspace = true, features = ["testing"] }
 
 proptest.workspace = true

--- a/crates/apps/Cargo.toml
+++ b/crates/apps/Cargo.toml
@@ -56,16 +56,21 @@ migrations = ["namada_apps_lib/migrations"]
 namada-eth-bridge = ["namada_apps_lib/namada-eth-bridge"]
 
 [dependencies]
-namada_apps_lib = {path = "../apps_lib"}
-namada_node = {path = "../node"}
+namada_apps_lib.workspace = true
+namada_node.workspace = true
 
 clap_complete.workspace = true
 clap_complete_nushell.workspace = true
 color-eyre.workspace = true
 eyre.workspace = true
-tokio = {workspace = true, features = ["full"]}
+tokio = { workspace = true, features = ["full"] }
 toml.workspace = true
-tracing-subscriber = { workspace = true, features = ["std", "json", "ansi", "tracing-log"]}
+tracing-subscriber = { workspace = true, features = [
+    "std",
+    "json",
+    "ansi",
+    "tracing-log",
+] }
 tracing.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/apps_lib/Cargo.toml
+++ b/crates/apps_lib/Cargo.toml
@@ -14,28 +14,20 @@ version.workspace = true
 
 [features]
 default = ["migrations"]
-mainnet = [
-  "namada_sdk/mainnet",
-]
+mainnet = ["namada_sdk/mainnet"]
 # for tests and test utilities
 testing = ["lazy_static", "namada_sdk/testing"]
 benches = ["lazy_static", "namada_sdk/benches"]
-migrations = [
-  "namada_migrations",
-  "namada_sdk/migrations",
-  "linkme"
-]
-namada-eth-bridge = [
-  "namada_sdk/namada-eth-bridge",
-]
+migrations = ["namada_migrations", "namada_sdk/migrations", "linkme"]
+namada-eth-bridge = ["namada_sdk/namada-eth-bridge"]
 
 [dependencies]
-namada_core = {path = "../core"}
-namada_macros = {path = "../macros"}
-namada_migrations = {path = "../migrations", optional = true}
-namada_sdk = {path = "../sdk", features = ["download-params", "multicore"]}
-namada_vm = {path = "../vm"}
-namada_wallet = { path = "../wallet", features = ["std"]}
+namada_core.workspace = true
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_sdk = { workspace = true, features = ["download-params", "multicore"] }
+namada_vm.workspace = true
+namada_wallet = { workspace = true, features = ["std"] }
 
 async-trait.workspace = true
 base64.workspace = true
@@ -66,7 +58,7 @@ rand_core = { workspace = true, features = ["std"] }
 rand = { workspace = true, features = ["std"] }
 reqwest.workspace = true
 rpassword.workspace = true
-serde_json = {workspace = true, features = ["raw_value"]}
+serde_json = { workspace = true, features = ["raw_value"] }
 serde.workspace = true
 sha2.workspace = true
 tar.workspace = true
@@ -75,20 +67,25 @@ tendermint-config.workspace = true
 tendermint-rpc = { workspace = true, features = ["http-client"] }
 textwrap-macros = "0.3.0"
 thiserror.workspace = true
-tokio = {workspace = true, features = ["full"]}
+tokio = { workspace = true, features = ["full"] }
 toml.workspace = true
 tracing-appender.workspace = true
 tracing-log.workspace = true
-tracing-subscriber = { workspace = true, features = ["std", "json", "ansi", "tracing-log"]}
+tracing-subscriber = { workspace = true, features = [
+  "std",
+  "json",
+  "ansi",
+  "tracing-log",
+] }
 tracing.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
-namada_sdk = {path = "../sdk", features = ["testing"]}
+namada_sdk = { workspace = true, features = ["testing"] }
 
 bit-set.workspace = true
 proptest.workspace = true
-lazy_static.workspace= true
+lazy_static.workspace = true
 pretty_assertions.workspace = true
 
 [build-dependencies]

--- a/crates/apps_lib/Cargo.toml
+++ b/crates/apps_lib/Cargo.toml
@@ -25,7 +25,10 @@ namada-eth-bridge = ["namada_sdk/namada-eth-bridge"]
 namada_core.workspace = true
 namada_macros.workspace = true
 namada_migrations = { workspace = true, optional = true }
-namada_sdk = { workspace = true, features = ["download-params", "multicore"] }
+namada_sdk = { workspace = true, default-features = true, features = [
+  "download-params",
+  "multicore",
+] }
 namada_vm.workspace = true
 namada_wallet = { workspace = true, features = ["std"] }
 
@@ -48,7 +51,7 @@ jubjub.workspace = true
 kdam.workspace = true
 lazy_static = { workspace = true, optional = true }
 linkme = { workspace = true, optional = true }
-ledger-lib = { workspace = true }
+ledger-lib.workspace = true
 ledger-namada-rs.workspace = true
 ledger-transport.workspace = true
 ledger-transport-hid.workspace = true
@@ -81,7 +84,9 @@ tracing.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
-namada_sdk = { workspace = true, features = ["testing"] }
+namada_sdk = { workspace = true, default-features = true, features = [
+  "testing",
+] }
 
 bit-set.workspace = true
 proptest.workspace = true

--- a/crates/benches/Cargo.toml
+++ b/crates/benches/Cargo.toml
@@ -33,24 +33,22 @@ harness = false
 path = "wasm_opcodes.rs"
 
 [features]
-namada-eth-bridge = [
-  "namada_apps_lib/namada-eth-bridge",
-]
+namada-eth-bridge = ["namada_apps_lib/namada-eth-bridge"]
 
 [dependencies]
 
 # NOTE: this crate MUST NOT import any dependency with testing features to prevent benchmarking non-production code
 [dev-dependencies]
-namada_apps_lib = { path = "../apps_lib", features = ["benches"] }
-namada_node = { path = "../node", features = ["benches"] }
-namada_vm = { path = "../vm", features = ["wasm-runtime"] }
-namada_vp = { path = "../vp" }
+namada_apps_lib = { workspace = true, features = ["benches"] }
+namada_node = { workspace = true, features = ["benches"] }
+namada_vm = { workspace = true, default-features = true }
+namada_vp.workspace = true
 
 masp_primitives.workspace = true
 masp_proofs = { workspace = true, features = ["benchmarks", "multicore"] }
 borsh.workspace = true
 criterion = { version = "0.5", features = ["html_reports"] }
-lazy_static.workspace= true
+lazy_static.workspace = true
 prost.workspace = true
 rand_core.workspace = true
 rand.workspace = true

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -12,10 +12,8 @@ readme.workspace = true
 repository.workspace = true
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-namada_core = { path = "../core" }
+namada_core.workspace = true
 
 smooth-operator.workspace = true
 thiserror.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -69,8 +69,8 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 smooth-operator.workspace = true
-tendermint = { workspace = true }
-tendermint-proto = { workspace = true }
+tendermint.workspace = true
+tendermint-proto.workspace = true
 thiserror.workspace = true
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tracing.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,18 +16,10 @@ version.workspace = true
 default = []
 mainnet = []
 rand = ["dep:rand", "rand_core"]
-ethers-derive = [
-  "ethbridge-structs/ethers-derive"
-]
+ethers-derive = ["ethbridge-structs/ethers-derive"]
 # for tests and test utilities
-testing = [
-  "rand",
-  "proptest",
-]
-migrations = [
-  "namada_migrations",
-  "linkme",
-]
+testing = ["rand", "proptest"]
+migrations = ["namada_migrations", "linkme"]
 benches = ["proptest"]
 control_flow = ["lazy_static", "tokio", "wasmtimer"]
 arbitrary = [
@@ -40,8 +32,8 @@ arbitrary = [
 task_env = ["tokio"]
 
 [dependencies]
-namada_macros = {path = "../macros"}
-namada_migrations = {path = "../migrations", optional = true}
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
 
 arbitrary = { workspace = true, optional = true }
 arse-merkle-tree.workspace = true
@@ -60,7 +52,7 @@ usize-set.workspace = true
 indexmap.workspace = true
 k256.workspace = true
 lazy_static = { workspace = true, optional = true }
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 masp_primitives.workspace = true
 num256.workspace = true
 num_enum = "0.7.0"
@@ -68,24 +60,23 @@ num-integer = "0.1.45"
 num-rational.workspace = true
 num-traits.workspace = true
 primitive-types.workspace = true
-proptest = {workspace = true, optional = true}
+proptest = { workspace = true, optional = true }
 prost-types.workspace = true
-rand = {version = "0.8", optional = true}
-rand_core = {version = "0.6", optional = true}
+rand = { version = "0.8", optional = true }
+rand_core = { version = "0.6", optional = true }
 ripemd.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 smooth-operator.workspace = true
-tendermint = {workspace = true}
-tendermint-proto = {workspace = true}
+tendermint = { workspace = true }
+tendermint-proto = { workspace = true }
 thiserror.workspace = true
-tiny-keccak = {version = "2.0.2", features = ["keccak"]}
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tracing.workspace = true
 uint = "0.9.5"
 zeroize.workspace = true
 wasmtimer = { workspace = true, optional = true }
-
 
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -93,7 +84,9 @@ tokio = { workspace = true, optional = true, features = ["full"] }
 rayon.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-tokio = { workspace = true, optional = true, default-features = false, features = ["sync"] }
+tokio = { workspace = true, optional = true, default-features = false, features = [
+  "sync",
+] }
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/crates/encoding_spec/Cargo.toml
+++ b/crates/encoding_spec/Cargo.toml
@@ -16,10 +16,10 @@ version.workspace = true
 default = []
 
 [dependencies]
-namada_account = { path = "../account" }
-namada_core = { path = "../core" }
-namada_token = { path = "../token" }
-namada_tx = { path = "../tx" }
+namada_account.workspace = true
+namada_core.workspace = true
+namada_token.workspace = true
+namada_tx.workspace = true
 
 borsh.workspace = true
 itertools.workspace = true

--- a/crates/ethereum_bridge/Cargo.toml
+++ b/crates/ethereum_bridge/Cargo.toml
@@ -21,50 +21,54 @@ testing = [
     "namada_state/testing",
     "namada_governance",
 ]
-migrations = [
-    "namada_migrations",
-    "linkme",
-]
+migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
-namada_account = {path = "../account", optional = true}
-namada_core = {path = "../core", default-features = false, features = ["ethers-derive"]}
-namada_events = { path = "../events", default-features = false }
-namada_governance = {path = "../governance", optional = true}
-namada_macros = {path = "../macros"}
-namada_migrations = {path = "../migrations", optional = true}
-namada_parameters = {path = "../parameters"}
-namada_proof_of_stake = {path = "../proof_of_stake", default-features = false}
-namada_state = {path = "../state"}
-namada_storage = {path = "../storage"}
-namada_systems = { path = "../systems" }
-namada_trans_token = {path = "../trans_token"}
-namada_tx = {path = "../tx"}
-namada_vote_ext = {path = "../vote_ext"}
-namada_vp_env = {path = "../vp_env"}
+namada_account = { workspace = true, optional = true }
+namada_core = { workspace = true, default-features = false, features = [
+    "ethers-derive",
+] }
+namada_events = { workspace = true, default-features = false }
+namada_governance = { workspace = true, optional = true }
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_parameters.workspace = true
+namada_proof_of_stake = { workspace = true, default-features = false }
+namada_state.workspace = true
+namada_storage.workspace = true
+namada_systems.workspace = true
+namada_trans_token = { workspace = true }
+namada_tx.workspace = true
+namada_vote_ext = { workspace = true }
+namada_vp_env = { workspace = true }
 
 borsh.workspace = true
 ethers.workspace = true
 eyre.workspace = true
 itertools.workspace = true
 konst.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 serde.workspace = true
 smooth-operator.workspace = true
 thiserror.workspace = true
 tracing = "0.1.30"
 
 [dev-dependencies]
-namada_account = {path = "../account"}
-namada_core = {path = "../core", default-features = false, features = ["ethers-derive", "testing"]}
-namada_gas = {path = "../gas"}
-namada_governance = {path = "../governance"}
-namada_proof_of_stake = {path = "../proof_of_stake", default-features = false, features = ["testing"]}
-namada_state = { path = "../state", features = ["testing"] }
-namada_token = {path = "../token", features = ["testing"]}
-namada_tx = {path = "../tx", features = ["testing"]}
-namada_vm = {path = "../vm", features = ["testing"]}
-namada_vp = {path = "../vp"}
+namada_account.workspace = true
+namada_core = { workspace = true, default-features = false, features = [
+    "ethers-derive",
+    "testing",
+] }
+namada_gas.workspace = true
+namada_governance.workspace = true
+namada_proof_of_stake = { workspace = true, default-features = false, features = [
+    "testing",
+] }
+namada_state = { workspace = true, features = ["testing"] }
+namada_token = { workspace = true, features = ["testing"] }
+namada_tx = { workspace = true, features = ["testing"] }
+namada_vm = { workspace = true, features = ["testing"] }
+namada_vp.workspace = true
 
 assert_matches.workspace = true
 data-encoding.workspace = true

--- a/crates/ethereum_bridge/Cargo.toml
+++ b/crates/ethereum_bridge/Cargo.toml
@@ -25,22 +25,20 @@ migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
 namada_account = { workspace = true, optional = true }
-namada_core = { workspace = true, default-features = false, features = [
-    "ethers-derive",
-] }
-namada_events = { workspace = true, default-features = false }
+namada_core = { workspace = true, features = ["ethers-derive"] }
+namada_events.workspace = true
 namada_governance = { workspace = true, optional = true }
 namada_macros.workspace = true
 namada_migrations = { workspace = true, optional = true }
 namada_parameters.workspace = true
-namada_proof_of_stake = { workspace = true, default-features = false }
+namada_proof_of_stake.workspace = true
 namada_state.workspace = true
 namada_storage.workspace = true
 namada_systems.workspace = true
-namada_trans_token = { workspace = true }
+namada_trans_token.workspace = true
 namada_tx.workspace = true
-namada_vote_ext = { workspace = true }
-namada_vp_env = { workspace = true }
+namada_vote_ext.workspace = true
+namada_vp_env.workspace = true
 
 borsh.workspace = true
 ethers.workspace = true
@@ -55,19 +53,16 @@ tracing = "0.1.30"
 
 [dev-dependencies]
 namada_account.workspace = true
-namada_core = { workspace = true, default-features = false, features = [
-    "ethers-derive",
-    "testing",
-] }
+namada_core = { workspace = true, features = ["ethers-derive", "testing"] }
 namada_gas.workspace = true
 namada_governance.workspace = true
-namada_proof_of_stake = { workspace = true, default-features = false, features = [
-    "testing",
-] }
+namada_proof_of_stake = { workspace = true, features = ["testing"] }
 namada_state = { workspace = true, features = ["testing"] }
 namada_token = { workspace = true, features = ["testing"] }
 namada_tx = { workspace = true, features = ["testing"] }
-namada_vm = { workspace = true, features = ["testing"] }
+namada_vm = { workspace = true, default-features = true, features = [
+    "testing",
+] }
 namada_vp.workspace = true
 
 assert_matches.workspace = true

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -16,18 +16,16 @@ version.workspace = true
 default = []
 debug = []
 mainnet = []
-migrations = [
-  "namada_migrations",
-  "linkme",
-]
+migrations = ["namada_migrations", "linkme"]
 testing = ["debug"]
 
 [dependencies]
-namada_core = {path = "../core"}
-namada_macros = {path = "../macros"}
-namada_migrations = {path = "../migrations", optional = true}
+namada_core.workspace = true
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+
 borsh.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/gas/Cargo.toml
+++ b/crates/gas/Cargo.toml
@@ -13,18 +13,16 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-migrations = [
-    "namada_migrations",
-    "linkme"
-]
+migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_macros = {path = "../macros"}
-namada_migrations = {path = "../migrations", optional = true}
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+
 borsh.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 serde.workspace = true
 thiserror.workspace = true
 

--- a/crates/gas/Cargo.toml
+++ b/crates/gas/Cargo.toml
@@ -17,7 +17,7 @@ migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_macros.workspace = true
 namada_migrations = { workspace = true, optional = true }
 

--- a/crates/governance/Cargo.toml
+++ b/crates/governance/Cargo.toml
@@ -20,13 +20,13 @@ migrations = ["namada_migrations", "linkme"]
 [dependencies]
 namada_account.workspace = true
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_macros.workspace = true
 namada_migrations = { workspace = true, optional = true }
 namada_state.workspace = true
 namada_systems.workspace = true
 namada_tx.workspace = true
-namada_vp_env = { workspace = true }
+namada_vp_env.workspace = true
 
 arbitrary = { workspace = true, optional = true }
 borsh.workspace = true
@@ -42,16 +42,16 @@ tracing.workspace = true
 
 
 [dev-dependencies]
-namada_core = { workspace = true, default-features = false, features = [
-    "testing",
-] }
+namada_core = { workspace = true, features = ["testing"] }
 namada_gas.workspace = true
 namada_parameters.workspace = true
 namada_proof_of_stake = { workspace = true, features = ["testing"] }
 namada_state = { workspace = true, features = ["testing"] }
 namada_token = { workspace = true, features = ["testing"] }
 namada_tx = { workspace = true, features = ["testing"] }
-namada_vm = { workspace = true, features = ["testing"] }
+namada_vm = { workspace = true, default-features = true, features = [
+    "testing",
+] }
 namada_vp.workspace = true
 
 assert_matches.workspace = true

--- a/crates/governance/Cargo.toml
+++ b/crates/governance/Cargo.toml
@@ -15,26 +15,23 @@ version.workspace = true
 [features]
 testing = ["proptest"]
 arbitrary = ["dep:arbitrary", "namada_core/arbitrary"]
-migrations = [
-    "namada_migrations",
-    "linkme",
-]
+migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
-namada_account = { path = "../account" }
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_macros = { path = "../macros" }
-namada_migrations = { path= "../migrations", optional = true }
-namada_state = { path = "../state" }
-namada_systems = { path = "../systems" }
-namada_tx = { path = "../tx" }
-namada_vp_env = { path = "../vp_env" }
+namada_account.workspace = true
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_state.workspace = true
+namada_systems.workspace = true
+namada_tx.workspace = true
+namada_vp_env = { workspace = true }
 
 arbitrary = { workspace = true, optional = true }
 borsh.workspace = true
 itertools.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 konst.workspace = true
 proptest = { workspace = true, optional = true }
 serde_json.workspace = true
@@ -45,15 +42,17 @@ tracing.workspace = true
 
 
 [dev-dependencies]
-namada_core = { path = "../core", default-features = false, features = ["testing"] }
-namada_gas = { path = "../gas" }
-namada_parameters = { path = "../parameters" }
-namada_proof_of_stake = { path = "../proof_of_stake", features = ["testing"] }
-namada_state = { path = "../state", features = ["testing"] }
-namada_token = { path = "../token", features = ["testing"] }
-namada_tx = { path = "../tx", features = ["testing"] }
-namada_vm = { path = "../vm", features = ["testing"] }
-namada_vp = { path = "../vp" }
+namada_core = { workspace = true, default-features = false, features = [
+    "testing",
+] }
+namada_gas.workspace = true
+namada_parameters.workspace = true
+namada_proof_of_stake = { workspace = true, features = ["testing"] }
+namada_state = { workspace = true, features = ["testing"] }
+namada_token = { workspace = true, features = ["testing"] }
+namada_tx = { workspace = true, features = ["testing"] }
+namada_vm = { workspace = true, features = ["testing"] }
+namada_vp.workspace = true
 
 assert_matches.workspace = true
 proptest.workspace = true

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -25,7 +25,7 @@ arbitrary = ["dep:arbitrary", "namada_core/arbitrary", "namada_token/arbitrary"]
 
 [dependencies]
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_gas.workspace = true
 namada_macros.workspace = true
 namada_migrations = { workspace = true, optional = true }
@@ -67,7 +67,9 @@ namada_proof_of_stake = { workspace = true, features = ["testing"] }
 namada_state = { workspace = true, features = ["testing"] }
 namada_token.workspace = true
 namada_tx = { workspace = true, features = ["testing"] }
-namada_vm = { workspace = true, features = ["testing"] }
+namada_vm = { workspace = true, default-features = true, features = [
+  "testing",
+] }
 
 assert_matches.workspace = true
 ibc-testkit.workspace = true

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -14,10 +14,7 @@ version.workspace = true
 
 [features]
 default = []
-migrations = [
-  "namada_migrations",
-  "linkme",
-]
+migrations = ["namada_migrations", "linkme"]
 testing = [
   "namada_core/testing",
   "namada_state/testing",
@@ -27,29 +24,29 @@ testing = [
 arbitrary = ["dep:arbitrary", "namada_core/arbitrary", "namada_token/arbitrary"]
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_gas = { path = "../gas" }
-namada_macros = {path = "../macros"}
-namada_migrations = {path = "../migrations", optional = true}
-namada_state = { path = "../state" }
-namada_systems = { path = "../systems" }
-namada_tx = { path = "../tx" }
-namada_vp = { path = "../vp" }
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_gas.workspace = true
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_state.workspace = true
+namada_systems.workspace = true
+namada_tx.workspace = true
+namada_vp.workspace = true
 
 arbitrary = { workspace = true, optional = true }
 borsh.workspace = true
 data-encoding.workspace = true
 dur.workspace = true
 konst.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 ibc.workspace = true
 ibc-derive.workspace = true
 ibc-middleware-module.workspace = true
 ibc-middleware-module-macros.workspace = true
 ibc-middleware-overflow-receive.workspace = true
 ibc-middleware-packet-forward.workspace = true
-ibc-testkit = {workspace = true, optional = true}
+ibc-testkit = { workspace = true, optional = true }
 ics23.workspace = true
 masp_primitives.workspace = true
 primitive-types.workspace = true
@@ -63,14 +60,14 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
-namada_governance = { path = "../governance" }
-namada_parameters = { path = "../parameters", features = ["testing"] }
-namada_proof_of_stake = { path = "../proof_of_stake", features = ["testing"] }
-namada_state = { path = "../state", features = ["testing"] }
-namada_token = { path = "../token" }
-namada_tx = { path = "../tx", features = ["testing"] }
-namada_vm = { path = "../vm", features = ["testing"] }
+namada_core = { workspace = true, features = ["testing"] }
+namada_governance.workspace = true
+namada_parameters = { workspace = true, features = ["testing"] }
+namada_proof_of_stake = { workspace = true, features = ["testing"] }
+namada_state = { workspace = true, features = ["testing"] }
+namada_token.workspace = true
+namada_tx = { workspace = true, features = ["testing"] }
+namada_vm = { workspace = true, features = ["testing"] }
 
 assert_matches.workspace = true
 ibc-testkit.workspace = true

--- a/crates/io/Cargo.toml
+++ b/crates/io/Cargo.toml
@@ -16,7 +16,8 @@ version.workspace = true
 async-send = []
 
 [dependencies]
-namada_core = { path = "../core" }
+namada_core.workspace = true
+
 async-trait.workspace = true
 tendermint-rpc.workspace = true
 thiserror.workspace = true

--- a/crates/light_sdk/Cargo.toml
+++ b/crates/light_sdk/Cargo.toml
@@ -12,18 +12,16 @@ readme.workspace = true
 repository.workspace = true
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 blocking = ["tokio"]
 namada-eth-bridge = ["namada_sdk/namada-eth-bridge"]
 
 [dependencies]
-namada_sdk = { path = "../sdk" }
+namada_sdk.workspace = true
 
 borsh.workspace = true
 prost.workspace = true
 tendermint-config.workspace = true
 tendermint-rpc = { workspace = true, features = ["http-client"] }
-tokio = {workspace = true, features = ["rt"], optional = true}
+tokio = { workspace = true, features = ["rt"], optional = true }
 serde_json = "1.0.108"

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 data-encoding.workspace = true
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = {version="1.0", features = ["full", "extra-traits"]}
+syn = { version = "1.0", features = ["full", "extra-traits"] }
 sha2.workspace = true
 
 [dev-dependencies]

--- a/crates/merkle_tree/Cargo.toml
+++ b/crates/merkle_tree/Cargo.toml
@@ -13,27 +13,24 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-migrations = [
-    "namada_migrations",
-    "linkme",
-]
+migrations = ["namada_migrations", "linkme"]
 testing = ["namada_core/testing"]
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_macros = { path = "../macros" }
-namada_migrations = { path = "../migrations", optional = true }
+namada_core.workspace = true
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
 
 arse-merkle-tree.workspace = true
 borsh.workspace = true
 eyre.workspace = true
 ics23.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 prost.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
+namada_core = { workspace = true, features = ["testing"] }
 
 assert_matches.workspace = true
 proptest.workspace = true

--- a/crates/migrations/Cargo.toml
+++ b/crates/migrations/Cargo.toml
@@ -12,10 +12,8 @@ readme.workspace = true
 repository.workspace = true
 version.workspace = true
 
-[lib]
-
 [dependencies]
-namada_macros = { path = "../macros" }
+namada_macros.workspace = true
 
 lazy_static.workspace = true
 linkme.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -34,13 +34,15 @@ migrations = ["namada_migrations", "namada_sdk/migrations", "linkme"]
 namada-eth-bridge = ["namada_sdk/namada-eth-bridge"]
 
 [dependencies]
-namada_apps_lib = { workspace = true }
+namada_apps_lib.workspace = true
 namada_migrations = { workspace = true, optional = true }
-namada_replay_protection = { workspace = true }
-namada_sdk = { workspace = true, features = ["wasm-runtime"] }
+namada_replay_protection.workspace = true
+namada_sdk = { workspace = true, default-features = true, features = [
+  "wasm-runtime",
+] }
 namada_test_utils = { workspace = true, optional = true }
 namada_vm.workspace = true
-namada_vote_ext = { workspace = true }
+namada_vote_ext.workspace = true
 namada_vp.workspace = true
 
 arse-merkle-tree = { workspace = true, features = ["blake2b"] }
@@ -103,8 +105,10 @@ zstd.workspace = true
 
 [dev-dependencies]
 namada_apps_lib = { workspace = true, features = ["testing"] }
-namada_test_utils = { workspace = true }
-namada_vm = { workspace = true, features = ["testing"] }
+namada_test_utils.workspace = true
+namada_vm = { workspace = true, default-features = true, features = [
+  "testing",
+] }
 
 assert_matches.workspace = true
 clap.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -14,9 +14,7 @@ version.workspace = true
 
 [features]
 default = ["migrations"]
-mainnet = [
-  "namada_sdk/mainnet",
-]
+mainnet = ["namada_sdk/mainnet"]
 # for tests and test utilities
 testing = [
   "namada_apps_lib/testing",
@@ -29,27 +27,21 @@ benches = [
   "namada_apps_lib/benches",
   "namada_test_utils",
   "tracing-subscriber",
-  "rand_core"
+  "rand_core",
 ]
 jemalloc = ["rocksdb/jemalloc"]
-migrations = [
-  "namada_migrations",
-  "namada_sdk/migrations",
-  "linkme",
-]
-namada-eth-bridge = [
-  "namada_sdk/namada-eth-bridge",
-]
+migrations = ["namada_migrations", "namada_sdk/migrations", "linkme"]
+namada-eth-bridge = ["namada_sdk/namada-eth-bridge"]
 
 [dependencies]
-namada_apps_lib = {path = "../apps_lib"}
-namada_migrations = {path = "../migrations", optional = true}
-namada_replay_protection = {path = "../replay_protection"}
-namada_sdk = {path = "../sdk", features = ["wasm-runtime"]}
-namada_test_utils = {path = "../test_utils", optional = true}
-namada_vm = {path = "../vm"}
-namada_vote_ext = { path = "../vote_ext" }
-namada_vp = {path = "../vp"}
+namada_apps_lib = { workspace = true }
+namada_migrations = { workspace = true, optional = true }
+namada_replay_protection = { workspace = true }
+namada_sdk = { workspace = true, features = ["wasm-runtime"] }
+namada_test_utils = { workspace = true, optional = true }
+namada_vm.workspace = true
+namada_vote_ext = { workspace = true }
+namada_vp.workspace = true
 
 arse-merkle-tree = { workspace = true, features = ["blake2b"] }
 async-trait.workspace = true
@@ -72,7 +64,10 @@ itertools.workspace = true
 lazy_static = { workspace = true, optional = true }
 linkme = { workspace = true, optional = true }
 masp_primitives = { workspace = true, features = ["transparent-inputs"] }
-masp_proofs = { workspace = true, features = ["bundled-prover", "download-params"] }
+masp_proofs = { workspace = true, features = [
+  "bundled-prover",
+  "download-params",
+] }
 num_cpus.workspace = true
 num256.workspace = true
 num-rational.workspace = true
@@ -85,30 +80,35 @@ rayon.workspace = true
 regex.workspace = true
 rlimit.workspace = true
 rocksdb.workspace = true
-serde_json = {workspace = true, features = ["raw_value"]}
+serde_json = { workspace = true, features = ["raw_value"] }
 sha2.workspace = true
 smooth-operator.workspace = true
 sysinfo.workspace = true
 tar.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
-tokio = {workspace = true, features = ["full"]}
+tokio = { workspace = true, features = ["full"] }
 toml.workspace = true
 tower-abci.workspace = true
 tower.workspace = true
-tracing-subscriber = { workspace = true, optional = true, features = ["std", "json", "ansi", "tracing-log"]}
+tracing-subscriber = { workspace = true, optional = true, features = [
+  "std",
+  "json",
+  "ansi",
+  "tracing-log",
+] }
 tracing.workspace = true
 warp = "0.3.2"
 zstd.workspace = true
 
 [dev-dependencies]
-namada_apps_lib = {path = "../apps_lib", features = ["testing"]}
-namada_test_utils = {path = "../test_utils"}
-namada_vm = {path = "../vm", features = ["testing"]}
+namada_apps_lib = { workspace = true, features = ["testing"] }
+namada_test_utils = { workspace = true }
+namada_vm = { workspace = true, features = ["testing"] }
 
 assert_matches.workspace = true
 clap.workspace = true
-lazy_static.workspace= true
+lazy_static.workspace = true
 proptest.workspace = true
 rand = { workspace = true, features = ["std"] }
 test-log.workspace = true

--- a/crates/parameters/Cargo.toml
+++ b/crates/parameters/Cargo.toml
@@ -14,21 +14,18 @@ version.workspace = true
 
 [features]
 default = []
-testing = [
-    "namada_core/testing",
-    "namada_state/testing",
-]
+testing = ["namada_core/testing", "namada_state/testing"]
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_macros = { path = "../macros" }
-namada_state = { path = "../state" }
-namada_systems = { path = "../systems" }
-namada_tx = { path = "../tx" }
-namada_vp_env = { path = "../vp_env" }
+namada_core.workspace = true
+namada_macros.workspace = true
+namada_state.workspace = true
+namada_systems.workspace = true
+namada_tx.workspace = true
+namada_vp_env.workspace = true
 
 smooth-operator.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-namada_state = { path = "../state", features = ["testing"] }
+namada_state = { workspace = true, features = ["testing"] }

--- a/crates/proof_of_stake/Cargo.toml
+++ b/crates/proof_of_stake/Cargo.toml
@@ -22,7 +22,7 @@ migrations = ["namada_migrations", "linkme"]
 namada_account.workspace = true
 namada_controller.workspace = true
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_macros.workspace = true
 namada_migrations = { workspace = true, optional = true }
 namada_state.workspace = true
@@ -47,7 +47,7 @@ namada_events = { workspace = true, features = ["testing"] }
 namada_governance.workspace = true
 namada_parameters.workspace = true
 namada_state = { workspace = true, features = ["testing"] }
-namada_trans_token = { workspace = true }
+namada_trans_token.workspace = true
 
 assert_matches.workspace = true
 itertools.workspace = true

--- a/crates/proof_of_stake/Cargo.toml
+++ b/crates/proof_of_stake/Cargo.toml
@@ -16,27 +16,24 @@ version.workspace = true
 default = []
 # testing helpers
 testing = ["proptest"]
-migrations = [
-    "namada_migrations",
-    "linkme",
-]
+migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
-namada_account = { path = "../account" }
-namada_controller = { path = "../controller" }
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_macros = { path = "../macros" }
-namada_migrations = { path = "../migrations", optional = true }
-namada_state = { path = "../state" }
-namada_systems = { path = "../systems" }
-namada_tx = { path = "../tx" }
-namada_vp_env = { path = "../vp_env" }
+namada_account.workspace = true
+namada_controller.workspace = true
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_state.workspace = true
+namada_systems.workspace = true
+namada_tx.workspace = true
+namada_vp_env.workspace = true
 
 borsh.workspace = true
 konst.workspace = true
 itertools.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 once_cell.workspace = true
 proptest = { workspace = true, optional = true }
 serde.workspace = true
@@ -44,14 +41,13 @@ smooth-operator.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
-namada_events = { path = "../events", features = ["testing"] }
-namada_governance = { path = "../governance" }
-namada_parameters = { path = "../parameters" }
-namada_state = { path = "../state", features = ["testing"] }
-namada_trans_token = { path = "../trans_token" }
+namada_core = { workspace = true, features = ["testing"] }
+namada_events = { workspace = true, features = ["testing"] }
+namada_governance.workspace = true
+namada_parameters.workspace = true
+namada_state = { workspace = true, features = ["testing"] }
+namada_trans_token = { workspace = true }
 
 assert_matches.workspace = true
 itertools.workspace = true

--- a/crates/replay_protection/Cargo.toml
+++ b/crates/replay_protection/Cargo.toml
@@ -12,6 +12,5 @@ readme.workspace = true
 repository.workspace = true
 version.workspace = true
 
-
 [dependencies]
-namada_core = { path = "../core" }
+namada_core.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -72,7 +72,7 @@ migrations = [
 [dependencies]
 namada_account.workspace = true
 namada_core.workspace = true
-namada_ethereum_bridge = { workspace = true, default-features = false }
+namada_ethereum_bridge.workspace = true
 namada_events.workspace = true
 namada_gas.workspace = true
 namada_governance.workspace = true
@@ -81,13 +81,13 @@ namada_io.workspace = true
 namada_macros.workspace = true
 namada_migrations = { workspace = true, optional = true }
 namada_parameters.workspace = true
-namada_proof_of_stake = { workspace = true }
+namada_proof_of_stake.workspace = true
 namada_state.workspace = true
 namada_storage.workspace = true
 namada_token = { workspace = true, features = ["masp"] }
 namada_tx.workspace = true
 namada_vm = { workspace = true, default-features = false }
-namada_vote_ext = { workspace = true }
+namada_vote_ext.workspace = true
 namada_vp.workspace = true
 namada_wallet.workspace = true
 
@@ -148,25 +148,18 @@ tokio = { workspace = true, default-features = false, features = ["sync"] }
 
 [dev-dependencies]
 namada_account = { workspace = true, features = ["testing"] }
-namada_core = { workspace = true, default-features = false, features = [
-  "rand",
-  "testing",
-] }
-namada_ethereum_bridge = { workspace = true, default-features = false, features = [
-  "testing",
-] }
+namada_core = { workspace = true, features = ["rand", "testing"] }
+namada_ethereum_bridge = { workspace = true, features = ["testing"] }
 namada_governance = { workspace = true, features = ["testing"] }
 namada_ibc = { workspace = true, features = ["testing"] }
 namada_parameters.workspace = true
-namada_proof_of_stake = { workspace = true, default-features = false, features = [
-  "testing",
-] }
+namada_proof_of_stake = { workspace = true, features = ["testing"] }
 namada_state = { workspace = true, features = ["testing"] }
 namada_storage = { workspace = true, features = ["testing"] }
 namada_token = { workspace = true, features = ["testing", "masp"] }
 namada_tx = { workspace = true, features = ["testing"] }
 namada_vm.workspace = true
-namada_vote_ext = { workspace = true }
+namada_vote_ext.workspace = true
 namada_vp.workspace = true
 
 assert_matches.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -12,11 +12,13 @@ readme.workspace = true
 repository.workspace = true
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 default = ["std"]
-mainnet = ["namada_core/mainnet", "namada_events/mainnet", "namada_token/mainnet"]
+mainnet = [
+  "namada_core/mainnet",
+  "namada_events/mainnet",
+  "namada_token/mainnet",
+]
 multicore = ["masp_proofs/multicore", "namada_token/multicore"]
 std = ["fd-lock", "download-params", "namada_token/std", "namada_wallet/std"]
 async-send = ["namada_io/async-send"]
@@ -68,26 +70,26 @@ migrations = [
 ]
 
 [dependencies]
-namada_account = { path = "../account" }
-namada_core = { path = "../core" }
-namada_ethereum_bridge = { path = "../ethereum_bridge", default-features = false }
-namada_events = { path = "../events" }
-namada_gas = { path = "../gas" }
-namada_governance = { path = "../governance" }
-namada_ibc = { path = "../ibc" }
-namada_io = { path = "../io" }
-namada_macros = { path = "../macros" }
-namada_migrations = { path = "../migrations", optional = true }
-namada_parameters = { path = "../parameters" }
-namada_proof_of_stake = { path = "../proof_of_stake" }
-namada_state = { path = "../state" }
-namada_storage = { path = "../storage" }
-namada_token = { path = "../token", features = ["masp"] }
-namada_tx = { path = "../tx" }
-namada_vm = { path = "../vm", default-features = false }
-namada_vote_ext = { path = "../vote_ext" }
-namada_vp = { path = "../vp" }
-namada_wallet = {path = "../wallet" }
+namada_account.workspace = true
+namada_core.workspace = true
+namada_ethereum_bridge = { workspace = true, default-features = false }
+namada_events.workspace = true
+namada_gas.workspace = true
+namada_governance.workspace = true
+namada_ibc.workspace = true
+namada_io.workspace = true
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_parameters.workspace = true
+namada_proof_of_stake = { workspace = true }
+namada_state.workspace = true
+namada_storage.workspace = true
+namada_token = { workspace = true, features = ["masp"] }
+namada_tx.workspace = true
+namada_vm = { workspace = true, default-features = false }
+namada_vote_ext = { workspace = true }
+namada_vp.workspace = true
+namada_wallet.workspace = true
 
 arbitrary = { workspace = true, optional = true }
 async-trait.workspace = true
@@ -108,7 +110,7 @@ init-once.workspace = true
 itertools.workspace = true
 jubjub = { workspace = true, optional = true }
 lazy_static.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 masp_primitives.workspace = true
 masp_proofs.workspace = true
 num256.workspace = true
@@ -145,27 +147,27 @@ tokio = { workspace = true, features = ["full"] }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 
 [dev-dependencies]
-namada_account = { path = "../account", features = ["testing"]}
-namada_core = { path = "../core", default-features = false, features = [
+namada_account = { workspace = true, features = ["testing"] }
+namada_core = { workspace = true, default-features = false, features = [
   "rand",
   "testing",
 ] }
-namada_ethereum_bridge = { path = "../ethereum_bridge", default-features = false, features = [
+namada_ethereum_bridge = { workspace = true, default-features = false, features = [
   "testing",
 ] }
-namada_governance = { path = "../governance", features = ["testing"] }
-namada_ibc = { path = "../ibc", features = ["testing"] }
-namada_parameters = {path = "../parameters"}
-namada_proof_of_stake = { path = "../proof_of_stake", default-features = false, features = [
+namada_governance = { workspace = true, features = ["testing"] }
+namada_ibc = { workspace = true, features = ["testing"] }
+namada_parameters.workspace = true
+namada_proof_of_stake = { workspace = true, default-features = false, features = [
   "testing",
 ] }
-namada_state = { path = "../state", features = ["testing"] }
-namada_storage = { path = "../storage", features = ["testing"] }
-namada_token = { path = "../token", features = ["testing", "masp"] }
-namada_tx = { path = "../tx", features = ["testing"]}
-namada_vm = { path = "../vm" }
-namada_vote_ext = { path = "../vote_ext" }
-namada_vp = { path = "../vp" }
+namada_state = { workspace = true, features = ["testing"] }
+namada_storage = { workspace = true, features = ["testing"] }
+namada_token = { workspace = true, features = ["testing", "masp"] }
+namada_tx = { workspace = true, features = ["testing"] }
+namada_vm.workspace = true
+namada_vote_ext = { workspace = true }
+namada_vp.workspace = true
 
 assert_matches.workspace = true
 

--- a/crates/shielded_token/Cargo.toml
+++ b/crates/shielded_token/Cargo.toml
@@ -25,7 +25,7 @@ testing = [
   "namada_tx/testing",
   "masp_primitives/test-dependencies",
   "proptest",
-  "std"
+  "std",
 ]
 download-params = ["masp_proofs/download-params"]
 masp = [
@@ -37,19 +37,19 @@ masp = [
 ]
 
 [dependencies]
-namada_account = { path = "../account" }
-namada_controller = { path = "../controller" }
-namada_core = { path = "../core"}
-namada_events = {path = "../events" }
-namada_gas = { path = "../gas" }
-namada_io = { path = "../io", optional = true }
-namada_macros = {path = "../macros" }
-namada_migrations = { path = "../migrations", optional = true }
-namada_state = { path = "../state" }
-namada_systems = { path = "../systems" }
-namada_tx = { path = "../tx" }
-namada_vp_env = { path = "../vp_env" }
-namada_wallet = { path = "../wallet", optional = true }
+namada_account.workspace = true
+namada_controller.workspace = true
+namada_core.workspace = true
+namada_events.workspace = true
+namada_gas.workspace = true
+namada_io = { workspace = true, optional = true }
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_state.workspace = true
+namada_systems.workspace = true
+namada_tx.workspace = true
+namada_vp_env = { workspace = true }
+namada_wallet = { workspace = true, optional = true }
 
 async-trait.workspace = true
 borsh.workspace = true
@@ -58,10 +58,10 @@ futures.workspace = true
 flume = { workspace = true, optional = true }
 itertools.workspace = true
 lazy_static.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 masp_primitives.workspace = true
 masp_proofs.workspace = true
-proptest = {workspace = true, optional = true}
+proptest = { workspace = true, optional = true }
 rand.workspace = true
 rand_core.workspace = true
 rayon = { workspace = true, optional = true }
@@ -78,14 +78,14 @@ xorf.workspace = true
 
 
 [dev-dependencies]
-namada_gas = { path = "../gas" }
-namada_governance = { path = "../governance", features = ["testing"] }
-namada_ibc = { path = "../ibc", features = ["testing"] }
-namada_parameters = { path = "../parameters", features = ["testing"] }
-namada_state = { path = "../state", features = ["testing"] }
-namada_trans_token = { path = "../trans_token" }
-namada_vm = { path = "../vm", features = ["testing"] }
-namada_vp = { path = "../vp" }
+namada_gas.workspace = true
+namada_governance = { workspace = true, features = ["testing"] }
+namada_ibc = { workspace = true, features = ["testing"] }
+namada_parameters = { workspace = true, features = ["testing"] }
+namada_state = { workspace = true, features = ["testing"] }
+namada_trans_token = { workspace = true }
+namada_vm = { workspace = true, features = ["testing"] }
+namada_vp.workspace = true
 
 lazy_static.workspace = true
 masp_primitives = { workspace = true, features = ["test-dependencies"] }

--- a/crates/shielded_token/Cargo.toml
+++ b/crates/shielded_token/Cargo.toml
@@ -48,7 +48,7 @@ namada_migrations = { workspace = true, optional = true }
 namada_state.workspace = true
 namada_systems.workspace = true
 namada_tx.workspace = true
-namada_vp_env = { workspace = true }
+namada_vp_env.workspace = true
 namada_wallet = { workspace = true, optional = true }
 
 async-trait.workspace = true
@@ -83,8 +83,10 @@ namada_governance = { workspace = true, features = ["testing"] }
 namada_ibc = { workspace = true, features = ["testing"] }
 namada_parameters = { workspace = true, features = ["testing"] }
 namada_state = { workspace = true, features = ["testing"] }
-namada_trans_token = { workspace = true }
-namada_vm = { workspace = true, features = ["testing"] }
+namada_trans_token.workspace = true
+namada_vm = { workspace = true, default-features = true, features = [
+  "testing",
+] }
 namada_vp.workspace = true
 
 lazy_static.workspace = true

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -31,21 +31,21 @@ migrations = [
 benches = []
 
 [dependencies]
-namada_core = { path = "../core", default-features = false }
-namada_events = { path = "../events", default-features = false }
-namada_gas = { path = "../gas" }
-namada_macros = { path = "../macros" }
-namada_merkle_tree = { path = "../merkle_tree" }
-namada_migrations = { path = "../migrations", optional = true }
-namada_replay_protection = { path = "../replay_protection" }
-namada_storage = { path = "../storage" }
-namada_systems = { path = "../systems" }
-namada_tx = { path = "../tx" }
+namada_core = { workspace = true, default-features = false }
+namada_events = { workspace = true, default-features = false }
+namada_gas.workspace = true
+namada_macros.workspace = true
+namada_merkle_tree = { workspace = true }
+namada_migrations = { workspace = true, optional = true }
+namada_replay_protection = { workspace = true }
+namada_storage.workspace = true
+namada_systems.workspace = true
+namada_tx.workspace = true
 
 borsh.workspace = true
 clru.workspace = true
 itertools.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 smooth-operator.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -53,9 +53,9 @@ patricia_tree.workspace = true
 proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
-namada_merkle_tree = { path = "../merkle_tree", features = ["testing"] }
-namada_parameters = { path = "../parameters", features = ["testing"] }
+namada_core = { workspace = true, features = ["testing"] }
+namada_merkle_tree = { workspace = true, features = ["testing"] }
+namada_parameters = { workspace = true, features = ["testing"] }
 
 assert_matches.workspace = true
 chrono.workspace = true

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -31,13 +31,13 @@ migrations = [
 benches = []
 
 [dependencies]
-namada_core = { workspace = true, default-features = false }
-namada_events = { workspace = true, default-features = false }
+namada_core.workspace = true
+namada_events.workspace = true
 namada_gas.workspace = true
 namada_macros.workspace = true
-namada_merkle_tree = { workspace = true }
+namada_merkle_tree.workspace = true
 namada_migrations = { workspace = true, optional = true }
-namada_replay_protection = { workspace = true }
+namada_replay_protection.workspace = true
 namada_storage.workspace = true
 namada_systems.workspace = true
 namada_tx.workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -14,25 +14,20 @@ version.workspace = true
 
 [features]
 default = []
-testing = [
-    "namada_core/testing",
-]
-migrations = [
-    "namada_migrations",
-    "linkme",
-]
+testing = ["namada_core/testing"]
+migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_gas = { path = "../gas" }
-namada_macros = { path = "../macros" }
-namada_merkle_tree = { path = "../merkle_tree" }
-namada_migrations = {path = "../migrations", optional = true }
-namada_replay_protection = { path = "../replay_protection" }
+namada_core.workspace = true
+namada_gas.workspace = true
+namada_macros.workspace = true
+namada_merkle_tree = { workspace = true }
+namada_migrations = { workspace = true, optional = true }
+namada_replay_protection = { workspace = true }
 
 borsh.workspace = true
 itertools.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 regex.workspace = true
 serde.workspace = true
 smooth-operator.workspace = true
@@ -40,4 +35,4 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
+namada_core = { workspace = true, features = ["testing"] }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -21,9 +21,9 @@ migrations = ["namada_migrations", "linkme"]
 namada_core.workspace = true
 namada_gas.workspace = true
 namada_macros.workspace = true
-namada_merkle_tree = { workspace = true }
+namada_merkle_tree.workspace = true
 namada_migrations = { workspace = true, optional = true }
-namada_replay_protection = { workspace = true }
+namada_replay_protection.workspace = true
 
 borsh.workspace = true
 itertools.workspace = true

--- a/crates/systems/Cargo.toml
+++ b/crates/systems/Cargo.toml
@@ -13,9 +13,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_events = { path = "../events" }
-namada_storage = { path = "../storage" }
+namada_core.workspace = true
+namada_events.workspace = true
+namada_storage.workspace = true
 
 [dev-dependencies]
 cargo_metadata.workspace = true

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -13,8 +13,9 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_state = { path = "../state" }
+namada_core.workspace = true
+namada_state.workspace = true
+
 borsh.workspace = true
 prost.workspace = true
 strum = {version = "0.24", features = ["derive"]}

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "namada_tests"
-description = "Namada integration and E2E tests"
+description = "Namada tests setup, integration and E2E tests"
 resolver = "2"
 authors.workspace = true
 edition.workspace = true
@@ -14,32 +14,31 @@ version.workspace = true
 
 [features]
 default = ["namada_sdk/std", "namada_sdk/masp"]
-mainnet = [
-  "namada_sdk/mainnet",
-]
-migrations = [
-  "namada_sdk/migrations",
-  "namada_core/migrations",
-]
+mainnet = ["namada_sdk/mainnet"]
+migrations = ["namada_sdk/migrations", "namada_core/migrations"]
 namada-eth-bridge = [
   "namada_sdk/namada-eth-bridge",
   "namada_apps_lib/namada-eth-bridge",
 ]
 
 [dependencies]
-namada_core = {path = "../core", features = ["testing"]}
-namada_sdk = {path = "../sdk", default-features=false, features = ["download-params", "testing", "wasm-runtime"]}
-namada_test_utils = {path = "../test_utils"}
-namada_tx_env = {path = "../tx_env"}
-namada_tx_prelude = {path = "../tx_prelude"}
-namada_vp = {path = "../vp"}
-namada_vp_prelude = {path = "../vp_prelude"}
-namada_vm = {path = "../vm", features = ["testing"]}
+namada_core = { workspace = true, features = ["testing"] }
+namada_sdk = { workspace = true, default-features = false, features = [
+  "download-params",
+  "testing",
+  "wasm-runtime",
+] }
+namada_test_utils.workspace = true
+namada_tx_env.workspace = true
+namada_tx_prelude.workspace = true
+namada_vp.workspace = true
+namada_vp_prelude.workspace = true
+namada_vm = { workspace = true, features = ["testing"] }
 
 concat-idents.workspace = true
 derivative.workspace = true
 dur.workspace = true
-hyper = {version = "0.14.20", features = ["full"]}
+hyper = { version = "0.14.20", features = ["full"] }
 ibc-middleware-packet-forward.workspace = true
 ibc-testkit.workspace = true
 ics23.workspace = true
@@ -53,16 +52,18 @@ serde_tuple.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 test-log.workspace = true
-tokio = {workspace = true, features = ["full"]}
+tokio = { workspace = true, features = ["full"] }
 wasmer.workspace = true
 
 [dev-dependencies]
-namada_apps_lib = {path = "../apps_lib", features = ["testing"]}
-namada_node = { path = "../node", features = ["testing"] }
-namada_sdk = {path = "../sdk", default-features = false, features = [
-  "download-params", "testing", "migrations"
-]}
-namada_vm_env = {path = "../vm_env"}
+namada_apps_lib = { workspace = true, features = ["testing"] }
+namada_node = { workspace = true, features = ["testing"] }
+namada_sdk = { workspace = true, default-features = false, features = [
+  "download-params",
+  "testing",
+  "migrations",
+] }
+namada_vm_env.workspace = true
 
 assert_cmd.workspace = true
 assert_matches.workspace = true
@@ -71,7 +72,7 @@ borsh.workspace = true
 color-eyre.workspace = true
 data-encoding.workspace = true
 # NOTE: enable "print" feature to see output from builds ran by e2e tests
-escargot = {workspace = true} # , features = ["print"]}
+escargot = { workspace = true }          # , features = ["print"]}
 expectrl.workspace = true
 eyre.workspace = true
 flate2.workspace = true

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -33,7 +33,9 @@ namada_tx_env.workspace = true
 namada_tx_prelude.workspace = true
 namada_vp.workspace = true
 namada_vp_prelude.workspace = true
-namada_vm = { workspace = true, features = ["testing"] }
+namada_vm = { workspace = true, default-features = true, features = [
+  "testing",
+] }
 
 concat-idents.workspace = true
 derivative.workspace = true
@@ -72,7 +74,7 @@ borsh.workspace = true
 color-eyre.workspace = true
 data-encoding.workspace = true
 # NOTE: enable "print" feature to see output from builds ran by e2e tests
-escargot = { workspace = true }          # , features = ["print"]}
+escargot.workspace = true          # , features = ["print"]}
 expectrl.workspace = true
 eyre.workspace = true
 flate2.workspace = true

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -74,7 +74,7 @@ borsh.workspace = true
 color-eyre.workspace = true
 data-encoding.workspace = true
 # NOTE: enable "print" feature to see output from builds ran by e2e tests
-escargot.workspace = true          # , features = ["print"]}
+escargot = { workspace = true } # , features = ["print"] }
 expectrl.workspace = true
 eyre.workspace = true
 flate2.workspace = true

--- a/crates/token/Cargo.toml
+++ b/crates/token/Cargo.toml
@@ -20,34 +20,38 @@ masp = ["namada_shielded_token/masp"]
 migrations = ["namada_migrations", "namada_shielded_token/migrations", "linkme"]
 multicore = ["namada_shielded_token/multicore"]
 download-params = ["namada_shielded_token/download-params"]
-testing = ["namada_core/testing", "namada_shielded_token/testing", "proptest", "masp_primitives"]
+testing = [
+    "namada_core/testing",
+    "namada_shielded_token/testing",
+    "proptest",
+    "masp_primitives",
+]
 arbitrary = ["dep:arbitrary", "namada_core/arbitrary"]
 
 [dependencies]
-masp_primitives = {workspace = true, optional = true }
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_macros = { path = "../macros" }
-namada_migrations = { path = "../migrations", optional = true }
-namada_shielded_token = { path = "../shielded_token" }
-namada_storage = { path = "../storage" }
-namada_systems = { path = "../systems" }
-namada_trans_token = { path = "../trans_token" }
-namada_tx = { path = "../tx" }
-namada_tx_env = { path = "../tx_env" }
+masp_primitives = { workspace = true, optional = true }
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_shielded_token.workspace = true
+namada_storage.workspace = true
+namada_systems.workspace = true
+namada_trans_token.workspace = true
+namada_tx.workspace = true
+namada_tx_env.workspace = true
 
 arbitrary = { workspace = true, optional = true }
 borsh.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 serde.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
-namada_shielded_token = { path = "../shielded_token", features = ["testing"] }
-namada_tests = { path = "../tests" }
+namada_core = { workspace = true, features = ["testing"] }
+namada_shielded_token = { workspace = true, features = ["testing"] }
+namada_tests.workspace = true
 
 masp_primitives.workspace = true
 
 proptest.workspace = true
-

--- a/crates/token/Cargo.toml
+++ b/crates/token/Cargo.toml
@@ -31,7 +31,7 @@ arbitrary = ["dep:arbitrary", "namada_core/arbitrary"]
 [dependencies]
 masp_primitives = { workspace = true, optional = true }
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_macros.workspace = true
 namada_migrations = { workspace = true, optional = true }
 namada_shielded_token.workspace = true

--- a/crates/trans_token/Cargo.toml
+++ b/crates/trans_token/Cargo.toml
@@ -18,7 +18,7 @@ migrations = ["linkme"]
 
 [dependencies]
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_state.workspace = true
 namada_systems.workspace = true
 namada_tx.workspace = true
@@ -39,7 +39,9 @@ namada_parameters = { workspace = true, features = ["testing"] }
 namada_state = { workspace = true, features = ["testing"] }
 namada_tests.workspace = true
 namada_tx = { workspace = true, features = ["testing"] }
-namada_vm = { workspace = true, features = ["testing"] }
+namada_vm = { workspace = true, default-features = true, features = [
+    "testing",
+] }
 namada_vp.workspace = true
 
 assert_matches.workspace = true

--- a/crates/trans_token/Cargo.toml
+++ b/crates/trans_token/Cargo.toml
@@ -14,35 +14,33 @@ version.workspace = true
 
 [features]
 default = []
-migrations = [
-    "linkme"
-]
+migrations = ["linkme"]
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_state = { path = "../state" }
-namada_systems = { path = "../systems" }
-namada_tx = { path = "../tx" }
-namada_tx_env = { path = "../tx_env" }
-namada_vp_env = { path = "../vp_env" }
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_state.workspace = true
+namada_systems.workspace = true
+namada_tx.workspace = true
+namada_tx_env.workspace = true
+namada_vp_env.workspace = true
 
 konst.workspace = true
-linkme = {workspace =  true, optional = true}
+linkme = { workspace = true, optional = true }
 thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
-namada_gas = { path = "../gas" }
-namada_governance = { path = "../governance", features = ["testing"] }
-namada_ibc = { path = "../ibc", features = ["testing"] }
-namada_parameters = { path = "../parameters", features = ["testing"] }
-namada_state = { path = "../state", features = ["testing"] }
-namada_tests = { path = "../tests" }
-namada_tx = { path = "../tx", features = ["testing"] }
-namada_vm = { path = "../vm", features = ["testing"] }
-namada_vp = { path = "../vp" }
+namada_core = { workspace = true, features = ["testing"] }
+namada_gas.workspace = true
+namada_governance = { workspace = true, features = ["testing"] }
+namada_ibc = { workspace = true, features = ["testing"] }
+namada_parameters = { workspace = true, features = ["testing"] }
+namada_state = { workspace = true, features = ["testing"] }
+namada_tests.workspace = true
+namada_tx = { workspace = true, features = ["testing"] }
+namada_vm = { workspace = true, features = ["testing"] }
+namada_vp.workspace = true
 
 assert_matches.workspace = true
 itertools.workspace = true

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -15,19 +15,20 @@ version.workspace = true
 [features]
 default = []
 testing = ["proptest", "namada_account/testing", "namada_core/testing"]
-migrations = [
-    "namada_migrations",
-    "linkme",
+migrations = ["namada_migrations", "linkme"]
+arbitrary = [
+    "dep:arbitrary",
+    "namada_account/arbitrary",
+    "namada_core/arbitrary",
 ]
-arbitrary = ["dep:arbitrary", "namada_account/arbitrary", "namada_core/arbitrary"]
 
 [dependencies]
-namada_account = { path = "../account" }
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_gas = { path = "../gas" }
-namada_macros = { path = "../macros" }
-namada_migrations = {path = "../migrations", optional = true }
+namada_account.workspace = true
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_gas.workspace = true
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
 
 arbitrary = { workspace = true, optional = true }
 ark-bls12-381.workspace = true
@@ -36,7 +37,7 @@ borsh.workspace = true
 data-encoding.workspace = true
 either.workspace = true
 konst.workspace = true
-linkme = {workspace = true, optional = true}
+linkme = { workspace = true, optional = true }
 masp_primitives.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true
@@ -50,7 +51,7 @@ sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
+namada_core = { workspace = true, features = ["testing"] }
 
 assert_matches.workspace = true
 proptest.workspace = true

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -25,7 +25,7 @@ arbitrary = [
 [dependencies]
 namada_account.workspace = true
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_gas.workspace = true
 namada_macros.workspace = true
 namada_migrations = { workspace = true, optional = true }

--- a/crates/tx_env/Cargo.toml
+++ b/crates/tx_env/Cargo.toml
@@ -14,5 +14,5 @@ version.workspace = true
 
 [dependencies]
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_storage.workspace = true

--- a/crates/tx_env/Cargo.toml
+++ b/crates/tx_env/Cargo.toml
@@ -13,6 +13,6 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_storage = { path = "../storage" }
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_storage.workspace = true

--- a/crates/tx_prelude/Cargo.toml
+++ b/crates/tx_prelude/Cargo.toml
@@ -19,7 +19,7 @@ testing = ["namada_core/testing", "namada_token/testing"]
 [dependencies]
 namada_account.workspace = true
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_gas.workspace = true
 namada_governance.workspace = true
 namada_ibc.workspace = true
@@ -28,7 +28,7 @@ namada_parameters.workspace = true
 namada_proof_of_stake.workspace = true
 namada_state.workspace = true
 namada_token.workspace = true
-namada_tx = { workspace = true, default-features = false }
+namada_tx.workspace = true
 namada_tx_env.workspace = true
 namada_vm_env.workspace = true
 

--- a/crates/tx_prelude/Cargo.toml
+++ b/crates/tx_prelude/Cargo.toml
@@ -17,22 +17,22 @@ default = []
 testing = ["namada_core/testing", "namada_token/testing"]
 
 [dependencies]
-namada_account = { path = "../account" }
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_gas = { path = "../gas" }
-namada_governance = { path = "../governance" }
-namada_ibc = { path = "../ibc" }
-namada_macros = { path = "../macros" }
-namada_parameters = { path = "../parameters" }
-namada_proof_of_stake = { path = "../proof_of_stake" }
-namada_state = { path = "../state" }
-namada_token = { path = "../token" }
-namada_tx = { path = "../tx", default-features = false }
-namada_tx_env = { path = "../tx_env" }
-namada_vm_env = { path = "../vm_env" }
+namada_account.workspace = true
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_gas.workspace = true
+namada_governance.workspace = true
+namada_ibc.workspace = true
+namada_macros.workspace = true
+namada_parameters.workspace = true
+namada_proof_of_stake.workspace = true
+namada_state.workspace = true
+namada_token.workspace = true
+namada_tx = { workspace = true, default-features = false }
+namada_tx_env.workspace = true
+namada_vm_env.workspace = true
 
 borsh.workspace = true
 
 [dev-dependencies]
-namada_token = { path = "../token", features = ["testing"] }
+namada_token = { workspace = true, features = ["testing"] }

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -28,7 +28,7 @@ testing = ["namada_account/testing", "namada_core/testing", "tempfile"]
 [dependencies]
 namada_account.workspace = true
 namada_core = { workspace = true, features = ["control_flow"] }
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_gas.workspace = true
 namada_parameters.workspace = true
 namada_state.workspace = true
@@ -52,7 +52,7 @@ wasmer-vm = { workspace = true, optional = true }
 wasmparser.workspace = true
 
 [dev-dependencies]
-namada_core = { workspace = true, default-features = false, features = [
+namada_core = { workspace = true, features = [
   "testing",
 ] }
 namada_state = { workspace = true, features = ["testing"] }
@@ -64,5 +64,5 @@ byte-unit.workspace = true
 itertools.workspace = true
 tempfile.workspace = true
 test-log.workspace = true
-wasmer-compiler = { workspace = true }
-wasmer-types = { workspace = true }
+wasmer-compiler.workspace = true
+wasmer-types.workspace = true

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -23,22 +23,18 @@ wasm-runtime = [
   "wasmer-vm",
   "wasmer",
 ]
-testing = [
-  "namada_account/testing",
-  "namada_core/testing",
-  "tempfile",
-]
+testing = ["namada_account/testing", "namada_core/testing", "tempfile"]
 
 [dependencies]
-namada_account = { path = "../account" }
-namada_core = { path = "../core", features = ["control_flow"] }
-namada_events = { path = "../events", default-features = false }
-namada_gas = { path = "../gas" }
-namada_parameters = { path = "../parameters" }
-namada_state = { path = "../state" }
-namada_token = { path = "../token" }
-namada_tx = { path = "../tx" }
-namada_vp = { path = "../vp" }
+namada_account.workspace = true
+namada_core = { workspace = true, features = ["control_flow"] }
+namada_events = { workspace = true, default-features = false }
+namada_gas.workspace = true
+namada_parameters.workspace = true
+namada_state.workspace = true
+namada_token.workspace = true
+namada_tx.workspace = true
+namada_vp.workspace = true
 
 borsh.workspace = true
 clru.workspace = true
@@ -56,12 +52,12 @@ wasmer-vm = { workspace = true, optional = true }
 wasmparser.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", default-features = false, features = [
+namada_core = { workspace = true, default-features = false, features = [
   "testing",
 ] }
-namada_state = { path = "../state", features = ["testing"] }
-namada_test_utils = { path = "../test_utils" }
-namada_tx = { path = "../tx", features = ["testing"] }
+namada_state = { workspace = true, features = ["testing"] }
+namada_test_utils.workspace = true
+namada_tx = { workspace = true, features = ["testing"] }
 
 assert_matches.workspace = true
 byte-unit.workspace = true

--- a/crates/vm_env/Cargo.toml
+++ b/crates/vm_env/Cargo.toml
@@ -16,4 +16,4 @@ version.workspace = true
 default = []
 
 [dependencies]
-namada_core = { path = "../core" }
+namada_core.workspace = true

--- a/crates/vote_ext/Cargo.toml
+++ b/crates/vote_ext/Cargo.toml
@@ -13,22 +13,19 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-migrations = [
-    "namada_migrations",
-    "linkme",
-]
+migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_macros = { path = "../macros" }
-namada_migrations = { path = "../migrations", optional = true }
-namada_tx = { path = "../tx" }
+namada_core.workspace = true
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
+namada_tx.workspace = true
 
 borsh.workspace = true
-linkme = {workspace = true, optional=true}
+linkme = { workspace = true, optional = true }
 serde.workspace = true
 
 [dev-dependencies]
-namada_core = { path = "../core", features = ["testing"] }
+namada_core = { workspace = true, features = ["testing"] }
 
 data-encoding.workspace = true

--- a/crates/vp/Cargo.toml
+++ b/crates/vp/Cargo.toml
@@ -17,7 +17,7 @@ testing = ["namada_core/testing"]
 
 [dependencies]
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_gas.workspace = true
 namada_state.workspace = true
 namada_tx.workspace = true

--- a/crates/vp/Cargo.toml
+++ b/crates/vp/Cargo.toml
@@ -16,12 +16,12 @@ version.workspace = true
 testing = ["namada_core/testing"]
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_gas = { path = "../gas" }
-namada_state = { path = "../state" }
-namada_tx = { path = "../tx" }
-namada_vp_env = { path = "../vp_env" }
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_gas.workspace = true
+namada_state.workspace = true
+namada_tx.workspace = true
+namada_vp_env.workspace = true
 
 smooth-operator.workspace = true
 thiserror.workspace = true

--- a/crates/vp_env/Cargo.toml
+++ b/crates/vp_env/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 [dependencies]
 namada_core.workspace = true
 namada_gas.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_storage.workspace = true
 namada_tx.workspace = true
 

--- a/crates/vp_env/Cargo.toml
+++ b/crates/vp_env/Cargo.toml
@@ -13,11 +13,11 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-namada_core = { path = "../core" }
-namada_gas = { path = "../gas" }
-namada_events = { path = "../events", default-features = false }
-namada_storage = { path = "../storage" }
-namada_tx = { path = "../tx" }
+namada_core.workspace = true
+namada_gas.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_storage.workspace = true
+namada_tx.workspace = true
 
 derivative.workspace = true
 masp_primitives.workspace = true

--- a/crates/vp_prelude/Cargo.toml
+++ b/crates/vp_prelude/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 [dependencies]
 namada_account.workspace = true
 namada_core.workspace = true
-namada_events = { workspace = true, default-features = false }
+namada_events.workspace = true
 namada_gas.workspace = true
 namada_governance.workspace = true
 namada_ibc.workspace = true
@@ -27,7 +27,7 @@ namada_parameters.workspace = true
 namada_proof_of_stake.workspace = true
 namada_storage.workspace = true
 namada_token.workspace = true
-namada_tx = { workspace = true, default-features = false }
+namada_tx.workspace = true
 namada_vm_env.workspace = true
 namada_vp_env.workspace = true
 

--- a/crates/vp_prelude/Cargo.toml
+++ b/crates/vp_prelude/Cargo.toml
@@ -16,20 +16,20 @@ version.workspace = true
 default = []
 
 [dependencies]
-namada_account = { path = "../account" }
-namada_core = { path = "../core" }
-namada_events = { path = "../events", default-features = false }
-namada_gas = { path = "../gas" }
-namada_governance = { path = "../governance" }
-namada_ibc = { path = "../ibc" }
-namada_macros = { path = "../macros" }
-namada_parameters = { path = "../parameters" }
-namada_proof_of_stake = { path = "../proof_of_stake" }
-namada_storage = { path = "../storage" }
-namada_token = { path = "../token" }
-namada_tx = { path = "../tx", default-features = false }
-namada_vm_env = { path = "../vm_env" }
-namada_vp_env = { path = "../vp_env" }
+namada_account.workspace = true
+namada_core.workspace = true
+namada_events = { workspace = true, default-features = false }
+namada_gas.workspace = true
+namada_governance.workspace = true
+namada_ibc.workspace = true
+namada_macros.workspace = true
+namada_parameters.workspace = true
+namada_proof_of_stake.workspace = true
+namada_storage.workspace = true
+namada_token.workspace = true
+namada_tx = { workspace = true, default-features = false }
+namada_vm_env.workspace = true
+namada_vp_env.workspace = true
 
 borsh.workspace = true
 sha2.workspace = true

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "namada_wallet"
-description = "Namada wallet"
+description = "Namada wallet library code"
 resolver = "2"
 authors.workspace = true
 edition.workspace = true
@@ -19,17 +19,17 @@ download-params = []
 migrations = ["namada_migrations"]
 
 [dependencies]
-namada_core = { path = "../core", features = ["rand"]}
-namada_ibc = {path = "../ibc" }
-namada_macros = { path = "../macros" }
-namada_migrations = {path = "../migrations", optional = true }
+namada_core = { workspace = true, features = ["rand"] }
+namada_ibc.workspace = true
+namada_macros.workspace = true
+namada_migrations = { workspace = true, optional = true }
 
 bimap.workspace = true
 borsh.workspace = true
 itertools.workspace = true
 derivation-path.workspace = true
 data-encoding.workspace = true
-fd-lock = {workspace = true, optional = true}
+fd-lock = { workspace = true, optional = true }
 masp_primitives.workspace = true
 orion.workspace = true
 rand.workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,17 +29,24 @@ namada-eth-bridge = ["namada_sdk/namada-eth-bridge"]
 
 [dev-dependencies]
 masp_primitives = { workspace = true, features = ["transparent-inputs"] }
-masp_proofs = { workspace = true, default-features = false, features = ["local-prover", "download-params"] }
-namada_apps_lib = {path = "../crates/apps_lib", features = ["migrations"]}
-namada_macros = {path = "../crates/macros"}
-namada_migrations = {path = "../crates/migrations"}
-namada_parameters = { path = "../crates/parameters"}
-namada_trans_token = {path = "../crates/trans_token", features = ["migrations"]}
-namada_sdk = { path = "../crates/sdk", default-features = false, features = ["std", "testing", "migrations"] }
-namada_shielded_token = { path = "../crates/shielded_token" }
+masp_proofs = { workspace = true, default-features = false, features = [
+    "local-prover",
+    "download-params",
+] }
+namada_apps_lib = { workspace = true, features = ["migrations"] }
+namada_macros = { workspace = true }
+namada_migrations = { workspace = true }
+namada_parameters = { workspace = true }
+namada_trans_token = { workspace = true, features = ["migrations"] }
+namada_sdk = { workspace = true, default-features = false, features = [
+    "std",
+    "testing",
+    "migrations",
+] }
+namada_shielded_token = { workspace = true }
 
 borsh.workspace = true
 data-encoding.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
-tokio = {workspace = true, default-features = false}
+tokio = { workspace = true, default-features = false }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-namada_apps_lib = { path = "../crates/apps_lib", features = ["testing"] }
-namada_core = { path = "../crates/core", features = ["testing"] }
-namada_node = { path = "../crates/node", features = ["testing"] }
-namada_sdk = { path = "../crates/sdk", features = ["testing", "arbitrary"] }
-namada_tx = { path = "../crates/tx", features = ["arbitrary"] }
+namada_apps_lib = { workspace = true, features = ["testing"] }
+namada_core = { workspace = true, features = ["testing"] }
+namada_node = { workspace = true, features = ["testing"] }
+namada_sdk = { workspace = true, features = ["testing", "arbitrary"] }
+namada_tx = { workspace = true, features = ["arbitrary"] }
 
 arbitrary = { workspace = true }
 data-encoding = { workspace = true }

--- a/release.toml
+++ b/release.toml
@@ -1,7 +1,7 @@
 allow-branch               = ["main", "maint-*"]
 consolidate-commits        = true
 pre-release-commit-message = "Namada libs {{version}}"
-publish                    = false
+publish                    = true
 push                       = false
 shared-version             = true
 tag                        = false


### PR DESCRIPTION
## Describe your changes

- remove unused borsh-ext dep declaration (replaced in https://github.com/anoma/namada/pull/4179)
- specify version for internal dependencies
- declare internal dependencies via workspace
- change cargo-release config to allow publishing

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
