### PR TITLE
Make `native_token` of `NamadaImpl` public

### DIFF
--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -677,7 +677,7 @@ where
     /// Captures the input/output streams used by this object
     pub io: I,
     /// The address of the native token
-    native_token: Address,
+    pub native_token: Address,
     /// The default builder for a Tx
     prototype: args::Tx,
 }


### PR DESCRIPTION
## Describe your changes
I'm doing some things with the Namada SDK and this seems like it would be useful to me.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
