### PR TITLE
move version detection build script from apps_lib into apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4989,6 +4989,7 @@ dependencies = [
 name = "namada_apps"
 version = "1.1.0"
 dependencies = [
+ "cargo_metadata",
  "clap_complete",
  "clap_complete_nushell",
  "color-eyre",
@@ -5011,7 +5012,6 @@ dependencies = [
  "base64 0.13.1",
  "bit-set",
  "borsh",
- "cargo_metadata",
  "clap",
  "color-eyre",
  "config",
@@ -5023,7 +5023,6 @@ dependencies = [
  "fd-lock",
  "flate2",
  "futures",
- "git2",
  "itertools 0.12.1",
  "kdam",
  "lazy_static",

--- a/crates/apps/Cargo.toml
+++ b/crates/apps/Cargo.toml
@@ -79,4 +79,5 @@ winapi.workspace = true
 [dev-dependencies]
 
 [build-dependencies]
+cargo_metadata.workspace = true
 git2.workspace = true

--- a/crates/apps/build.rs
+++ b/crates/apps/build.rs
@@ -1,13 +1,10 @@
+use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
-use std::{env, str};
 
 use cargo_metadata::MetadataCommand;
 use git2::{DescribeFormatOptions, DescribeOptions, Repository};
-
-/// Path to the .proto source files, relative to `apps_lib` directory
-const PROTO_SRC: &str = "./proto";
 
 fn main() {
     // Discover the repository version, if it exists
@@ -50,7 +47,7 @@ fn main() {
                     "--locked".to_string(),
                     "--offline".to_string(),
                 ])
-                .manifest_path("../apps/Cargo.toml")
+                .manifest_path("./Cargo.toml")
                 .exec()
                 .ok()
                 .and_then(|metadata| {
@@ -72,7 +69,4 @@ fn main() {
                 .expect("cannot write version");
         }
     };
-
-    // Tell Cargo that if the given file changes, to rerun this build script.
-    println!("cargo:rerun-if-changed={}", PROTO_SRC);
 }

--- a/crates/apps/src/bin/namada-client/main.rs
+++ b/crates/apps/src/bin/namada-client/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     // run the CLI
     CliApi::handle_client_command::<HttpClient, _>(
         None,
-        cli::namada_client_cli()?,
+        cli::namada_client_cli(namada_apps::namada_version())?,
         CliIo,
     )
     .await

--- a/crates/apps/src/bin/namada-node/cli.rs
+++ b/crates/apps/src/bin/namada-node/cli.rs
@@ -11,7 +11,7 @@ use namada_apps_lib::time::{DateTimeUtc, Utc};
 use namada_node as node;
 
 pub fn main() -> Result<()> {
-    let cmd = cli::namada_node_cli()?;
+    let cmd = cli::namada_node_cli(namada_apps::namada_version())?;
     match cmd {
         cli::NamadaNode::Ledger(cmd, ctx) => match cmd {
             cmds::Ledger::Run(cmds::LedgerRun(args)) => {
@@ -28,7 +28,12 @@ pub fn main() -> Result<()> {
                     );
                     ScheduledMigration::from_path(p, hash, height).unwrap()
                 });
-                node::run(chain_ctx.config, wasm_dir, scheduled_migration);
+                node::run(
+                    chain_ctx.config,
+                    wasm_dir,
+                    scheduled_migration,
+                    namada_apps::namada_version(),
+                );
             }
             cmds::Ledger::RunUntil(cmds::LedgerRunUntil(args)) => {
                 let mut chain_ctx = ctx.take_chain_or_exit();
@@ -36,7 +41,12 @@ pub fn main() -> Result<()> {
                 sleep_until(args.time);
                 chain_ctx.config.ledger.shell.action_at_height =
                     Some(args.action_at_height);
-                node::run(chain_ctx.config, wasm_dir, None);
+                node::run(
+                    chain_ctx.config,
+                    wasm_dir,
+                    None,
+                    namada_apps::namada_version(),
+                );
             }
             cmds::Ledger::Reset(_) => {
                 let chain_ctx = ctx.take_chain_or_exit();

--- a/crates/apps/src/bin/namada-relayer/_main.rs
+++ b/crates/apps/src/bin/namada-relayer/_main.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
     // init logging
     logging::init_from_env_or(LevelFilter::INFO)?;
 
-    let cmd = cli::namada_relayer_cli()?;
+    let cmd = cli::namada_relayer_cli(namada_apps::namada_version())?;
     // run the CLI
     CliApi::handle_relayer_command::<HttpClient>(None, cmd, CliIo).await
 }

--- a/crates/apps/src/bin/namada-wallet/main.rs
+++ b/crates/apps/src/bin/namada-wallet/main.rs
@@ -5,7 +5,7 @@ use namada_apps_lib::cli::api::{CliApi, CliIo};
 #[tokio::main]
 pub async fn main() -> Result<()> {
     color_eyre::install()?;
-    let (cmd, ctx) = cli::namada_wallet_cli()?;
+    let (cmd, ctx) = cli::namada_wallet_cli(namada_apps::namada_version())?;
     // run the CLI
     CliApi::handle_wallet_command(cmd, ctx, &CliIo).await
 }

--- a/crates/apps/src/bin/namada/cli.rs
+++ b/crates/apps/src/bin/namada/cli.rs
@@ -12,7 +12,7 @@ use eyre::Result;
 use namada_apps_lib::cli;
 
 pub fn main() -> Result<()> {
-    let (cmd, raw_sub_cmd) = cli::namada_cli();
+    let (cmd, raw_sub_cmd) = cli::namada_cli(namada_apps::namada_version());
     handle_command(cmd, raw_sub_cmd)
 }
 
@@ -69,12 +69,13 @@ fn handle_command(cmd: cli::cmds::Namada, raw_sub_cmd: String) -> Result<()> {
             use clap_complete::{generate, shells};
             use clap_complete_nushell::Nushell;
 
+            let version = namada_apps::namada_version();
             for (mut app, name) in [
-                (cli::namada_app(), "namada"),
-                (cli::namada_node_app(), "namadan"),
-                (cli::namada_client_app(), "namadac"),
-                (cli::namada_wallet_app(), "namadaw"),
-                (cli::namada_relayer_app(), "namadar"),
+                (cli::namada_app(version), "namada"),
+                (cli::namada_node_app(version), "namadan"),
+                (cli::namada_client_app(version), "namadac"),
+                (cli::namada_wallet_app(version), "namadaw"),
+                (cli::namada_relayer_app(version), "namadar"),
             ] {
                 match shell {
                     cli::args::Shell::Bash => {

--- a/crates/apps/src/lib.rs
+++ b/crates/apps/src/lib.rs
@@ -1,0 +1,2 @@
+// Imports `pub fn namada_version() -> &'static str` made by build script
+include!(concat!(env!("OUT_DIR"), "/version.rs"));

--- a/crates/apps_lib/Cargo.toml
+++ b/crates/apps_lib/Cargo.toml
@@ -92,7 +92,3 @@ bit-set.workspace = true
 proptest.workspace = true
 lazy_static.workspace = true
 pretty_assertions.workspace = true
-
-[build-dependencies]
-cargo_metadata.workspace = true
-git2.workspace = true

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -22,9 +22,6 @@ pub use utils::{safe_exit, Cmd};
 pub use self::context::Context;
 use crate::cli::api::CliIo;
 
-// Imports `pub fn namada_version() -> &'static str` made by build script
-include!(concat!(env!("OUT_DIR"), "/version.rs"));
-
 const APP_NAME: &str = "Namada";
 
 // Main Namada sub-commands
@@ -9046,8 +9043,8 @@ pub mod args {
     }
 }
 
-pub fn namada_cli() -> (cmds::Namada, String) {
-    let app = namada_app();
+pub fn namada_cli(version: &'static str) -> (cmds::Namada, String) {
+    let app = namada_app(version);
     let matches = app.get_matches();
     let raw_sub_cmd =
         matches.subcommand().map(|(raw, _matches)| raw.to_string());
@@ -9055,7 +9052,7 @@ pub fn namada_cli() -> (cmds::Namada, String) {
     match (result, raw_sub_cmd) {
         (Some(cmd), Some(raw_sub)) => return (cmd, raw_sub),
         _ => {
-            namada_app().print_help().unwrap();
+            namada_app(version).print_help().unwrap();
         }
     }
     safe_exit(2);
@@ -9068,8 +9065,8 @@ pub enum NamadaNode {
     Utils(cmds::NodeUtils, args::Global),
 }
 
-pub fn namada_node_cli() -> Result<NamadaNode> {
-    let app = namada_node_app();
+pub fn namada_node_cli(version: &'static str) -> Result<NamadaNode> {
+    let app = namada_node_app(version);
     let matches = app.clone().get_matches();
     match Cmd::parse(&matches) {
         Some(cmd) => {
@@ -9102,8 +9099,8 @@ pub enum NamadaClient {
     WithContext(Box<(cmds::NamadaClientWithContext, Context)>),
 }
 
-pub fn namada_client_cli() -> Result<NamadaClient> {
-    let app = namada_client_app();
+pub fn namada_client_cli(version: &'static str) -> Result<NamadaClient> {
+    let app = namada_client_app(version);
     let matches = app.clone().get_matches();
     match Cmd::parse(&matches) {
         Some(cmd) => {
@@ -9129,8 +9126,10 @@ pub fn namada_client_cli() -> Result<NamadaClient> {
     }
 }
 
-pub fn namada_wallet_cli() -> Result<(cmds::NamadaWallet, Context)> {
-    let app = namada_wallet_app();
+pub fn namada_wallet_cli(
+    version: &'static str,
+) -> Result<(cmds::NamadaWallet, Context)> {
+    let app = namada_wallet_app(version);
     cmds::NamadaWallet::parse_or_print_help(app)
 }
 
@@ -9140,8 +9139,8 @@ pub enum NamadaRelayer {
     ValidatorSet(cmds::ValidatorSet),
 }
 
-pub fn namada_relayer_cli() -> Result<NamadaRelayer> {
-    let app = namada_relayer_app();
+pub fn namada_relayer_cli(version: &'static str) -> Result<NamadaRelayer> {
+    let app = namada_relayer_app(version);
     let matches = app.clone().get_matches();
     match Cmd::parse(&matches) {
         Some(cmd) => match cmd {
@@ -9169,9 +9168,9 @@ pub fn namada_relayer_cli() -> Result<NamadaRelayer> {
     }
 }
 
-pub fn namada_app() -> App {
+pub fn namada_app(version: &'static str) -> App {
     let app = App::new(APP_NAME)
-        .version(namada_version())
+        .version(version)
         .about("Namada command line interface.")
         .color(ColorChoice::Auto)
         .subcommand_required(true)
@@ -9179,9 +9178,9 @@ pub fn namada_app() -> App {
     cmds::Namada::add_sub(args::Global::def(app))
 }
 
-pub fn namada_node_app() -> App {
+pub fn namada_node_app(version: &'static str) -> App {
     let app = App::new(APP_NAME)
-        .version(namada_version())
+        .version(version)
         .about("Namada node command line interface.")
         .color(ColorChoice::Auto)
         .subcommand_required(true)
@@ -9189,9 +9188,9 @@ pub fn namada_node_app() -> App {
     cmds::NamadaNode::add_sub(args::Global::def(app))
 }
 
-pub fn namada_client_app() -> App {
+pub fn namada_client_app(version: &'static str) -> App {
     let app = App::new(APP_NAME)
-        .version(namada_version())
+        .version(version)
         .about("Namada client command line interface.")
         .color(ColorChoice::Auto)
         .subcommand_required(true)
@@ -9199,9 +9198,9 @@ pub fn namada_client_app() -> App {
     cmds::NamadaClient::add_sub(args::Global::def(app))
 }
 
-pub fn namada_wallet_app() -> App {
+pub fn namada_wallet_app(version: &'static str) -> App {
     let app = App::new(APP_NAME)
-        .version(namada_version())
+        .version(version)
         .about("Namada wallet command line interface.")
         .color(ColorChoice::Auto)
         .subcommand_required(true)
@@ -9209,9 +9208,9 @@ pub fn namada_wallet_app() -> App {
     cmds::NamadaWallet::add_sub(args::Global::def(app))
 }
 
-pub fn namada_relayer_app() -> App {
+pub fn namada_relayer_app(version: &'static str) -> App {
     let app = App::new(APP_NAME)
-        .version(namada_version())
+        .version(version)
         .about("Namada relayer command line interface.")
         .subcommand_required(true);
     cmds::NamadaRelayer::add_sub(args::Global::def(app))


### PR DESCRIPTION
## Describe your changes

fixes namada_node release that is not able to access namada_apps manifest as it's not in its build tree:

```
error: failed to run custom build command for `namada_apps_lib v0.47.1`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/namada/target/package/namada_node-0.47.1/target/debug/build/namada_apps_lib-5075df52883ad4e6/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=../../.git
```

The build script is moved into the apps crate to use its own manifest and hence avoid this issue

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
