### PR TITLE
fix crates build with some non-default features

### DIFF
--- a/.changelog/unreleased/bug-fixes/4403-fix-crates-build.md
+++ b/.changelog/unreleased/bug-fixes/4403-fix-crates-build.md
@@ -1,0 +1,2 @@
+- Fixed the build of some crates with non-default features.
+  ([\#4403](https://github.com/anoma/namada/pull/4403))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6548,6 +6548,7 @@ dependencies = [
  "derivation-path",
  "fd-lock",
  "itertools 0.14.0",
+ "linkme",
  "masp_primitives",
  "nam-tiny-hderive",
  "namada_core",

--- a/crates/governance/Cargo.toml
+++ b/crates/governance/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-testing = ["proptest"]
+testing = ["proptest", "namada_core/testing"]
 arbitrary = ["dep:arbitrary", "namada_core/arbitrary"]
 migrations = ["namada_migrations", "linkme"]
 

--- a/crates/proof_of_stake/Cargo.toml
+++ b/crates/proof_of_stake/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 [features]
 default = []
 # testing helpers
-testing = ["proptest"]
+testing = ["proptest", "namada_core/testing"]
 migrations = ["namada_migrations", "linkme"]
 
 [dependencies]

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -16,7 +16,7 @@ version.workspace = true
 default = []
 std = ["fd-lock", "download-params"]
 download-params = []
-migrations = ["namada_migrations"]
+migrations = ["namada_migrations", "linkme"]
 
 [dependencies]
 namada_core = { workspace = true, features = ["rand"] }
@@ -30,6 +30,7 @@ itertools.workspace = true
 derivation-path.workspace = true
 data-encoding.workspace = true
 fd-lock = { workspace = true, optional = true }
+linkme = { workspace = true, optional = true }
 masp_primitives.workspace = true
 orion.workspace = true
 rand.workspace = true


### PR DESCRIPTION
## Describe your changes

In #4401 it was found that some crates released in 0.47.2 fail to build with certain features. To be able to run #4401 check reliably the baseline (i.e. last release it's comparing the API with) has to be fixed first.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
