### PR TITLE
Prevent DenominatedAmount comparison from overflowing.

### DIFF
--- a/.changelog/unreleased/improvements/4472-generalize-amount-comparison.md
+++ b/.changelog/unreleased/improvements/4472-generalize-amount-comparison.md
@@ -1,0 +1,3 @@
+- Generalize the comparison of denominated amounts to
+  support the case where gap between denominations is large.
+  ([\#4472](https://github.com/anoma/namada/pull/4472))


### PR DESCRIPTION
## Describe your changes
Generalized comparison of `DenominatedAmount`s to support the case where the difference between the denominations of the operands exceeds 77 (the maximum power of 10 that can be contained by an unsigned 256-bit integer type). This change is necessary to make proptests that generate arbitrary `DenominatedAmount`s pass in extreme cases.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
