### PR TITLE
Murisi/client anchor patch optimized

### DIFF
--- a/.changelog/unreleased/bug-fixes/4442-client-anchor-patch-optimized.md
+++ b/.changelog/unreleased/bug-fixes/4442-client-anchor-patch-optimized.md
@@ -1,0 +1,3 @@
+- Fixes the commitment tree anchor mismatch bug by making
+  the client search for the correct Transaction ordering
+  ([\#4442](https://github.com/anoma/namada/pull/4442))

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -663,20 +663,25 @@ impl MaspClient for IndexerMaspClient {
             ))
         })?;
 
+        let mut masp_index = 0;
+        let mut prev_block_height = None;
+
         Ok(payload
             .notes_index
             .into_iter()
-            .enumerate()
             .map(
-                |(
-                    masp_index,
-                    Note {
-                        block_index,
-                        batch_index,
-                        block_height,
-                        note_position,
-                    },
-                )| {
+                |Note {
+                     block_index,
+                     batch_index,
+                     block_height,
+                     note_position,
+                 }| {
+                    if Some(block_height) != prev_block_height {
+                        masp_index = 0;
+                        prev_block_height = Some(block_height);
+                    } else {
+                        masp_index += 1;
+                    }
                     (
                         IndexedTx {
                             block_index: TxIndex(block_index),

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -205,6 +205,12 @@ impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
                 .to_string(),
         ))
     }
+
+    async fn commitment_anchor_exists(&self, root: &Node) -> Result<bool, Error> {
+        let anchor_key =
+            crate::token::storage_key::masp_commitment_anchor_key(*root);
+        crate::rpc::query_has_storage_key(&self.inner.client, &anchor_key).await
+    }
 }
 
 #[derive(Debug)]
@@ -727,6 +733,13 @@ impl MaspClient for IndexerMaspClient {
                 Ok(accum)
             },
         )
+    }
+
+    async fn commitment_anchor_exists(&self, _root: &Node) -> Result<bool, Error> {
+        Err(Error::Other(
+            "Commitment anchor checking is not implemented by this client"
+                .to_string(),
+        ))
     }
 }
 

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -206,7 +206,10 @@ impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
         ))
     }
 
-    async fn commitment_anchor_exists(&self, root: &Node) -> Result<bool, Error> {
+    async fn commitment_anchor_exists(
+        &self,
+        root: &Node,
+    ) -> Result<bool, Error> {
         let anchor_key =
             crate::token::storage_key::masp_commitment_anchor_key(*root);
         crate::rpc::query_has_storage_key(&self.inner.client, &anchor_key).await
@@ -735,7 +738,10 @@ impl MaspClient for IndexerMaspClient {
         )
     }
 
-    async fn commitment_anchor_exists(&self, _root: &Node) -> Result<bool, Error> {
+    async fn commitment_anchor_exists(
+        &self,
+        _root: &Node,
+    ) -> Result<bool, Error> {
         Err(Error::Other(
             "Commitment anchor checking is not implemented by this client"
                 .to_string(),

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -382,7 +382,7 @@ where
         }
     }
 
-    // Search for the Transaction order usedby the protocol using trial and
+    // Search for the Transaction order used by the protocol using trial and
     // error.
     async fn transaction_order_search(
         &mut self,
@@ -391,8 +391,6 @@ where
         let mut ordered_txs = vec![];
         // Get the unordered Transactions with their indices
         let mut indexed_txs = self.cache.fetched.take().into_iter().peekable();
-        let needs_witness_map_update =
-            self.client.capabilities().needs_witness_map_update();
         while let Some(first_tx) = indexed_txs.next() {
             // Take only Transactions belonging to one block
             let mut block_txs = vec![first_tx];
@@ -402,9 +400,7 @@ where
                 block_txs.push(next_tx);
             }
             // Do not apply these Transactions if they have been applied before
-            if !needs_witness_map_update
-                || Some(&block_txs[0].0) <= last_witnessed_tx.as_ref()
-            {
+            if Some(&block_txs[0].0) <= last_witnessed_tx.as_ref() {
                 continue;
             }
             // Save the initial state of the ShieldedContext in case reversion
@@ -428,7 +424,7 @@ where
                 for (indexed_tx, stx_batch) in &subset {
                     tracing::debug!("Transaction Index: {:?}", indexed_tx);
                     fee_transfers.insert(indexed_tx);
-                    self.ctx.update_witness_map(*indexed_tx, stx_batch).await?;
+                    self.ctx.update_witness_map(*indexed_tx, stx_batch)?;
                 }
                 // Apply the second subsequence, which corresponds to the
                 // Transactions not used in the fees
@@ -437,9 +433,7 @@ where
                     // first
                     if !fee_transfers.contains(indexed_tx) {
                         tracing::debug!("Transaction Index: {:?}", indexed_tx);
-                        self.ctx
-                            .update_witness_map(*indexed_tx, stx_batch)
-                            .await?;
+                        self.ctx.update_witness_map(*indexed_tx, stx_batch)?;
                     }
                 }
                 // Compute what the note commitment tree root would look like

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -490,8 +490,11 @@ where
 
         let needs_witness_map_update =
             self.client.capabilities().needs_witness_map_update();
-        let ordered_txs =
-            self.transaction_order_search(last_witnessed_tx).await?;
+        let ordered_txs = if needs_witness_map_update {
+            self.transaction_order_search(last_witnessed_tx).await?
+        } else {
+            self.cache.fetched.take().into_iter().collect()
+        };
 
         for (indexed_tx, stx_batch) in ordered_txs {
             self.ctx

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -350,7 +350,7 @@ where
                 Ok(None)
             }
             DispatcherState::Normal => {
-                self.apply_cache_to_shielded_context(&initial_state)?;
+                self.apply_cache_to_shielded_context(&initial_state).await?;
                 self.finish_progress_bars();
                 self.ctx.save().await.map_err(|err| {
                     eyre!("Failed to save the shielded context: {err}")
@@ -381,7 +381,7 @@ where
         }
     }
 
-    fn apply_cache_to_shielded_context(
+    async fn apply_cache_to_shielded_context(
         &mut self,
         InitialState {
             last_witnessed_tx,
@@ -407,7 +407,7 @@ where
             if needs_witness_map_update
                 && Some(&indexed_tx) > last_witnessed_tx.as_ref()
             {
-                self.ctx.update_witness_map(indexed_tx, &stx_batch)?;
+                self.ctx.update_witness_map(&self.client, indexed_tx, &stx_batch).await?;
             }
             let first_note_pos = self.ctx.note_index[&indexed_tx];
             let mut vk_heights = BTreeMap::new();
@@ -930,6 +930,7 @@ mod dispatcher_tests {
                         start_height: Default::default(),
                         last_query_height: 9.into(),
                     })
+                    .await
                     .expect("Test failed");
                 assert!(dispatcher.cache.fetched.is_empty());
                 assert!(dispatcher.cache.trial_decrypted.is_empty());

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -39,6 +39,26 @@ impl TrialDecrypted {
             .sum::<usize>()
     }
 
+    /// Update the transaction indices according to the given map. If a key is
+    /// not found, then return it.
+    pub fn reindex(
+        &mut self,
+        key_map: &BTreeMap<IndexedTx, IndexedTx>,
+    ) -> Option<IndexedTx> {
+        let mut value_map = HashMap::new();
+        // First grab all the values we need to make sure that we do not
+        // accidentally overwrite
+        for (old, new) in key_map {
+            if let Some(value) = self.inner.swap_remove(old) {
+                value_map.insert(*new, value);
+            } else {
+                return Some(*old);
+            }
+        }
+        self.inner.extend(value_map);
+        None
+    }
+
     /// Get cached notes decrypted with `vk`, indexed at `itx`.
     pub fn get(
         &self,

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -265,7 +265,10 @@ pub trait MaspClient: Clone {
 
     /// Check whether the given commitment anchor exists
     #[allow(async_fn_in_trait)]
-    async fn commitment_anchor_exists(&self, root: &Node) -> Result<bool, Self::Error>;
+    async fn commitment_anchor_exists(
+        &self,
+        root: &Node,
+    ) -> Result<bool, Self::Error>;
 }
 
 /// Given a block height range we wish to request and a cache of fetched block

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -348,8 +348,9 @@ mod test_blocks_left_to_fetch {
             .map(|height| {
                 (
                     IndexedTx {
-                        height,
-                        index: TxIndex(0),
+                        block_height: height,
+                        masp_index: 0,
+                        block_index: TxIndex(0),
                         batch_index: None,
                     },
                     masp_tx.clone(),

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -262,6 +262,10 @@ pub trait MaspClient: Clone {
         &self,
         height: BlockHeight,
     ) -> Result<HashMap<usize, IncrementalWitness<Node>>, Self::Error>;
+
+    /// Check whether the given commitment anchor exists
+    #[allow(async_fn_in_trait)]
+    async fn commitment_anchor_exists(&self, root: &Node) -> Result<bool, Self::Error>;
 }
 
 /// Given a block height range we wish to request and a cache of fetched block

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -143,12 +143,11 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
 
     /// Update the merkle tree of witnesses the first time we
     /// scan new MASP transactions.
-    pub(crate) async fn update_witness_map<M: MaspClient + Send + Sync + Unpin + 'static,>(
+    pub(crate) async fn update_witness_map(
         &mut self,
-        client: &M,
         indexed_tx: IndexedTx,
         shielded: &Transaction,
-    ) -> Result<bool, eyre::Error> {
+    ) -> Result<(), eyre::Error> {
         let mut note_pos = self.tree.size();
         self.note_index.insert(indexed_tx, note_pos);
 
@@ -174,14 +173,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
             self.witness_map.insert(note_pos, witness);
             note_pos = checked!(note_pos + 1).unwrap();
         }
-        let root = self.tree.root();
-        let anchor_exists = client.commitment_anchor_exists(&root).await?;
-        #[allow(clippy::print_stdout)] {
-            println!("Transaction Index: {:?}", indexed_tx);
-            println!("Commitment Anchor: {:?}", root);
-            println!("Commitment Anchor Exists: {}", anchor_exists);
-        }
-        Ok(anchor_exists)
+        Ok(())
     }
 
     /// Sync the current state of the multi-asset shielded pool in a

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -141,6 +141,25 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
         self.utils.save(self).await
     }
 
+    /// Update only the Merkle tree without updating anything else. Useful for
+    /// checking note commitment tree anchors with less overhead.
+    pub(crate) fn update_merkle_tree(
+        &mut self,
+        shielded: &Transaction,
+    ) -> Result<(), eyre::Error> {
+        for so in shielded
+            .sapling_bundle()
+            .map_or(&vec![], |x| &x.shielded_outputs)
+        {
+            // Create merkle tree leaf node from note commitment
+            let node = Node::new(so.cmu.to_repr());
+            self.tree.append(node).map_err(|()| {
+                eyre!("note commitment tree is full".to_string())
+            })?;
+        }
+        Ok(())
+    }
+
     /// Update the merkle tree of witnesses the first time we
     /// scan new MASP transactions.
     pub(crate) fn update_witness_map(

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -218,7 +218,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
             ));
         };
         Ok(maybe_least_synced_vk_height
-            .map_or_else(BlockHeight::first, |itx| itx.height))
+            .map_or_else(BlockHeight::first, |itx| itx.block_height))
     }
 
     #[allow(missing_docs)]

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -143,7 +143,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
 
     /// Update the merkle tree of witnesses the first time we
     /// scan new MASP transactions.
-    pub(crate) async fn update_witness_map(
+    pub(crate) fn update_witness_map(
         &mut self,
         indexed_tx: IndexedTx,
         shielded: &Transaction,

--- a/crates/shielded_token/src/masp/test_utils.rs
+++ b/crates/shielded_token/src/masp/test_utils.rs
@@ -439,6 +439,15 @@ impl MaspClient for TestingMaspClient {
     ) -> Result<HashMap<usize, IncrementalWitness<Node>>, Self::Error> {
         unimplemented!("Witness map fetching is not implemented by this client")
     }
+
+    async fn commitment_anchor_exists(
+        &self,
+        _: &Node,
+    ) -> Result<bool, Self::Error> {
+        unimplemented!(
+            "Commitment anchor checking is not implemented by this client"
+        )
+    }
 }
 
 /// A shielded context for testing

--- a/crates/shielded_token/src/masp/test_utils.rs
+++ b/crates/shielded_token/src/masp/test_utils.rs
@@ -444,9 +444,7 @@ impl MaspClient for TestingMaspClient {
         &self,
         _: &Node,
     ) -> Result<bool, Self::Error> {
-        unimplemented!(
-            "Commitment anchor checking is not implemented by this client"
-        )
+        Ok(true)
     }
 }
 

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -906,9 +906,11 @@ impl<'tx> Tx {
 )]
 pub struct IndexedTx {
     /// The block height of the indexed tx
-    pub height: BlockHeight,
+    pub block_height: BlockHeight,
+    /// Relative index of this tx in the MASP
+    pub masp_index: u32,
     /// The index in the block of the tx
-    pub index: TxIndex,
+    pub block_index: TxIndex,
     /// The optional index of an inner tx within this batc
     pub batch_index: Option<u32>,
 }
@@ -918,8 +920,9 @@ impl IndexedTx {
     /// txs in a block with some height `height`.
     pub const fn entire_block(height: BlockHeight) -> Self {
         Self {
-            height,
-            index: TxIndex(u32::MAX),
+            block_height: height,
+            masp_index: u32::MAX,
+            block_index: TxIndex(u32::MAX),
             batch_index: None,
         }
     }
@@ -928,8 +931,9 @@ impl IndexedTx {
 impl Default for IndexedTx {
     fn default() -> Self {
         Self {
-            height: BlockHeight::first(),
-            index: TxIndex(0),
+            block_height: BlockHeight::first(),
+            masp_index: 0,
+            block_index: TxIndex(0),
             batch_index: None,
         }
     }
@@ -952,13 +956,15 @@ impl IndexedTxRange {
     pub const fn between_heights(from: BlockHeight, to: BlockHeight) -> Self {
         Self::new(
             IndexedTx {
-                height: from,
-                index: TxIndex(0),
+                block_height: from,
+                masp_index: 0,
+                block_index: TxIndex(0),
                 batch_index: None,
             },
             IndexedTx {
-                height: to,
-                index: TxIndex(u32::MAX),
+                block_height: to,
+                masp_index: u32::MAX,
+                block_index: TxIndex(u32::MAX),
                 batch_index: None,
             },
         )


### PR DESCRIPTION
## Describe your changes
Implemented a patch on the MASP client to search for the `Transaction` ordering used by the protocol. Specifically, for a given block, the client goes through different permutations of its `Transaction`s and checks if applying them would result in a note commitment tree anchor in agreement with the protocol. When this condition is met, the client then moves onto the next block doing the same thing until the client is fully synchronized.

Improvements from original patch in https://github.com/anoma/namada/tree/murisi/check-acknowledgement :
* Restricted the set of permutations tried to only those that can actually happen
* Reduced the amount of commitment anchor existence queries by only doing so on block boundaries
* Deduplicated calls to `update_witness_map` by not destroying `ShieldedContext` state after finding correct ordering
* Now respect `last_witnessed_tx` so that previously applied `Transaction`s are no longer reapplied
* Now respect the `needs_witness_map_update` capability by not updating witness map if it is false
* Replaced error-prone index arithmetic with iterator usage and factored out hack into separate function
* Adjusted the client to not reorder (to block ordering) the `Transaction`s it obtains from events or the indexer

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
