### PR TITLE
Adjusted test vector generator to also generate tokens in whitelist.

### DIFF
--- a/.changelog/unreleased/improvements/4445-generate-whitelisted-addresses.md
+++ b/.changelog/unreleased/improvements/4445-generate-whitelisted-addresses.md
@@ -1,0 +1,2 @@
+- Generate test vectors that use whitelisted tokens for the hardware wallet.
+  ([\#4445](https://github.com/anoma/namada/pull/4445))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ env:
   AWS_REGION: us-west-2
   NIGHTLY: nightly-2024-09-08
   NAMADA_MASP_PARAMS_DIR: /masp/.masp-params
-  LEDGER_APP_VERSION: "3.0.1"
+  LEDGER_APP_VERSION: "3.0.4"
   ROLE: arn:aws:iam::375643557360:role/github-runners-ci-shared
 
 jobs:

--- a/crates/core/src/address.rs
+++ b/crates/core/src/address.rs
@@ -811,6 +811,7 @@ pub mod testing {
         prop_oneof![
             arb_established_address().prop_map(Address::Established),
             arb_implicit_address().prop_map(Address::Implicit),
+            arb_whitelisted_address(),
         ]
     }
 
@@ -820,7 +821,43 @@ pub mod testing {
             arb_established_address().prop_map(Address::Established),
             arb_implicit_address().prop_map(Address::Implicit),
             arb_internal_address().prop_map(Address::Internal),
+            arb_whitelisted_address(),
         ]
+    }
+
+    /// A list of tokens whitelisted on hardware wallets
+    pub fn address_whitelist() -> HashMap<Address, &'static str> {
+        const EXPECT: &str = "The token address decoding shouldn't fail";
+        let nam =
+            Address::decode("tnam1q9gr66cvu4hrzm0sd5kmlnjje82gs3xlfg3v6nu7");
+        let osmo =
+            Address::decode("tnam1p5z8ruwyu7ha8urhq2l0dhpk2f5dv3ts7uyf2n75");
+        let atom =
+            Address::decode("tnam1pkg30gnt4q0zn7j00r6hms4ajrxn6f5ysyyl7w9m");
+        let tia =
+            Address::decode("tnam1pklj3kwp0cpsdvv56584rsajty974527qsp8n0nm");
+        let st_osmo =
+            Address::decode("tnam1p4px8sw3am4qvetj7eu77gftm4fz4hcw2ulpldc7");
+        let st_atom =
+            Address::decode("tnam1p5z5538v3kdk3wdx7r2hpqm4uq9926dz3ughcp7n");
+        let st_tia =
+            Address::decode("tnam1ph6xhf0defk65hm7l5ursscwqdj8ehrcdv300u4g");
+        let mut whitelist = HashMap::new();
+        whitelist.insert(nam.expect(EXPECT), "NAM");
+        whitelist.insert(osmo.expect(EXPECT), "uOSMO");
+        whitelist.insert(atom.expect(EXPECT), "uATOM");
+        whitelist.insert(tia.expect(EXPECT), "uTIA");
+        whitelist.insert(st_osmo.expect(EXPECT), "ustOSMO");
+        whitelist.insert(st_atom.expect(EXPECT), "ustATOM");
+        whitelist.insert(st_tia.expect(EXPECT), "ustTIA");
+        whitelist
+    }
+
+    /// Generate an arbitrary whitelisted address
+    pub fn arb_whitelisted_address() -> impl Strategy<Value = Address> {
+        any::<prop::sample::Selector>().prop_map(|selector| {
+            selector.select(address_whitelist().keys().cloned())
+        })
     }
 
     /// Generate an arbitrary [`EstablishedAddress`].

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -857,9 +857,7 @@ pub mod testing {
     use governance::ProposalType;
     use masp_primitives::transaction::components::sapling::builder::StoredBuildParams;
     use namada_account::{InitAccount, UpdateAccount};
-    use namada_core::address::testing::{
-        arb_established_address, arb_non_internal_address,
-    };
+    use namada_core::address::testing::arb_non_internal_address;
     use namada_core::collections::{HashMap, HashSet};
     use namada_core::eth_bridge_pool::PendingTransfer;
     use namada_core::hash::testing::arb_hash;
@@ -1020,7 +1018,7 @@ pub mod testing {
         /// Generate an arbitrary fee
         pub fn arb_fee()(
             amount_per_gas_unit in arb_denominated_amount(),
-            token in arb_established_address().prop_map(Address::Established),
+            token in arb_non_internal_address(),
         ) -> Fee {
             Fee {
                 amount_per_gas_unit,

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -338,9 +338,7 @@ pub mod testing {
     use masp_primitives::transaction::components::{TxOut, U64Sum};
     use masp_primitives::transaction::fees::fixed::FeeRule;
     use masp_primitives::zip32::PseudoExtendedKey;
-    use namada_core::address::testing::{
-        arb_established_address, arb_non_internal_address,
-    };
+    use namada_core::address::testing::arb_non_internal_address;
     use namada_core::address::{Address, MASP};
     use namada_core::collections::HashMap;
     use namada_core::masp::{encode_asset_type, AssetData, TAddrData};
@@ -367,7 +365,7 @@ pub mod testing {
         fn arb_single_transparent_transfer()(
             source in arb_non_internal_address(),
             target in arb_non_internal_address(),
-            token in arb_established_address().prop_map(Address::Established),
+            token in arb_non_internal_address(),
             amount in arb_denominated_amount(),
         ) -> (Address, Address, Address, DenominatedAmount) {
             (

--- a/examples/generate_txs.rs
+++ b/examples/generate_txs.rs
@@ -1,23 +1,22 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 
 use data_encoding::HEXLOWER;
+use namada_sdk::address::testing::address_whitelist;
 use namada_sdk::signing::to_ledger_vector;
 use namada_sdk::testing::arb_signed_tx;
-use namada_sdk::wallet::fs::FsWalletUtils;
 use proptest::strategy::{Strategy, ValueTree};
 use proptest::test_runner::{Reason, TestRunner};
 
 #[tokio::main]
 async fn main() -> Result<(), Reason> {
     let mut runner = TestRunner::deterministic();
-    let wallet = FsWalletUtils::new(PathBuf::from("wallet.toml"));
+    let addr_whitelist = address_whitelist();
     let mut debug_vectors = vec![];
     let mut test_vectors = vec![];
     let mut serialized_txs = vec![];
     for i in 0..10000 {
         let (tx, tx_data) = arb_signed_tx().new_tree(&mut runner)?.current();
-        let mut ledger_vector = to_ledger_vector(&wallet, &tx)
+        let mut ledger_vector = to_ledger_vector(&addr_whitelist, &tx)
             .await
             .expect("unable to construct test vector");
         let sechashes = tx.sechashes();


### PR DESCRIPTION
## Describe your changes
Adjusted the test vector generator so that it also sometimes generates tokens from the current hardware wallet whitelist. The purpose of this PR is to test hardware wallet functionality regarding printing tokens with known tickers. The following mapping is being used:
* NAM - `tnam1q9gr66cvu4hrzm0sd5kmlnjje82gs3xlfg3v6nu7`
* uOSMO - `tnam1p5z8ruwyu7ha8urhq2l0dhpk2f5dv3ts7uyf2n75`
* uATOM - `tnam1pkg30gnt4q0zn7j00r6hms4ajrxn6f5ysyyl7w9m`
* uTIA - `tnam1pklj3kwp0cpsdvv56584rsajty974527qsp8n0nm`
* ustOSMO - `tnam1p4px8sw3am4qvetj7eu77gftm4fz4hcw2ulpldc7`
* ustATOM - `tnam1p5z5538v3kdk3wdx7r2hpqm4uq9926dz3ughcp7n`
* ustTIA - `tnam1ph6xhf0defk65hm7l5ursscwqdj8ehrcdv300u4g`

See attached the generated test vectors: [testvecs_formatted.json](https://github.com/user-attachments/files/19072563/testvecs_formatted.json) [testdbgs.txt.gz](https://github.com/user-attachments/files/19072566/testdbgs.txt.gz)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
