### PR TITLE
sdk/tx-result: print tx events if any

### DIFF
--- a/.changelog/unreleased/improvements/4347-tx-result-events.md
+++ b/.changelog/unreleased/improvements/4347-tx-result-events.md
@@ -1,0 +1,2 @@
+- Print tx's events in output of `namadac tx-result`.
+  ([\#4347](https://github.com/anoma/namada/pull/4347))

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -490,12 +490,27 @@ pub fn display_batch_resp(context: &impl Namada, resp: &TxResponse) {
     let mut all_inners_successful = true;
     for (inner_hash, result) in batch_results {
         match result {
-            InnerTxResult::Success(_) => {
+            InnerTxResult::Success(result) => {
                 display_line!(
                     context.io(),
                     "Transaction {} was successfully applied.",
                     inner_hash,
                 );
+                if !result.events.is_empty() {
+                    display_line!(context.io(), "Events:");
+                    for event in result.events.clone() {
+                        display_line!(
+                            context.io(),
+                            "{:2} - {} - {}:",
+                            "",
+                            event.level(),
+                            event.kind(),
+                        );
+                        for (k, v) in event.into_attributes() {
+                            display_line!(context.io(), "{:4} - {k}: {v}", "")
+                        }
+                    }
+                }
             }
             InnerTxResult::VpsRejected(inner) => {
                 let changed_keys: Vec<_> = inner


### PR DESCRIPTION
## Describe your changes

Print events emitted by a tx, if any.

Example output of `namadac tx-result`:
```
Checking if tx ADCB491136F8699069A816F15111FFA984B5B768E886E077A911C00AB16BD439 is applied...
Transaction batch ADCB491136F8699069A816F15111FFA984B5B768E886E077A911C00AB16BD439 was applied at height 580.
Batch results:
Transaction DE55BEA23344962AFB8161CF73D3D8B026DD712AFBA73DC523A2FFE4DE5B0770 was successfully applied.
Events:
   - tx - token/transfer:
     - post-balances: [[["internal-address/tnam1qgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8j2fp","tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e"],"100000000096"],[["internal-address/tnam1qyczahj5gmtsv694q2wngsl00qjpyxyyrsrtq5yk","tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e"],"1900075012169"]]
     - source-accounts: [[["internal-address/tnam1qgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8j2fp","tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e"],"20787578"]]
     - target-accounts: [[["internal-address/tnam1qyczahj5gmtsv694q2wngsl00qjpyxyyrsrtq5yk","tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e"],"20787578"]]
     - token-event-descriptor: pos-claim-rewards
 The batch consumed 16513 gas units.
 ```

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
