### PR TITLE
Murisi/load storage conversions

### DIFF
--- a/.changelog/unreleased/improvements/4423-configurable-masp-precision.md
+++ b/.changelog/unreleased/improvements/4423-configurable-masp-precision.md
@@ -1,0 +1,2 @@
+- Allow the shielded reward precision for tokens to be explicitly set via
+  governance proposals ([\#4423](https://github.com/anoma/namada/pull/4423))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,7 +588,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-ledger-app:
-    timeout-minutes: 30
+    timeout-minutes: 40
     runs-on: [ubuntu-latest]
 
     env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5750,6 +5750,7 @@ dependencies = [
  "masp_primitives",
  "masp_proofs",
  "namada_apps_lib",
+ "namada_core",
  "namada_macros",
  "namada_migrations",
  "namada_parameters",
@@ -5934,6 +5935,7 @@ version = "0.48.0"
 dependencies = [
  "lazy_static",
  "linkme",
+ "masp_primitives",
  "namada_macros",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5088,9 +5088,9 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+checksum = "cfa6b33e4b4d7eb2ec6d8a6b3db92cd92b63b50b15f226e227188b3ec6a1f92c"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -5103,9 +5103,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+checksum = "57c4482dd67fb614da7840a08b56d387e43ec8a06129e4f7bdba02900f4e3dbc"
 dependencies = [
  "aes",
  "arbitrary",
@@ -5137,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+checksum = "f07358ecd7aa622deec656874eee2d309dcd9f046f89022105336de73d97b34f"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6284,6 +6284,7 @@ dependencies = [
  "ibc-testkit",
  "ics23",
  "itertools 0.14.0",
+ "masp_primitives",
  "namada_apps_lib",
  "namada_core",
  "namada_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,8 +189,8 @@ libfuzzer-sys = "0.4"
 libloading = "0.8"
 linkme = "0.3"
 madato = "0.7"
-masp_primitives = { version = "1.2" }
-masp_proofs = { version = "1.2", default-features = false, features = ["local-prover"] }
+masp_primitives = { version = "1.4" }
+masp_proofs = { version = "1.4", default-features = false, features = ["local-prover"] }
 num256 = "0.6"
 num_cpus = "1.13"
 num_enum = "0.7"

--- a/crates/core/src/chain.rs
+++ b/crates/core/src/chain.rs
@@ -357,7 +357,7 @@ impl Epoch {
     pub fn iter_bounds_inclusive(
         start: Self,
         end: Self,
-    ) -> impl Iterator<Item = Epoch> + Clone {
+    ) -> impl DoubleEndedIterator<Item = Epoch> + Clone {
         let start_ix = start.0;
         let end_ix = end.0;
         (start_ix..=end_ix).map(Epoch::from)

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -135,6 +135,14 @@ impl MaspEpoch {
         ))
     }
 
+    /// Iterate a range of epochs, inclusive of the start and end.
+    pub fn iter_bounds_inclusive(
+        start: Self,
+        end: Self,
+    ) -> impl DoubleEndedIterator<Item = Self> + Clone {
+        Epoch::iter_bounds_inclusive(start.0, end.0).map(Self)
+    }
+
     /// Returns a 0 masp epoch
     pub const fn zero() -> Self {
         Self(Epoch(0))

--- a/crates/migrations/Cargo.toml
+++ b/crates/migrations/Cargo.toml
@@ -13,7 +13,11 @@ repository.workspace = true
 version.workspace = true
 rust-version.workspace = true
 
+[features]
+masp = ["masp_primitives"]
+
 [dependencies]
+masp_primitives = { workspace = true, optional = true }
 namada_macros.workspace = true
 
 lazy_static.workspace = true

--- a/crates/migrations/src/foreign_types.rs
+++ b/crates/migrations/src/foreign_types.rs
@@ -12,3 +12,5 @@ derive_typehash!(Vec::<u8>);
 derive_typehash!(Vec::<String>);
 derive_typehash!(u64);
 derive_typehash!(u128);
+#[cfg(feature = "masp")]
+derive_typehash!(masp_primitives::convert::AllowedConversion);

--- a/crates/migrations/src/foreign_types.rs
+++ b/crates/migrations/src/foreign_types.rs
@@ -11,3 +11,4 @@ use crate::TypeHash;
 derive_typehash!(Vec::<u8>);
 derive_typehash!(Vec::<String>);
 derive_typehash!(u64);
+derive_typehash!(u128);

--- a/crates/node/src/shell/mod.rs
+++ b/crates/node/src/shell/mod.rs
@@ -402,7 +402,7 @@ pub fn is_key_diff_storable(key: &namada_sdk::storage::Key) -> bool {
         && *key != token::storage_key::masp_convert_anchor_key()
         && *key != token::storage_key::masp_token_map_key()
         && *key != token::storage_key::masp_assets_hash_key()
-        && !token::storage_key::is_masp_commitment_anchor_key(key)
+        && token::storage_key::is_masp_commitment_anchor_key(key).is_none()
         || ibc::storage::is_ibc_counter_key(key)
         || proof_of_stake::storage_key::is_delegation_targets_key(key))
 }

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -50,6 +50,7 @@ use crate::ethereum_oracle::{
     control, last_processed_block, try_process_eth_events,
 };
 use crate::shell::testing::utils::TestDir;
+use crate::shell::token::MaspEpoch;
 use crate::shell::{EthereumOracleChannels, Shell};
 use crate::shims::abcipp_shim_types::shim::request::{
     FinalizeBlock, ProcessedTx,
@@ -405,6 +406,16 @@ impl MockNode {
             .in_mem()
             .get_current_epoch()
             .0
+    }
+
+    pub fn current_masp_epoch(&mut self) -> MaspEpoch {
+        let masp_epoch_multiplier =
+            namada_sdk::parameters::read_masp_epoch_multiplier_parameter(
+                &self.shell.lock().unwrap().state,
+            )
+            .unwrap();
+        let current_epoch = self.current_epoch();
+        MaspEpoch::try_from_epoch(current_epoch, masp_epoch_multiplier).unwrap()
     }
 
     pub fn next_masp_epoch(&mut self) -> Epoch {

--- a/crates/sdk/src/migrations.rs
+++ b/crates/sdk/src/migrations.rs
@@ -607,6 +607,8 @@ pub fn commit<D, H>(
 derive_borshdeserializer!(Vec::<u8>);
 derive_borshdeserializer!(Vec::<String>);
 derive_borshdeserializer!(u64);
+derive_borshdeserializer!(u128);
+derive_borshdeserializer!(masp_primitives::convert::AllowedConversion);
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[repr(transparent)]

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -107,11 +107,11 @@ where
         storage.read(&reward_precision_key)?.map_or_else(
             || -> Result<u128> {
                 // Since reading reward precision has failed, choose a
-                // thousandth of the given token
+                // thousandth of the given token. But clamp the precision above
+                // by 10^38, the maximum power of 10 that can be contained by a
+                // u128.
                 let precision_denom =
-                    std::cmp::max(u32::from(denomination.0), 3)
-                        .checked_sub(3)
-                        .expect("Cannot underflow");
+                    u32::from(denomination.0).saturating_sub(3).clamp(0, 38);
                 let reward_precision = checked!(10u128 ^ precision_denom)?;
                 // Record the precision that is now being used so that it does
                 // not have to be recomputed each time, and to

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 #[cfg(any(feature = "multicore", test))]
 use masp_primitives::asset_type::AssetType;
 #[cfg(any(feature = "multicore", test))]
-use masp_primitives::convert::AllowedConversion;
+use masp_primitives::convert::{AllowedConversion, UncheckedAllowedConversion};
 #[cfg(any(feature = "multicore", test))]
 use masp_primitives::transaction::components::I128Sum as MaspAmount;
 use namada_controller::PDController;
@@ -529,7 +529,8 @@ where
     S: StorageWrite + StorageRead + WithConversionState,
 {
     let conversion_key_prefix = masp_conversion_key_prefix();
-    let mut conversion_updates = BTreeMap::new();
+    let mut conversion_updates =
+        BTreeMap::<_, UncheckedAllowedConversion>::new();
     // Read conversion updates from storage and store them in a map
     for conv_result in iter_prefix_with_filter_map(
         storage,
@@ -556,7 +557,7 @@ where
             );
             continue;
         };
-        leaf.conversion = conv;
+        leaf.conversion = conv.0;
     }
     // Delete the updates now that they have been applied
     storage.delete_prefix(&conversion_key_prefix)?;

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -34,7 +34,7 @@ use crate::storage_key::{masp_assets_hash_key, masp_token_map_key};
 use crate::storage_key::{
     masp_kd_gain_key, masp_kp_gain_key, masp_last_inflation_key,
     masp_last_locked_amount_key, masp_locked_amount_target_key,
-    masp_max_reward_rate_key,
+    masp_max_reward_rate_key, masp_reward_precision_key,
 };
 #[cfg(any(feature = "multicore", test))]
 use crate::{ConversionLeaf, Error, OptionExt, ResultExt};
@@ -87,21 +87,44 @@ pub fn calculate_masp_rewards_precision<S, TransToken>(
 ) -> Result<(u128, Denomination)>
 where
     S: StorageWrite + StorageRead,
-    TransToken: trans_token::Read<S>,
+    TransToken: trans_token::Keys + trans_token::Read<S>,
 {
     let denomination = TransToken::read_denom(storage, addr)?
         .expect("failed to read token denomination");
+
     // Inflation is implicitly denominated by this value. The lower this
     // figure, the less precise inflation computations are. This is especially
     // problematic when inflation is coming from a token with much higher
     // denomination than the native token. The higher this figure, the higher
     // the threshold of holdings required in order to receive non-zero rewards.
-    // This value should be fixed constant for each asset type. Here we choose
-    // a thousandth of the given asset.
-    let precision_denom = std::cmp::max(u32::from(denomination.0), 3)
-        .checked_sub(3)
-        .expect("Cannot underflow");
-    Ok((checked!(10u128 ^ precision_denom)?, denomination))
+    // This value should be fixed constant for each asset type. Here we read a
+    // value from storage and failing that we choose a thousandth of the given
+    // asset.
+    // Key to read/write reward precision from
+    let reward_precision_key = masp_reward_precision_key::<TransToken>(addr);
+    // Now read the desired reward precision for this token address
+    let reward_precision: u128 =
+        storage.read(&reward_precision_key)?.map_or_else(
+            || -> Result<u128> {
+                // Since reading reward precision has failed, choose a
+                // thousandth of the given token
+                let precision_denom =
+                    std::cmp::max(u32::from(denomination.0), 3)
+                        .checked_sub(3)
+                        .expect("Cannot underflow");
+                let reward_precision = checked!(10u128 ^ precision_denom)?;
+                // Record the precision that is now being used so that it does
+                // not have to be recomputed each time, and to
+                // ensure that this value is not accidentally
+                // changed even by a change to this initialization
+                // algorithm.
+                storage.write(&reward_precision_key, reward_precision)?;
+                Ok(reward_precision)
+            },
+            Ok,
+        )?;
+
+    Ok((reward_precision, denomination))
 }
 
 /// Get the balance of the given token at the MASP address that is eligble to

--- a/crates/shielded_token/src/storage_key.rs
+++ b/crates/shielded_token/src/storage_key.rs
@@ -2,8 +2,9 @@
 
 use std::str::FromStr;
 
+use masp_primitives::asset_type::AssetType;
 use masp_primitives::bls12_381::Scalar;
-use masp_primitives::sapling::Nullifier;
+use masp_primitives::sapling::{Node, Nullifier};
 use namada_core::address::{self, Address};
 use namada_core::hash::Hash;
 use namada_core::storage::{self, DbKeySeg, KeySeg};
@@ -15,6 +16,8 @@ const BALANCE_STORAGE_KEY: &str = "balance";
 pub const MASP_NULLIFIERS_KEY: &str = "nullifiers";
 /// The key for the masp reward balance
 pub const MASP_UNDATED_BALANCE_KEY: &str = "undated_balance";
+/// Key segment prefix for the conversions
+pub const MASP_CONVERSIONS_KEY: &str = "conversions";
 /// Key segment prefix for the note commitment merkle tree
 pub const MASP_NOTE_COMMITMENT_TREE_KEY: &str = "commitment_tree";
 /// Key segment prefix for the note commitment anchor
@@ -141,21 +144,26 @@ pub fn is_masp_key(key: &storage::Key) -> bool {
     }
 }
 
+/// Check if the given storage key is allowed to be touched by a governance
+/// proposal
+pub fn is_masp_governance_key(key: &storage::Key) -> bool {
+    is_masp_token_map_key(key) || is_masp_conversion_key(key).is_some()
+}
+
 /// Check if the given storage key is allowed to be touched by a masp transfer
 pub fn is_masp_transfer_key(key: &storage::Key) -> bool {
-    match &key.segments[..] {
+    is_masp_commitment_tree_key(key)
+        || is_masp_nullifier_key(key)
+        || is_masp_balance_key(key)
+        || is_masp_undated_balance_key(key).is_some()
+}
+
+/// Check if the given storage key is a masp commitment tree key
+pub fn is_masp_commitment_tree_key(key: &storage::Key) -> bool {
+    matches!(&key.segments[..],
         [DbKeySeg::AddressSeg(addr), DbKeySeg::StringSeg(key)]
             if *addr == address::MASP
-                && key == MASP_NOTE_COMMITMENT_TREE_KEY =>
-        {
-            true
-        }
-        _ => {
-            is_masp_nullifier_key(key)
-                || is_masp_balance_key(key)
-                || is_masp_undated_balance_key(key).is_some()
-        }
-    }
+                && key == MASP_NOTE_COMMITMENT_TREE_KEY)
 }
 
 /// Check if the given storage key is a masp nullifier key
@@ -168,12 +176,19 @@ pub fn is_masp_nullifier_key(key: &storage::Key) -> bool {
 }
 
 /// Check if the given key is a masp commitment anchor
-pub fn is_masp_commitment_anchor_key(key: &storage::Key) -> bool {
-    matches!(&key.segments[..],
-    [DbKeySeg::AddressSeg(addr),
-             DbKeySeg::StringSeg(prefix),
-            ..
-        ] if *addr == address::MASP && prefix == MASP_NOTE_COMMITMENT_ANCHOR_PREFIX)
+pub fn is_masp_commitment_anchor_key(key: &storage::Key) -> Option<Node> {
+    match &key.segments[..] {
+        [
+            DbKeySeg::AddressSeg(addr),
+            DbKeySeg::StringSeg(prefix),
+            DbKeySeg::StringSeg(anchor),
+        ] if *addr == address::MASP
+            && prefix == MASP_NOTE_COMMITMENT_ANCHOR_PREFIX =>
+        {
+            Hash::from_str(anchor).map(|x| Node::new(x.0)).ok()
+        }
+        _ => None,
+    }
 }
 
 /// Check if the given storage key is a masp token map key
@@ -184,12 +199,42 @@ pub fn is_masp_token_map_key(key: &storage::Key) -> bool {
         ] if *addr == address::MASP && prefix == MASP_TOKEN_MAP_KEY)
 }
 
+/// Check if the given storage key is a masp nullifier key
+pub fn is_masp_conversion_key(key: &storage::Key) -> Option<AssetType> {
+    match &key.segments[..] {
+        [
+            DbKeySeg::AddressSeg(address::MASP),
+            DbKeySeg::StringSeg(prefix),
+            DbKeySeg::StringSeg(asset_type),
+        ] if prefix == MASP_CONVERSIONS_KEY => {
+            AssetType::from_str(asset_type).ok()
+        }
+        _ => None,
+    }
+}
+
 /// Get a key for a masp nullifier
 pub fn masp_nullifier_key(nullifier: &Nullifier) -> storage::Key {
     storage::Key::from(address::MASP.to_db_key())
         .push(&MASP_NULLIFIERS_KEY.to_owned())
         .expect("Cannot obtain a storage key")
         .push(&Hash(nullifier.0))
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get a key for a masp conversion
+pub fn masp_conversion_key(asset_type: &AssetType) -> storage::Key {
+    storage::Key::from(address::MASP.to_db_key())
+        .push(&MASP_CONVERSIONS_KEY.to_owned())
+        .expect("Cannot obtain a storage key")
+        .push(&asset_type.to_string())
+        .expect("Cannot obtain a storage key")
+}
+
+/// Get the key prefix for masp conversions
+pub fn masp_conversion_key_prefix() -> storage::Key {
+    storage::Key::from(address::MASP.to_db_key())
+        .push(&MASP_CONVERSIONS_KEY.to_owned())
         .expect("Cannot obtain a storage key")
 }
 

--- a/crates/shielded_token/src/storage_key.rs
+++ b/crates/shielded_token/src/storage_key.rs
@@ -40,6 +40,8 @@ pub const MASP_LOCKED_AMOUNT_TARGET_KEY: &str = "locked_amount_target";
 pub const MASP_MAX_REWARD_RATE_KEY: &str = "max_reward_rate";
 /// The key for the total inflation rewards minted by MASP
 pub const MASP_TOTAL_REWARDS: &str = "max_total_rewards";
+/// The key for the reward precision for a given asset
+pub const MASP_REWARD_PRECISION_KEY: &str = "reward_precision";
 
 /// Obtain the nominal proportional key for the given token
 pub fn masp_kp_gain_key<TransToken: trans_token::Keys>(
@@ -63,6 +65,14 @@ pub fn masp_max_reward_rate_key<TransToken: trans_token::Keys>(
 ) -> storage::Key {
     TransToken::parameter_prefix(token_addr)
         .with_segment(MASP_MAX_REWARD_RATE_KEY.to_owned())
+}
+
+/// The precision of rewards for the given token
+pub fn masp_reward_precision_key<TransToken: trans_token::Keys>(
+    token_addr: &Address,
+) -> storage::Key {
+    TransToken::parameter_prefix(token_addr)
+        .with_segment(MASP_REWARD_PRECISION_KEY.to_owned())
 }
 
 /// Obtain the locked target amount key for the given token

--- a/crates/shielded_token/src/storage_key.rs
+++ b/crates/shielded_token/src/storage_key.rs
@@ -70,7 +70,7 @@ pub fn masp_max_reward_rate_key<TransToken: trans_token::Keys>(
         .with_segment(MASP_MAX_REWARD_RATE_KEY.to_owned())
 }
 
-/// The precision of rewards for the given token
+/// The shielded reward precision key for the given token
 pub fn masp_reward_precision_key<TransToken: trans_token::Keys>(
     token_addr: &Address,
 ) -> storage::Key {
@@ -102,7 +102,7 @@ pub fn masp_last_inflation_key<TransToken: trans_token::Keys>(
         .with_segment(MASP_LAST_INFLATION_KEY.to_owned())
 }
 
-/// Check if the given storage key is a masp reward balance key
+/// Check if the given storage key is the undated balance of a token
 pub fn is_masp_undated_balance_key(key: &storage::Key) -> Option<Address> {
     match &key.segments[..] {
         [
@@ -199,7 +199,7 @@ pub fn is_masp_token_map_key(key: &storage::Key) -> bool {
         ] if *addr == address::MASP && prefix == MASP_TOKEN_MAP_KEY)
 }
 
-/// Check if the given storage key is a masp nullifier key
+/// Check if the given storage key is a masp conversion key
 pub fn is_masp_conversion_key(key: &storage::Key) -> Option<AssetType> {
     match &key.segments[..] {
         [

--- a/crates/shielded_token/src/vp.rs
+++ b/crates/shielded_token/src/vp.rs
@@ -30,7 +30,7 @@ use namada_tx::BatchedTxRef;
 use namada_vp_env::{Error, Result, VpEnv};
 
 use crate::storage_key::{
-    is_masp_key, is_masp_nullifier_key, is_masp_token_map_key,
+    is_masp_governance_key, is_masp_key, is_masp_nullifier_key,
     is_masp_transfer_key, is_masp_undated_balance_key,
     masp_commitment_anchor_key, masp_commitment_tree_key,
     masp_convert_anchor_key, masp_nullifier_key, masp_undated_balance_key,
@@ -99,7 +99,7 @@ where
         let masp_keys_changed: Vec<&Key> =
             keys_changed.iter().filter(|key| is_masp_key(key)).collect();
         let non_allowed_changes = masp_keys_changed.iter().any(|key| {
-            !is_masp_transfer_key(key) && !is_masp_token_map_key(key)
+            !is_masp_transfer_key(key) && !is_masp_governance_key(key)
         });
 
         // Check that the transaction didn't write unallowed masp keys
@@ -108,20 +108,20 @@ where
                 "Found modifications to non-allowed masp keys",
             ));
         }
-        let masp_token_map_changed = masp_keys_changed
+        let masp_governance_changes = masp_keys_changed
             .iter()
-            .any(|key| is_masp_token_map_key(key));
+            .any(|key| is_masp_governance_key(key));
         let masp_transfer_changes = masp_keys_changed
             .iter()
             .any(|key| is_masp_transfer_key(key));
-        if masp_token_map_changed && masp_transfer_changes {
+        if masp_governance_changes && masp_transfer_changes {
             Err(Error::new_const(
                 "Cannot simultaneously do governance proposal and MASP \
                  transfer",
             ))
-        } else if masp_token_map_changed {
-            // The token map can only be changed by a successful governance
-            // proposal
+        } else if masp_governance_changes {
+            // The token map or allowed conversions can only be changed by a
+            // successful governance proposal
             Self::is_valid_parameter_change(ctx, tx_data)
         } else if masp_transfer_changes {
             // The MASP transfer keys can only be changed by a valid Transaction

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -59,9 +59,9 @@ pub use namada_storage::conversion_state::{
 pub use namada_storage::types::{KVBytes, PatternIterator, PrefixIterator};
 pub use namada_storage::{
     collections, iter_prefix, iter_prefix_bytes, iter_prefix_with_filter,
-    mockdb, tx_queue, BlockStateRead, BlockStateWrite, DBIter, DBWriteBatch,
-    DbError, DbResult, Error, OptionExt, Result, ResultExt, StorageHasher,
-    StorageRead, StorageWrite, DB,
+    iter_prefix_with_filter_map, mockdb, tx_queue, BlockStateRead,
+    BlockStateWrite, DBIter, DBWriteBatch, DbError, DbResult, Error, OptionExt,
+    Result, ResultExt, StorageHasher, StorageRead, StorageWrite, DB,
 };
 use namada_systems::parameters;
 use thiserror::Error;

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -251,6 +251,65 @@ where
 /// Note that this is preferable over the regular `iter_prefix` combined with
 /// the iterator's `filter` function as it avoids trying to decode values that
 /// don't pass the filter. For `iter_prefix_bytes`, `filter` works fine.
+pub fn iter_prefix_with_filter_map<'a, K, T, F>(
+    storage: &'a impl StorageRead,
+    prefix: &Key,
+    filter_map: F,
+) -> Result<impl Iterator<Item = Result<(K, T)>> + 'a>
+where
+    T: BorshDeserialize,
+    F: Fn(&Key) -> Option<K> + 'a,
+{
+    let mut iter = storage.iter_prefix(prefix)?;
+    let iter = std::iter::from_fn(move || {
+        // The loop is for applying filter - we `continue` when the current key
+        // doesn't pass the predicate.
+        loop {
+            match storage.iter_next(&mut iter) {
+                Ok(Some((key, val))) => {
+                    let key = match Key::parse(key).into_storage_result() {
+                        Ok(key) => key,
+                        Err(err) => {
+                            // Propagate key encoding errors into Iterator's
+                            // Item
+                            return Some(Err(err));
+                        }
+                    };
+                    // Check the predicate
+                    let Some(mapped_key) = filter_map(&key) else {
+                        continue;
+                    };
+                    let val =
+                        match T::try_from_slice(&val).into_storage_result() {
+                            Ok(val) => val,
+                            Err(err) => {
+                                // Propagate val encoding errors into Iterator's
+                                // Item
+                                return Some(Err(err));
+                            }
+                        };
+                    return Some(Ok((mapped_key, val)));
+                }
+                Ok(None) => return None,
+                Err(err) => {
+                    // Propagate `iter_next` errors into Iterator's Item
+                    return Some(Err(err));
+                }
+            }
+        }
+    });
+    Ok(iter)
+}
+
+/// Iterate Borsh encoded items matching the given prefix and passing the given
+/// `filter` predicate, ordered by the storage keys.
+///
+/// The `filter` predicate is a function from a storage key to bool and only
+/// the items that return `true` will be returned from the iterator.
+///
+/// Note that this is preferable over the regular `iter_prefix` combined with
+/// the iterator's `filter` function as it avoids trying to decode values that
+/// don't pass the filter. For `iter_prefix_bytes`, `filter` works fine.
 pub fn iter_prefix_with_filter<'a, T, F>(
     storage: &'a impl StorageRead,
     prefix: &Key,

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -46,6 +46,7 @@ ibc-middleware-packet-forward.workspace = true
 ibc-testkit.workspace = true
 ics23.workspace = true
 itertools.workspace = true
+masp_primitives.workspace = true
 proptest.workspace = true
 prost.workspace = true
 regex.workspace = true

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use color_eyre::eyre::Result;
 use color_eyre::owo_colors::OwoColorize;
+use masp_primitives::convert::AllowedConversion;
 use masp_primitives::transaction::components::I128Sum;
 use namada_apps_lib::wallet::defaults::{
     get_unencrypted_keypair, is_use_device,
@@ -1767,7 +1768,10 @@ fn reset_conversions() -> Result<()> {
         precision_btcs
             .entry((epoch, digit))
             .or_insert_with(|| {
-                I128Sum::from_pair(asset_type(epoch, digit), PRECISION)
+                AllowedConversion::from(I128Sum::from_pair(
+                    asset_type(epoch, digit),
+                    PRECISION,
+                ))
             })
             .clone()
     };
@@ -1784,7 +1788,7 @@ fn reset_conversions() -> Result<()> {
     // Write the new BTC conversions to memory
     for digit in token::MaspDigitPos::iter() {
         // -PRECISION BTC[ep, digit] + PRECISION BTC[current_ep, digit]
-        let mut reward = I128Sum::zero();
+        let mut reward: AllowedConversion = I128Sum::zero().into();
         for epoch in MaspEpoch::iter_bounds_inclusive(
             MaspEpoch::zero(),
             node.current_masp_epoch().prev().unwrap(),

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -75,6 +75,11 @@ pub mod storage_key {
         shielded::masp_max_reward_rate_key::<TransToken>(token_addr)
     }
 
+    /// The shielded rewards precision key for the given token
+    pub fn masp_reward_precision_key(token_addr: &Address) -> storage::Key {
+        shielded::masp_reward_precision_key::<TransToken>(token_addr)
+    }
+
     /// Obtain the locked target amount key for the given token
     pub fn masp_locked_amount_target_key(token_addr: &Address) -> storage::Key {
         shielded::masp_locked_amount_target_key::<TransToken>(token_addr)

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -53,8 +53,8 @@ pub mod storage_key {
         is_masp_commitment_anchor_key, is_masp_key, is_masp_nullifier_key,
         is_masp_token_map_key, is_masp_transfer_key, masp_assets_hash_key,
         masp_commitment_anchor_key, masp_commitment_tree_key,
-        masp_convert_anchor_key, masp_nullifier_key, masp_token_map_key,
-        masp_total_rewards,
+        masp_conversion_key, masp_convert_anchor_key, masp_nullifier_key,
+        masp_token_map_key, masp_total_rewards,
     };
     pub use namada_trans_token::storage_key::*;
 

--- a/crates/tx_prelude/src/token.rs
+++ b/crates/tx_prelude/src/token.rs
@@ -7,7 +7,8 @@ pub use namada_token::testing;
 pub use namada_token::tx::apply_shielded_transfer;
 use namada_token::TransparentTransfersRef;
 pub use namada_token::{
-    storage_key, utils, Amount, DenominatedAmount, Store, Transfer,
+    storage_key, utils, Amount, DenominatedAmount, Denomination, MaspDigitPos,
+    Store, Transfer,
 };
 use namada_tx::BatchedTx;
 use namada_tx_env::Address;

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -34,8 +34,9 @@ masp_proofs = { workspace = true, default-features = false, features = [
     "download-params",
 ] }
 namada_apps_lib = { workspace = true, features = ["migrations"] }
+namada_core = { workspace = true, default-features = false }
 namada_macros = { workspace = true }
-namada_migrations = { workspace = true }
+namada_migrations = { workspace = true, features = ["masp"] }
 namada_parameters = { workspace = true }
 namada_trans_token = { workspace = true, features = ["migrations"] }
 namada_sdk = { workspace = true, default-features = false, features = [

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -34,7 +34,7 @@ masp_proofs = { workspace = true, default-features = false, features = [
     "download-params",
 ] }
 namada_apps_lib = { workspace = true, features = ["migrations"] }
-namada_core = { workspace = true, default-features = false }
+namada_core = { workspace = true }
 namada_macros = { workspace = true }
 namada_migrations = { workspace = true, features = ["masp"] }
 namada_parameters = { workspace = true }

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use masp_primitives::convert::AllowedConversion;
+use masp_primitives::transaction::components::I128Sum;
+use namada_core::masp::encode_asset_type;
 use namada_macros::BorshDeserializer;
 use namada_sdk::address::Address;
 use namada_sdk::ibc::trace::ibc_token;
@@ -9,10 +12,12 @@ use namada_sdk::masp_primitives::merkle_tree::FrozenCommitmentTree;
 use namada_sdk::masp_primitives::sapling;
 use namada_sdk::migrations;
 use namada_sdk::storage::DbColFam;
-use namada_shielded_token::storage_key::masp_reward_precision_key;
-use namada_shielded_token::{ConversionLeaf, ConversionState};
+use namada_shielded_token::storage_key::{
+    masp_conversion_key, masp_reward_precision_key,
+};
+use namada_shielded_token::{ConversionLeaf, ConversionState, MaspEpoch};
 use namada_trans_token::storage_key::{balance_key, minted_balance_key};
-use namada_trans_token::{Amount, Store};
+use namada_trans_token::{Amount, Denomination, MaspDigitPos, Store};
 
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -121,8 +126,117 @@ fn shielded_reward_precision_migration() {
     .unwrap();
 }
 
+// Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
+// their allowed conversions with conversions that do not contain rewards.
+fn shielded_reward_reset_migration() {
+    pub type ChannelId = &'static str;
+    pub type BaseToken = &'static str;
+    // Valid precisions must be in the intersection of i128 and u128
+    pub type Precision = i128;
+
+    // The MASP epoch in which this migration will be applied. This number
+    // controls the number of epochs of conversions created.
+    const TARGET_MASP_EPOCH: MaspEpoch = MaspEpoch::new(2000);
+    // The denomination of the targetted token. Since all tokens here are IBC
+    // tokens, this is 0.
+    const DENOMINATION: Denomination = Denomination(0u8);
+    // The tokens whose rewarrds will be reset.
+    const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
+        ("channel-1", "uosmo", 1000i128),
+        ("channel-2", "uatom", 1000i128),
+        ("channel-3", "utia", 1000i128),
+        ("channel-0", "stuosmo", 1000i128),
+        ("channel-0", "stuatom", 1000i128),
+        ("channel-0", "stutia", 1000i128),
+    ];
+
+    let mut updates = Vec::new();
+    // Reset the allowed conversions for the above tokens
+    for (channel_id, base_token, precision) in IBC_TOKENS {
+        let ibc_denom = format!("transfer/{channel_id}/{base_token}");
+        let token_address = ibc_token(&ibc_denom).clone();
+
+        // Erase the TOK rewards that have been distributed so far
+        let mut asset_types = BTreeMap::new();
+        let mut precision_toks = BTreeMap::new();
+        let mut reward_deltas = BTreeMap::new();
+        // TOK[ep, digit]
+        let mut asset_type = |epoch, digit| {
+            *asset_types.entry((epoch, digit)).or_insert_with(|| {
+                encode_asset_type(
+                    token_address.clone(),
+                    DENOMINATION,
+                    digit,
+                    Some(epoch),
+                )
+                .expect("unable to encode asset type")
+            })
+        };
+        // PRECISION TOK[ep, digit]
+        let mut precision_tok = |epoch, digit| {
+            precision_toks
+                .entry((epoch, digit))
+                .or_insert_with(|| {
+                    AllowedConversion::from(I128Sum::from_pair(
+                        asset_type(epoch, digit),
+                        precision,
+                    ))
+                })
+                .clone()
+        };
+        // -PRECISION TOK[ep, digit] + PRECISION TOK[ep+1, digit]
+        let mut reward_delta = |epoch, digit| {
+            reward_deltas
+                .entry((epoch, digit))
+                .or_insert_with(|| {
+                    -precision_tok(epoch, digit)
+                        + precision_tok(epoch.next().unwrap(), digit)
+                })
+                .clone()
+        };
+        // Write the new TOK conversions to memory
+        for digit in MaspDigitPos::iter() {
+            // -PRECISION TOK[ep, digit] + PRECISION TOK[current_ep, digit]
+            let mut reward: AllowedConversion = I128Sum::zero().into();
+            for epoch in MaspEpoch::iter_bounds_inclusive(
+                MaspEpoch::zero(),
+                TARGET_MASP_EPOCH.prev().unwrap(),
+            )
+            .rev()
+            {
+                // TOK[ep, digit]
+                let asset_type = encode_asset_type(
+                    token_address.clone(),
+                    DENOMINATION,
+                    digit,
+                    Some(epoch),
+                )
+                .expect("unable to encode asset type");
+                reward += reward_delta(epoch, digit);
+                // Write the conversion update to memory
+                updates.push(migrations::DbUpdateType::Add {
+                    key: masp_conversion_key(&asset_type),
+                    cf: DbColFam::SUBSPACE,
+                    value: reward.clone().into(),
+                    force: false,
+                });
+            }
+        }
+    }
+
+    let changes = migrations::DbChanges {
+        changes: updates.into_iter().collect(),
+    };
+    std::fs::write(
+        "shielded_reward_reset_migration.json",
+        serde_json::to_string(&changes).unwrap(),
+    )
+    .unwrap();
+}
+
 // Generate various migrations
 fn main() {
     minted_balance_migration();
     shielded_reward_precision_migration();
+    shielded_reward_reset_migration();
 }

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -194,6 +194,16 @@ fn shielded_reward_reset_migration() {
                 })
                 .clone()
         };
+        // The key holding the shielded reward precision of current token
+        let shielded_token_reward_precision_key =
+            masp_reward_precision_key::<Store<()>>(&token_address);
+
+        updates.push(migrations::DbUpdateType::Add {
+            key: shielded_token_reward_precision_key,
+            cf: DbColFam::SUBSPACE,
+            value: (precision as u128).into(),
+            force: false,
+        });
         // Write the new TOK conversions to memory
         for digit in MaspDigitPos::iter() {
             // -PRECISION TOK[ep, digit] + PRECISION TOK[current_ep, digit]

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -3,14 +3,16 @@ use std::collections::BTreeMap;
 use borsh::{BorshDeserialize, BorshSerialize};
 use namada_macros::BorshDeserializer;
 use namada_sdk::address::Address;
+use namada_sdk::ibc::trace::ibc_token;
 use namada_sdk::masp_primitives::asset_type::AssetType;
 use namada_sdk::masp_primitives::merkle_tree::FrozenCommitmentTree;
 use namada_sdk::masp_primitives::sapling;
 use namada_sdk::migrations;
 use namada_sdk::storage::DbColFam;
+use namada_shielded_token::storage_key::masp_reward_precision_key;
 use namada_shielded_token::{ConversionLeaf, ConversionState};
 use namada_trans_token::storage_key::{balance_key, minted_balance_key};
-use namada_trans_token::Amount;
+use namada_trans_token::{Amount, Store};
 
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -38,8 +40,8 @@ impl From<ConversionState> for NewConversionState {
     }
 }
 
-#[allow(dead_code)]
-fn example() {
+// Demonstrate how to set the minted balance using a migration
+fn minted_balance_migration() {
     let person =
         Address::decode("tnam1q9rhgyv3ydq0zu3whnftvllqnvhvhm270qxay5tn")
             .unwrap();
@@ -68,10 +70,59 @@ fn example() {
     let changes = migrations::DbChanges {
         changes: updates.into_iter().collect(),
     };
-    std::fs::write("migrations.json", serde_json::to_string(&changes).unwrap())
-        .unwrap();
+    std::fs::write(
+        "minted_balance_migration.json",
+        serde_json::to_string(&changes).unwrap(),
+    )
+    .unwrap();
 }
 
+// Demonstrate how to set the shielded reward precision of IBC tokens using a
+// migration
+fn shielded_reward_precision_migration() {
+    pub type ChannelId = &'static str;
+    pub type BaseToken = &'static str;
+    pub type Precision = u128;
+
+    const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
+        ("channel-1", "uosmo", 1000u128),
+        ("channel-2", "uatom", 1000u128),
+        ("channel-3", "utia", 1000u128),
+        ("channel-0", "stuosmo", 1000u128),
+        ("channel-0", "stuatom", 1000u128),
+        ("channel-0", "stutia", 1000u128),
+    ];
+
+    let mut updates = Vec::new();
+    // Set IBC token shielded reward precisions
+    for (channel_id, base_token, precision) in IBC_TOKENS {
+        let ibc_denom = format!("transfer/{channel_id}/{base_token}");
+        let token_address = ibc_token(&ibc_denom).clone();
+
+        // The key holding the shielded reward precision of current token
+        let shielded_token_reward_precision_key =
+            masp_reward_precision_key::<Store<()>>(&token_address);
+
+        updates.push(migrations::DbUpdateType::Add {
+            key: shielded_token_reward_precision_key,
+            cf: DbColFam::SUBSPACE,
+            value: precision.into(),
+            force: false,
+        });
+    }
+
+    let changes = migrations::DbChanges {
+        changes: updates.into_iter().collect(),
+    };
+    std::fs::write(
+        "shielded_reward_precision_migration.json",
+        serde_json::to_string(&changes).unwrap(),
+    )
+    .unwrap();
+}
+
+// Generate various migrations
 fn main() {
-    example()
+    minted_balance_migration();
+    shielded_reward_precision_migration();
 }

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -4083,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+checksum = "cfa6b33e4b4d7eb2ec6d8a6b3db92cd92b63b50b15f226e227188b3ec6a1f92c"
 dependencies = [
  "borsh",
  "chacha20",
@@ -4097,9 +4097,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+checksum = "57c4482dd67fb614da7840a08b56d387e43ec8a06129e4f7bdba02900f4e3dbc"
 dependencies = [
  "aes",
  "bip0039",
@@ -4130,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+checksum = "f07358ecd7aa622deec656874eee2d309dcd9f046f89022105336de73d97b34f"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -4834,6 +4834,7 @@ dependencies = [
  "ibc-testkit",
  "ics23",
  "itertools 0.14.0",
+ "masp_primitives",
  "namada_core",
  "namada_sdk",
  "namada_test_utils",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -2273,9 +2273,9 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "masp_note_encryption"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9736dbd86140a9d6711b464297a87af9cc0ae485d73a956c595f1bc1f6a7920"
+checksum = "cfa6b33e4b4d7eb2ec6d8a6b3db92cd92b63b50b15f226e227188b3ec6a1f92c"
 dependencies = [
  "borsh",
  "chacha20",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "masp_primitives"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb184254ca5cd5fb12e11b81a6a0d6b955d98c7263eae11057f669c31c7123c"
+checksum = "57c4482dd67fb614da7840a08b56d387e43ec8a06129e4f7bdba02900f4e3dbc"
 dependencies = [
  "aes",
  "bip0039",
@@ -2319,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "masp_proofs"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb23ccc5e4781636f6a7b2e720f60f31e53e534d1abb2b0ac5e86eb099c14"
+checksum = "f07358ecd7aa622deec656874eee2d309dcd9f046f89022105336de73d97b34f"
 dependencies = [
  "bellman",
  "blake2b_simd",


### PR DESCRIPTION
## Describe your changes
Based on #4423 . Implemented loading conversion leaf updates from storage. This feature is required because the asset conversion table is currently stored in memory making it difficult to modify using governance proposals. Furthermore, the fact that a given epoch's conversion state is a function of the previous epoch's conversion state makes it difficult to correctly alter it without more advanced migration capabilities (that can inspect the current state).

So in order to address the above problems, this PR does the following:
* It introduces a new key to store conversion leaf updates: `<MASP address>/conversions/<asset type>`. These keys store `AllowedConversion`s instead of `I128Sum` to give the creator a opportunities to optimize their construction.
* The reward distribution algorithm now scans through all keys of this form and sets the corresponding entry in the conversion table (in memory) to the value currently in storage
* Afterwards the reward distribution algorithm deletes all keys of the above form to ensure that they are not reapplied in future epochs. I.e. these keys are not always initialized and are generally intended to be write-only.
* Introduces a new integration test called `reset_conversions` that zeros all the rewards that have been distributed for BTC and checks that BTC holders' balances go down. The conversion leafs are not simply zeroed because that would make them malformed.
* Implements as an example a migration that clears all existing rewards for specified IBC tokens using the mechanism introduced by this PR. The generated migration is about 27 megabytes. Alternatively, existing rewards can be cleared using a governance proposal like https://github.com/anoma/namada-governance-upgrades/pull/39 .

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
