### PR TITLE
Increase the accuracy of rewards by minting based on the real reward.

### DIFF
--- a/.changelog/unreleased/improvements/4369-increase-masp-minting-accuracy.md
+++ b/.changelog/unreleased/improvements/4369-increase-masp-minting-accuracy.md
@@ -1,0 +1,2 @@
+- Improve accuracy in the determination of NAM to be minted by the MASP.
+  ([\#4369](https://github.com/anoma/namada/pull/4369))

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -1728,7 +1728,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.18963"));
+    assert!(captured.contains("nam: 0.18887"));
 
     // Wait till epoch boundary
     node.next_masp_epoch();
@@ -1870,7 +1870,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 1.384131"));
+    assert!(captured.contains("nam: 1.383286"));
 
     // Wait till epoch boundary
     node.next_masp_epoch();
@@ -1979,7 +1979,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 3.270374"));
+    assert!(captured.contains("nam: 3.267817"));
 
     // Wait till epoch boundary
     node.next_masp_epoch();
@@ -2072,7 +2072,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 3.774374"));
+    assert!(captured.contains("nam: 3.77117"));
 
     // Wait till epoch boundary
     node.next_masp_epoch();
@@ -2143,7 +2143,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 3.774374"));
+    assert!(captured.contains("nam: 3.77117"));
 
     // Wait till epoch boundary to prevent conversion expiry during transaction
     // construction
@@ -2282,7 +2282,7 @@ fn masp_incentives() -> Result<()> {
         )
     });
     assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.003216"));
+    assert!(captured.contains("nam: 0.000012"));
 
     Ok(())
 }


### PR DESCRIPTION
## Describe your changes
This PR is an attempt to slightly mitigate https://github.com/anoma/namada/issues/4372 by reducing the amount of unclaimable rewards created by the rewards algorithm. The approach taken is to try and reduce the amount of NAM minted for non-native tokens so that it's closer to what can actually be claimed. And this reduction is achieved by minting NAM based on the deflated rewards for non-native tokens (which is what is actually put into the allowed conversions) rather than the inflated rewards they are based on. Because clients can combine (deflated) reward NAM[0] with pre-existing NAM[0] in their balance to meet the threshold for conversion to the current epoch and because the distribution algorithm now works with deflated amounts, it no longer ignores the dust arising during the mint amount computations.

To see the impact of this PR, note that the dust left at the MASP address after all shielded tokens are unshielded in https://github.com/anoma/namada/pull/4369/files#diff-78668f42dcc983dea532ff370112f41796cfae99510ea10156df37c4e1e4e0d2L2285 has gone down from `nam: 0.003216` to `nam: 0.000012`.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
