### PR TITLE
client: also query and print masp epoch

### DIFF
--- a/.changelog/unreleased/improvements/4457-sdk-override-rewards-target.md
+++ b/.changelog/unreleased/improvements/4457-sdk-override-rewards-target.md
@@ -1,0 +1,2 @@
+- Added MASP epoch to the `namada client epoch` query.
+  ([\#4457](https://github.com/anoma/namada/pull/4457))

--- a/crates/apps_lib/src/cli/client.rs
+++ b/crates/apps_lib/src/cli/client.rs
@@ -494,6 +494,7 @@ impl CliApi {
                         client.wait_until_node_is_synced(&io).await?;
                         let namada = ctx.to_sdk(client, io);
                         rpc::query_and_print_epoch(&namada).await;
+                        rpc::query_and_print_masp_epoch(&namada).await;
                     }
                     Sub::QueryNextEpochInfo(QueryNextEpochInfo(args)) => {
                         let chain_ctx = ctx.borrow_mut_chain_or_exit();


### PR DESCRIPTION
## Describe your changes

`namadac epoch` now prints e.g.:

```
Last committed epoch: 2200
Last committed masp epoch: 550
```

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
