### PR TITLE
Make sure that the conversion state is also written into memory.

### DIFF
--- a/.changelog/unreleased/improvements/4452-load-conversion-migration.md
+++ b/.changelog/unreleased/improvements/4452-load-conversion-migration.md
@@ -1,0 +1,2 @@
+- Make sure that conversion state migrations are not ignored by the rewards
+  distrbiution algorithm. ([\#4452](https://github.com/anoma/namada/pull/4452))


### PR DESCRIPTION
## Describe your changes
This PR tries to ensure that conversion state migrations are written directly into memory in addition to database storage. This would make conversion state migrations similar to those that happen in the subspace column family, which do already have their values written to both memory and database storage.

This is required because migrations are done after the conversion state is loaded into memory, meaning that the migration conversion state would not have an effect on the shielded rewards algorithm in the currently running `namadan` instance. Furthermore, the conversion state in memory overwrites that in storage when shutting down, meaning that a conversion migration state would never not survive in storage beyond the shutting down of the currently running `namadan` instance. Hence all conversion state migrations are nullipotent without some additional logic accounting for the conversion state's presence in memory.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
