### PR TITLE
Fix masp events

### DIFF
--- a/.changelog/unreleased/bug-fixes/4449-fix-masp-events.md
+++ b/.changelog/unreleased/bug-fixes/4449-fix-masp-events.md
@@ -1,0 +1,2 @@
+- Fixed the production of masp events for masp fee payment transactions.
+  ([\#4449](https://github.com/anoma/namada/pull/4449))

--- a/crates/events/src/extend.rs
+++ b/crates/events/src/extend.rs
@@ -9,9 +9,6 @@ use namada_core::address::Address;
 use namada_core::chain::BlockHeight;
 use namada_core::collections::HashMap;
 use namada_core::hash::Hash;
-use namada_core::ibc::IbcTxDataHash;
-use namada_core::masp::MaspTxId;
-use namada_core::storage::TxIndex;
 use serde::Deserializer;
 
 use super::*;
@@ -482,60 +479,6 @@ impl EventAttributeEntry<'static> for Info {
     type ValueOwned = Self::Value;
 
     const KEY: &'static str = "info";
-
-    fn into_value(self) -> Self::Value {
-        self.0
-    }
-}
-
-/// A type representing the possible reference to some MASP data, either a masp
-/// section or ibc tx data
-#[derive(Clone, Serialize, Deserialize)]
-pub enum MaspTxRef {
-    /// Reference to a MASP section
-    MaspSection(MaspTxId),
-    /// Reference to an ibc tx data section
-    IbcData(IbcTxDataHash),
-}
-
-/// A list of MASP tx references
-#[derive(Default, Clone, Serialize, Deserialize)]
-pub struct MaspTxRefs(pub Vec<MaspTxRef>);
-
-/// A mapping between the index of a transaction in a block and the set of
-/// associated masp data
-#[derive(Clone, Serialize, Deserialize)]
-pub struct IndexedMaspData {
-    /// The transaction index in the block
-    pub tx_index: TxIndex,
-    /// The set of masp data
-    pub masp_refs: MaspTxRefs,
-}
-
-impl Display for IndexedMaspData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).unwrap())
-    }
-}
-
-impl FromStr for IndexedMaspData {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s)
-    }
-}
-
-/// Extend an [`Event`] with `masp_data_refs` data, mapping a transaction
-/// index in the block to a collection of either the MASP sections or the data
-/// sections for shielded actions.
-pub struct MaspDataRefs(pub IndexedMaspData);
-
-impl EventAttributeEntry<'static> for MaspDataRefs {
-    type Value = IndexedMaspData;
-    type ValueOwned = Self::Value;
-
-    const KEY: &'static str = "masp_data_refs";
 
     fn into_value(self) -> Self::Value {
         self.0

--- a/crates/node/src/dry_run_tx.rs
+++ b/crates/node/src/dry_run_tx.rs
@@ -36,55 +36,54 @@ where
     let height = state.in_mem().get_last_block_height();
 
     // Wrapper dry run to allow estimating the entire gas cost of a transaction
-    let (wrapper_hash, extended_tx_result, tx_gas_meter) =
-        match tx.header().tx_type {
-            TxType::Wrapper(wrapper) => {
-                let gas_limit = wrapper
-                    .gas_limit
-                    .as_scaled_gas(gas_scale)
-                    .into_storage_result()?;
-                let tx_gas_meter =
-                    RefCell::new(TxGasMeter::new(gas_limit, gas_scale));
-                let mut shell_params = ShellParams::new(
-                    &tx_gas_meter,
-                    &mut state,
-                    &mut vp_wasm_cache,
-                    &mut tx_wasm_cache,
-                );
-                let tx_result = protocol::apply_wrapper_tx(
-                    &tx,
-                    &wrapper,
-                    &request.data,
-                    &TxIndex::default(),
-                    height,
-                    &tx_gas_meter,
-                    &mut shell_params,
-                    None,
-                )
+    let (wrapper_hash, tx_result, tx_gas_meter) = match tx.header().tx_type {
+        TxType::Wrapper(wrapper) => {
+            let gas_limit = wrapper
+                .gas_limit
+                .as_scaled_gas(gas_scale)
                 .into_storage_result()?;
+            let tx_gas_meter =
+                RefCell::new(TxGasMeter::new(gas_limit, gas_scale));
+            let mut shell_params = ShellParams::new(
+                &tx_gas_meter,
+                &mut state,
+                &mut vp_wasm_cache,
+                &mut tx_wasm_cache,
+            );
+            let tx_result = protocol::apply_wrapper_tx(
+                &tx,
+                &wrapper,
+                &request.data,
+                &TxIndex::default(),
+                height,
+                &tx_gas_meter,
+                &mut shell_params,
+                None,
+            )
+            .into_storage_result()?;
 
-                state.write_log_mut().commit_tx_to_batch();
-                (Some(tx.header_hash()), tx_result, tx_gas_meter)
-            }
-            _ => {
-                // When dry running only the inner tx(s), use the max block gas
-                // as the gas limit
-                let max_block_gas = parameters::get_max_block_gas(&state)?;
-                let gas_limit = GasLimit::from(max_block_gas)
-                    .as_scaled_gas(gas_scale)
-                    .into_storage_result()?;
-                (
-                    None,
-                    TxResult::default().to_extended_result(None),
-                    RefCell::new(TxGasMeter::new(gas_limit, gas_scale)),
-                )
-            }
-        };
+            state.write_log_mut().commit_tx_to_batch();
+            (Some(tx.header_hash()), tx_result, tx_gas_meter)
+        }
+        _ => {
+            // When dry running only the inner tx(s), use the max block gas
+            // as the gas limit
+            let max_block_gas = parameters::get_max_block_gas(&state)?;
+            let gas_limit = GasLimit::from(max_block_gas)
+                .as_scaled_gas(gas_scale)
+                .into_storage_result()?;
+            (
+                None,
+                TxResult::default(),
+                RefCell::new(TxGasMeter::new(gas_limit, gas_scale)),
+            )
+        }
+    };
 
-    let extended_tx_result = protocol::dispatch_inner_txs(
+    let tx_result = protocol::dispatch_inner_txs(
         &tx,
         wrapper_hash.as_ref(),
-        extended_tx_result,
+        tx_result,
         TxIndex(0),
         height,
         &tx_gas_meter,
@@ -94,7 +93,7 @@ where
     )
     .map_err(|err| err.error)
     .into_storage_result()?;
-    let tx_result_string = extended_tx_result.tx_result.to_result_string();
+    let tx_result_string = tx_result.to_result_string();
     let dry_run_result = DryRunResult(
         tx_result_string,
         tx_gas_meter

--- a/crates/node/src/dry_run_tx.rs
+++ b/crates/node/src/dry_run_tx.rs
@@ -33,6 +33,7 @@ where
     tx.validate_tx().into_storage_result()?;
 
     let gas_scale = parameters::get_gas_scale(&state)?;
+    let height = state.in_mem().get_last_block_height();
 
     // Wrapper dry run to allow estimating the entire gas cost of a transaction
     let (wrapper_hash, extended_tx_result, tx_gas_meter) =
@@ -55,6 +56,7 @@ where
                     &wrapper,
                     &request.data,
                     &TxIndex::default(),
+                    height,
                     &tx_gas_meter,
                     &mut shell_params,
                     None,
@@ -84,6 +86,7 @@ where
         wrapper_hash.as_ref(),
         extended_tx_result,
         TxIndex(0),
+        height,
         &tx_gas_meter,
         &mut state,
         &mut vp_wasm_cache,
@@ -104,7 +107,7 @@ where
         data: dry_run_result.serialize_to_vec(),
         proof: None,
         info: Default::default(),
-        height: state.in_mem().get_last_block_height(),
+        height,
     })
 }
 

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -7,6 +7,7 @@ use either::Either;
 use eyre::{eyre, WrapErr};
 use namada_sdk::address::{Address, InternalAddress};
 use namada_sdk::booleans::BoolResultUnitExt;
+use namada_sdk::chain::BlockHeight;
 use namada_sdk::collections::HashSet;
 use namada_sdk::events::extend::{
     ComposeEvent, Height as HeightAttr, TxHash as TxHashAttr, UserAccount,
@@ -170,7 +171,7 @@ pub enum DispatchArgs<'a, CA: 'static + WasmCacheAccess + Sync> {
         /// The tx index
         tx_index: TxIndex,
         /// The block height
-        height: namada_sdk::chain::BlockHeight,
+        height: BlockHeight,
         /// Hash of the header of the wrapper tx containing
         /// this raw tx
         wrapper_hash: Option<&'a Hash>,
@@ -191,7 +192,7 @@ pub enum DispatchArgs<'a, CA: 'static + WasmCacheAccess + Sync> {
         /// The tx index
         tx_index: TxIndex,
         /// The block height
-        height: namada_sdk::chain::BlockHeight,
+        height: BlockHeight,
         /// The block proposer
         block_proposer: &'a Address,
         /// Vp cache
@@ -328,7 +329,7 @@ pub(crate) fn dispatch_inner_txs<'a, S, D, H, CA>(
     wrapper_hash: Option<&'a Hash>,
     mut tx_result: TxResult<Error>,
     tx_index: TxIndex,
-    height: namada_sdk::chain::BlockHeight,
+    height: BlockHeight,
     tx_gas_meter: &'a RefCell<TxGasMeter>,
     state: &'a mut S,
     vp_wasm_cache: &'a mut VpCache<CA>,
@@ -462,7 +463,7 @@ pub(crate) fn apply_wrapper_tx<S, D, H, CA>(
     wrapper: &WrapperTx,
     tx_bytes: &[u8],
     tx_index: &TxIndex,
-    height: namada_sdk::chain::BlockHeight,
+    height: BlockHeight,
     tx_gas_meter: &RefCell<TxGasMeter>,
     shell_params: &mut ShellParams<'_, S, D, H, CA>,
     block_proposer: Option<&Address>,

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -8,8 +8,7 @@ use eyre::{eyre, WrapErr};
 use namada_sdk::address::{Address, InternalAddress};
 use namada_sdk::booleans::BoolResultUnitExt;
 use namada_sdk::events::extend::{
-    ComposeEvent, Height as HeightAttr, MaspTxRef, MaspTxRefs,
-    TxHash as TxHashAttr, UserAccount,
+    ComposeEvent, Height as HeightAttr, TxHash as TxHashAttr, UserAccount,
 };
 use namada_sdk::events::EventLevel;
 use namada_sdk::gas::{self, Gas, GasMetering, TxGasMeter, VpGasMeter};
@@ -28,7 +27,8 @@ use namada_sdk::tx::data::{
     BatchedTxResult, ExtendedTxResult, TxResult, VpStatusFlags, VpsResult,
     WrapperTx,
 };
-use namada_sdk::tx::{BatchedTxRef, Tx, TxCommitments};
+use namada_sdk::tx::event::{MaspTxRef, MaspTxRefs};
+use namada_sdk::tx::{BatchedTxRef, IndexedTx, Tx, TxCommitments};
 use namada_sdk::validation::{
     EthBridgeNutVp, EthBridgePoolVp, EthBridgeVp, GovernanceVp, IbcVp, MaspVp,
     MultitokenVp, NativeVpCtx, ParametersVp, PgfVp, PosVp,
@@ -168,6 +168,8 @@ pub enum DispatchArgs<'a, CA: 'static + WasmCacheAccess + Sync> {
     Raw {
         /// The tx index
         tx_index: TxIndex,
+        /// The block height
+        height: namada_sdk::chain::BlockHeight,
         /// Hash of the header of the wrapper tx containing
         /// this raw tx
         wrapper_hash: Option<&'a Hash>,
@@ -187,6 +189,8 @@ pub enum DispatchArgs<'a, CA: 'static + WasmCacheAccess + Sync> {
         tx_bytes: &'a [u8],
         /// The tx index
         tx_index: TxIndex,
+        /// The block height
+        height: namada_sdk::chain::BlockHeight,
         /// The block proposer
         block_proposer: &'a Address,
         /// Vp cache
@@ -214,6 +218,7 @@ where
     match dispatch_args {
         DispatchArgs::Raw {
             tx_index,
+            height,
             wrapper_hash,
             wrapper_tx_result,
             vp_wasm_cache,
@@ -236,6 +241,7 @@ where
                     wrapper_hash,
                     tx_result,
                     tx_index,
+                    height,
                     tx_gas_meter,
                     state,
                     vp_wasm_cache,
@@ -290,6 +296,7 @@ where
             wrapper,
             tx_bytes,
             tx_index,
+            height,
             block_proposer,
             vp_wasm_cache,
             tx_wasm_cache,
@@ -306,6 +313,7 @@ where
                 wrapper,
                 tx_bytes,
                 &tx_index,
+                height,
                 tx_gas_meter,
                 &mut shell_params,
                 Some(block_proposer),
@@ -317,12 +325,16 @@ where
 
 pub(crate) fn get_batch_txs_to_execute<'a>(
     tx: &'a Tx,
-    masp_tx_refs: &MaspTxRefs,
+    masp_tx_refs: &mut MaspTxRefs,
 ) -> impl Iterator<Item = &'a TxCommitments> {
     let mut batch_iter = tx.commitments().iter();
-    if !masp_tx_refs.0.is_empty() {
-        // If fees were paid via masp skip the first transaction of the batch
-        // which has already been executed
+    // Remove the masp ref of fee payment if any. We have already emitted the
+    // event for it
+    if masp_tx_refs.0.pop().is_some() {
+        // FIXME: look here if we change the masp events, we still need to skip
+        // the first tx of the batch! If fees were paid via masp skip
+        // the first transaction of the batch which has already been
+        // executed
         batch_iter.next();
     }
 
@@ -335,6 +347,7 @@ pub(crate) fn dispatch_inner_txs<'a, S, D, H, CA>(
     wrapper_hash: Option<&'a Hash>,
     mut extended_tx_result: ExtendedTxResult<Error>,
     tx_index: TxIndex,
+    height: namada_sdk::chain::BlockHeight,
     tx_gas_meter: &'a RefCell<TxGasMeter>,
     state: &'a mut S,
     vp_wasm_cache: &'a mut VpCache<CA>,
@@ -350,7 +363,9 @@ where
     H: 'static + StorageHasher + Sync,
     CA: 'static + WasmCacheAccess + Sync,
 {
-    for cmt in get_batch_txs_to_execute(tx, &extended_tx_result.masp_tx_refs) {
+    for cmt in
+        get_batch_txs_to_execute(tx, &mut extended_tx_result.masp_tx_refs)
+    {
         match apply_wasm_tx(
             &tx.batch_ref_tx(cmt),
             &tx_index,
@@ -380,6 +395,8 @@ where
                     Err(_) => None,
                 };
 
+                // FIXME: here we insert the inner tx result which also contains
+                // the events
                 extended_tx_result.tx_result.insert_inner_tx_result(
                     wrapper_hash,
                     either::Right(cmt),
@@ -395,7 +412,22 @@ where
                             cmt,
                             Either::Right(res),
                         )? {
-                            extended_tx_result.masp_tx_refs.0.push(masp_ref)
+                            // FIXME: here we should cache the event directly
+                            // into res (if it is ok)
+                            extended_tx_result.masp_tx_refs.0.push((
+                                IndexedTx {
+                                    height,
+                                    index: tx_index,
+                                    batch_index: tx
+                                        .header
+                                        .batch
+                                        .get_index_of(cmt)
+                                        .and_then(|idx| {
+                                            u32::try_from(idx).ok()
+                                        }),
+                                },
+                                masp_ref,
+                            ))
                         }
                         state.write_log_mut().commit_tx_to_batch();
                     }
@@ -431,11 +463,13 @@ pub struct MaspTxResult {
 ///  - replay protection
 ///  - fee payment
 ///  - gas accounting
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn apply_wrapper_tx<S, D, H, CA>(
     tx: &Tx,
     wrapper: &WrapperTx,
     tx_bytes: &[u8],
     tx_index: &TxIndex,
+    height: namada_sdk::chain::BlockHeight,
     tx_gas_meter: &RefCell<TxGasMeter>,
     shell_params: &mut ShellParams<'_, S, D, H, CA>,
     block_proposer: Option<&Address>,
@@ -475,6 +509,8 @@ where
         .write_log_mut()
         .commit_batch_and_current_tx();
 
+    // FIXME: here we should probably just push the event inside the events
+    // field of TxResult without the need for ExtendedTxResult
     let (batch_results, masp_section_refs) = payment_result.map_or_else(
         || (TxResult::default(), None),
         |masp_tx_result| {
@@ -488,7 +524,14 @@ where
             );
             (
                 batch,
-                Some(MaspTxRefs(vec![masp_tx_result.masp_section_ref])),
+                Some(MaspTxRefs(vec![(
+                    IndexedTx {
+                        height,
+                        index: tx_index.to_owned(),
+                        batch_index: Some(0),
+                    },
+                    masp_tx_result.masp_section_ref,
+                )])),
             )
         },
     );
@@ -993,6 +1036,7 @@ where
 
     let initialized_accounts = state.write_log().get_initialized_accounts();
     let changed_keys = state.write_log().get_keys();
+    // FIXME: seems like here we extract the events produced by the tx
     let events = state.write_log_mut().take_events();
 
     Ok(BatchedTxResult {

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -37,13 +37,6 @@ fn extract_masp_tx(
     tx: &Tx,
     masp_ref: &MaspTxRef,
 ) -> Result<Transaction, Error> {
-    // NOTE: It is possible to have two identical references in a same batch:
-    // this is because, some types of MASP data packet can be correctly executed
-    // more than once (output descriptions). We have to make sure we account for
-    // this by using collections that allow for duplicates (both in the args
-    // and in the returned type): if the same reference shows up multiple
-    // times in the input we must process it the same number of times to
-    // ensure we contruct the correct state
     match masp_ref {
         MaspTxRef::MaspSection(id) => {
             // Simply looking for masp sections attached to the tx

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -112,7 +112,11 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
         .into_iter()
         .map(|event| {
             // Check if the event is a Masp one
-            let kind = namada_events::EventType::from_str(&event.kind)?;
+            let Ok(kind) = namada_events::EventType::from_str(&event.kind)
+            else {
+                return Ok(None);
+            };
+
             let kind = if kind == namada_tx::event::masp_types::TRANSFER {
                 MaspEventKind::Transfer
             } else if kind == namada_tx::event::masp_types::FEE_PAYMENT {

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -112,17 +112,7 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
             events
                 .into_iter()
                 .filter_map(|event| {
-                    // FIXME: improve here
-                    let Ok(data) = MaspTxRef::read_from_event_attributes(
-                        &event.attributes,
-                    ) else {
-                        return None;
-                    };
-                    let Ok(tx_index) = IndexedTx::read_from_event_attributes(
-                        &event.attributes,
-                    ) else {
-                        return None;
-                    };
+                    // Check if the event is a Masp one
                     let Ok(kind) =
                         namada_events::EventType::from_str(&event.kind)
                     else {
@@ -135,6 +125,18 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
                     {
                         MaspEventKind::FeePayment
                     } else {
+                        return None;
+                    };
+
+                    // Extract the data from the event's attributes
+                    let Ok(data) = MaspTxRef::read_from_event_attributes(
+                        &event.attributes,
+                    ) else {
+                        return None;
+                    };
+                    let Ok(tx_index) = IndexedTx::read_from_event_attributes(
+                        &event.attributes,
+                    ) else {
                         return None;
                     };
 

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -62,7 +62,7 @@ fn extract_masp_tx(
         }
         MaspTxRef::IbcData(hash) => {
             // Dereference the masp ref to the first instance that
-            // matches is, even if it is not the exact one that produced
+            // matches it, even if it is not the exact one that produced
             // the event, the data we extract will be exactly the same
             let masp_ibc_tx = tx
                 .commitments()

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -15,7 +15,7 @@ use namada_core::control_flow::time::{
 use namada_core::storage::TxIndex;
 use namada_io::Client;
 use namada_token::masp::utils::{
-    IndexedNoteEntry, MaspClient, MaspClientCapabilities,
+    IndexedNoteEntry, MaspClient, MaspClientCapabilities, MaspIndexedTx,
 };
 use namada_tx::event::MaspEvent;
 use namada_tx::{IndexedTx, Tx};
@@ -110,7 +110,7 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
 
             for MaspEvent {
                 tx_index,
-                kind: _,
+                kind,
                 data,
             } in txs_results
             {
@@ -129,7 +129,13 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
                 let extracted_masp_tx = extract_masp_tx(tx, &data)
                     .map_err(|e| Error::Other(e.to_string()))?;
 
-                txs.push((tx_index, extracted_masp_tx));
+                txs.push((
+                    MaspIndexedTx {
+                        indexed_tx: tx_index,
+                        kind,
+                    },
+                    extracted_masp_tx,
+                ));
             }
         }
 
@@ -393,7 +399,7 @@ impl MaspClient for IndexerMaspClient {
 
         #[derive(Deserialize)]
         struct Transaction {
-            tx_index: IndexedTx,
+            masp_indexed_tx: MaspIndexedTx,
             transaction: TransactionSlot,
         }
 
@@ -515,7 +521,7 @@ impl MaspClient for IndexerMaspClient {
 
         while let Some(result) = stream_of_fetches.next().await {
             for Transaction {
-                tx_index,
+                masp_indexed_tx,
                 transaction,
             } in result?
             {
@@ -527,11 +533,13 @@ impl MaspClient for IndexerMaspClient {
                         "Could not deserialize the masp txs borsh data at \
                          height {}, block index {} and batch index: {:#?}: \
                          {err}",
-                        tx_index.height, tx_index.index, tx_index.batch_index
+                        masp_indexed_tx.indexed_tx.height,
+                        masp_indexed_tx.indexed_tx.index,
+                        masp_indexed_tx.indexed_tx.batch_index
                     ))
                 })?;
 
-                txs.push((tx_index, extracted_masp_tx));
+                txs.push((masp_indexed_tx, extracted_masp_tx));
             }
         }
 

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -16,8 +16,9 @@ use namada_core::storage::TxIndex;
 use namada_io::Client;
 use namada_token::masp::utils::{
     IndexedNoteEntry, MaspClient, MaspClientCapabilities, MaspIndexedTx,
+    MaspTxKind,
 };
-use namada_tx::event::{MaspEvent, MaspEventKind};
+use namada_tx::event::MaspEvent;
 use namada_tx::{IndexedTx, Tx};
 use tokio::sync::Semaphore;
 
@@ -132,7 +133,7 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
                 txs.push((
                     MaspIndexedTx {
                         indexed_tx: tx_index,
-                        kind,
+                        kind: kind.into(),
                     },
                     extracted_masp_tx,
                 ));
@@ -541,9 +542,9 @@ impl MaspClient for IndexerMaspClient {
                         })?;
 
                     let kind = if slot.is_masp_fee_payment {
-                        MaspEventKind::FeePayment
+                        MaspTxKind::FeePayment
                     } else {
-                        MaspEventKind::Transfer
+                        MaspTxKind::Transfer
                     };
                     let masp_indexed_tx = MaspIndexedTx {
                         kind,
@@ -683,9 +684,9 @@ impl MaspClient for IndexerMaspClient {
                                 batch_index: Some(batch_index),
                             },
                             kind: if is_masp_fee_payment {
-                                MaspEventKind::FeePayment
+                                MaspTxKind::FeePayment
                             } else {
-                                MaspEventKind::Transfer
+                                MaspTxKind::Transfer
                             },
                         },
                         note_position,

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -13,11 +13,11 @@ use namada_core::control_flow::time::{
     Duration, LinearBackoff, Sleep, SleepStrategy,
 };
 use namada_core::storage::TxIndex;
-use namada_events::extend::IndexedMaspData;
 use namada_io::Client;
 use namada_token::masp::utils::{
     IndexedNoteEntry, MaspClient, MaspClientCapabilities,
 };
+use namada_tx::event::MaspEvent;
 use namada_tx::{IndexedTx, Tx};
 use tokio::sync::Semaphore;
 
@@ -94,12 +94,6 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
             };
 
             let block = {
-                // Query the actual block to get the txs bytes. If we only need
-                // one tx it might be slightly better to query
-                // the /tx endpoint to reduce the amount of data
-                // sent over the network, but this is a
-                // minimal improvement and it's even hard to tell how many times
-                // we'd need a single masp tx to make this worth it
                 self.inner
                     .client
                     .block(height as u32)
@@ -111,23 +105,22 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
                     .data
             };
 
-            for IndexedMaspData {
+            for MaspEvent {
                 tx_index,
-                masp_refs,
+                kind: _,
+                data,
             } in txs_results
             {
-                let tx =
-                    Tx::try_from_bytes(block[tx_index.0 as usize].as_ref())
-                        .map_err(|e| Error::Other(e.to_string()))?;
-                let extracted_masp_txs = extract_masp_tx(&tx, &masp_refs)
+                let tx = Tx::try_from_bytes(
+                    block[tx_index.index.0 as usize].as_ref(),
+                )
+                .map_err(|e| Error::Other(e.to_string()))?;
+                // FIXME: need to iterate on all the inner txs of this tx
+                // without deserializing the tx more than once
+                let extracted_masp_tx = extract_masp_tx(&tx, &data)
                     .map_err(|e| Error::Other(e.to_string()))?;
 
-                index_txs(
-                    &mut txs,
-                    extracted_masp_txs,
-                    height.into(),
-                    tx_index,
-                )?;
+                txs.push((tx_index, extracted_masp_tx));
             }
         }
 
@@ -391,9 +384,8 @@ impl MaspClient for IndexerMaspClient {
 
         #[derive(Deserialize)]
         struct Transaction {
-            batch: Vec<TransactionSlot>,
-            block_index: u32,
-            block_height: u64,
+            tx_index: IndexedTx,
+            transaction: TransactionSlot,
         }
 
         #[derive(Deserialize)]
@@ -514,31 +506,23 @@ impl MaspClient for IndexerMaspClient {
 
         while let Some(result) = stream_of_fetches.next().await {
             for Transaction {
-                batch,
-                block_index,
-                block_height,
+                tx_index,
+                transaction,
             } in result?
             {
-                let mut extracted_masp_txs = Vec::with_capacity(batch.len());
+                let extracted_masp_tx = MaspTx::try_from_slice(
+                    &transaction.bytes,
+                )
+                .map_err(|err| {
+                    Error::Other(format!(
+                        "Could not deserialize the masp txs borsh data at \
+                         height {}, block index {} and batch index: {:#?}: \
+                         {err}",
+                        tx_index.height, tx_index.index, tx_index.batch_index
+                    ))
+                })?;
 
-                for TransactionSlot { bytes } in batch {
-                    extracted_masp_txs.push(
-                        MaspTx::try_from_slice(&bytes).map_err(|err| {
-                            Error::Other(format!(
-                                "Could not deserialize the masp txs borsh \
-                                 data at height {block_height} and index \
-                                 {block_index}: {err}"
-                            ))
-                        })?,
-                    );
-                }
-
-                index_txs(
-                    &mut txs,
-                    extracted_masp_txs,
-                    block_height.into(),
-                    block_index.into(),
-                )?;
+                txs.push((tx_index, extracted_masp_tx));
             }
         }
 
@@ -728,35 +712,6 @@ impl MaspClient for IndexerMaspClient {
             },
         )
     }
-}
-
-#[allow(clippy::result_large_err)]
-fn index_txs(
-    txs: &mut Vec<(IndexedTx, MaspTx)>,
-    extracted_masp_txs: impl IntoIterator<Item = MaspTx>,
-    height: BlockHeight,
-    index: TxIndex,
-) -> Result<(), Error> {
-    // Note that the index of the extracted MASP transaction does
-    // not necessarely match the index of the inner tx in the batch,
-    // we are only interested in giving a sequential ordering to the
-    // data
-    for (batch_index, transaction) in extracted_masp_txs.into_iter().enumerate()
-    {
-        txs.push((
-            IndexedTx {
-                height,
-                index,
-                batch_index: Some(
-                    u32::try_from(batch_index)
-                        .map_err(|e| Error::Other(e.to_string()))?,
-                ),
-            },
-            transaction,
-        ));
-    }
-
-    Ok(())
 }
 
 #[derive(Copy, Clone)]

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -318,7 +318,7 @@ pub type WitnessMap = HashMap<usize, IncrementalWitness<Node>>;
 pub enum ContextSyncStatus {
     /// The context contains data that has been confirmed by the protocol
     Confirmed,
-    /// The context possibly contains that that has not yet been confirmed by
+    /// The context possibly contains data that has not yet been confirmed by
     /// the protocol and could be incomplete or invalid
     Speculative,
 }

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -40,11 +40,11 @@ use namada_io::{MaybeSend, MaybeSync};
 use namada_macros::BorshDeserializer;
 #[cfg(feature = "migrations")]
 use namada_migrations::*;
-use namada_tx::IndexedTx;
 use rand_core::{CryptoRng, RngCore};
 pub use shielded_wallet::ShieldedWallet;
 use thiserror::Error;
 
+use self::utils::MaspIndexedTx;
 pub use crate::masp::shielded_sync::dispatcher::{Dispatcher, DispatcherCache};
 #[cfg(not(target_family = "wasm"))]
 pub use crate::masp::shielded_sync::MaspLocalTaskEnv;
@@ -308,7 +308,7 @@ pub type TransferDelta = HashMap<Address, MaspChange>;
 pub type TransactionDelta = HashMap<ViewingKey, I128Sum>;
 
 /// Maps a shielded tx to the index of its first output note.
-pub type NoteIndex = BTreeMap<IndexedTx, usize>;
+pub type NoteIndex = BTreeMap<MaspIndexedTx, usize>;
 
 /// Maps the note index (in the commitment tree) to a witness
 pub type WitnessMap = HashMap<usize, IncrementalWitness<Node>>;

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -24,7 +24,7 @@ use namada_io::{MaybeSend, MaybeSync, ProgressBar};
 use namada_tx::IndexedTx;
 use namada_wallet::{DatedKeypair, DatedSpendingKey};
 
-use super::utils::{IndexedNoteEntry, MaspClient, MaspIndexedTx};
+use super::utils::{IndexedNoteEntry, MaspClient, MaspIndexedTx, MaspTxKind};
 use crate::masp::shielded_sync::trial_decrypt;
 use crate::masp::utils::{
     blocks_left_to_fetch, DecryptedData, Fetched, RetryStrategy, TrialDecrypted,
@@ -451,7 +451,7 @@ where
             // NB: the entire block is synced
             *h = Some(MaspIndexedTx {
                 indexed_tx: IndexedTx::entire_block(*last_query_height),
-                kind: namada_tx::event::MaspEventKind::Transfer,
+                kind: MaspTxKind::Transfer,
             });
         }
 
@@ -492,7 +492,7 @@ where
                     vk.key,
                     Some(MaspIndexedTx {
                         indexed_tx: IndexedTx::entire_block(vk.birthday),
-                        kind: namada_tx::event::MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     }),
                 );
             }
@@ -885,7 +885,6 @@ mod dispatcher_tests {
     use namada_core::storage::TxIndex;
     use namada_core::task_env::TaskEnvironment;
     use namada_io::DevNullProgressBar;
-    use namada_tx::event::MaspEventKind;
     use namada_tx::IndexedTx;
     use namada_wallet::StoredKeypair;
     use tempfile::tempdir;
@@ -928,7 +927,7 @@ mod dispatcher_tests {
                             index: Default::default(),
                             batch_index: None,
                         },
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     };
                     dispatcher.cache.fetched.insert((itx, arbitrary_masp_tx()));
                     dispatcher.ctx.note_index.insert(itx, h as usize);
@@ -952,7 +951,7 @@ mod dispatcher_tests {
                     arbitrary_vk(),
                     Some(MaspIndexedTx {
                         indexed_tx: IndexedTx::entire_block(9.into()),
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     }),
                 )]);
                 assert_eq!(expected, dispatcher.ctx.vk_heights);
@@ -1140,7 +1139,7 @@ mod dispatcher_tests {
                 index: TxIndex(0),
                 batch_index: None,
             },
-            kind: MaspEventKind::Transfer,
+            kind: MaspTxKind::Transfer,
         });
 
         // the min height should now be 6
@@ -1223,7 +1222,7 @@ mod dispatcher_tests {
                                 index: TxIndex(1),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1236,7 +1235,7 @@ mod dispatcher_tests {
                                 index: TxIndex(2),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1258,7 +1257,7 @@ mod dispatcher_tests {
                             index: TxIndex(1),
                             batch_index: None,
                         },
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     },
                     MaspIndexedTx {
                         indexed_tx: IndexedTx {
@@ -1266,7 +1265,7 @@ mod dispatcher_tests {
                             index: TxIndex(2),
                             batch_index: None,
                         },
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     },
                 ]);
 
@@ -1275,7 +1274,7 @@ mod dispatcher_tests {
                     *ctx.vk_heights[&vk.key].as_ref().unwrap(),
                     MaspIndexedTx {
                         indexed_tx: IndexedTx::entire_block(2.into(),),
-                        kind: MaspEventKind::Transfer
+                        kind: MaspTxKind::Transfer
                     }
                 );
                 assert_eq!(ctx.note_map.len(), 2);
@@ -1318,7 +1317,7 @@ mod dispatcher_tests {
                                 index: TxIndex(1),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1331,7 +1330,7 @@ mod dispatcher_tests {
                                 index: TxIndex(2),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1356,7 +1355,7 @@ mod dispatcher_tests {
                                 index: TxIndex(1),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     ),
@@ -1367,7 +1366,7 @@ mod dispatcher_tests {
                                 index: TxIndex(2),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     ),
@@ -1412,7 +1411,7 @@ mod dispatcher_tests {
                                 index: TxIndex(1),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1462,7 +1461,7 @@ mod dispatcher_tests {
                         index: TxIndex(1),
                         batch_index: None,
                     },
-                    kind: MaspEventKind::Transfer,
+                    kind: MaspTxKind::Transfer,
                 },
                 masp_tx.clone(),
             )))
@@ -1496,11 +1495,11 @@ mod dispatcher_tests {
             vec![
                 Some(MaspIndexedTx {
                     indexed_tx: IndexedTx::entire_block(BlockHeight(30)),
-                    kind: MaspEventKind::Transfer
+                    kind: MaspTxKind::Transfer
                 }),
                 Some(MaspIndexedTx {
                     indexed_tx: IndexedTx::entire_block(BlockHeight(10)),
-                    kind: MaspEventKind::Transfer
+                    kind: MaspTxKind::Transfer
                 })
             ]
         );
@@ -1518,7 +1517,7 @@ mod dispatcher_tests {
                         index: TxIndex(1),
                         batch_index: None,
                     },
-                    kind: MaspEventKind::Transfer,
+                    kind: MaspTxKind::Transfer,
                 },
                 masp_tx.clone(),
             )))
@@ -1543,11 +1542,11 @@ mod dispatcher_tests {
             vec![
                 Some(MaspIndexedTx {
                     indexed_tx: IndexedTx::entire_block(BlockHeight(60)),
-                    kind: MaspEventKind::Transfer
+                    kind: MaspTxKind::Transfer
                 }),
                 Some(MaspIndexedTx {
                     indexed_tx: IndexedTx::entire_block(BlockHeight(10)),
-                    kind: MaspEventKind::Transfer
+                    kind: MaspTxKind::Transfer
                 })
             ]
         )

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -24,7 +24,7 @@ use namada_io::{MaybeSend, MaybeSync, ProgressBar};
 use namada_tx::IndexedTx;
 use namada_wallet::{DatedKeypair, DatedSpendingKey};
 
-use super::utils::{IndexedNoteEntry, MaspClient};
+use super::utils::{IndexedNoteEntry, MaspClient, MaspIndexedTx};
 use crate::masp::shielded_sync::trial_decrypt;
 use crate::masp::utils::{
     blocks_left_to_fetch, DecryptedData, Fetched, RetryStrategy, TrialDecrypted,
@@ -153,7 +153,9 @@ struct TaskError<C> {
 #[allow(clippy::large_enum_variant)]
 enum Message {
     UpdateCommitmentTree(Result<CommitmentTree<Node>, TaskError<BlockHeight>>),
-    UpdateNotesMap(Result<BTreeMap<IndexedTx, usize>, TaskError<BlockHeight>>),
+    UpdateNotesMap(
+        Result<BTreeMap<MaspIndexedTx, usize>, TaskError<BlockHeight>>,
+    ),
     UpdateWitnessMap(
         Result<
             HashMap<usize, IncrementalWitness<Node>>,
@@ -167,7 +169,7 @@ enum Message {
         >,
     ),
     TrialDecrypt(
-        IndexedTx,
+        MaspIndexedTx,
         ViewingKey,
         ControlFlow<(), BTreeMap<usize, DecryptedData>>,
     ),
@@ -222,7 +224,7 @@ enum DispatcherState {
 
 #[derive(Default, Debug)]
 struct InitialState {
-    last_witnessed_tx: Option<IndexedTx>,
+    last_witnessed_tx: Option<MaspIndexedTx>,
     start_height: BlockHeight,
     last_query_height: BlockHeight,
 }
@@ -405,29 +407,22 @@ where
             self.ctx
                 .save_shielded_spends(&stx_batch, needs_witness_map_update);
             if needs_witness_map_update
-                && Some(&masp_indexed_tx.indexed_tx)
-                    > last_witnessed_tx.as_ref()
+                && Some(&masp_indexed_tx) > last_witnessed_tx.as_ref()
             {
-                self.ctx.update_witness_map(
-                    masp_indexed_tx.indexed_tx,
-                    &stx_batch,
-                )?;
+                self.ctx.update_witness_map(masp_indexed_tx, &stx_batch)?;
             }
-            let first_note_pos =
-                self.ctx.note_index[&masp_indexed_tx.indexed_tx];
+            let first_note_pos = self.ctx.note_index[&masp_indexed_tx];
             let mut vk_heights = BTreeMap::new();
             std::mem::swap(&mut vk_heights, &mut self.ctx.vk_heights);
             for (vk, _) in vk_heights
                 .iter()
                 // NB: skip keys that are synced past the given `indexed_tx`
-                .filter(|(_vk, h)| {
-                    h.as_ref() < Some(&masp_indexed_tx.indexed_tx)
-                })
+                .filter(|(_vk, h)| h.as_ref() < Some(&masp_indexed_tx))
             {
                 for (note_pos_offset, (note, pa, memo)) in self
                     .cache
                     .trial_decrypted
-                    .take(&masp_indexed_tx.indexed_tx, vk)
+                    .take(&masp_indexed_tx, vk)
                     .unwrap_or_default()
                 {
                     self.ctx.save_decrypted_shielded_outputs(
@@ -449,11 +444,15 @@ where
             .iter_mut()
             // NB: skip keys that are synced past the last input height
             .filter(|(_vk, h)| {
-                h.as_ref().map(|itx| &itx.height) < Some(last_query_height)
+                h.as_ref().map(|itx| &itx.indexed_tx.height)
+                    < Some(last_query_height)
             })
         {
             // NB: the entire block is synced
-            *h = Some(IndexedTx::entire_block(*last_query_height));
+            *h = Some(MaspIndexedTx {
+                indexed_tx: IndexedTx::entire_block(*last_query_height),
+                kind: namada_tx::event::MaspEventKind::Transfer,
+            });
         }
 
         Ok(())
@@ -485,13 +484,17 @@ where
         {
             if let Some(h) = self.ctx.vk_heights.entry(vk.key).or_default() {
                 let birthday = IndexedTx::entire_block(vk.birthday);
-                if birthday > *h {
-                    *h = birthday;
+                if birthday > h.indexed_tx {
+                    h.indexed_tx = birthday;
                 }
             } else if vk.birthday >= BlockHeight::first() {
-                self.ctx
-                    .vk_heights
-                    .insert(vk.key, Some(IndexedTx::entire_block(vk.birthday)));
+                self.ctx.vk_heights.insert(
+                    vk.key,
+                    Some(MaspIndexedTx {
+                        indexed_tx: IndexedTx::entire_block(vk.birthday),
+                        kind: namada_tx::event::MaspEventKind::Transfer,
+                    }),
+                );
             }
         }
 
@@ -628,7 +631,7 @@ where
             .set_upper_limit(number_of_fetches);
 
         for (itx, tx) in self.cache.fetched.iter() {
-            self.spawn_trial_decryptions(itx.indexed_tx, tx);
+            self.spawn_trial_decryptions(*itx, tx);
         }
     }
 
@@ -671,8 +674,8 @@ where
                 }
             }
             Message::FetchTxs(Ok((from, to, tx_batch))) => {
-                for (itx, txs) in &tx_batch {
-                    self.spawn_trial_decryptions(itx.indexed_tx, txs);
+                for (itx, tx) in &tx_batch {
+                    self.spawn_trial_decryptions(*itx, tx);
                 }
                 self.cache.fetched.extend(tx_batch);
 
@@ -801,7 +804,7 @@ where
         spawned_tasks
     }
 
-    fn spawn_trial_decryptions(&self, itx: IndexedTx, tx: &Transaction) {
+    fn spawn_trial_decryptions(&self, itx: MaspIndexedTx, tx: &Transaction) {
         for (vk, vk_height) in self.ctx.vk_heights.iter() {
             let key_is_outdated = vk_height.as_ref() < Some(&itx);
             let cached = self.cache.trial_decrypted.get(&itx, vk).is_some();
@@ -919,18 +922,15 @@ mod dispatcher_tests {
                     BTreeMap::from([(arbitrary_vk(), None)]);
                 // fill up the dispatcher's cache
                 for h in 0u64..10 {
-                    let itx = IndexedTx {
-                        height: h.into(),
-                        index: Default::default(),
-                        batch_index: None,
-                    };
-                    dispatcher.cache.fetched.insert((
-                        MaspIndexedTx {
-                            indexed_tx: itx,
-                            kind: MaspEventKind::Transfer,
+                    let itx = MaspIndexedTx {
+                        indexed_tx: IndexedTx {
+                            height: h.into(),
+                            index: Default::default(),
+                            batch_index: None,
                         },
-                        arbitrary_masp_tx(),
-                    ));
+                        kind: MaspEventKind::Transfer,
+                    };
+                    dispatcher.cache.fetched.insert((itx, arbitrary_masp_tx()));
                     dispatcher.ctx.note_index.insert(itx, h as usize);
                     dispatcher.cache.trial_decrypted.insert(
                         itx,
@@ -950,7 +950,10 @@ mod dispatcher_tests {
                 assert!(dispatcher.cache.trial_decrypted.is_empty());
                 let expected = BTreeMap::from([(
                     arbitrary_vk(),
-                    Some(IndexedTx::entire_block(9.into())),
+                    Some(MaspIndexedTx {
+                        indexed_tx: IndexedTx::entire_block(9.into()),
+                        kind: MaspEventKind::Transfer,
+                    }),
                 )]);
                 assert_eq!(expected, dispatcher.ctx.vk_heights);
             })
@@ -1131,10 +1134,13 @@ mod dispatcher_tests {
         assert_eq!(height, BlockHeight(1));
 
         // let's bump the vk height
-        *shielded_ctx.vk_heights.get_mut(&vk).unwrap() = Some(IndexedTx {
-            height: 6.into(),
-            index: TxIndex(0),
-            batch_index: None,
+        *shielded_ctx.vk_heights.get_mut(&vk).unwrap() = Some(MaspIndexedTx {
+            indexed_tx: IndexedTx {
+                height: 6.into(),
+                index: TxIndex(0),
+                batch_index: None,
+            },
+            kind: MaspEventKind::Transfer,
         });
 
         // the min height should now be 6
@@ -1246,22 +1252,31 @@ mod dispatcher_tests {
                 let keys =
                     ctx.note_index.keys().cloned().collect::<BTreeSet<_>>();
                 let expected = BTreeSet::from([
-                    IndexedTx {
-                        height: 1.into(),
-                        index: TxIndex(1),
-                        batch_index: None,
+                    MaspIndexedTx {
+                        indexed_tx: IndexedTx {
+                            height: 1.into(),
+                            index: TxIndex(1),
+                            batch_index: None,
+                        },
+                        kind: MaspEventKind::Transfer,
                     },
-                    IndexedTx {
-                        height: 1.into(),
-                        index: TxIndex(2),
-                        batch_index: None,
+                    MaspIndexedTx {
+                        indexed_tx: IndexedTx {
+                            height: 1.into(),
+                            index: TxIndex(2),
+                            batch_index: None,
+                        },
+                        kind: MaspEventKind::Transfer,
                     },
                 ]);
 
                 assert_eq!(keys, expected);
                 assert_eq!(
                     *ctx.vk_heights[&vk.key].as_ref().unwrap(),
-                    IndexedTx::entire_block(2.into(),)
+                    MaspIndexedTx {
+                        indexed_tx: IndexedTx::entire_block(2.into(),),
+                        kind: MaspEventKind::Transfer
+                    }
                 );
                 assert_eq!(ctx.note_map.len(), 2);
             })
@@ -1479,8 +1494,14 @@ mod dispatcher_tests {
         assert_eq!(
             birthdays,
             vec![
-                Some(IndexedTx::entire_block(BlockHeight(30))),
-                Some(IndexedTx::entire_block(BlockHeight(10)))
+                Some(MaspIndexedTx {
+                    indexed_tx: IndexedTx::entire_block(BlockHeight(30)),
+                    kind: MaspEventKind::Transfer
+                }),
+                Some(MaspIndexedTx {
+                    indexed_tx: IndexedTx::entire_block(BlockHeight(10)),
+                    kind: MaspEventKind::Transfer
+                })
             ]
         );
 
@@ -1520,8 +1541,14 @@ mod dispatcher_tests {
         assert_eq!(
             birthdays,
             vec![
-                Some(IndexedTx::entire_block(BlockHeight(60))),
-                Some(IndexedTx::entire_block(BlockHeight(10)))
+                Some(MaspIndexedTx {
+                    indexed_tx: IndexedTx::entire_block(BlockHeight(60)),
+                    kind: MaspEventKind::Transfer
+                }),
+                Some(MaspIndexedTx {
+                    indexed_tx: IndexedTx::entire_block(BlockHeight(10)),
+                    kind: MaspEventKind::Transfer
+                })
             ]
         )
     }

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -599,7 +599,6 @@ mod test_blocks_left_to_fetch {
     }
 
     #[test]
-    // FIXME: proptest here?
     fn test_sort_indexed_masp_events() {
         let ev1 = MaspIndexedTx {
             kind: MaspEventKind::FeePayment,
@@ -618,6 +617,14 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev3 = MaspIndexedTx {
+            kind: MaspEventKind::FeePayment,
+            indexed_tx: IndexedTx {
+                height: BlockHeight(3),
+                index: TxIndex(2),
+                batch_index: Some(2),
+            },
+        };
+        let ev4 = MaspIndexedTx {
             kind: MaspEventKind::Transfer,
             indexed_tx: IndexedTx {
                 height: BlockHeight(1),
@@ -625,7 +632,7 @@ mod test_blocks_left_to_fetch {
                 batch_index: Some(1),
             },
         };
-        let ev4 = MaspIndexedTx {
+        let ev5 = MaspIndexedTx {
             kind: MaspEventKind::Transfer,
             indexed_tx: IndexedTx {
                 height: BlockHeight(1),
@@ -634,10 +641,10 @@ mod test_blocks_left_to_fetch {
             },
         };
 
-        let mut txs = [ev1.clone(), ev2.clone(), ev3.clone(), ev4.clone()];
+        let mut txs = [ev1, ev2, ev3, ev4, ev5];
 
         txs.sort();
 
-        assert_eq!(txs, [ev1, ev4, ev3, ev2])
+        assert_eq!(txs, [ev1, ev5, ev4, ev2, ev3])
     }
 }

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -8,16 +8,40 @@ use masp_primitives::sapling::{Node, Note, PaymentAddress, ViewingKey};
 use masp_primitives::transaction::Transaction;
 use namada_core::chain::BlockHeight;
 use namada_core::collections::HashMap;
+use namada_tx::event::MaspEventKind;
 use namada_tx::{IndexedTx, IndexedTxRange};
+use serde::{Deserialize, Serialize};
+
+/// An indexed masp tx carrying information on wether it was a fee paying tx or
+/// a normal transfer
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialOrd,
+    PartialEq,
+    Eq,
+    Ord,
+    Serialize,
+    Deserialize,
+)]
+pub struct MaspIndexedTx {
+    /// The masp tx kind, fee-payment or transfer
+    pub kind: MaspEventKind,
+    /// The pointer to the inner tx carrying this masp tx
+    pub indexed_tx: IndexedTx,
+}
 
 /// Type alias for convenience and profit
-pub type IndexedNoteData = BTreeMap<IndexedTx, Transaction>;
+pub type IndexedNoteData = BTreeMap<MaspIndexedTx, Transaction>;
 
 /// Type alias for the entries of [`IndexedNoteData`] iterators
-pub type IndexedNoteEntry = (IndexedTx, Transaction);
+pub type IndexedNoteEntry = (MaspIndexedTx, Transaction);
 
 /// Borrowed version of an [`IndexedNoteEntry`]
-pub type IndexedNoteEntryRefs<'a> = (&'a IndexedTx, &'a Transaction);
+pub type IndexedNoteEntryRefs<'a> = (&'a MaspIndexedTx, &'a Transaction);
 
 /// Type alias for a successful note decryption.
 pub type DecryptedData = (Note, PaymentAddress, MemoBytes);
@@ -124,6 +148,11 @@ impl Fetched {
     /// block height.
     pub fn contains_height(&self, height: BlockHeight) -> bool {
         self.txs
+            .iter()
+            .map(|(masp_indexed_tx, transaction)| {
+                (masp_indexed_tx.indexed_tx, transaction)
+            })
+            .collect::<BTreeMap<_, _>>()
             .range(IndexedTxRange::with_height(height))
             .next()
             .is_some()
@@ -340,10 +369,13 @@ mod test_blocks_left_to_fetch {
             .into_iter()
             .map(|height| {
                 (
-                    IndexedTx {
-                        height,
-                        index: TxIndex(0),
-                        batch_index: None,
+                    MaspIndexedTx {
+                        indexed_tx: IndexedTx {
+                            height,
+                            index: TxIndex(0),
+                            batch_index: None,
+                        },
+                        kind: MaspEventKind::Transfer,
                     },
                     masp_tx.clone(),
                 )

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -15,6 +15,39 @@ use namada_tx::event::MaspEventKind;
 use namada_tx::IndexedTx;
 use serde::{Deserialize, Serialize};
 
+/// The type of a MASP transaction
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialOrd,
+    PartialEq,
+    Eq,
+    Ord,
+    Serialize,
+    Deserialize,
+    Hash,
+)]
+pub enum MaspTxKind {
+    /// A MASP transaction used for fee payment
+    FeePayment,
+    /// A general MASP transfer
+    #[default]
+    Transfer,
+}
+
+impl From<MaspEventKind> for MaspTxKind {
+    fn from(value: MaspEventKind) -> Self {
+        match value {
+            MaspEventKind::FeePayment => Self::FeePayment,
+            MaspEventKind::Transfer => Self::Transfer,
+        }
+    }
+}
+
 /// An indexed masp tx carrying information on whether it was a fee paying tx or
 /// a normal transfer
 #[derive(
@@ -32,7 +65,7 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct MaspIndexedTx {
     /// The masp tx kind, fee-payment or transfer
-    pub kind: MaspEventKind,
+    pub kind: MaspTxKind,
     /// The pointer to the inner tx carrying this masp tx
     pub indexed_tx: IndexedTx,
 }
@@ -74,7 +107,7 @@ impl MaspIndexedTxRange {
     pub const fn between_heights(from: BlockHeight, to: BlockHeight) -> Self {
         Self::new(
             MaspIndexedTx {
-                kind: MaspEventKind::FeePayment,
+                kind: MaspTxKind::FeePayment,
                 indexed_tx: IndexedTx {
                     height: from,
                     index: TxIndex(0),
@@ -82,7 +115,7 @@ impl MaspIndexedTxRange {
                 },
             },
             MaspIndexedTx {
-                kind: MaspEventKind::Transfer,
+                kind: MaspTxKind::Transfer,
                 indexed_tx: IndexedTx {
                     height: to,
                     index: TxIndex(u32::MAX),
@@ -464,7 +497,7 @@ mod test_blocks_left_to_fetch {
                             index: TxIndex(0),
                             batch_index: None,
                         },
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     },
                     masp_tx.clone(),
                 )
@@ -668,7 +701,7 @@ mod test_blocks_left_to_fetch {
     #[test]
     fn test_sort_indexed_masp_events() {
         let ev1 = MaspIndexedTx {
-            kind: MaspEventKind::FeePayment,
+            kind: MaspTxKind::FeePayment,
             indexed_tx: IndexedTx {
                 height: BlockHeight(1),
                 index: TxIndex(2),
@@ -676,7 +709,7 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev2 = MaspIndexedTx {
-            kind: MaspEventKind::Transfer,
+            kind: MaspTxKind::Transfer,
             indexed_tx: IndexedTx {
                 height: BlockHeight(2),
                 index: TxIndex(0),
@@ -684,7 +717,7 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev3 = MaspIndexedTx {
-            kind: MaspEventKind::FeePayment,
+            kind: MaspTxKind::FeePayment,
             indexed_tx: IndexedTx {
                 height: BlockHeight(3),
                 index: TxIndex(2),
@@ -692,7 +725,7 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev4 = MaspIndexedTx {
-            kind: MaspEventKind::Transfer,
+            kind: MaspTxKind::Transfer,
             indexed_tx: IndexedTx {
                 height: BlockHeight(1),
                 index: TxIndex(1),
@@ -700,7 +733,7 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev5 = MaspIndexedTx {
-            kind: MaspEventKind::Transfer,
+            kind: MaspTxKind::Transfer,
             indexed_tx: IndexedTx {
                 height: BlockHeight(1),
                 index: TxIndex(1),

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -43,11 +43,11 @@ use namada_io::{
     display_line, edisplay_line, Io, MaybeSend, MaybeSync, NamadaIo,
     ProgressBar,
 };
-use namada_tx::IndexedTx;
 use namada_wallet::{DatedKeypair, DatedSpendingKey};
 use rand::prelude::StdRng;
 use rand_core::{OsRng, SeedableRng};
 
+use super::utils::MaspIndexedTx;
 use crate::masp::utils::MaspClient;
 #[cfg(any(test, feature = "testing"))]
 use crate::masp::{testing, ENV_VAR_MASP_TEST_SEED};
@@ -70,7 +70,7 @@ pub struct ShieldedWallet<U: ShieldedUtils> {
     pub tree: CommitmentTree<Node>,
     /// Maps viewing keys to the block height to which they are synced.
     /// In particular, the height given by the value *has been scanned*.
-    pub vk_heights: BTreeMap<ViewingKey, Option<IndexedTx>>,
+    pub vk_heights: BTreeMap<ViewingKey, Option<MaspIndexedTx>>,
     /// Maps viewing keys to applicable note positions
     pub pos_map: HashMap<ViewingKey, BTreeSet<usize>>,
     /// Maps a nullifier to the note position to which it applies
@@ -145,11 +145,11 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
     /// scan new MASP transactions.
     pub(crate) fn update_witness_map(
         &mut self,
-        indexed_tx: IndexedTx,
+        masp_indexed_tx: MaspIndexedTx,
         shielded: &Transaction,
     ) -> Result<(), eyre::Error> {
         let mut note_pos = self.tree.size();
-        self.note_index.insert(indexed_tx, note_pos);
+        self.note_index.insert(masp_indexed_tx, note_pos);
 
         for so in shielded
             .sapling_bundle()
@@ -218,7 +218,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
             ));
         };
         Ok(maybe_least_synced_vk_height
-            .map_or_else(BlockHeight::first, |itx| itx.height))
+            .map_or_else(BlockHeight::first, |itx| itx.indexed_tx.height))
     }
 
     #[allow(missing_docs)]

--- a/crates/shielded_token/src/masp/test_utils.rs
+++ b/crates/shielded_token/src/masp/test_utils.rs
@@ -23,12 +23,12 @@ use namada_core::time::DurationSecs;
 use namada_core::token::{Denomination, MaspDigitPos};
 use namada_io::client::EncodedResponseQuery;
 use namada_io::{Client, MaybeSend, MaybeSync, NamadaIo, NullIo};
-use namada_tx::IndexedTx;
 use namada_wallet::DatedKeypair;
 use thiserror::Error;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::Mutex;
 
+use super::utils::MaspIndexedTx;
 use crate::masp::shielded_wallet::ShieldedQueries;
 use crate::masp::utils::{
     IndexedNoteEntry, MaspClient, MaspClientCapabilities,
@@ -427,7 +427,7 @@ impl MaspClient for TestingMaspClient {
     async fn fetch_note_index(
         &self,
         _: BlockHeight,
-    ) -> Result<BTreeMap<IndexedTx, usize>, Self::Error> {
+    ) -> Result<BTreeMap<MaspIndexedTx, usize>, Self::Error> {
         unimplemented!(
             "Transaction notes map fetching is not implemented by this client"
         )

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -23,7 +23,6 @@ use namada_core::borsh::{
 };
 use namada_core::hash::Hash;
 use namada_core::storage;
-use namada_events::extend::MaspTxRefs;
 use namada_events::Event;
 use namada_gas::WholeGas;
 use namada_macros::BorshDeserializer;
@@ -37,6 +36,7 @@ use sha2::{Digest, Sha256};
 pub use wrapper::*;
 
 use crate::data::protocol::ProtocolTx;
+use crate::event::MaspTxRefs;
 use crate::TxCommitments;
 
 /// The different result codes that the ledger may send back to a client
@@ -190,11 +190,15 @@ pub struct ExtendedTxResult<T> {
     pub tx_result: TxResult<T>,
     /// The optional references to masp data (either MASP sections or tx Data
     /// for shielded actions)
+    // FIXME: review this note
     // NOTE: it's paramount to enforce a single, ordered collection for all the
     // masp transactions to ensure that the exact view on the tx sequence is
     // preserved in the events. Also, it is possible for two refs to be exactly
     // the same, we must make sure to emit events for both so that the
     // client/indexer can properly construct their internal state
+    // FIXME: I don't think we need this anymore? We can just push the events
+    // to the events themselves and then commit them as usual when evaluating
+    // the tx results
     pub masp_tx_refs: MaspTxRefs,
 }
 

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -36,7 +36,6 @@ use sha2::{Digest, Sha256};
 pub use wrapper::*;
 
 use crate::data::protocol::ProtocolTx;
-use crate::event::MaspTxRefs;
 use crate::TxCommitments;
 
 /// The different result codes that the ledger may send back to a client
@@ -183,34 +182,6 @@ pub fn compute_inner_tx_hash(
     Hash(state.finalize_reset().into())
 }
 
-/// The extended transaction result, containing the references to masp
-/// sections (if any)
-pub struct ExtendedTxResult<T> {
-    /// The transaction result
-    pub tx_result: TxResult<T>,
-    /// The optional references to masp data (either MASP sections or tx Data
-    /// for shielded actions)
-    // FIXME: review this note
-    // NOTE: it's paramount to enforce a single, ordered collection for all the
-    // masp transactions to ensure that the exact view on the tx sequence is
-    // preserved in the events. Also, it is possible for two refs to be exactly
-    // the same, we must make sure to emit events for both so that the
-    // client/indexer can properly construct their internal state
-    // FIXME: I don't think we need this anymore? We can just push the events
-    // to the events themselves and then commit them as usual when evaluating
-    // the tx results
-    pub masp_tx_refs: MaspTxRefs,
-}
-
-impl<T> Default for ExtendedTxResult<T> {
-    fn default() -> Self {
-        Self {
-            tx_result: Default::default(),
-            masp_tx_refs: Default::default(),
-        }
-    }
-}
-
 #[derive(Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 /// The result of a dry run, included the actual transaction result and the gas
 /// used
@@ -308,17 +279,6 @@ impl<T: Display> TxResult<T> {
         }
 
         TxResult(batch_results)
-    }
-
-    /// Converts this result to [`ExtendedTxResult`]
-    pub fn to_extended_result(
-        self,
-        masp_tx_refs: Option<MaspTxRefs>,
-    ) -> ExtendedTxResult<T> {
-        ExtendedTxResult {
-            tx_result: self,
-            masp_tx_refs: masp_tx_refs.unwrap_or_default(),
-        }
     }
 }
 

--- a/crates/tx/src/event.rs
+++ b/crates/tx/src/event.rs
@@ -172,7 +172,6 @@ pub struct MaspEvent {
     /// A flag signaling the type of the masp transaction
     pub kind: MaspEventKind,
     /// The reference to the masp data
-    // FIXME: rename this field?
     pub data: MaspTxRef,
 }
 
@@ -193,7 +192,6 @@ impl EventAttributeEntry<'static> for MaspTxRef {
     type Value = MaspTxRef;
     type ValueOwned = Self::Value;
 
-    // FIXME: rename this?
     const KEY: &'static str = "section";
 
     fn into_value(self) -> Self::Value {

--- a/crates/tx/src/event.rs
+++ b/crates/tx/src/event.rs
@@ -115,10 +115,24 @@ pub mod masp_types {
 }
 
 /// MASP event kind
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialOrd,
+    PartialEq,
+    Eq,
+    Ord,
+    Serialize,
+    Deserialize,
+)]
 pub enum MaspEventKind {
     /// A MASP transaction used for fee payment
     FeePayment,
     /// A general MASP transfer
+    #[default]
     Transfer,
 }
 

--- a/crates/tx/src/event.rs
+++ b/crates/tx/src/event.rs
@@ -119,6 +119,7 @@ pub mod masp_types {
     Debug,
     Default,
     Clone,
+    Copy,
     BorshSerialize,
     BorshDeserialize,
     PartialOrd,
@@ -127,6 +128,7 @@ pub mod masp_types {
     Ord,
     Serialize,
     Deserialize,
+    Hash,
 )]
 pub enum MaspEventKind {
     /// A MASP transaction used for fee payment

--- a/crates/tx/src/event.rs
+++ b/crates/tx/src/event.rs
@@ -1,17 +1,23 @@
 //! Transaction events.
 
+use std::fmt::Display;
+use std::str::FromStr;
+
 use namada_core::borsh::{BorshDeserialize, BorshSerialize};
+use namada_core::ibc::IbcTxDataHash;
+use namada_core::masp::MaspTxId;
 use namada_events::extend::{
     ComposeEvent, EventAttributeEntry, Height, Log, TxHash,
 };
-use namada_events::{Event, EventLevel, EventToEmit};
+use namada_events::{Event, EventLevel, EventToEmit, EventType};
 use namada_macros::BorshDeserializer;
 #[cfg(feature = "migrations")]
 use namada_migrations::*;
+use serde::{Deserialize, Serialize};
 
 use super::Tx;
 use crate::data::{ResultCode, TxResult};
-use crate::TxType;
+use crate::{IndexedTx, TxType};
 
 /// Transaction event.
 #[derive(
@@ -89,5 +95,119 @@ impl<'result> EventAttributeEntry<'result> for Batch<'result> {
 
     fn into_value(self) -> Self::Value {
         self.0
+    }
+}
+
+pub mod masp_types {
+    //! MASP event types
+
+    use namada_events::EventType;
+
+    use super::MaspEvent;
+
+    /// MASP fee payment event
+    pub const FEE_PAYMENT: EventType =
+        namada_events::event_type!(MaspEvent, "fee-payment");
+
+    /// General MASP transfer event
+    pub const TRANSFER: EventType =
+        namada_events::event_type!(MaspEvent, "transfer");
+}
+
+/// MASP event kind
+pub enum MaspEventKind {
+    /// A MASP transaction used for fee payment
+    FeePayment,
+    /// A general MASP transfer
+    Transfer,
+}
+
+impl From<&MaspEventKind> for EventType {
+    fn from(masp_event_kind: &MaspEventKind) -> Self {
+        match masp_event_kind {
+            MaspEventKind::FeePayment => masp_types::FEE_PAYMENT,
+            MaspEventKind::Transfer => masp_types::TRANSFER,
+        }
+    }
+}
+
+impl From<MaspEventKind> for EventType {
+    fn from(masp_event_kind: MaspEventKind) -> Self {
+        (&masp_event_kind).into()
+    }
+}
+
+/// A type representing the possible reference to some MASP data, either a masp
+/// section or ibc tx data
+#[derive(Clone, Serialize, Deserialize)]
+pub enum MaspTxRef {
+    /// Reference to a MASP section
+    MaspSection(MaspTxId),
+    /// Reference to an ibc tx data section
+    IbcData(IbcTxDataHash),
+}
+
+impl Display for MaspTxRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
+}
+
+impl FromStr for MaspTxRef {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+/// A list of MASP tx references
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct MaspTxRefs(pub Vec<(IndexedTx, MaspTxRef)>);
+
+/// MASP transaction event
+pub struct MaspEvent {
+    /// The indexed transaction that generated this event
+    pub tx_index: IndexedTx,
+    /// A flag signaling the type of the masp transaction
+    pub kind: MaspEventKind,
+    /// The reference to the masp data
+    // FIXME: rename this field?
+    pub data: MaspTxRef,
+}
+
+impl EventToEmit for MaspEvent {
+    const DOMAIN: &'static str = "masp";
+}
+
+impl From<MaspEvent> for Event {
+    fn from(masp_event: MaspEvent) -> Self {
+        Self::new(masp_event.kind.into(), EventLevel::Tx)
+            .with(masp_event.data)
+            .with(masp_event.tx_index)
+            .into()
+    }
+}
+
+impl EventAttributeEntry<'static> for MaspTxRef {
+    type Value = MaspTxRef;
+    type ValueOwned = Self::Value;
+
+    // FIXME: rename this?
+    const KEY: &'static str = "section";
+
+    fn into_value(self) -> Self::Value {
+        self
+    }
+}
+
+impl EventAttributeEntry<'static> for IndexedTx {
+    type Value = IndexedTx;
+    type ValueOwned = Self::Value;
+
+    const KEY: &'static str = "indexed-tx";
+
+    fn into_value(self) -> Self::Value {
+        self
     }
 }

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -1,8 +1,10 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::fmt::Display;
 use std::hash::Hash;
 use std::io;
 use std::ops::{Bound, RangeBounds};
+use std::str::FromStr;
 
 use masp_primitives::transaction::Transaction;
 use namada_account::AccountPublicKeysMap;
@@ -903,13 +905,15 @@ impl<'tx> Tx {
     Ord,
     PartialOrd,
     Hash,
+    Serialize,
+    Deserialize,
 )]
 pub struct IndexedTx {
     /// The block height of the indexed tx
     pub height: BlockHeight,
     /// The index in the block of the tx
     pub index: TxIndex,
-    /// The optional index of an inner tx within this batc
+    /// The optional index of an inner tx within this batch
     pub batch_index: Option<u32>,
 }
 
@@ -932,6 +936,20 @@ impl Default for IndexedTx {
             index: TxIndex(0),
             batch_index: None,
         }
+    }
+}
+
+impl Display for IndexedTx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
+}
+
+impl FromStr for IndexedTx {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
     }
 }
 


### PR DESCRIPTION
## Describe your changes

Partially addresses #3824 (removes `ExtendedTxResult`).
Partially addresses #3827 as we take events out of `BatchedTxResult` in case of masp fee payment.

Ensures that events for masp fee payment txs are emitted as soon as the storage changes are committed

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [x] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
        - ~https://github.com/anoma/namada-masp-indexer/pull/50~ ->https://github.com/anoma/namada-masp-indexer/pull/64
        - https://github.com/anoma/namada-indexer/pull/331
