### PR TITLE
Murisi/sequential payment addresses

### DIFF
--- a/.changelog/unreleased/improvements/4417-sequential-payment-addresses.md
+++ b/.changelog/unreleased/improvements/4417-sequential-payment-addresses.md
@@ -1,0 +1,2 @@
+- Generate shielded payment addresses sequentially instead of randomly.
+  ([\#4417](https://github.com/anoma/namada/pull/4417))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -891,7 +891,7 @@ pub mod cmds {
         fn def() -> App {
             App::new(Self::CMD)
                 .about(wrap!(
-                    "Generates a payment address from the given spending key."
+                    "Generate the next payment address for a viewing key."
                 ))
                 .add_args::<args::PayAddressGen>()
         }
@@ -3368,7 +3368,7 @@ pub mod args {
 
     use data_encoding::HEXUPPER;
     use either::Either;
-    use namada_core::masp::{MaspEpoch, PaymentAddress};
+    use namada_core::masp::{DiversifierIndex, MaspEpoch, PaymentAddress};
     use namada_sdk::address::{Address, EstablishedAddress};
     pub use namada_sdk::args::*;
     use namada_sdk::chain::{ChainId, ChainIdPrefix};
@@ -3482,6 +3482,8 @@ pub mod args {
     pub const DECRYPT: ArgFlag = flag("decrypt");
     pub const DESCRIPTION_OPT: ArgOpt<String> = arg_opt("description");
     pub const DISPOSABLE_SIGNING_KEY: ArgFlag = flag("disposable-gas-payer");
+    pub const DIVERSIFIER_INDEX: ArgOpt<DiversifierIndex> =
+        arg_opt("diversifier-index");
     pub const DESTINATION_VALIDATOR: Arg<WalletAddress> =
         arg("destination-validator");
     pub const DISCORD_OPT: ArgOpt<String> = arg_opt("discord-handle");
@@ -7921,6 +7923,7 @@ pub mod args {
                 alias: self.alias,
                 alias_force: self.alias_force,
                 viewing_key: self.viewing_key,
+                diversifier_index: self.diversifier_index,
             })
         }
     }
@@ -7929,10 +7932,12 @@ pub mod args {
         fn parse(matches: &ArgMatches) -> Self {
             let alias = ALIAS.parse(matches);
             let alias_force = ALIAS_FORCE.parse(matches);
+            let diversifier_index = DIVERSIFIER_INDEX.parse(matches);
             let viewing_key = VIEWING_KEY_ALIAS.parse(matches);
             Self {
                 alias,
                 alias_force,
+                diversifier_index,
                 viewing_key,
             }
         }
@@ -7943,6 +7948,9 @@ pub mod args {
             )))
             .arg(ALIAS_FORCE.def().help(wrap!(
                 "Override the alias without confirmation if it already exists."
+            )))
+            .arg(DIVERSIFIER_INDEX.def().help(wrap!(
+                "Set the viewing key's current diversifier index beforehand."
             )))
             .arg(VIEWING_KEY.def().help(wrap!("The viewing key.")))
         }

--- a/crates/apps_lib/src/cli/wallet.rs
+++ b/crates/apps_lib/src/cli/wallet.rs
@@ -402,7 +402,7 @@ fn payment_address_gen(
         alias,
         alias_force,
         viewing_key: viewing_key_alias,
-        ..
+        diversifier_index,
     }: args::PayAddressGen,
 ) {
     let mut wallet = load_wallet(ctx);
@@ -415,10 +415,12 @@ fn payment_address_gen(
             eprintln!("Unknown viewing key {}", viewing_key_alias,);
             cli::safe_exit(1)
         });
-    let diversifier_index = wallet
-        .find_diversifier_index(viewing_key_alias.clone())
-        .copied()
-        .unwrap_or_default();
+    let diversifier_index = diversifier_index.unwrap_or_else(|| {
+        wallet
+            .find_diversifier_index(viewing_key_alias.clone())
+            .copied()
+            .unwrap_or_default()
+    });
     let (diversifier_index, masp_payment_addr) =
         ExtendedFullViewingKey::from(viewing_key)
             .find_address(diversifier_index.into())

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -329,6 +329,12 @@ impl From<DiversifierIndex> for u128 {
 #[derive(Clone, Debug, Copy, Default)]
 pub struct ParseDiversifierError;
 
+impl std::fmt::Display for ParseDiversifierError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        "unable to parse diversifier index".fmt(f)
+    }
+}
+
 impl FromStr for DiversifierIndex {
     type Err = ParseDiversifierError;
 
@@ -354,7 +360,7 @@ impl serde::Serialize for DiversifierIndex {
     where
         S: serde::Serializer,
     {
-        serde::Serialize::serialize(&u128::from(*self), serializer)
+        serde::Serialize::serialize(&self.to_string(), serializer)
     }
 }
 
@@ -364,8 +370,8 @@ impl<'de> serde::Deserialize<'de> for DiversifierIndex {
         D: serde::Deserializer<'de>,
     {
         use serde::de::Error;
-        let encoded: u128 = serde::Deserialize::deserialize(deserializer)?;
-        encoded.try_into().map_err(D::Error::custom)
+        let encoded: String = serde::Deserialize::deserialize(deserializer)?;
+        Self::from_str(&encoded).map_err(D::Error::custom)
     }
 }
 

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -326,6 +326,7 @@ impl From<DiversifierIndex> for u128 {
 }
 
 /// The describing a failure to parse a diversifier index
+#[derive(Clone, Debug, Copy, Default)]
 pub struct ParseDiversifierError;
 
 impl FromStr for DiversifierIndex {

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -3006,13 +3006,13 @@ pub struct KeyAddressRemove {
 
 /// Generate payment address arguments
 #[derive(Clone, Debug)]
-pub struct PayAddressGen<C: NamadaTypes = SdkTypes> {
-    /// Key alias
+pub struct PayAddressGen {
+    /// Payment address alias
     pub alias: String,
     /// Whether to force overwrite the alias
     pub alias_force: bool,
     /// Viewing key
-    pub viewing_key: C::ViewingKey,
+    pub viewing_key: String,
 }
 
 /// Bridge pool batch recommendation.

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -15,7 +15,7 @@ use namada_core::dec::Dec;
 use namada_core::ethereum_events::EthAddress;
 use namada_core::keccak::KeccakHash;
 use namada_core::key::{common, SchemeType};
-use namada_core::masp::{MaspEpoch, PaymentAddress};
+use namada_core::masp::{DiversifierIndex, MaspEpoch, PaymentAddress};
 use namada_core::string_encoding::StringEncoded;
 use namada_core::time::DateTimeUtc;
 use namada_core::token::Amount;
@@ -3013,6 +3013,8 @@ pub struct PayAddressGen {
     pub alias_force: bool,
     /// Viewing key
     pub viewing_key: String,
+    /// Diversifier index to start search at
+    pub diversifier_index: Option<DiversifierIndex>,
 }
 
 /// Bridge pool batch recommendation.

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -20,7 +20,7 @@ use namada_core::chain::BlockHeight;
 use namada_core::collections::{HashMap, HashSet};
 use namada_core::key::*;
 use namada_core::masp::{
-    ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress,
+    DiversifierIndex, ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress,
 };
 use namada_core::time::DateTimeUtc;
 use namada_ibc::trace::is_ibc_denom;
@@ -448,6 +448,14 @@ impl<U> Wallet<U> {
         alias: impl AsRef<str>,
     ) -> Option<&BlockHeight> {
         self.store.find_birthday(alias.as_ref())
+    }
+
+    /// Find the diversifier index of the given alias
+    pub fn find_diversifier_index(
+        &self,
+        alias: impl AsRef<str>,
+    ) -> Option<&DiversifierIndex> {
+        self.store.find_diversifier_index(alias.as_ref())
     }
 
     /// Find the payment address with the given alias in the wallet and return
@@ -1228,6 +1236,18 @@ impl<U: WalletIo> Wallet<U> {
     ) -> Option<String> {
         self.store
             .insert_payment_addr::<U>(alias.into(), payment_addr, force_alias)
+            .map(Into::into)
+    }
+
+    /// Insert a diversifier index into the wallet under the given alias. Useful
+    /// for sequential payment address generation.
+    pub fn insert_diversifier_index(
+        &mut self,
+        alias: String,
+        div_index: DiversifierIndex,
+    ) -> Option<String> {
+        self.store
+            .insert_diversifier_index(alias.into(), div_index)
             .map(Into::into)
     }
 


### PR DESCRIPTION
## Describe your changes
Implemented deterministic shielded payment address generation replacing the former method of randomly generating payment addresses. Determinism is achieved by maintaining a diversifier index for each viewing key in the wallet store and incrementing it each time a payment address is generated. Specifically, the following changes have been made:
* Extended the wallet store with a diversifier index field
* Implemented migration so the wallet can read older `Store` versions that do not contain diversifier indices
* Extended the `gen-payment-addr` CLI command with a flag to set the current diversifier index for a viewing key
* Altered payment address generation to use stored/specified diversifier index and increment it afterwards

A drawback of the approach taken is that `gen-payment-addr` must now take the alias of a viewing key as its argument instead of a literal viewing key. This is because it needs to have an alias to write the updated diversifier index back to. But under the assumption that end-users were not calling `gen-payment-addr` with literal keys, the CLI command can continue to be used in exactly the same way as before.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [x] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
