### PR TITLE
Fixed the `speculative_context` integration test for the hardware wallet.

### DIFF
--- a/.changelog/unreleased/testing/4418-fix-hw-speculative_context.md
+++ b/.changelog/unreleased/testing/4418-fix-hw-speculative_context.md
@@ -1,0 +1,2 @@
+- Fixed the speculative_context integration test so that it passes with the
+  hardware wallet. ([\#4418](https://github.com/anoma/namada/pull/4418))

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -5995,7 +5995,7 @@ fn speculative_context() -> Result<()> {
             run(
                 &node,
                 Bin::Client,
-                vec![
+                apply_use_device(vec![
                     "shield",
                     "--source",
                     ALBERT,
@@ -6007,7 +6007,7 @@ fn speculative_context() -> Result<()> {
                     "100",
                     "--node",
                     validator_one_rpc,
-                ],
+                ]),
             )
         });
         assert!(captured.result.is_ok());
@@ -6050,7 +6050,7 @@ fn speculative_context() -> Result<()> {
         run(
             &node,
             Bin::Client,
-            vec![
+            apply_use_device(vec![
                 "transfer",
                 "--source",
                 A_SPENDING_KEY,
@@ -6064,7 +6064,7 @@ fn speculative_context() -> Result<()> {
                 ALBERT_KEY,
                 "--node",
                 validator_one_rpc,
-            ],
+            ]),
         )
     });
     assert!(captured.result.is_ok());
@@ -6098,7 +6098,7 @@ fn speculative_context() -> Result<()> {
         run(
             &node,
             Bin::Client,
-            vec![
+            apply_use_device(vec![
                 "transfer",
                 "--source",
                 A_SPENDING_KEY,
@@ -6115,7 +6115,7 @@ fn speculative_context() -> Result<()> {
                 "10000",
                 "--node",
                 validator_one_rpc,
-            ],
+            ]),
         )
     });
     assert!(captured.result.is_ok());
@@ -6147,7 +6147,7 @@ fn speculative_context() -> Result<()> {
         run(
             &node,
             Bin::Client,
-            vec![
+            apply_use_device(vec![
                 "transfer",
                 "--source",
                 A_SPENDING_KEY,
@@ -6161,7 +6161,7 @@ fn speculative_context() -> Result<()> {
                 ALBERT_KEY,
                 "--node",
                 validator_one_rpc,
-            ],
+            ]),
         )
     });
     assert!(captured.result.is_ok());


### PR DESCRIPTION
## Describe your changes
Fixed the `speculative_context` integration test for the hardware wallet by ensuring that the `--use-device` flag is applied to its commands when the environment variable `NAMADA_E2E_USE_DEVICE=true`.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
