### PR TITLE
tx: build tonic artifacts into OUT_DIR

### DIFF
--- a/crates/tx/build.rs
+++ b/crates/tx/build.rs
@@ -15,7 +15,6 @@ fn main() {
     println!("cargo:rerun-if-changed={}", PROTO_SRC);
 
     tonic_build::configure()
-        .out_dir("src/proto/generated")
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&[format!("{}/types.proto", PROTO_SRC)], &[PROTO_SRC])
         .unwrap();

--- a/crates/tx/src/proto/generated.rs
+++ b/crates/tx/src/proto/generated.rs
@@ -1,3 +1,6 @@
 #![allow(missing_docs)]
 
-pub mod types;
+/// Tonic tx types generated from protobuf definitions at build
+pub mod types {
+    include!(concat!(env!("OUT_DIR"), "/types.rs"));
+}


### PR DESCRIPTION
## Describe your changes

This fixes an issue raised during publishing of namada_tx crate (caught by verification introduced from https://github.com/rust-lang/cargo/issues/5073)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
