### PR TITLE
enable rocksdb bindgen-runtime by default

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,6 @@ env:
   MINOR_VERSION_RELEASE: "0.47.999" # bump on a major release
   BACKPORT_LIBS_LABEL: "backport-libs-0.47" # also bump on major release
   MAINT_LIBS_BRANCH: "maint-libs-0.47" # also bump on major release
-  LIBCLANG_PATH: "/usr/lib/llvm-18/lib" # Needed for RocksDB, installed in build deps
 
 jobs:
   # Check if a PR has no major breaking changes to be backported to library
@@ -53,9 +52,7 @@ jobs:
       - name: Instal cargo release  
         run: cargo binstall -y cargo-release
       - name: Install build deps
-        run: sudo apt-get install -y protobuf-compiler libudev-dev llvm-18
-      - name: Symlink libclang for RocksDB
-        run: sudo ln -s /usr/lib/llvm-18/lib/libclang-18.so.1 /usr/lib/llvm-18/lib/libclang-18.so
+        run: sudo apt-get install -y protobuf-compiler libudev-dev
       - name: Totally safe 
         # Workaround for https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -4938,6 +4939,16 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ regex = "1.10"
 reqwest = { version = "0.12", features = ["json"] }
 ripemd = "0.1"
 rlimit = "0.10"
-rocksdb = {version = "0.23", features = ['zstd'], default-features = false}
+rocksdb = {version = "0.23", features = ["zstd", "bindgen-runtime"], default-features = false}
 rpassword = "7.3"
 rustversion = "1.0"
 serde = {version = "1.0", features = ["derive"]}


### PR DESCRIPTION
## Describe your changes

follow-up to #4378 to enable a new feature to restore 0.22 build behaviour

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
