### PR TITLE
define and check minimum supported Rust version in CI

### DIFF
--- a/.changelog/unreleased/miscellanous/4398-add-msrv.md
+++ b/.changelog/unreleased/miscellanous/4398-add-msrv.md
@@ -1,0 +1,2 @@
+- Specified a minimum-supported-Rust-version.
+  ([\#4398](https://github.com/anoma/namada/pull/4398))

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,3 +80,50 @@ jobs:
         if: steps.semver.outcome == 'failure'
         with:
           labels: "breaking:api"
+
+  # Check minimum supported Rust version of the SDK, tx_prelude, vp_prelude and apps_lib crates
+  msrv:
+    name: msrv
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [ ubuntu, macos ]
+        include:
+          - build: ubuntu
+            os: ubuntu-latest
+          - build: macos
+            os: macos-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    steps:
+      - name: checkout_repo
+        uses: actions/checkout@v4
+      - name: install_rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: install_cargo_msrv
+        if: matrix.build == 'ubuntu'
+        run: cargo install cargo-msrv
+      - name: install_cargo_msrv_no_default
+        if: matrix.build != 'ubuntu'
+        run: cargo install cargo-msrv --no-default-features
+      - name: version_of_cargo_msrv
+        run: cargo msrv --version
+      - name: Install build deps
+        if: matrix.build == 'ubuntu'
+        run: sudo apt-get install -y protobuf-compiler libudev-dev
+      - name: Install build deps MacOS
+        if: matrix.build != 'ubuntu'
+        run: brew install protobuf
+      - name: run_cargo_msrv in sdk
+        run: |
+          cargo msrv verify --path crates/sdk  --output-format json
+      - name: run_cargo_msrv in tx_prelude
+        run: |
+          cargo msrv verify --path crates/tx_prelude  --output-format json
+      - name: run_cargo_msrv in vp_prelude
+        run: |
+          cargo msrv verify --path crates/vp_prelude  --output-format json
+      - name: run_cargo_msrv in apps_lib
+        run: |
+          cargo msrv verify --path crates/apps_lib  --output-format json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ license = "GPL-3.0"
 readme = "README.md"
 repository = "https://github.com/anoma/namada"
 version = "0.47.0"
+rust-version = "1.80"
 
 [workspace.dependencies]
 namada_account = { version = "0.47.0", path = "crates/account" }

--- a/crates/account/Cargo.toml
+++ b/crates/account/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/apps_lib/Cargo.toml
+++ b/crates/apps_lib/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["migrations"]

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 namada_core.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/ethereum_bridge/Cargo.toml
+++ b/crates/ethereum_bridge/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/gas/Cargo.toml
+++ b/crates/gas/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 migrations = ["namada_migrations", "linkme"]

--- a/crates/governance/Cargo.toml
+++ b/crates/governance/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 testing = ["proptest", "namada_core/testing"]

--- a/crates/ibc/Cargo.toml
+++ b/crates/ibc/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/io/Cargo.toml
+++ b/crates/io/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 async-send = []

--- a/crates/light_sdk/Cargo.toml
+++ b/crates/light_sdk/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 blocking = ["tokio"]

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/merkle_tree/Cargo.toml
+++ b/crates/merkle_tree/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 migrations = ["namada_migrations", "linkme"]

--- a/crates/migrations/Cargo.toml
+++ b/crates/migrations/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 namada_macros.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["migrations"]

--- a/crates/parameters/Cargo.toml
+++ b/crates/parameters/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/proof_of_stake/Cargo.toml
+++ b/crates/proof_of_stake/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/replay_protection/Cargo.toml
+++ b/crates/replay_protection/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 namada_core.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/shielded_token/Cargo.toml
+++ b/crates/shielded_token/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/systems/Cargo.toml
+++ b/crates/systems/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 namada_core.workspace = true

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 namada_core.workspace = true

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["namada_sdk/std", "namada_sdk/masp"]

--- a/crates/token/Cargo.toml
+++ b/crates/token/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/trans_token/Cargo.toml
+++ b/crates/trans_token/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/tx/Cargo.toml
+++ b/crates/tx/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/tx_env/Cargo.toml
+++ b/crates/tx_env/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 namada_core.workspace = true

--- a/crates/tx_prelude/Cargo.toml
+++ b/crates/tx_prelude/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["wasm-runtime"]

--- a/crates/vm_env/Cargo.toml
+++ b/crates/vm_env/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/vote_ext/Cargo.toml
+++ b/crates/vote_ext/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 migrations = ["namada_migrations", "linkme"]

--- a/crates/vp/Cargo.toml
+++ b/crates/vp/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 testing = ["namada_core/testing"]

--- a/crates/vp_env/Cargo.toml
+++ b/crates/vp_env/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 namada_core.workspace = true

--- a/crates/vp_prelude/Cargo.toml
+++ b/crates/vp_prelude/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 repository.workspace = true
 version.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
## Describe your changes

Our current MSRV is 1.80 because of orion dep that requires it

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
