### PR TITLE
Print the transaction's chain ID in expert mode. (re-opened from #4332 after revert)

### DIFF
--- a/.changelog/unreleased/improvements/4282-test-vectors-with-chain-ids.md
+++ b/.changelog/unreleased/improvements/4282-test-vectors-with-chain-ids.md
@@ -1,0 +1,2 @@
+- Make the test vector generator print the chain ID of transactions in expert
+  mode ([\#4282](https://github.com/anoma/namada/issues/4282))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ env:
   AWS_REGION: us-west-2
   NIGHTLY: nightly-2024-09-08
   NAMADA_MASP_PARAMS_DIR: /masp/.masp-params
-  LEDGER_APP_VERSION: "2.0.4"
+  LEDGER_APP_VERSION: "3.0.1"
   ROLE: arn:aws:iam::375643557360:role/github-runners-ci-shared
 
 jobs:

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -2182,6 +2182,7 @@ pub async fn to_ledger_vector(
                     .map_err(|e| Error::Other(format!("{}", e)))?,
             );
             tv.output_expert.extend(vec![
+                format!("Chain ID : {}", tx.header.chain_id),
                 format!(
                     "Timestamp : {}",
                     format_timestamp(tx.header.timestamp)


### PR DESCRIPTION
## Describe your changes
An attempt to address #4282 by displaying the chain ID of the transaction in expert mode. The chain ID is still not printed in normal mode because too much information is already being displayed there. See attached what the test vectors would look like after this change:  [testvecs-formatted.json.gz](https://github.com/user-attachments/files/18672175/testvecs-formatted.json.gz) for the JSON output and [testdbgs.txt.gz](https://github.com/user-attachments/files/18672177/testdbgs.txt.gz) for the debug formatting.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
