### PR TITLE
ci/pr: lock msrv deps versions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,7 +103,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: install_cargo_msrv
         if: matrix.build == 'ubuntu'
-        run: cargo install cargo-msrv
+        run: cargo install cargo-msrv --locked
       - name: install_cargo_msrv_no_default
         if: matrix.build != 'ubuntu'
         run: cargo install cargo-msrv --no-default-features


### PR DESCRIPTION
## Describe your changes

fix the failing CI job to lock deps versions as one of the new ones requires rust edition2024

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
