### PR TITLE
apps_lib: output artifacts from build script into OUT_DIR

### DIFF
--- a/crates/apps_lib/build.rs
+++ b/crates/apps_lib/build.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::Write;
-use std::str;
+use std::path::PathBuf;
+use std::{env, str};
 
 use cargo_metadata::MetadataCommand;
 use git2::{DescribeFormatOptions, DescribeOptions, Repository};
@@ -23,8 +24,10 @@ fn main() {
         Some(describe) => describe.format(Some(&describe_format)).ok(),
         None => None,
     };
+    let out_dir = env::var("OUT_DIR").unwrap();
     let mut version_rs =
-        File::create("./version.rs").expect("cannot write version");
+        File::create(PathBuf::from_iter([&out_dir, "version.rs"]))
+            .expect("cannot write version");
     let pre = "pub fn namada_version() -> &'static str { \"";
     let post = "\" }";
     match version_string {

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -22,7 +22,8 @@ pub use utils::{safe_exit, Cmd};
 pub use self::context::Context;
 use crate::cli::api::CliIo;
 
-include!("../version.rs");
+// Imports `pub fn namada_version() -> &'static str` made by build script
+include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
 const APP_NAME: &str = "Namada";
 


### PR DESCRIPTION
## Describe your changes

similar issue to #4351

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
