### PR TITLE
Informal Systems shielded swaps audit

### DIFF
--- a/crates/ibc/src/context/middlewares/pfm_mod.rs
+++ b/crates/ibc/src/context/middlewares/pfm_mod.rs
@@ -81,22 +81,6 @@ where
     fn next_middleware_mut(&mut self) -> &mut Self::NextMiddleware {
         &mut self.transfer_module
     }
-
-    fn middleware_on_recv_packet_execute(
-        &mut self,
-        packet: &Packet,
-        relayer: &Signer,
-    ) -> (ModuleExtras, Option<Acknowledgement>) {
-        let Ok(packet_data) =
-            serde_json::from_slice::<PacketData>(&packet.data)
-        else {
-            return self
-                .transfer_module
-                .on_recv_packet_execute(packet, relayer);
-        };
-
-        self.transfer_module.on_recv_packet_execute(packet, relayer)
-    }
 }
 
 impl<C, Params> PfmContext for PfmTransferModule<C, Params>

--- a/crates/ibc/src/context/middlewares/pfm_mod.rs
+++ b/crates/ibc/src/context/middlewares/pfm_mod.rs
@@ -95,15 +95,7 @@ where
                 .on_recv_packet_execute(packet, relayer);
         };
 
-        if crate::is_packet_forward(&packet_data) {
-            self.transfer_module.ctx.enable_parse_addr_as_governance();
-            let ret =
-                self.transfer_module.on_recv_packet_execute(packet, relayer);
-            self.transfer_module.ctx.disable_parse_addr_as_governance();
-            ret
-        } else {
-            self.transfer_module.on_recv_packet_execute(packet, relayer)
-        }
+        self.transfer_module.on_recv_packet_execute(packet, relayer)
     }
 }
 

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -1875,6 +1875,7 @@ pub async fn query_osmosis_pool_routes(
             ("tokenIn", coin.as_str()),
             ("tokenOutDenom", output_denom),
             ("humanDenoms", "false"),
+            ("singleRoute", "true"),
         ])
         .send()
         .await


### PR DESCRIPTION
## Describe your changes
This PR implements two of the three recommendations from the Informal Systems audit for shielded swap.
 * When querying Osmosis for a route of liquidity pools, we explicitly limit the result to a single one.
 * We remove the logic that makes the address parseable as the governance address.
 
 We have not implemented IBC size limits. If we do so, it will be in another PR. However, these are implicitly limited by Namada tx size limits anyways.

