### PR TITLE
Allow the shielded reward precision for tokens to be explicitly set.

### DIFF
--- a/.changelog/unreleased/improvements/4423-configurable-masp-precision.md
+++ b/.changelog/unreleased/improvements/4423-configurable-masp-precision.md
@@ -1,0 +1,2 @@
+- Allow the shielded reward precision for tokens to be explicitly set via
+  governance proposals ([\#4423](https://github.com/anoma/namada/pull/4423))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5088,9 +5088,9 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+checksum = "cfa6b33e4b4d7eb2ec6d8a6b3db92cd92b63b50b15f226e227188b3ec6a1f92c"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5103,9 +5103,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+checksum = "57c4482dd67fb614da7840a08b56d387e43ec8a06129e4f7bdba02900f4e3dbc"
 dependencies = [
  "aes",
  "arbitrary",
@@ -5137,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+checksum = "f07358ecd7aa622deec656874eee2d309dcd9f046f89022105336de73d97b34f"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,8 +189,8 @@ libfuzzer-sys = "0.4"
 libloading = "0.8"
 linkme = "0.3"
 madato = "0.7"
-masp_primitives = { version = "1.2" }
-masp_proofs = { version = "1.2", default-features = false, features = ["local-prover"] }
+masp_primitives = { version = "1.4" }
+masp_proofs = { version = "1.4", default-features = false, features = ["local-prover"] }
 num256 = "0.6"
 num_cpus = "1.13"
 num_enum = "0.7"

--- a/crates/migrations/src/foreign_types.rs
+++ b/crates/migrations/src/foreign_types.rs
@@ -11,3 +11,4 @@ use crate::TypeHash;
 derive_typehash!(Vec::<u8>);
 derive_typehash!(Vec::<String>);
 derive_typehash!(u64);
+derive_typehash!(u128);

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -107,11 +107,11 @@ where
         storage.read(&reward_precision_key)?.map_or_else(
             || -> Result<u128> {
                 // Since reading reward precision has failed, choose a
-                // thousandth of the given token
+                // thousandth of the given token. But clamp the precision above
+                // by 10^38, the maximum power of 10 that can be contained by a
+                // u128.
                 let precision_denom =
-                    std::cmp::max(u32::from(denomination.0), 3)
-                        .checked_sub(3)
-                        .expect("Cannot underflow");
+                    u32::from(denomination.0).saturating_sub(3).clamp(0, 38);
                 let reward_precision = checked!(10u128 ^ precision_denom)?;
                 // Record the precision that is now being used so that it does
                 // not have to be recomputed each time, and to

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -34,7 +34,7 @@ use crate::storage_key::{masp_assets_hash_key, masp_token_map_key};
 use crate::storage_key::{
     masp_kd_gain_key, masp_kp_gain_key, masp_last_inflation_key,
     masp_last_locked_amount_key, masp_locked_amount_target_key,
-    masp_max_reward_rate_key,
+    masp_max_reward_rate_key, masp_reward_precision_key,
 };
 #[cfg(any(feature = "multicore", test))]
 use crate::{ConversionLeaf, Error, OptionExt, ResultExt};
@@ -87,21 +87,44 @@ pub fn calculate_masp_rewards_precision<S, TransToken>(
 ) -> Result<(u128, Denomination)>
 where
     S: StorageWrite + StorageRead,
-    TransToken: trans_token::Read<S>,
+    TransToken: trans_token::Keys + trans_token::Read<S>,
 {
     let denomination = TransToken::read_denom(storage, addr)?
         .expect("failed to read token denomination");
+
     // Inflation is implicitly denominated by this value. The lower this
     // figure, the less precise inflation computations are. This is especially
     // problematic when inflation is coming from a token with much higher
     // denomination than the native token. The higher this figure, the higher
     // the threshold of holdings required in order to receive non-zero rewards.
-    // This value should be fixed constant for each asset type. Here we choose
-    // a thousandth of the given asset.
-    let precision_denom = std::cmp::max(u32::from(denomination.0), 3)
-        .checked_sub(3)
-        .expect("Cannot underflow");
-    Ok((checked!(10u128 ^ precision_denom)?, denomination))
+    // This value should be fixed constant for each asset type. Here we read a
+    // value from storage and failing that we choose a thousandth of the given
+    // asset.
+    // Key to read/write reward precision from
+    let reward_precision_key = masp_reward_precision_key::<TransToken>(addr);
+    // Now read the desired reward precision for this token address
+    let reward_precision: u128 =
+        storage.read(&reward_precision_key)?.map_or_else(
+            || -> Result<u128> {
+                // Since reading reward precision has failed, choose a
+                // thousandth of the given token
+                let precision_denom =
+                    std::cmp::max(u32::from(denomination.0), 3)
+                        .checked_sub(3)
+                        .expect("Cannot underflow");
+                let reward_precision = checked!(10u128 ^ precision_denom)?;
+                // Record the precision that is now being used so that it does
+                // not have to be recomputed each time, and to
+                // ensure that this value is not accidentally
+                // changed even by a change to this initialization
+                // algorithm.
+                storage.write(&reward_precision_key, reward_precision)?;
+                Ok(reward_precision)
+            },
+            Ok,
+        )?;
+
+    Ok((reward_precision, denomination))
 }
 
 /// Get the balance of the given token at the MASP address that is eligble to

--- a/crates/shielded_token/src/storage_key.rs
+++ b/crates/shielded_token/src/storage_key.rs
@@ -40,6 +40,8 @@ pub const MASP_LOCKED_AMOUNT_TARGET_KEY: &str = "locked_amount_target";
 pub const MASP_MAX_REWARD_RATE_KEY: &str = "max_reward_rate";
 /// The key for the total inflation rewards minted by MASP
 pub const MASP_TOTAL_REWARDS: &str = "max_total_rewards";
+/// The key for the reward precision for a given asset
+pub const MASP_REWARD_PRECISION_KEY: &str = "reward_precision";
 
 /// Obtain the nominal proportional key for the given token
 pub fn masp_kp_gain_key<TransToken: trans_token::Keys>(
@@ -63,6 +65,14 @@ pub fn masp_max_reward_rate_key<TransToken: trans_token::Keys>(
 ) -> storage::Key {
     TransToken::parameter_prefix(token_addr)
         .with_segment(MASP_MAX_REWARD_RATE_KEY.to_owned())
+}
+
+/// The precision of rewards for the given token
+pub fn masp_reward_precision_key<TransToken: trans_token::Keys>(
+    token_addr: &Address,
+) -> storage::Key {
+    TransToken::parameter_prefix(token_addr)
+        .with_segment(MASP_REWARD_PRECISION_KEY.to_owned())
 }
 
 /// Obtain the locked target amount key for the given token

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -75,6 +75,11 @@ pub mod storage_key {
         shielded::masp_max_reward_rate_key::<TransToken>(token_addr)
     }
 
+    /// The shielded rewards precision key for the given token
+    pub fn masp_reward_precision_key(token_addr: &Address) -> storage::Key {
+        shielded::masp_reward_precision_key::<TransToken>(token_addr)
+    }
+
     /// Obtain the locked target amount key for the given token
     pub fn masp_locked_amount_target_key(token_addr: &Address) -> storage::Key {
         shielded::masp_locked_amount_target_key::<TransToken>(token_addr)

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -3,14 +3,16 @@ use std::collections::BTreeMap;
 use borsh::{BorshDeserialize, BorshSerialize};
 use namada_macros::BorshDeserializer;
 use namada_sdk::address::Address;
+use namada_sdk::ibc::trace::ibc_token;
 use namada_sdk::masp_primitives::asset_type::AssetType;
 use namada_sdk::masp_primitives::merkle_tree::FrozenCommitmentTree;
 use namada_sdk::masp_primitives::sapling;
 use namada_sdk::migrations;
 use namada_sdk::storage::DbColFam;
+use namada_shielded_token::storage_key::masp_reward_precision_key;
 use namada_shielded_token::{ConversionLeaf, ConversionState};
 use namada_trans_token::storage_key::{balance_key, minted_balance_key};
-use namada_trans_token::Amount;
+use namada_trans_token::{Amount, Store};
 
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -38,8 +40,8 @@ impl From<ConversionState> for NewConversionState {
     }
 }
 
-#[allow(dead_code)]
-fn example() {
+// Demonstrate how to set the minted balance using a migration
+fn minted_balance_migration() {
     let person =
         Address::decode("tnam1q9rhgyv3ydq0zu3whnftvllqnvhvhm270qxay5tn")
             .unwrap();
@@ -68,10 +70,59 @@ fn example() {
     let changes = migrations::DbChanges {
         changes: updates.into_iter().collect(),
     };
-    std::fs::write("migrations.json", serde_json::to_string(&changes).unwrap())
-        .unwrap();
+    std::fs::write(
+        "minted_balance_migration.json",
+        serde_json::to_string(&changes).unwrap(),
+    )
+    .unwrap();
 }
 
+// Demonstrate how to set the shielded reward precision of IBC tokens using a
+// migration
+fn shielded_reward_precision_migration() {
+    pub type ChannelId = &'static str;
+    pub type BaseToken = &'static str;
+    pub type Precision = u128;
+
+    const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
+        ("channel-1", "uosmo", 1000u128),
+        ("channel-2", "uatom", 1000u128),
+        ("channel-3", "utia", 1000u128),
+        ("channel-0", "stuosmo", 1000u128),
+        ("channel-0", "stuatom", 1000u128),
+        ("channel-0", "stutia", 1000u128),
+    ];
+
+    let mut updates = Vec::new();
+    // Set IBC token shielded reward precisions
+    for (channel_id, base_token, precision) in IBC_TOKENS {
+        let ibc_denom = format!("transfer/{channel_id}/{base_token}");
+        let token_address = ibc_token(&ibc_denom).clone();
+
+        // The key holding the shielded reward precision of current token
+        let shielded_token_reward_precision_key =
+            masp_reward_precision_key::<Store<()>>(&token_address);
+
+        updates.push(migrations::DbUpdateType::Add {
+            key: shielded_token_reward_precision_key,
+            cf: DbColFam::SUBSPACE,
+            value: precision.into(),
+            force: false,
+        });
+    }
+
+    let changes = migrations::DbChanges {
+        changes: updates.into_iter().collect(),
+    };
+    std::fs::write(
+        "shielded_reward_precision_migration.json",
+        serde_json::to_string(&changes).unwrap(),
+    )
+    .unwrap();
+}
+
+// Generate various migrations
 fn main() {
-    example()
+    minted_balance_migration();
+    shielded_reward_precision_migration();
 }

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -4083,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+checksum = "cfa6b33e4b4d7eb2ec6d8a6b3db92cd92b63b50b15f226e227188b3ec6a1f92c"
 dependencies = [
  "borsh",
  "chacha20",
@@ -4097,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+checksum = "57c4482dd67fb614da7840a08b56d387e43ec8a06129e4f7bdba02900f4e3dbc"
 dependencies = [
  "aes",
  "bip0039",
@@ -4130,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+checksum = "f07358ecd7aa622deec656874eee2d309dcd9f046f89022105336de73d97b34f"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2273,9 +2273,9 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+checksum = "cfa6b33e4b4d7eb2ec6d8a6b3db92cd92b63b50b15f226e227188b3ec6a1f92c"
 dependencies = [
  "borsh",
  "chacha20",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+checksum = "57c4482dd67fb614da7840a08b56d387e43ec8a06129e4f7bdba02900f4e3dbc"
 dependencies = [
  "aes",
  "bip0039",
@@ -2319,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+checksum = "f07358ecd7aa622deec656874eee2d309dcd9f046f89022105336de73d97b34f"
 dependencies = [
  "bellman",
  "blake2b_simd",


### PR DESCRIPTION
## Describe your changes
An attempt to address https://github.com/anoma/namada/issues/4422 by introducing new storage keys to hold the shielded reward precision for each token and reading that instead of deducting it. More precisely, the changes are as follows:
* Made a new storage key to hold the shielded rewards precision for each token
* The function for obtaining a token's reward precision now reads this new storage key
  * And if the storage key is uninitialized, it initializes it using the old algorithm: `10^(max(denom,3)-3)`
* Implements as an example a migration that sets the precision for existing IBC tokens
  * Alternatively, for an example of a governance upgrade taking advantage of this PR, see: https://github.com/anoma/namada-governance-upgrades/pull/38 .

This PR should be backwards compatible in the sense it can read/support current mainnet state without any migrations. And simultaneously it allows the shielded rewards precision to be set for new tokens as they are introduced by governance proposals. But to fix the precision of IBC tokens that have already been introduced into the system, purging of its `ConversionLeaf::conversion` entries (by setting them to `MaspAmount::zero()`) would also have to be done in addition to setting its desired shielded reward precision in storage. (More generally, once the shielded reward precision for a token is set, it cannot be changed without doing a similar purging process.)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
