### PR TITLE
apps: allow to publish namada_apps to crates.io

### DIFF
--- a/crates/apps/release.toml
+++ b/crates/apps/release.toml
@@ -1,7 +1,7 @@
 allow-branch               = ["main", "maint-*"]
 consolidate-commits        = true
 pre-release-commit-message = "Namada {{version}}"
-publish                    = false
+publish                    = true
 push                       = false
 shared-version             = false
 tag                        = false


### PR DESCRIPTION
## Describe your changes

Updates the release config to allow publishing on the binaries crate

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
