### PR TITLE
keep a separate commit for release changelogs

### DIFF
--- a/scripts/release_bins.sh
+++ b/scripts/release_bins.sh
@@ -27,12 +27,12 @@ cargo release version --execute $VERSION
 git commit -am "Namada $VERSION"
 HASH_AFTER=$(git rev-parse HEAD)
 
-# update the changelog (1 fixup)
+# update the changelog
 cd $REPO_ROOT
 unclog release $TAG_NAME
 unclog build > CHANGELOG.md
 git add .changelog CHANGELOG.md
-git commit --fixup=$HASH_AFTER
+git commit --message "Changelog: Release apps $VERSION"
 
 # show the user the result
 git rebase --interactive --autosquash --keep-base $HASH_BEFORE

--- a/scripts/release_libs.sh
+++ b/scripts/release_libs.sh
@@ -42,12 +42,12 @@ git add Cargo.lock
 git add Cargo.toml
 git commit --fixup=$HASH_AFTER
 
-# update the changelog (1 fixup)
+# update the changelog
 cd $REPO_ROOT
 unclog release $TAG_NAME
 unclog build > CHANGELOG.md
 git add .changelog CHANGELOG.md
-git commit --fixup=$HASH_AFTER
+git commit --message "Changelog: Release libs $VERSION"
 
 # show the user the result
 git rebase --interactive --autosquash --keep-base $HASH_BEFORE


### PR DESCRIPTION
## Describe your changes

This makes it easier to cherry-pick changelogs from maintenance releases into main

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
