### PR TITLE
deps: update rocksdb

### DIFF
--- a/.changelog/unreleased/miscellaneous/4378-up-rocksdb.md
+++ b/.changelog/unreleased/miscellaneous/4378-up-rocksdb.md
@@ -1,0 +1,2 @@
+- Updated rust-rocksdb dependency to v0.23 which uses RocksDB (C++) 9.9.3.
+  ([\#4378](https://github.com/anoma/namada/pull/4378))

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,7 @@ env:
   MINOR_VERSION_RELEASE: "0.47.999" # bump on a major release
   BACKPORT_LIBS_LABEL: "backport-libs-0.47" # also bump on major release
   MAINT_LIBS_BRANCH: "maint-libs-0.47" # also bump on major release
+  LIBCLANG_PATH: "/usr/lib/llvm-18/lib" # Needed for RocksDB, installed in build deps
 
 jobs:
   # Check if a PR has no major breaking changes to be backported to library
@@ -52,7 +53,9 @@ jobs:
       - name: Instal cargo release  
         run: cargo binstall -y cargo-release
       - name: Install build deps
-        run: sudo apt-get install -y protobuf-compiler libudev-dev
+        run: sudo apt-get install -y protobuf-compiler libudev-dev llvm-18
+      - name: Symlink libclang for RocksDB
+        run: sudo ln -s /usr/lib/llvm-18/lib/libclang-18.so.1 /usr/lib/llvm-18/lib/libclang-18.so
       - name: Totally safe 
         # Workaround for https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,6 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
 ]
 
 [[package]]
@@ -4942,16 +4941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4970,14 +4959,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.1+9.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "tikv-jemalloc-sys",
@@ -7997,9 +7985,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -9401,9 +9389,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ regex = "1.10"
 reqwest = { version = "0.12", features = ["json"] }
 ripemd = "0.1"
 rlimit = "0.10"
-rocksdb = {version = "0.22.0", features = ['zstd'], default-features = false}
+rocksdb = {version = "0.23", features = ['zstd'], default-features = false}
 rpassword = "7.3"
 rustversion = "1.0"
 serde = {version = "1.0", features = ["derive"]}

--- a/crates/node/src/shims/abcipp_shim.rs
+++ b/crates/node/src/shims/abcipp_shim.rs
@@ -223,6 +223,8 @@ impl AbcippShim {
         let TakeSnapshot::Yes(db_path, height) = take_snapshot else {
             return;
         };
+        // Ensure that the DB is flushed before making a checkpoint
+        namada_sdk::state::DB::flush(self.service.state.db(), true).unwrap();
         let base_dir = self.service.base_dir.clone();
 
         let (snap_send, snap_recv) = tokio::sync::oneshot::channel();

--- a/crates/node/src/storage/rocksdb.rs
+++ b/crates/node/src/storage/rocksdb.rs
@@ -1128,8 +1128,15 @@ impl DB for RocksDB {
     fn flush(&self, wait: bool) -> Result<()> {
         let mut flush_opts = FlushOptions::default();
         flush_opts.set_wait(wait);
+        let cfs = self
+            .column_families()
+            .into_iter()
+            .map(|(_, cf)| cf)
+            .collect::<Vec<_>>();
+        // "For manual flush, application has to specify the list of column
+        // families to flush atomically" from <https://github.com/facebook/rocksdb/wiki/Atomic-flush>
         self.inner
-            .flush_opt(&flush_opts)
+            .flush_cfs_opt(&cfs, &flush_opts)
             .map_err(|e| Error::DBError(e.into_string()))
     }
 

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -2132,6 +2132,10 @@ fn apply_snapshot() -> Result<()> {
     let captured = CapturedOutput::of(|| run(&node, Bin::Client, args));
     assert!(captured.contains("1981234"));
 
+    // DB must be flushed before checkpoint
+    namada_sdk::state::DB::flush(node.shell.lock().unwrap().state.db(), true)
+        .unwrap();
+
     let base_dir = node.test_dir.path();
     let db = namada_node::storage::open(node.db_path(), true, None)
         .expect("Could not open DB");


### PR DESCRIPTION
## Describe your changes

Updated rust-rocksdb dependency to v0.23 which uses RocksDB (C++) 9.9.3.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
