### PR TITLE
Fix masp events [rebase]

### DIFF
--- a/.changelog/unreleased/bug-fixes/4449-fix-masp-events.md
+++ b/.changelog/unreleased/bug-fixes/4449-fix-masp-events.md
@@ -1,0 +1,2 @@
+- Fixed the production of masp events for masp fee payment transactions.
+  ([\#4449](https://github.com/anoma/namada/pull/4449))

--- a/crates/events/src/extend.rs
+++ b/crates/events/src/extend.rs
@@ -9,9 +9,6 @@ use namada_core::address::Address;
 use namada_core::chain::BlockHeight;
 use namada_core::collections::HashMap;
 use namada_core::hash::Hash;
-use namada_core::ibc::IbcTxDataHash;
-use namada_core::masp::MaspTxId;
-use namada_core::storage::TxIndex;
 use serde::Deserializer;
 
 use super::*;
@@ -546,60 +543,6 @@ impl EventAttributeEntry<'static> for Info {
     type ValueOwned = Self::Value;
 
     const KEY: &'static str = "info";
-
-    fn into_value(self) -> Self::Value {
-        self.0
-    }
-}
-
-/// A type representing the possible reference to some MASP data, either a masp
-/// section or ibc tx data
-#[derive(Clone, Serialize, Deserialize)]
-pub enum MaspTxRef {
-    /// Reference to a MASP section
-    MaspSection(MaspTxId),
-    /// Reference to an ibc tx data section
-    IbcData(IbcTxDataHash),
-}
-
-/// A list of MASP tx references
-#[derive(Default, Clone, Serialize, Deserialize)]
-pub struct MaspTxRefs(pub Vec<MaspTxRef>);
-
-/// A mapping between the index of a transaction in a block and the set of
-/// associated masp data
-#[derive(Clone, Serialize, Deserialize)]
-pub struct IndexedMaspData {
-    /// The transaction index in the block
-    pub tx_index: TxIndex,
-    /// The set of masp data
-    pub masp_refs: MaspTxRefs,
-}
-
-impl Display for IndexedMaspData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", serde_json::to_string(self).unwrap())
-    }
-}
-
-impl FromStr for IndexedMaspData {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s)
-    }
-}
-
-/// Extend an [`Event`] with `masp_data_refs` data, mapping a transaction
-/// index in the block to a collection of either the MASP sections or the data
-/// sections for shielded actions.
-pub struct MaspDataRefs(pub IndexedMaspData);
-
-impl EventAttributeEntry<'static> for MaspDataRefs {
-    type Value = IndexedMaspData;
-    type ValueOwned = Self::Value;
-
-    const KEY: &'static str = "masp_data_refs";
 
     fn into_value(self) -> Self::Value {
         self.0

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -29,9 +29,7 @@ use namada_sdk::borsh::{
 };
 use namada_sdk::chain::testing::get_dummy_header;
 use namada_sdk::chain::{BlockHeight, ChainId, Epoch};
-use namada_sdk::events::extend::{
-    ComposeEvent, IndexedMaspData, MaspDataRefs, MaspTxRef, MaspTxRefs,
-};
+use namada_sdk::events::extend::ComposeEvent;
 use namada_sdk::events::Event;
 use namada_sdk::gas::TxGasMeter;
 use namada_sdk::governance::storage::proposal::ProposalType;
@@ -93,9 +91,9 @@ use namada_sdk::time::DateTimeUtc;
 use namada_sdk::token::{self, Amount, DenominatedAmount, Transfer};
 use namada_sdk::tx::data::pos::Bond;
 use namada_sdk::tx::data::{BatchedTxResult, Fee, TxResult, VpsResult};
-use namada_sdk::tx::event::{new_tx_event, Batch};
+use namada_sdk::tx::event::{new_tx_event, Batch, MaspEvent, MaspTxRef};
 use namada_sdk::tx::{
-    Authorization, BatchedTx, BatchedTxRef, Code, Data, Section, Tx,
+    Authorization, BatchedTx, BatchedTxRef, Code, Data, IndexedTx, Section, Tx,
 };
 pub use namada_sdk::tx::{
     TX_BECOME_VALIDATOR_WASM, TX_BOND_WASM, TX_BRIDGE_POOL_WASM,
@@ -1037,53 +1035,61 @@ impl Client for BenchShell {
         let end_block_events = if height.value()
             == shell.inner.state.in_mem().get_last_block_height().0
         {
-            Some(
-                shell
-                    .last_block_masp_txs
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, (tx, changed_keys))| {
-                        let tx_result = {
-                            let mut batch_results = TxResult::new();
-                            batch_results.insert_inner_tx_result(
-                                tx.wrapper_hash().as_ref(),
-                                either::Right(tx.first_commitments().unwrap()),
-                                Ok(BatchedTxResult {
-                                    changed_keys: changed_keys.to_owned(),
-                                    vps_result: VpsResult::default(),
-                                    initialized_accounts: vec![],
-                                    events: BTreeSet::default(),
-                                }),
-                            );
-                            batch_results
-                        };
-                        let event: Event = new_tx_event(tx, height.value())
-                            .with(Batch(&tx_result))
-                            .with(MaspDataRefs(IndexedMaspData {
-                                tx_index: TxIndex::must_from_usize(idx),
-                                masp_refs: MaspTxRefs(vec![
-                                    tx.sections
-                                        .iter()
-                                        .find_map(|section| {
-                                            if let Section::MaspTx(
-                                                transaction,
-                                            ) = section
-                                            {
-                                                Some(MaspTxRef::MaspSection(
-                                                    transaction.txid().into(),
-                                                ))
-                                            } else {
-                                                None
-                                            }
-                                        })
-                                        .unwrap(),
-                                ]),
-                            }))
-                            .into();
-                        namada_sdk::tendermint::abci::Event::from(event)
-                    })
-                    .collect(),
-            )
+            let mut res = vec![];
+            for (idx, (tx, changed_keys)) in
+                shell.last_block_masp_txs.iter().enumerate()
+            {
+                let tx_result = {
+                    let mut batch_results = TxResult::new();
+                    batch_results.insert_inner_tx_result(
+                        tx.wrapper_hash().as_ref(),
+                        either::Right(tx.first_commitments().unwrap()),
+                        Ok(BatchedTxResult {
+                            changed_keys: changed_keys.to_owned(),
+                            vps_result: VpsResult::default(),
+                            initialized_accounts: vec![],
+                            events: BTreeSet::default(),
+                        }),
+                    );
+                    batch_results
+                };
+                let tx_event: Event = new_tx_event(tx, height.value())
+                    .with(Batch(&tx_result))
+                    .into();
+                let mut masp_ref = None;
+                for section in &tx.sections {
+                    if let Section::MaspTx(transaction) = section {
+                        masp_ref = Some(MaspTxRef::MaspSection(
+                            transaction.txid().into(),
+                        ));
+                        // Expect a single masp tx in the batch
+                        break;
+                    }
+                }
+
+                let masp_event = masp_ref.map(|data| {
+                    let masp_event: Event = MaspEvent {
+                        tx_index: IndexedTx {
+                            block_height: namada_sdk::chain::BlockHeight(
+                                u64::from(height),
+                            ),
+                            block_index: TxIndex::must_from_usize(idx),
+                            batch_index: Some(0),
+                        },
+                        kind: namada_sdk::tx::event::MaspEventKind::Transfer,
+                        data,
+                    }
+                    .into();
+                    masp_event
+                });
+
+                res.push(namada_sdk::tendermint::abci::Event::from(tx_event));
+
+                if let Some(event) = masp_event {
+                    res.push(namada_sdk::tendermint::abci::Event::from(event));
+                }
+            }
+            Some(res)
         } else {
             None
         };

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -1056,16 +1056,14 @@ impl Client for BenchShell {
                 let tx_event: Event = new_tx_event(tx, height.value())
                     .with(Batch(&tx_result))
                     .into();
-                let mut masp_ref = None;
-                for section in &tx.sections {
+                // Expect a single masp tx in the batch
+                let masp_ref = tx.sections.iter().find_map(|section| {
                     if let Section::MaspTx(transaction) = section {
-                        masp_ref = Some(MaspTxRef::MaspSection(
-                            transaction.txid().into(),
-                        ));
-                        // Expect a single masp tx in the batch
-                        break;
+                        Some(MaspTxRef::MaspSection(transaction.txid().into()))
+                    } else {
+                        None
                     }
-                }
+                });
 
                 let masp_event = masp_ref.map(|data| {
                     let masp_event: Event = MaspEvent {

--- a/crates/node/src/dry_run_tx.rs
+++ b/crates/node/src/dry_run_tx.rs
@@ -36,55 +36,54 @@ where
     let height = state.in_mem().get_last_block_height();
 
     // Wrapper dry run to allow estimating the entire gas cost of a transaction
-    let (wrapper_hash, extended_tx_result, tx_gas_meter) =
-        match tx.header().tx_type {
-            TxType::Wrapper(wrapper) => {
-                let gas_limit = wrapper
-                    .gas_limit
-                    .as_scaled_gas(gas_scale)
-                    .into_storage_result()?;
-                let tx_gas_meter =
-                    RefCell::new(TxGasMeter::new(gas_limit, gas_scale));
-                let mut shell_params = ShellParams::new(
-                    &tx_gas_meter,
-                    &mut state,
-                    &mut vp_wasm_cache,
-                    &mut tx_wasm_cache,
-                );
-                let tx_result = protocol::apply_wrapper_tx(
-                    &tx,
-                    &wrapper,
-                    &request.data,
-                    &TxIndex::default(),
-                    height,
-                    &tx_gas_meter,
-                    &mut shell_params,
-                    None,
-                )
+    let (wrapper_hash, tx_result, tx_gas_meter) = match tx.header().tx_type {
+        TxType::Wrapper(wrapper) => {
+            let gas_limit = wrapper
+                .gas_limit
+                .as_scaled_gas(gas_scale)
                 .into_storage_result()?;
+            let tx_gas_meter =
+                RefCell::new(TxGasMeter::new(gas_limit, gas_scale));
+            let mut shell_params = ShellParams::new(
+                &tx_gas_meter,
+                &mut state,
+                &mut vp_wasm_cache,
+                &mut tx_wasm_cache,
+            );
+            let tx_result = protocol::apply_wrapper_tx(
+                &tx,
+                &wrapper,
+                &request.data,
+                &TxIndex::default(),
+                height,
+                &tx_gas_meter,
+                &mut shell_params,
+                None,
+            )
+            .into_storage_result()?;
 
-                state.write_log_mut().commit_tx_to_batch();
-                (Some(tx.header_hash()), tx_result, tx_gas_meter)
-            }
-            _ => {
-                // When dry running only the inner tx(s), use the max block gas
-                // as the gas limit
-                let max_block_gas = parameters::get_max_block_gas(&state)?;
-                let gas_limit = GasLimit::from(max_block_gas)
-                    .as_scaled_gas(gas_scale)
-                    .into_storage_result()?;
-                (
-                    None,
-                    TxResult::default().to_extended_result(None),
-                    RefCell::new(TxGasMeter::new(gas_limit, gas_scale)),
-                )
-            }
-        };
+            state.write_log_mut().commit_tx_to_batch();
+            (Some(tx.header_hash()), tx_result, tx_gas_meter)
+        }
+        _ => {
+            // When dry running only the inner tx(s), use the max block gas
+            // as the gas limit
+            let max_block_gas = parameters::get_max_block_gas(&state)?;
+            let gas_limit = GasLimit::from(max_block_gas)
+                .as_scaled_gas(gas_scale)
+                .into_storage_result()?;
+            (
+                None,
+                TxResult::default(),
+                RefCell::new(TxGasMeter::new(gas_limit, gas_scale)),
+            )
+        }
+    };
 
-    let extended_tx_result = protocol::dispatch_inner_txs(
+    let tx_result = protocol::dispatch_inner_txs(
         &tx,
         wrapper_hash.as_ref(),
-        extended_tx_result,
+        tx_result,
         TxIndex(0),
         height,
         &tx_gas_meter,
@@ -94,7 +93,7 @@ where
     )
     .map_err(|err| err.error)
     .into_storage_result()?;
-    let tx_result_string = extended_tx_result.tx_result.to_result_string();
+    let tx_result_string = tx_result.to_result_string();
     let dry_run_result = DryRunResult(
         tx_result_string,
         tx_gas_meter

--- a/crates/node/src/dry_run_tx.rs
+++ b/crates/node/src/dry_run_tx.rs
@@ -33,6 +33,7 @@ where
     tx.validate_tx().into_storage_result()?;
 
     let gas_scale = parameters::get_gas_scale(&state)?;
+    let height = state.in_mem().get_last_block_height();
 
     // Wrapper dry run to allow estimating the entire gas cost of a transaction
     let (wrapper_hash, extended_tx_result, tx_gas_meter) =
@@ -55,6 +56,7 @@ where
                     &wrapper,
                     &request.data,
                     &TxIndex::default(),
+                    height,
                     &tx_gas_meter,
                     &mut shell_params,
                     None,
@@ -84,6 +86,7 @@ where
         wrapper_hash.as_ref(),
         extended_tx_result,
         TxIndex(0),
+        height,
         &tx_gas_meter,
         &mut state,
         &mut vp_wasm_cache,
@@ -104,7 +107,7 @@ where
         data: dry_run_result.serialize_to_vec(),
         proof: None,
         info: Default::default(),
-        height: state.in_mem().get_last_block_height(),
+        height,
     })
 }
 

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -24,10 +24,9 @@ use namada_sdk::token::Amount;
 use namada_sdk::tx::action::{self, Read};
 use namada_sdk::tx::data::protocol::{ProtocolTx, ProtocolTxType};
 use namada_sdk::tx::data::{
-    BatchedTxResult, ExtendedTxResult, TxResult, VpStatusFlags, VpsResult,
-    WrapperTx,
+    BatchedTxResult, TxResult, VpStatusFlags, VpsResult, WrapperTx,
 };
-use namada_sdk::tx::event::{MaspTxRef, MaspTxRefs};
+use namada_sdk::tx::event::{MaspEvent, MaspEventKind, MaspTxRef};
 use namada_sdk::tx::{BatchedTxRef, IndexedTx, Tx, TxCommitments};
 use namada_sdk::validation::{
     EthBridgeNutVp, EthBridgePoolVp, EthBridgeVp, GovernanceVp, IbcVp, MaspVp,
@@ -140,9 +139,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub struct DispatchError {
     /// The result of the function call
     pub error: Error,
-    /// The extended tx result produced. It could be produced even in case of
+    /// The tx result produced. It could be produced even in case of
     /// an error
-    pub tx_result: Option<ExtendedTxResult<Error>>,
+    pub tx_result: Option<TxResult<Error>>,
 }
 
 impl Display for DispatchError {
@@ -175,7 +174,7 @@ pub enum DispatchArgs<'a, CA: 'static + WasmCacheAccess + Sync> {
         wrapper_hash: Option<&'a Hash>,
         /// The result of the corresponding wrapper tx (missing if governance
         /// transaction)
-        wrapper_tx_result: Option<ExtendedTxResult<Error>>,
+        wrapper_tx_result: Option<TxResult<Error>>,
         /// Vp cache
         vp_wasm_cache: &'a mut VpCache<CA>,
         /// Tx cache
@@ -209,7 +208,7 @@ pub fn dispatch_tx<'a, D, H, CA>(
     dispatch_args: DispatchArgs<'a, CA>,
     tx_gas_meter: &'a RefCell<TxGasMeter>,
     state: &'a mut WlState<D, H>,
-) -> std::result::Result<ExtendedTxResult<Error>, DispatchError>
+) -> std::result::Result<TxResult<Error>, DispatchError>
 where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
@@ -272,8 +271,7 @@ where
                         Ok(batched_tx_result),
                     );
                     batch_results
-                }
-                .to_extended_result(None))
+                })
             }
         }
         DispatchArgs::Protocol(protocol_tx) => {
@@ -290,8 +288,7 @@ where
                     Ok(batched_tx_result),
                 );
                 batch_results
-            }
-            .to_extended_result(None))
+            })
         }
         DispatchArgs::Wrapper {
             wrapper,
@@ -324,18 +321,14 @@ where
     }
 }
 
-pub(crate) fn get_batch_txs_to_execute<'a>(
-    tx: &'a Tx,
-    masp_tx_refs: &mut MaspTxRefs,
-) -> impl Iterator<Item = &'a TxCommitments> {
+pub(crate) fn get_batch_txs_to_execute(
+    tx: &Tx,
+    ran_masp_fee_payment: bool,
+) -> impl Iterator<Item = &TxCommitments> {
     let mut batch_iter = tx.commitments().iter();
-    // Remove the masp ref of fee payment if any. We have already emitted the
-    // event for it
-    if masp_tx_refs.0.pop().is_some() {
-        // FIXME: look here if we change the masp events, we still need to skip
-        // the first tx of the batch! If fees were paid via masp skip
-        // the first transaction of the batch which has already been
-        // executed
+    if ran_masp_fee_payment {
+        // If fees were paid via masp skip the first transaction of the batch
+        // which has already been executed
         batch_iter.next();
     }
 
@@ -346,14 +339,14 @@ pub(crate) fn get_batch_txs_to_execute<'a>(
 pub(crate) fn dispatch_inner_txs<'a, S, D, H, CA>(
     tx: &Tx,
     wrapper_hash: Option<&'a Hash>,
-    mut extended_tx_result: ExtendedTxResult<Error>,
+    mut tx_result: TxResult<Error>,
     tx_index: TxIndex,
     height: namada_sdk::chain::BlockHeight,
     tx_gas_meter: &'a RefCell<TxGasMeter>,
     state: &'a mut S,
     vp_wasm_cache: &'a mut VpCache<CA>,
     tx_wasm_cache: &'a mut TxCache<CA>,
-) -> std::result::Result<ExtendedTxResult<Error>, DispatchError>
+) -> std::result::Result<TxResult<Error>, DispatchError>
 where
     S: 'static
         + State<D = D, H = H>
@@ -364,9 +357,8 @@ where
     H: 'static + StorageHasher + Sync,
     CA: 'static + WasmCacheAccess + Sync,
 {
-    for cmt in
-        get_batch_txs_to_execute(tx, &mut extended_tx_result.masp_tx_refs)
-    {
+    let ran_masp_fee_payment = !tx_result.is_empty();
+    for cmt in get_batch_txs_to_execute(tx, ran_masp_fee_payment) {
         match apply_wasm_tx(
             wrapper_hash,
             &tx.batch_ref_tx(cmt),
@@ -380,7 +372,7 @@ where
         ) {
             Err(Error::GasError(ref msg)) => {
                 // Gas error aborts the execution of the entire batch
-                extended_tx_result.tx_result.insert_inner_tx_result(
+                tx_result.insert_inner_tx_result(
                     wrapper_hash,
                     either::Right(cmt),
                     Err(Error::GasError(msg.to_owned())),
@@ -388,71 +380,72 @@ where
                 state.write_log_mut().drop_tx();
                 return Err(DispatchError {
                     error: Error::GasError(msg.to_owned()),
-                    tx_result: Some(extended_tx_result),
+                    tx_result: Some(tx_result),
                 });
             }
-            res => {
-                let batched_tx_result = match &res {
-                    Ok(batched_tx_result) => Some(batched_tx_result.to_owned()),
-                    Err(_) => None,
+            mut res => {
+                let is_tx_accepted = match &mut res {
+                    Ok(batched_tx_result)
+                        if batched_tx_result.is_accepted() =>
+                    {
+                        // If the transaction was a masp one generate the
+                        // appropriate event
+                        if let Some(masp_ref) = get_optional_masp_ref(
+                            state,
+                            cmt,
+                            Either::Right(batched_tx_result),
+                        )? {
+                            batched_tx_result.events.insert(
+                                MaspEvent {
+                                    tx_index: IndexedTx {
+                                        block_height: height,
+                                        block_index: tx_index,
+                                        batch_index: tx
+                                            .header
+                                            .batch
+                                            .get_index_of(cmt)
+                                            .map(|idx| {
+                                                TxIndex::must_from_usize(idx)
+                                                    .into()
+                                            }),
+                                    },
+                                    kind: MaspEventKind::Transfer,
+                                    data: masp_ref,
+                                }
+                                .into(),
+                            );
+                        }
+
+                        true
+                    }
+                    _ => false,
                 };
 
-                // FIXME: here we insert the inner tx result which also contains
-                // the events
-                extended_tx_result.tx_result.insert_inner_tx_result(
+                tx_result.insert_inner_tx_result(
                     wrapper_hash,
                     either::Right(cmt),
                     res,
                 );
 
-                match batched_tx_result {
-                    Some(ref res) if res.is_accepted() => {
-                        // If the transaction was a masp one append the
-                        // transaction refs for the events.
-                        if let Some(masp_ref) = get_optional_masp_ref(
-                            state,
-                            cmt,
-                            Either::Right(res),
-                        )? {
-                            // FIXME: here we should cache the event directly
-                            // into res (if it is ok)
-                            extended_tx_result.masp_tx_refs.0.push((
-                                IndexedTx {
-                                    block_height: height,
-                                    block_index: tx_index,
-                                    batch_index: tx
-                                        .header
-                                        .batch
-                                        .get_index_of(cmt)
-                                        .and_then(|idx| {
-                                            u32::try_from(idx).ok()
-                                        }),
-                                },
-                                masp_ref,
-                            ))
-                        }
-                        state.write_log_mut().commit_tx_to_batch();
-                    }
-                    _ => {
-                        state.write_log_mut().drop_tx();
+                if is_tx_accepted {
+                    state.write_log_mut().commit_tx_to_batch();
+                } else {
+                    state.write_log_mut().drop_tx();
 
-                        if tx.header.atomic {
-                            // Stop the execution of an atomic batch at the
-                            // first failed transaction
-                            return Err(DispatchError {
-                                error: Error::FailingAtomicBatch(
-                                    cmt.get_hash(),
-                                ),
-                                tx_result: Some(extended_tx_result),
-                            });
-                        }
+                    if tx.header.atomic {
+                        // Stop the execution of an atomic batch at the
+                        // first failed transaction
+                        return Err(DispatchError {
+                            error: Error::FailingAtomicBatch(cmt.get_hash()),
+                            tx_result: Some(tx_result),
+                        });
                     }
                 }
             }
         };
     }
 
-    Ok(extended_tx_result)
+    Ok(tx_result)
 }
 
 /// Transaction result for masp transfer
@@ -475,7 +468,7 @@ pub(crate) fn apply_wrapper_tx<S, D, H, CA>(
     tx_gas_meter: &RefCell<TxGasMeter>,
     shell_params: &mut ShellParams<'_, S, D, H, CA>,
     block_proposer: Option<&Address>,
-) -> Result<ExtendedTxResult<Error>>
+) -> Result<TxResult<Error>>
 where
     S: 'static
         + State<D = D, H = H>
@@ -511,12 +504,23 @@ where
         .write_log_mut()
         .commit_batch_and_current_tx();
 
-    // FIXME: here we should probably just push the event inside the events
-    // field of TxResult without the need for ExtendedTxResult
-    let (batch_results, masp_section_refs) = payment_result.map_or_else(
-        || (TxResult::default(), None),
-        |masp_tx_result| {
+    let batch_results =
+        payment_result.map_or_else(TxResult::default, |mut masp_tx_result| {
             let mut batch = TxResult::default();
+            // Generate Masp event if needed
+            masp_tx_result.tx_result.events.insert(
+                MaspEvent {
+                    tx_index: IndexedTx {
+                        block_height: height,
+                        block_index: tx_index.to_owned(),
+                        batch_index: Some(0),
+                    },
+                    kind: MaspEventKind::FeePayment,
+                    data: masp_tx_result.masp_section_ref,
+                }
+                .into(),
+            );
+
             batch.insert_inner_tx_result(
                 // Ok to unwrap cause if we have a batched result it means
                 // we've executed the first tx in the batch
@@ -524,19 +528,9 @@ where
                 either::Right(tx.first_commitments().unwrap()),
                 Ok(masp_tx_result.tx_result),
             );
-            (
-                batch,
-                Some(MaspTxRefs(vec![(
-                    IndexedTx {
-                        block_height: height,
-                        block_index: tx_index.to_owned(),
-                        batch_index: Some(0),
-                    },
-                    masp_tx_result.masp_section_ref,
-                )])),
-            )
-        },
-    );
+
+            batch
+        });
 
     // Account for gas
     tx_gas_meter
@@ -544,7 +538,7 @@ where
         .add_wrapper_gas(tx_bytes)
         .map_err(|err| Error::GasError(err.to_string()))?;
 
-    Ok(batch_results.to_extended_result(masp_section_refs))
+    Ok(batch_results)
 }
 
 /// Perform the actual transfer of fees from the fee payer to the block
@@ -1042,7 +1036,6 @@ where
 
     let initialized_accounts = state.write_log().get_initialized_accounts();
     let changed_keys = state.write_log().get_keys();
-    // FIXME: seems like here we extract the events produced by the tx
     let events = state.write_log_mut().take_events();
 
     Ok(BatchedTxResult {

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -7,6 +7,7 @@ use either::Either;
 use eyre::{eyre, WrapErr};
 use namada_sdk::address::{Address, InternalAddress};
 use namada_sdk::booleans::BoolResultUnitExt;
+use namada_sdk::collections::HashSet;
 use namada_sdk::events::extend::{
     ComposeEvent, Height as HeightAttr, TxHash as TxHashAttr, UserAccount,
 };
@@ -24,7 +25,8 @@ use namada_sdk::token::Amount;
 use namada_sdk::tx::action::{self, Read};
 use namada_sdk::tx::data::protocol::{ProtocolTx, ProtocolTxType};
 use namada_sdk::tx::data::{
-    BatchedTxResult, TxResult, VpStatusFlags, VpsResult, WrapperTx,
+    compute_inner_tx_hash, BatchedTxResult, TxResult, VpStatusFlags, VpsResult,
+    WrapperTx,
 };
 use namada_sdk::tx::event::{MaspEvent, MaspEventKind, MaspTxRef};
 use namada_sdk::tx::{BatchedTxRef, IndexedTx, Tx, TxCommitments};
@@ -321,20 +323,6 @@ where
     }
 }
 
-pub(crate) fn get_batch_txs_to_execute(
-    tx: &Tx,
-    ran_masp_fee_payment: bool,
-) -> impl Iterator<Item = &TxCommitments> {
-    let mut batch_iter = tx.commitments().iter();
-    if ran_masp_fee_payment {
-        // If fees were paid via masp skip the first transaction of the batch
-        // which has already been executed
-        batch_iter.next();
-    }
-
-    batch_iter
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn dispatch_inner_txs<'a, S, D, H, CA>(
     tx: &Tx,
@@ -357,8 +345,20 @@ where
     H: 'static + StorageHasher + Sync,
     CA: 'static + WasmCacheAccess + Sync,
 {
-    let ran_masp_fee_payment = !tx_result.is_empty();
-    for cmt in get_batch_txs_to_execute(tx, ran_masp_fee_payment) {
+    // Extract the inner transactions of the batch that need to be executed,
+    // excluding those that already ran during the handling of the wrapper tx.
+    let inner_txs = tx
+        .commitments()
+        .iter()
+        .filter(|cmt| {
+            let inner_tx_hash =
+                compute_inner_tx_hash(wrapper_hash, Either::Right(cmt));
+            !tx_result.0.contains_key(&inner_tx_hash)
+        })
+        .collect::<HashSet<_>>()
+        .into_iter();
+
+    for cmt in inner_txs {
         match apply_wasm_tx(
             wrapper_hash,
             &tx.batch_ref_tx(cmt),

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -7,6 +7,7 @@ use either::Either;
 use eyre::{eyre, WrapErr};
 use namada_sdk::address::{Address, InternalAddress};
 use namada_sdk::booleans::BoolResultUnitExt;
+use namada_sdk::chain::BlockHeight;
 use namada_sdk::collections::HashSet;
 use namada_sdk::events::extend::{
     ComposeEvent, Height as HeightAttr, TxHash as TxHashAttr, UserAccount,
@@ -170,7 +171,7 @@ pub enum DispatchArgs<'a, CA: 'static + WasmCacheAccess + Sync> {
         /// The tx index
         tx_index: TxIndex,
         /// The block height
-        height: namada_sdk::chain::BlockHeight,
+        height: BlockHeight,
         /// Hash of the header of the wrapper tx containing
         /// this raw tx
         wrapper_hash: Option<&'a Hash>,
@@ -191,7 +192,7 @@ pub enum DispatchArgs<'a, CA: 'static + WasmCacheAccess + Sync> {
         /// The tx index
         tx_index: TxIndex,
         /// The block height
-        height: namada_sdk::chain::BlockHeight,
+        height: BlockHeight,
         /// The block proposer
         block_proposer: &'a Address,
         /// Vp cache
@@ -329,7 +330,7 @@ pub(crate) fn dispatch_inner_txs<'a, S, D, H, CA>(
     wrapper_hash: Option<&'a Hash>,
     mut tx_result: TxResult<Error>,
     tx_index: TxIndex,
-    height: namada_sdk::chain::BlockHeight,
+    height: BlockHeight,
     tx_gas_meter: &'a RefCell<TxGasMeter>,
     state: &'a mut S,
     vp_wasm_cache: &'a mut VpCache<CA>,
@@ -464,7 +465,7 @@ pub(crate) fn apply_wrapper_tx<S, D, H, CA>(
     wrapper: &WrapperTx,
     tx_bytes: &[u8],
     tx_index: &TxIndex,
-    height: namada_sdk::chain::BlockHeight,
+    height: BlockHeight,
     tx_gas_meter: &RefCell<TxGasMeter>,
     shell_params: &mut ShellParams<'_, S, D, H, CA>,
     block_proposer: Option<&Address>,

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -37,13 +37,6 @@ fn extract_masp_tx(
     tx: &Tx,
     masp_ref: &MaspTxRef,
 ) -> Result<Transaction, Error> {
-    // NOTE: It is possible to have two identical references in a same batch:
-    // this is because, some types of MASP data packet can be correctly executed
-    // more than once (output descriptions). We have to make sure we account for
-    // this by using collections that allow for duplicates (both in the args
-    // and in the returned type): if the same reference shows up multiple
-    // times in the input we must process it the same number of times to
-    // ensure we contruct the correct state
     match masp_ref {
         MaspTxRef::MaspSection(id) => {
             // Simply looking for masp sections attached to the tx

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -112,7 +112,11 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
         .into_iter()
         .map(|event| {
             // Check if the event is a Masp one
-            let kind = namada_events::EventType::from_str(&event.kind)?;
+            let Ok(kind) = namada_events::EventType::from_str(&event.kind)
+            else {
+                return Ok(None);
+            };
+
             let kind = if kind == namada_tx::event::masp_types::TRANSFER {
                 MaspEventKind::Transfer
             } else if kind == namada_tx::event::masp_types::FEE_PAYMENT {

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -112,17 +112,7 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
             events
                 .into_iter()
                 .filter_map(|event| {
-                    // FIXME: improve here
-                    let Ok(data) = MaspTxRef::read_from_event_attributes(
-                        &event.attributes,
-                    ) else {
-                        return None;
-                    };
-                    let Ok(tx_index) = IndexedTx::read_from_event_attributes(
-                        &event.attributes,
-                    ) else {
-                        return None;
-                    };
+                    // Check if the event is a Masp one
                     let Ok(kind) =
                         namada_events::EventType::from_str(&event.kind)
                     else {
@@ -135,6 +125,18 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
                     {
                         MaspEventKind::FeePayment
                     } else {
+                        return None;
+                    };
+
+                    // Extract the data from the event's attributes
+                    let Ok(data) = MaspTxRef::read_from_event_attributes(
+                        &event.attributes,
+                    ) else {
+                        return None;
+                    };
+                    let Ok(tx_index) = IndexedTx::read_from_event_attributes(
+                        &event.attributes,
+                    ) else {
                         return None;
                     };
 

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -62,7 +62,7 @@ fn extract_masp_tx(
         }
         MaspTxRef::IbcData(hash) => {
             // Dereference the masp ref to the first instance that
-            // matches is, even if it is not the exact one that produced
+            // matches it, even if it is not the exact one that produced
             // the event, the data we extract will be exactly the same
             let masp_ibc_tx = tx
                 .commitments()

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -16,8 +16,9 @@ use namada_core::storage::TxIndex;
 use namada_io::Client;
 use namada_token::masp::utils::{
     IndexedNoteEntry, MaspClient, MaspClientCapabilities, MaspIndexedTx,
+    MaspTxKind,
 };
-use namada_tx::event::{MaspEvent, MaspEventKind};
+use namada_tx::event::MaspEvent;
 use namada_tx::{IndexedTx, Tx};
 use tokio::sync::Semaphore;
 
@@ -132,7 +133,7 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
                 txs.push((
                     MaspIndexedTx {
                         indexed_tx: tx_index,
-                        kind,
+                        kind: kind.into(),
                     },
                     extracted_masp_tx,
                 ));
@@ -550,9 +551,9 @@ impl MaspClient for IndexerMaspClient {
                         })?;
 
                     let kind = if slot.is_masp_fee_payment {
-                        MaspEventKind::FeePayment
+                        MaspTxKind::FeePayment
                     } else {
-                        MaspEventKind::Transfer
+                        MaspTxKind::Transfer
                     };
                     let masp_indexed_tx = MaspIndexedTx {
                         kind,
@@ -701,9 +702,9 @@ impl MaspClient for IndexerMaspClient {
                                 batch_index: Some(batch_index),
                             },
                             kind: if is_masp_fee_payment {
-                                MaspEventKind::FeePayment
+                                MaspTxKind::FeePayment
                             } else {
-                                MaspEventKind::Transfer
+                                MaspTxKind::Transfer
                             },
                         },
                         note_position,

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -105,19 +105,28 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
                     .data
             };
 
+            // Cache the last tx seen to avoid multiple deserializations
+            let mut last_tx: Option<(Tx, TxIndex)> = None;
+
             for MaspEvent {
                 tx_index,
                 kind: _,
                 data,
             } in txs_results
             {
-                let tx = Tx::try_from_bytes(
-                    block[tx_index.block_index.0 as usize].as_ref(),
-                )
-                .map_err(|e| Error::Other(e.to_string()))?;
-                // FIXME: need to iterate on all the inner txs of this tx
-                // without deserializing the tx more than once
-                let extracted_masp_tx = extract_masp_tx(&tx, &data)
+                let tx = match &last_tx {
+                    Some((tx, idx)) if idx == &tx_index.block_index => tx,
+                    _ => {
+                        let tx = Tx::try_from_bytes(
+                            block[tx_index.block_index.0 as usize].as_ref(),
+                        )
+                        .map_err(|e| Error::Other(e.to_string()))?;
+                        last_tx = Some((tx, tx_index.block_index));
+
+                        &last_tx.as_ref().unwrap().0
+                    }
+                };
+                let extracted_masp_tx = extract_masp_tx(tx, &data)
                     .map_err(|e| Error::Other(e.to_string()))?;
 
                 txs.push((tx_index, extracted_masp_tx));

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -17,7 +17,7 @@ use namada_io::Client;
 use namada_token::masp::utils::{
     IndexedNoteEntry, MaspClient, MaspClientCapabilities, MaspIndexedTx,
 };
-use namada_tx::event::MaspEvent;
+use namada_tx::event::{MaspEvent, MaspEventKind};
 use namada_tx::{IndexedTx, Tx};
 use tokio::sync::Semaphore;
 
@@ -197,7 +197,7 @@ impl<C: Client + Send + Sync> MaspClient for LedgerMaspClient<C> {
     async fn fetch_note_index(
         &self,
         _: BlockHeight,
-    ) -> Result<BTreeMap<IndexedTx, usize>, Error> {
+    ) -> Result<BTreeMap<MaspIndexedTx, usize>, Error> {
         Err(Error::Other(
             "Transaction notes map fetching is not implemented by this client"
                 .to_string(),
@@ -403,13 +403,16 @@ impl MaspClient for IndexerMaspClient {
 
         #[derive(Deserialize)]
         struct TransactionSlot {
+            masp_tx_index: u64,
+            is_masp_fee_payment: bool,
             bytes: Vec<u8>,
         }
 
         #[derive(Deserialize)]
         struct Transaction {
-            masp_indexed_tx: MaspIndexedTx,
-            transaction: TransactionSlot,
+            block_height: u64,
+            block_index: u64,
+            batch: Vec<TransactionSlot>,
         }
 
         #[derive(Deserialize)]
@@ -530,25 +533,39 @@ impl MaspClient for IndexerMaspClient {
 
         while let Some(result) = stream_of_fetches.next().await {
             for Transaction {
-                masp_indexed_tx,
-                transaction,
+                block_height,
+                block_index,
+                batch: transactions,
             } in result?
             {
-                let extracted_masp_tx = MaspTx::try_from_slice(
-                    &transaction.bytes,
-                )
-                .map_err(|err| {
-                    Error::Other(format!(
-                        "Could not deserialize the masp txs borsh data at \
-                         height {}, block index {} and batch index: {:#?}: \
-                         {err}",
-                        masp_indexed_tx.indexed_tx.block_height,
-                        masp_indexed_tx.indexed_tx.block_index,
-                        masp_indexed_tx.indexed_tx.batch_index
-                    ))
-                })?;
+                for slot in transactions {
+                    let extracted_masp_tx = MaspTx::try_from_slice(&slot.bytes)
+                        .map_err(|err| {
+                            Error::Other(format!(
+                                "Could not deserialize the masp txs borsh \
+                                 data at height {}, block index {} and batch \
+                                 index: {:#?}: {err}",
+                                block_height, block_index, slot.masp_tx_index
+                            ))
+                        })?;
 
-                txs.push((masp_indexed_tx, extracted_masp_tx));
+                    let kind = if slot.is_masp_fee_payment {
+                        MaspEventKind::FeePayment
+                    } else {
+                        MaspEventKind::Transfer
+                    };
+                    let masp_indexed_tx = MaspIndexedTx {
+                        kind,
+                        indexed_tx: IndexedTx {
+                            block_height: block_height.into(),
+                            block_index: TxIndex::must_from_usize(
+                                block_index as usize,
+                            ),
+                            batch_index: Some(slot.masp_tx_index as u32),
+                        },
+                    };
+                    txs.push((masp_indexed_tx, extracted_masp_tx));
+                }
             }
         }
 
@@ -611,7 +628,7 @@ impl MaspClient for IndexerMaspClient {
     async fn fetch_note_index(
         &self,
         BlockHeight(height): BlockHeight,
-    ) -> Result<BTreeMap<IndexedTx, usize>, Error> {
+    ) -> Result<BTreeMap<MaspIndexedTx, usize>, Error> {
         use serde::Deserialize;
 
         #[derive(Deserialize)]
@@ -621,6 +638,7 @@ impl MaspClient for IndexerMaspClient {
             batch_index: u32,
             block_index: u32,
             block_height: u64,
+            is_masp_fee_payment: bool,
         }
 
         #[derive(Deserialize)]
@@ -667,6 +685,7 @@ impl MaspClient for IndexerMaspClient {
                      batch_index,
                      block_height,
                      note_position,
+                     is_masp_fee_payment,
                  }| {
                     if Some(block_height) != prev_block_height {
                         masp_index = 0;
@@ -675,10 +694,17 @@ impl MaspClient for IndexerMaspClient {
                         masp_index += 1;
                     }
                     (
-                        IndexedTx {
-                            block_index: TxIndex(block_index),
-                            block_height: BlockHeight(block_height),
-                            batch_index: Some(batch_index),
+                        MaspIndexedTx {
+                            indexed_tx: IndexedTx {
+                                block_index: TxIndex(block_index),
+                                block_height: BlockHeight(block_height),
+                                batch_index: Some(batch_index),
+                            },
+                            kind: if is_masp_fee_payment {
+                                MaspEventKind::FeePayment
+                            } else {
+                                MaspEventKind::Transfer
+                            },
                         },
                         note_position,
                     )

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -318,7 +318,7 @@ pub type WitnessMap = HashMap<usize, IncrementalWitness<Node>>;
 pub enum ContextSyncStatus {
     /// The context contains data that has been confirmed by the protocol
     Confirmed,
-    /// The context possibly contains that that has not yet been confirmed by
+    /// The context possibly contains data that has not yet been confirmed by
     /// the protocol and could be incomplete or invalid
     Speculative,
 }

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -40,11 +40,11 @@ use namada_io::{MaybeSend, MaybeSync};
 use namada_macros::BorshDeserializer;
 #[cfg(feature = "migrations")]
 use namada_migrations::*;
-use namada_tx::IndexedTx;
 use rand_core::{CryptoRng, RngCore};
 pub use shielded_wallet::ShieldedWallet;
 use thiserror::Error;
 
+use self::utils::MaspIndexedTx;
 pub use crate::masp::shielded_sync::dispatcher::{Dispatcher, DispatcherCache};
 #[cfg(not(target_family = "wasm"))]
 pub use crate::masp::shielded_sync::MaspLocalTaskEnv;
@@ -308,7 +308,7 @@ pub type TransferDelta = HashMap<Address, MaspChange>;
 pub type TransactionDelta = HashMap<ViewingKey, I128Sum>;
 
 /// Maps a shielded tx to the index of its first output note.
-pub type NoteIndex = BTreeMap<IndexedTx, usize>;
+pub type NoteIndex = BTreeMap<MaspIndexedTx, usize>;
 
 /// Maps the note index (in the commitment tree) to a witness
 pub type WitnessMap = HashMap<usize, IncrementalWitness<Node>>;

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -399,30 +399,35 @@ where
             self.ctx.note_index = nm;
         }
 
-        for (indexed_tx, stx_batch) in self.cache.fetched.take() {
+        for (masp_indexed_tx, stx_batch) in self.cache.fetched.take() {
             let needs_witness_map_update =
                 self.client.capabilities().needs_witness_map_update();
             self.ctx
                 .save_shielded_spends(&stx_batch, needs_witness_map_update);
             if needs_witness_map_update
-                && Some(&indexed_tx) > last_witnessed_tx.as_ref()
+                && Some(&masp_indexed_tx.indexed_tx)
+                    > last_witnessed_tx.as_ref()
             {
-                self.ctx.update_witness_map(indexed_tx, &stx_batch)?;
+                self.ctx.update_witness_map(
+                    masp_indexed_tx.indexed_tx,
+                    &stx_batch,
+                )?;
             }
-            self.ctx
-                .save_shielded_spends(&stx_batch, needs_witness_map_update);
-            let first_note_pos = self.ctx.note_index[&indexed_tx];
+            let first_note_pos =
+                self.ctx.note_index[&masp_indexed_tx.indexed_tx];
             let mut vk_heights = BTreeMap::new();
             std::mem::swap(&mut vk_heights, &mut self.ctx.vk_heights);
             for (vk, _) in vk_heights
                 .iter()
                 // NB: skip keys that are synced past the given `indexed_tx`
-                .filter(|(_vk, h)| h.as_ref() < Some(&indexed_tx))
+                .filter(|(_vk, h)| {
+                    h.as_ref() < Some(&masp_indexed_tx.indexed_tx)
+                })
             {
                 for (note_pos_offset, (note, pa, memo)) in self
                     .cache
                     .trial_decrypted
-                    .take(&indexed_tx, vk)
+                    .take(&masp_indexed_tx.indexed_tx, vk)
                     .unwrap_or_default()
                 {
                     self.ctx.save_decrypted_shielded_outputs(
@@ -624,7 +629,7 @@ where
             .set_upper_limit(number_of_fetches);
 
         for (itx, tx) in self.cache.fetched.iter() {
-            self.spawn_trial_decryptions(*itx, tx);
+            self.spawn_trial_decryptions(itx.indexed_tx, tx);
         }
     }
 
@@ -668,7 +673,7 @@ where
             }
             Message::FetchTxs(Ok((from, to, tx_batch))) => {
                 for (itx, txs) in &tx_batch {
-                    self.spawn_trial_decryptions(*itx, txs);
+                    self.spawn_trial_decryptions(itx.indexed_tx, txs);
                 }
                 self.cache.fetched.extend(tx_batch);
 
@@ -878,6 +883,7 @@ mod dispatcher_tests {
     use namada_core::storage::TxIndex;
     use namada_core::task_env::TaskEnvironment;
     use namada_io::DevNullProgressBar;
+    use namada_tx::event::MaspEventKind;
     use namada_tx::IndexedTx;
     use namada_wallet::StoredKeypair;
     use tempfile::tempdir;
@@ -888,6 +894,7 @@ mod dispatcher_tests {
         arbitrary_masp_tx, arbitrary_masp_tx_with_fee_unshielding,
         arbitrary_vk, dated_arbitrary_vk, TestingMaspClient,
     };
+    use crate::masp::utils::MaspIndexedTx;
     use crate::masp::{MaspLocalTaskEnv, ShieldedSyncConfig};
 
     #[tokio::test]
@@ -918,7 +925,13 @@ mod dispatcher_tests {
                         block_index: Default::default(),
                         batch_index: None,
                     };
-                    dispatcher.cache.fetched.insert((itx, arbitrary_masp_tx()));
+                    dispatcher.cache.fetched.insert((
+                        MaspIndexedTx {
+                            indexed_tx: itx,
+                            kind: MaspEventKind::Transfer,
+                        },
+                        arbitrary_masp_tx(),
+                    ));
                     dispatcher.ctx.note_index.insert(itx, h as usize);
                     dispatcher.cache.trial_decrypted.insert(
                         itx,
@@ -1200,20 +1213,26 @@ mod dispatcher_tests {
                 masp_tx_sender.send(None).expect("Test failed");
                 masp_tx_sender
                     .send(Some((
-                        IndexedTx {
-                            block_height: 1.into(),
-                            block_index: TxIndex(1),
-                            batch_index: None,
+                        MaspIndexedTx {
+                            indexed_tx: IndexedTx {
+                                block_height: 1.into(),
+                                block_index: TxIndex(1),
+                                batch_index: None,
+                            },
+                            kind: MaspEventKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
                     .expect("Test failed");
                 masp_tx_sender
                     .send(Some((
-                        IndexedTx {
-                            block_height: 1.into(),
-                            block_index: TxIndex(2),
-                            batch_index: None,
+                        MaspIndexedTx {
+                            indexed_tx: IndexedTx {
+                                block_height: 1.into(),
+                                block_index: TxIndex(2),
+                                batch_index: None,
+                            },
+                            kind: MaspEventKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1280,20 +1299,26 @@ mod dispatcher_tests {
                 let masp_tx = arbitrary_masp_tx();
                 masp_tx_sender
                     .send(Some((
-                        IndexedTx {
-                            block_height: 1.into(),
-                            block_index: TxIndex(1),
-                            batch_index: None,
+                        MaspIndexedTx {
+                            indexed_tx: IndexedTx {
+                                block_height: 1.into(),
+                                block_index: TxIndex(1),
+                                batch_index: None,
+                            },
+                            kind: MaspEventKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
                     .expect("Test failed");
                 masp_tx_sender
                     .send(Some((
-                        IndexedTx {
-                            block_height: 1.into(),
-                            block_index: TxIndex(2),
-                            batch_index: None,
+                        MaspIndexedTx {
+                            indexed_tx: IndexedTx {
+                                block_height: 1.into(),
+                                block_index: TxIndex(2),
+                                batch_index: None,
+                            },
+                            kind: MaspEventKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1312,18 +1337,24 @@ mod dispatcher_tests {
                 let cache = utils.cache_load().await.expect("Test failed");
                 let expected = BTreeMap::from([
                     (
-                        IndexedTx {
-                            block_height: 1.into(),
-                            block_index: TxIndex(1),
-                            batch_index: None,
+                        MaspIndexedTx {
+                            indexed_tx: IndexedTx {
+                                block_height: 1.into(),
+                                block_index: TxIndex(1),
+                                batch_index: None,
+                            },
+                            kind: MaspEventKind::Transfer,
                         },
                         masp_tx.clone(),
                     ),
                     (
-                        IndexedTx {
-                            block_height: 1.into(),
-                            block_index: TxIndex(2),
-                            batch_index: None,
+                        MaspIndexedTx {
+                            indexed_tx: IndexedTx {
+                                block_height: 1.into(),
+                                block_index: TxIndex(2),
+                                batch_index: None,
+                            },
+                            kind: MaspEventKind::Transfer,
                         },
                         masp_tx.clone(),
                     ),
@@ -1362,10 +1393,13 @@ mod dispatcher_tests {
                 let masp_tx = arbitrary_masp_tx();
                 masp_tx_sender
                     .send(Some((
-                        IndexedTx {
-                            block_height: 1.into(),
-                            block_index: TxIndex(1),
-                            batch_index: None,
+                        MaspIndexedTx {
+                            indexed_tx: IndexedTx {
+                                block_height: 1.into(),
+                                block_index: TxIndex(1),
+                                batch_index: None,
+                            },
+                            kind: MaspEventKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1409,10 +1443,13 @@ mod dispatcher_tests {
         let masp_tx = arbitrary_masp_tx();
         masp_tx_sender
             .send(Some((
-                IndexedTx {
-                    block_height: 1.into(),
-                    block_index: TxIndex(1),
-                    batch_index: None,
+                MaspIndexedTx {
+                    indexed_tx: IndexedTx {
+                        block_height: 1.into(),
+                        block_index: TxIndex(1),
+                        batch_index: None,
+                    },
+                    kind: MaspEventKind::Transfer,
                 },
                 masp_tx.clone(),
             )))
@@ -1456,10 +1493,13 @@ mod dispatcher_tests {
         sk.birthday = 60.into();
         masp_tx_sender
             .send(Some((
-                IndexedTx {
-                    block_height: 1.into(),
-                    block_index: TxIndex(1),
-                    batch_index: None,
+                MaspIndexedTx {
+                    indexed_tx: IndexedTx {
+                        block_height: 1.into(),
+                        block_index: TxIndex(1),
+                        batch_index: None,
+                    },
+                    kind: MaspEventKind::Transfer,
                 },
                 masp_tx.clone(),
             )))

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::ops::ControlFlow;
 use std::pin::Pin;
@@ -11,7 +11,6 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use eyre::{eyre, WrapErr};
 use futures::future::{select, Either};
 use futures::task::AtomicWaker;
-use itertools::Itertools;
 use masp_primitives::merkle_tree::{CommitmentTree, IncrementalWitness};
 use masp_primitives::sapling::{Node, ViewingKey};
 use masp_primitives::transaction::Transaction;
@@ -382,103 +381,6 @@ where
         }
     }
 
-    // Search for the Transaction order used by the protocol using trial and
-    // error.
-    async fn transaction_order_search(
-        &mut self,
-        last_witnessed_tx: &Option<IndexedTx>,
-    ) -> Result<Vec<(IndexedTx, Transaction)>, eyre::Error> {
-        let mut ordered_txs = vec![];
-        // Get the unordered Transactions with their indices
-        let mut indexed_txs = self.cache.fetched.take().into_iter().peekable();
-        while let Some(first_tx) = indexed_txs.next() {
-            // Take only Transactions belonging to one block
-            let mut block_txs = vec![first_tx];
-            while let Some(next_tx) = indexed_txs.next_if(|next_tx| {
-                next_tx.0.block_height == block_txs[0].0.block_height
-            }) {
-                block_txs.push(next_tx);
-            }
-            // Do not apply these Transactions if they have been applied before
-            if Some(&block_txs[0].0) <= last_witnessed_tx.as_ref() {
-                continue;
-            }
-            // Save the initial state of the ShieldedContext in case reversion
-            // to initial state is necessary
-            let initial_tree = self.ctx.tree.clone();
-            let mut anchor_exists = false;
-            // Valid Transaction orderings are always the concatenation of two
-            // subsequences of the ordered events. Let's iterate through
-            // possible values of the first subsequence
-            for subset in block_txs.iter().powerset() {
-                let mut fee_transfers = BTreeSet::new();
-                // Apply the first subsequence, which corresponds to the
-                // Transactions that were first applied for the fees
-                for (indexed_tx, stx_batch) in &subset {
-                    tracing::debug!("Transaction Index: {:?}", indexed_tx);
-                    fee_transfers.insert(indexed_tx);
-                    self.ctx.update_merkle_tree(stx_batch)?;
-                }
-                // Apply the second subsequence, which corresponds to the
-                // Transactions not used in the fees
-                for (indexed_tx, stx_batch) in
-                    block_txs.iter().filter(|tx| !fee_transfers.contains(&tx.0))
-                {
-                    tracing::debug!("Transaction Index: {:?}", indexed_tx);
-                    self.ctx.update_merkle_tree(stx_batch)?;
-                }
-                // Compute what the note commitment tree root would look like
-                // after applying the above order and check if it's recognized
-                // by the protocol
-                let root = self.ctx.tree.root();
-                anchor_exists =
-                    self.client.commitment_anchor_exists(&root).await?;
-                tracing::debug!("Commitment Anchor: {:?}", root);
-                tracing::debug!("Commitment Anchor Exists: {}", anchor_exists);
-                // Make sure that we restore the tree to a clean state
-                // uncorrupted by the preceding trials
-                self.ctx.tree = initial_tree.clone();
-                // If this ordering is recognized by the protocol, then record
-                // it in state and ordered_txs
-                if anchor_exists {
-                    let complement_txs = block_txs
-                        .iter()
-                        .filter(|tx| !fee_transfers.contains(&tx.0));
-                    let ordered_block_txs =
-                        subset.into_iter().chain(complement_txs).cloned();
-                    // Track how the tx indicies get reordered/changed
-                    let mut index_map = BTreeMap::new();
-                    for (masp_index, (old_indexed_tx, stx_batch)) in
-                        ordered_block_txs.enumerate()
-                    {
-                        // Reindex tx now that we know its correct MASP position
-                        let indexed_tx = IndexedTx {
-                            masp_index: masp_index as u32,
-                            ..old_indexed_tx
-                        };
-                        index_map.insert(old_indexed_tx, indexed_tx);
-                        self.ctx.update_witness_map(indexed_tx, &stx_batch)?;
-                        ordered_txs.push((indexed_tx, stx_batch));
-                    }
-                    // Update the indices in the trial decrypted map
-                    self.cache.trial_decrypted.reindex(&index_map);
-                    break;
-                }
-            }
-            // If none of the orderings yield an anchor recognized by the
-            // protocol, then something has gone seriously wrong. Either the
-            // client is missing notes or has phantom notes, or both
-            if !anchor_exists {
-                return Err(eyre!(
-                    "Unable to find anchor for block {}",
-                    block_txs[0].0.block_height,
-                ));
-            }
-        }
-        // Return the ordering that has been found by the above trials
-        Ok(ordered_txs)
-    }
-
     async fn apply_cache_to_shielded_context(
         &mut self,
         InitialState {
@@ -497,15 +399,16 @@ where
             self.ctx.note_index = nm;
         }
 
-        let needs_witness_map_update =
-            self.client.capabilities().needs_witness_map_update();
-        let ordered_txs = if needs_witness_map_update {
-            self.transaction_order_search(last_witnessed_tx).await?
-        } else {
-            self.cache.fetched.take().into_iter().collect()
-        };
-
-        for (indexed_tx, stx_batch) in ordered_txs {
+        for (indexed_tx, stx_batch) in self.cache.fetched.take() {
+            let needs_witness_map_update =
+                self.client.capabilities().needs_witness_map_update();
+            self.ctx
+                .save_shielded_spends(&stx_batch, needs_witness_map_update);
+            if needs_witness_map_update
+                && Some(&indexed_tx) > last_witnessed_tx.as_ref()
+            {
+                self.ctx.update_witness_map(indexed_tx, &stx_batch)?;
+            }
             self.ctx
                 .save_shielded_spends(&stx_batch, needs_witness_map_update);
             let first_note_pos = self.ctx.note_index[&indexed_tx];
@@ -1012,7 +915,6 @@ mod dispatcher_tests {
                 for h in 0u64..10 {
                     let itx = IndexedTx {
                         block_height: h.into(),
-                        masp_index: 0,
                         block_index: Default::default(),
                         batch_index: None,
                     };
@@ -1220,7 +1122,6 @@ mod dispatcher_tests {
         // let's bump the vk height
         *shielded_ctx.vk_heights.get_mut(&vk).unwrap() = Some(IndexedTx {
             block_height: 6.into(),
-            masp_index: 0,
             block_index: TxIndex(0),
             batch_index: None,
         });
@@ -1301,7 +1202,6 @@ mod dispatcher_tests {
                     .send(Some((
                         IndexedTx {
                             block_height: 1.into(),
-                            masp_index: 1,
                             block_index: TxIndex(1),
                             batch_index: None,
                         },
@@ -1312,7 +1212,6 @@ mod dispatcher_tests {
                     .send(Some((
                         IndexedTx {
                             block_height: 1.into(),
-                            masp_index: 2,
                             block_index: TxIndex(2),
                             batch_index: None,
                         },
@@ -1332,13 +1231,11 @@ mod dispatcher_tests {
                 let expected = BTreeSet::from([
                     IndexedTx {
                         block_height: 1.into(),
-                        masp_index: 0,
                         block_index: TxIndex(1),
                         batch_index: None,
                     },
                     IndexedTx {
                         block_height: 1.into(),
-                        masp_index: 1,
                         block_index: TxIndex(2),
                         batch_index: None,
                     },
@@ -1385,7 +1282,6 @@ mod dispatcher_tests {
                     .send(Some((
                         IndexedTx {
                             block_height: 1.into(),
-                            masp_index: 1,
                             block_index: TxIndex(1),
                             batch_index: None,
                         },
@@ -1396,7 +1292,6 @@ mod dispatcher_tests {
                     .send(Some((
                         IndexedTx {
                             block_height: 1.into(),
-                            masp_index: 2,
                             block_index: TxIndex(2),
                             batch_index: None,
                         },
@@ -1419,7 +1314,6 @@ mod dispatcher_tests {
                     (
                         IndexedTx {
                             block_height: 1.into(),
-                            masp_index: 1,
                             block_index: TxIndex(1),
                             batch_index: None,
                         },
@@ -1428,7 +1322,6 @@ mod dispatcher_tests {
                     (
                         IndexedTx {
                             block_height: 1.into(),
-                            masp_index: 2,
                             block_index: TxIndex(2),
                             batch_index: None,
                         },
@@ -1471,7 +1364,6 @@ mod dispatcher_tests {
                     .send(Some((
                         IndexedTx {
                             block_height: 1.into(),
-                            masp_index: 1,
                             block_index: TxIndex(1),
                             batch_index: None,
                         },
@@ -1519,7 +1411,6 @@ mod dispatcher_tests {
             .send(Some((
                 IndexedTx {
                     block_height: 1.into(),
-                    masp_index: 1,
                     block_index: TxIndex(1),
                     batch_index: None,
                 },
@@ -1567,7 +1458,6 @@ mod dispatcher_tests {
             .send(Some((
                 IndexedTx {
                     block_height: 1.into(),
-                    masp_index: 1,
                     block_index: TxIndex(1),
                     batch_index: None,
                 },

--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -24,7 +24,7 @@ use namada_io::{MaybeSend, MaybeSync, ProgressBar};
 use namada_tx::IndexedTx;
 use namada_wallet::{DatedKeypair, DatedSpendingKey};
 
-use super::utils::{IndexedNoteEntry, MaspClient, MaspIndexedTx};
+use super::utils::{IndexedNoteEntry, MaspClient, MaspIndexedTx, MaspTxKind};
 use crate::masp::shielded_sync::trial_decrypt;
 use crate::masp::utils::{
     blocks_left_to_fetch, DecryptedData, Fetched, RetryStrategy, TrialDecrypted,
@@ -451,7 +451,7 @@ where
             // NB: the entire block is synced
             *h = Some(MaspIndexedTx {
                 indexed_tx: IndexedTx::entire_block(*last_query_height),
-                kind: namada_tx::event::MaspEventKind::Transfer,
+                kind: MaspTxKind::Transfer,
             });
         }
 
@@ -492,7 +492,7 @@ where
                     vk.key,
                     Some(MaspIndexedTx {
                         indexed_tx: IndexedTx::entire_block(vk.birthday),
-                        kind: namada_tx::event::MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     }),
                 );
             }
@@ -885,7 +885,6 @@ mod dispatcher_tests {
     use namada_core::storage::TxIndex;
     use namada_core::task_env::TaskEnvironment;
     use namada_io::DevNullProgressBar;
-    use namada_tx::event::MaspEventKind;
     use namada_tx::IndexedTx;
     use namada_wallet::StoredKeypair;
     use tempfile::tempdir;
@@ -928,7 +927,7 @@ mod dispatcher_tests {
                             block_index: Default::default(),
                             batch_index: None,
                         },
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     };
                     dispatcher.cache.fetched.insert((itx, arbitrary_masp_tx()));
                     dispatcher.ctx.note_index.insert(itx, h as usize);
@@ -953,7 +952,7 @@ mod dispatcher_tests {
                     arbitrary_vk(),
                     Some(MaspIndexedTx {
                         indexed_tx: IndexedTx::entire_block(9.into()),
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     }),
                 )]);
                 assert_eq!(expected, dispatcher.ctx.vk_heights);
@@ -1141,7 +1140,7 @@ mod dispatcher_tests {
                 block_index: TxIndex(0),
                 batch_index: None,
             },
-            kind: MaspEventKind::Transfer,
+            kind: MaspTxKind::Transfer,
         });
 
         // the min height should now be 6
@@ -1224,7 +1223,7 @@ mod dispatcher_tests {
                                 block_index: TxIndex(1),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1237,7 +1236,7 @@ mod dispatcher_tests {
                                 block_index: TxIndex(2),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1259,7 +1258,7 @@ mod dispatcher_tests {
                             block_index: TxIndex(1),
                             batch_index: None,
                         },
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     },
                     MaspIndexedTx {
                         indexed_tx: IndexedTx {
@@ -1267,7 +1266,7 @@ mod dispatcher_tests {
                             block_index: TxIndex(2),
                             batch_index: None,
                         },
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     },
                 ]);
 
@@ -1276,7 +1275,7 @@ mod dispatcher_tests {
                     *ctx.vk_heights[&vk.key].as_ref().unwrap(),
                     MaspIndexedTx {
                         indexed_tx: IndexedTx::entire_block(2.into(),),
-                        kind: MaspEventKind::Transfer
+                        kind: MaspTxKind::Transfer
                     }
                 );
                 assert_eq!(ctx.note_map.len(), 2);
@@ -1319,7 +1318,7 @@ mod dispatcher_tests {
                                 block_index: TxIndex(1),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1332,7 +1331,7 @@ mod dispatcher_tests {
                                 block_index: TxIndex(2),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1357,7 +1356,7 @@ mod dispatcher_tests {
                                 block_index: TxIndex(1),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     ),
@@ -1368,7 +1367,7 @@ mod dispatcher_tests {
                                 block_index: TxIndex(2),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     ),
@@ -1413,7 +1412,7 @@ mod dispatcher_tests {
                                 block_index: TxIndex(1),
                                 batch_index: None,
                             },
-                            kind: MaspEventKind::Transfer,
+                            kind: MaspTxKind::Transfer,
                         },
                         masp_tx.clone(),
                     )))
@@ -1463,7 +1462,7 @@ mod dispatcher_tests {
                         block_index: TxIndex(1),
                         batch_index: None,
                     },
-                    kind: MaspEventKind::Transfer,
+                    kind: MaspTxKind::Transfer,
                 },
                 masp_tx.clone(),
             )))
@@ -1497,11 +1496,11 @@ mod dispatcher_tests {
             vec![
                 Some(MaspIndexedTx {
                     indexed_tx: IndexedTx::entire_block(BlockHeight(30)),
-                    kind: MaspEventKind::Transfer
+                    kind: MaspTxKind::Transfer
                 }),
                 Some(MaspIndexedTx {
                     indexed_tx: IndexedTx::entire_block(BlockHeight(10)),
-                    kind: MaspEventKind::Transfer
+                    kind: MaspTxKind::Transfer
                 })
             ]
         );
@@ -1519,7 +1518,7 @@ mod dispatcher_tests {
                         block_index: TxIndex(1),
                         batch_index: None,
                     },
-                    kind: MaspEventKind::Transfer,
+                    kind: MaspTxKind::Transfer,
                 },
                 masp_tx.clone(),
             )))
@@ -1544,11 +1543,11 @@ mod dispatcher_tests {
             vec![
                 Some(MaspIndexedTx {
                     indexed_tx: IndexedTx::entire_block(BlockHeight(60)),
-                    kind: MaspEventKind::Transfer
+                    kind: MaspTxKind::Transfer
                 }),
                 Some(MaspIndexedTx {
                     indexed_tx: IndexedTx::entire_block(BlockHeight(10)),
-                    kind: MaspEventKind::Transfer
+                    kind: MaspTxKind::Transfer
                 })
             ]
         )

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -727,14 +727,30 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev3 = MaspIndexedTx {
+            kind: MaspTxKind::Transfer,
+            indexed_tx: IndexedTx {
+                block_height: BlockHeight(3),
+                block_index: TxIndex(1),
+                batch_index: Some(1),
+            },
+        };
+        let ev4 = MaspIndexedTx {
+            kind: MaspTxKind::FeePayment,
+            indexed_tx: IndexedTx {
+                block_height: BlockHeight(3),
+                block_index: TxIndex(3),
+                batch_index: Some(2),
+            },
+        };
+        let ev5 = MaspIndexedTx {
             kind: MaspTxKind::FeePayment,
             indexed_tx: IndexedTx {
                 block_height: BlockHeight(3),
                 block_index: TxIndex(2),
-                batch_index: Some(2),
+                batch_index: Some(0),
             },
         };
-        let ev4 = MaspIndexedTx {
+        let ev6 = MaspIndexedTx {
             kind: MaspTxKind::Transfer,
             indexed_tx: IndexedTx {
                 block_height: BlockHeight(1),
@@ -742,7 +758,7 @@ mod test_blocks_left_to_fetch {
                 batch_index: Some(1),
             },
         };
-        let ev5 = MaspIndexedTx {
+        let ev7 = MaspIndexedTx {
             kind: MaspTxKind::Transfer,
             indexed_tx: IndexedTx {
                 block_height: BlockHeight(1),
@@ -751,10 +767,10 @@ mod test_blocks_left_to_fetch {
             },
         };
 
-        let mut txs = [ev1, ev2, ev3, ev4, ev5];
+        let mut txs = [ev1, ev2, ev3, ev4, ev5, ev6, ev7];
 
         txs.sort();
 
-        assert_eq!(txs, [ev1, ev5, ev4, ev2, ev3])
+        assert_eq!(txs, [ev1, ev7, ev6, ev2, ev5, ev4, ev3])
     }
 }

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -15,6 +15,39 @@ use namada_tx::event::MaspEventKind;
 use namada_tx::IndexedTx;
 use serde::{Deserialize, Serialize};
 
+/// The type of a MASP transaction
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialOrd,
+    PartialEq,
+    Eq,
+    Ord,
+    Serialize,
+    Deserialize,
+    Hash,
+)]
+pub enum MaspTxKind {
+    /// A MASP transaction used for fee payment
+    FeePayment,
+    /// A general MASP transfer
+    #[default]
+    Transfer,
+}
+
+impl From<MaspEventKind> for MaspTxKind {
+    fn from(value: MaspEventKind) -> Self {
+        match value {
+            MaspEventKind::FeePayment => Self::FeePayment,
+            MaspEventKind::Transfer => Self::Transfer,
+        }
+    }
+}
+
 /// An indexed masp tx carrying information on whether it was a fee paying tx or
 /// a normal transfer
 #[derive(
@@ -32,7 +65,7 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct MaspIndexedTx {
     /// The masp tx kind, fee-payment or transfer
-    pub kind: MaspEventKind,
+    pub kind: MaspTxKind,
     /// The pointer to the inner tx carrying this masp tx
     pub indexed_tx: IndexedTx,
 }
@@ -77,7 +110,7 @@ impl MaspIndexedTxRange {
     pub const fn between_heights(from: BlockHeight, to: BlockHeight) -> Self {
         Self::new(
             MaspIndexedTx {
-                kind: MaspEventKind::FeePayment,
+                kind: MaspTxKind::FeePayment,
                 indexed_tx: IndexedTx {
                     block_height: from,
                     block_index: TxIndex(0),
@@ -85,7 +118,7 @@ impl MaspIndexedTxRange {
                 },
             },
             MaspIndexedTx {
-                kind: MaspEventKind::Transfer,
+                kind: MaspTxKind::Transfer,
                 indexed_tx: IndexedTx {
                     block_height: to,
                     block_index: TxIndex(u32::MAX),
@@ -474,7 +507,7 @@ mod test_blocks_left_to_fetch {
                             block_index: TxIndex(0),
                             batch_index: None,
                         },
-                        kind: MaspEventKind::Transfer,
+                        kind: MaspTxKind::Transfer,
                     },
                     masp_tx.clone(),
                 )
@@ -678,7 +711,7 @@ mod test_blocks_left_to_fetch {
     #[test]
     fn test_sort_indexed_masp_events() {
         let ev1 = MaspIndexedTx {
-            kind: MaspEventKind::FeePayment,
+            kind: MaspTxKind::FeePayment,
             indexed_tx: IndexedTx {
                 block_height: BlockHeight(1),
                 block_index: TxIndex(2),
@@ -686,7 +719,7 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev2 = MaspIndexedTx {
-            kind: MaspEventKind::Transfer,
+            kind: MaspTxKind::Transfer,
             indexed_tx: IndexedTx {
                 block_height: BlockHeight(2),
                 block_index: TxIndex(0),
@@ -694,7 +727,7 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev3 = MaspIndexedTx {
-            kind: MaspEventKind::FeePayment,
+            kind: MaspTxKind::FeePayment,
             indexed_tx: IndexedTx {
                 block_height: BlockHeight(3),
                 block_index: TxIndex(2),
@@ -702,7 +735,7 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev4 = MaspIndexedTx {
-            kind: MaspEventKind::Transfer,
+            kind: MaspTxKind::Transfer,
             indexed_tx: IndexedTx {
                 block_height: BlockHeight(1),
                 block_index: TxIndex(1),
@@ -710,7 +743,7 @@ mod test_blocks_left_to_fetch {
             },
         };
         let ev5 = MaspIndexedTx {
-            kind: MaspEventKind::Transfer,
+            kind: MaspTxKind::Transfer,
             indexed_tx: IndexedTx {
                 block_height: BlockHeight(1),
                 block_index: TxIndex(1),

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -1,4 +1,5 @@
 //! Helper functions and types
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -18,14 +19,14 @@ use serde::{Deserialize, Serialize};
     Debug,
     Default,
     Clone,
+    Copy,
     BorshSerialize,
     BorshDeserialize,
-    PartialOrd,
     PartialEq,
     Eq,
-    Ord,
     Serialize,
     Deserialize,
+    Hash,
 )]
 pub struct MaspIndexedTx {
     /// The masp tx kind, fee-payment or transfer
@@ -34,6 +35,25 @@ pub struct MaspIndexedTx {
     pub indexed_tx: IndexedTx,
 }
 
+impl Ord for MaspIndexedTx {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // If txs are in different blocks we just have to compare their block
+        // heights. If instead txs are in the same block, masp fee paying txs
+        // take precedence over transfer masp txs. After that we sort them based
+        // on their indexes
+        self.indexed_tx.height.cmp(&other.indexed_tx.height).then(
+            self.kind
+                .cmp(&other.kind)
+                .then(self.indexed_tx.cmp(&other.indexed_tx)),
+        )
+    }
+}
+
+impl PartialOrd for MaspIndexedTx {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 /// Type alias for convenience and profit
 pub type IndexedNoteData = BTreeMap<MaspIndexedTx, Transaction>;
 
@@ -49,8 +69,10 @@ pub type DecryptedData = (Note, PaymentAddress, MemoBytes);
 /// Cache of decrypted notes.
 #[derive(Default, BorshSerialize, BorshDeserialize)]
 pub struct TrialDecrypted {
-    inner:
-        HashMap<IndexedTx, HashMap<ViewingKey, BTreeMap<usize, DecryptedData>>>,
+    inner: HashMap<
+        MaspIndexedTx,
+        HashMap<ViewingKey, BTreeMap<usize, DecryptedData>>,
+    >,
 }
 
 impl TrialDecrypted {
@@ -86,7 +108,7 @@ impl TrialDecrypted {
     /// Get cached notes decrypted with `vk`, indexed at `itx`.
     pub fn get(
         &self,
-        itx: &IndexedTx,
+        itx: &MaspIndexedTx,
         vk: &ViewingKey,
     ) -> Option<&BTreeMap<usize, DecryptedData>> {
         self.inner.get(itx).and_then(|h| h.get(vk))
@@ -95,7 +117,7 @@ impl TrialDecrypted {
     /// Take cached notes decrypted with `vk`, indexed at `itx`.
     pub fn take(
         &mut self,
-        itx: &IndexedTx,
+        itx: &MaspIndexedTx,
         vk: &ViewingKey,
     ) -> Option<BTreeMap<usize, DecryptedData>> {
         let (notes, no_more_notes) = {
@@ -112,7 +134,7 @@ impl TrialDecrypted {
     /// Cache `notes` decrypted with `vk`, indexed at `itx`.
     pub fn insert(
         &mut self,
-        itx: IndexedTx,
+        itx: MaspIndexedTx,
         vk: ViewingKey,
         notes: BTreeMap<usize, DecryptedData>,
     ) {
@@ -303,7 +325,7 @@ pub trait MaspClient: Clone {
     async fn fetch_note_index(
         &self,
         height: BlockHeight,
-    ) -> Result<BTreeMap<IndexedTx, usize>, Self::Error>;
+    ) -> Result<BTreeMap<MaspIndexedTx, usize>, Self::Error>;
 
     /// Fetch the witness map of height `height`.
     #[allow(async_fn_in_trait)]
@@ -601,5 +623,48 @@ mod test_blocks_left_to_fetch {
             fetched_cache_with_blocks(blocks_in_range(1.into(), 5.into()));
         let blocks_to_fetch = blocks_left_to_fetch(2.into(), 4.into(), &cache);
         assert!(blocks_to_fetch.is_empty());
+    }
+
+    #[test]
+    // FIXME: proptest here?
+    fn test_sort_indexed_masp_events() {
+        let ev1 = MaspIndexedTx {
+            kind: MaspEventKind::FeePayment,
+            indexed_tx: IndexedTx {
+                height: BlockHeight(1),
+                index: TxIndex(2),
+                batch_index: Some(0),
+            },
+        };
+        let ev2 = MaspIndexedTx {
+            kind: MaspEventKind::Transfer,
+            indexed_tx: IndexedTx {
+                height: BlockHeight(2),
+                index: TxIndex(0),
+                batch_index: Some(0),
+            },
+        };
+        let ev3 = MaspIndexedTx {
+            kind: MaspEventKind::Transfer,
+            indexed_tx: IndexedTx {
+                height: BlockHeight(1),
+                index: TxIndex(1),
+                batch_index: Some(1),
+            },
+        };
+        let ev4 = MaspIndexedTx {
+            kind: MaspEventKind::Transfer,
+            indexed_tx: IndexedTx {
+                height: BlockHeight(1),
+                index: TxIndex(1),
+                batch_index: Some(0),
+            },
+        };
+
+        let mut txs = [ev1.clone(), ev2.clone(), ev3.clone(), ev4.clone()];
+
+        txs.sort();
+
+        assert_eq!(txs, [ev1, ev4, ev3, ev2])
     }
 }

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -122,7 +122,7 @@ impl MaspIndexedTxRange {
                 indexed_tx: IndexedTx {
                     block_height: to,
                     block_index: TxIndex(u32::MAX),
-                    batch_index: None,
+                    batch_index: Some(u32::MAX),
                 },
             },
         )

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -369,7 +369,6 @@ mod test_blocks_left_to_fetch {
                 (
                     IndexedTx {
                         block_height: height,
-                        masp_index: 0,
                         block_index: TxIndex(0),
                         batch_index: None,
                     },

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -1,6 +1,7 @@
 //! Helper functions and types
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
+use std::ops::{Bound, RangeBounds};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use masp_primitives::memo::MemoBytes;
@@ -9,11 +10,12 @@ use masp_primitives::sapling::{Node, Note, PaymentAddress, ViewingKey};
 use masp_primitives::transaction::Transaction;
 use namada_core::chain::BlockHeight;
 use namada_core::collections::HashMap;
+use namada_state::TxIndex;
 use namada_tx::event::MaspEventKind;
-use namada_tx::{IndexedTx, IndexedTxRange};
+use namada_tx::IndexedTx;
 use serde::{Deserialize, Serialize};
 
-/// An indexed masp tx carrying information on wether it was a fee paying tx or
+/// An indexed masp tx carrying information on whether it was a fee paying tx or
 /// a normal transfer
 #[derive(
     Debug,
@@ -57,6 +59,76 @@ impl PartialOrd for MaspIndexedTx {
         Some(self.cmp(other))
     }
 }
+
+/// Inclusive range of [`MaspIndexedTx`] entries.
+pub struct MaspIndexedTxRange {
+    lo: MaspIndexedTx,
+    hi: MaspIndexedTx,
+}
+
+impl MaspIndexedTxRange {
+    /// Create a new [`MaspIndexedTxRange`].
+    pub const fn new(lo: MaspIndexedTx, hi: MaspIndexedTx) -> Self {
+        Self { lo, hi }
+    }
+
+    /// Create a new [`MaspIndexedTxRange`] over a range of [block
+    /// heights](BlockHeight).
+    pub const fn between_heights(from: BlockHeight, to: BlockHeight) -> Self {
+        Self::new(
+            MaspIndexedTx {
+                kind: MaspEventKind::FeePayment,
+                indexed_tx: IndexedTx {
+                    block_height: from,
+                    block_index: TxIndex(0),
+                    batch_index: None,
+                },
+            },
+            MaspIndexedTx {
+                kind: MaspEventKind::Transfer,
+                indexed_tx: IndexedTx {
+                    block_height: to,
+                    block_index: TxIndex(u32::MAX),
+                    batch_index: None,
+                },
+            },
+        )
+    }
+
+    /// Create a new [`MaspIndexedTxRange`] over a given [`BlockHeight`].
+    pub const fn with_height(height: BlockHeight) -> Self {
+        Self::between_heights(height, height)
+    }
+
+    /// The start of the range.
+    pub const fn start(&self) -> MaspIndexedTx {
+        self.lo
+    }
+
+    /// The end of the range.
+    pub const fn end(&self) -> MaspIndexedTx {
+        self.hi
+    }
+}
+
+impl RangeBounds<MaspIndexedTx> for MaspIndexedTxRange {
+    fn start_bound(&self) -> Bound<&MaspIndexedTx> {
+        Bound::Included(&self.lo)
+    }
+
+    fn end_bound(&self) -> Bound<&MaspIndexedTx> {
+        Bound::Included(&self.hi)
+    }
+
+    fn contains<U>(&self, item: &U) -> bool
+    where
+        MaspIndexedTx: PartialOrd<U>,
+        U: PartialOrd<MaspIndexedTx> + ?Sized,
+    {
+        *item >= self.lo && *item <= self.hi
+    }
+}
+
 /// Type alias for convenience and profit
 pub type IndexedNoteData = BTreeMap<MaspIndexedTx, Transaction>;
 
@@ -173,12 +245,7 @@ impl Fetched {
     /// block height.
     pub fn contains_height(&self, height: BlockHeight) -> bool {
         self.txs
-            .iter()
-            .map(|(masp_indexed_tx, transaction)| {
-                (masp_indexed_tx.indexed_tx, transaction)
-            })
-            .collect::<BTreeMap<_, _>>()
-            .range(IndexedTxRange::with_height(height))
+            .range(MaspIndexedTxRange::with_height(height))
             .next()
             .is_some()
     }

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -141,25 +141,6 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
         self.utils.save(self).await
     }
 
-    /// Update only the Merkle tree without updating anything else. Useful for
-    /// checking note commitment tree anchors with less overhead.
-    pub(crate) fn update_merkle_tree(
-        &mut self,
-        shielded: &Transaction,
-    ) -> Result<(), eyre::Error> {
-        for so in shielded
-            .sapling_bundle()
-            .map_or(&vec![], |x| &x.shielded_outputs)
-        {
-            // Create merkle tree leaf node from note commitment
-            let node = Node::new(so.cmu.to_repr());
-            self.tree.append(node).map_err(|()| {
-                eyre!("note commitment tree is full".to_string())
-            })?;
-        }
-        Ok(())
-    }
-
     /// Update the merkle tree of witnesses the first time we
     /// scan new MASP transactions.
     pub(crate) fn update_witness_map(

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -43,11 +43,11 @@ use namada_io::{
     display_line, edisplay_line, Io, MaybeSend, MaybeSync, NamadaIo,
     ProgressBar,
 };
-use namada_tx::IndexedTx;
 use namada_wallet::{DatedKeypair, DatedSpendingKey};
 use rand::prelude::StdRng;
 use rand_core::{OsRng, SeedableRng};
 
+use super::utils::MaspIndexedTx;
 use crate::masp::utils::MaspClient;
 #[cfg(any(test, feature = "testing"))]
 use crate::masp::{testing, ENV_VAR_MASP_TEST_SEED};
@@ -70,7 +70,7 @@ pub struct ShieldedWallet<U: ShieldedUtils> {
     pub tree: CommitmentTree<Node>,
     /// Maps viewing keys to the block height to which they are synced.
     /// In particular, the height given by the value *has been scanned*.
-    pub vk_heights: BTreeMap<ViewingKey, Option<IndexedTx>>,
+    pub vk_heights: BTreeMap<ViewingKey, Option<MaspIndexedTx>>,
     /// Maps viewing keys to applicable note positions
     pub pos_map: HashMap<ViewingKey, BTreeSet<usize>>,
     /// Maps a nullifier to the note position to which it applies
@@ -145,11 +145,11 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
     /// scan new MASP transactions.
     pub(crate) fn update_witness_map(
         &mut self,
-        indexed_tx: IndexedTx,
+        masp_indexed_tx: MaspIndexedTx,
         shielded: &Transaction,
     ) -> Result<(), eyre::Error> {
         let mut note_pos = self.tree.size();
-        self.note_index.insert(indexed_tx, note_pos);
+        self.note_index.insert(masp_indexed_tx, note_pos);
 
         for so in shielded
             .sapling_bundle()
@@ -218,7 +218,7 @@ impl<U: ShieldedUtils + MaybeSend + MaybeSync> ShieldedWallet<U> {
             ));
         };
         Ok(maybe_least_synced_vk_height
-            .map_or_else(BlockHeight::first, |itx| itx.block_height))
+            .map_or_else(BlockHeight::first, |itx| itx.indexed_tx.block_height))
     }
 
     #[allow(missing_docs)]

--- a/crates/shielded_token/src/masp/test_utils.rs
+++ b/crates/shielded_token/src/masp/test_utils.rs
@@ -23,12 +23,12 @@ use namada_core::time::DurationSecs;
 use namada_core::token::{Denomination, MaspDigitPos};
 use namada_io::client::EncodedResponseQuery;
 use namada_io::{Client, MaybeSend, MaybeSync, NamadaIo, NullIo};
-use namada_tx::IndexedTx;
 use namada_wallet::DatedKeypair;
 use thiserror::Error;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::Mutex;
 
+use super::utils::MaspIndexedTx;
 use crate::masp::shielded_wallet::ShieldedQueries;
 use crate::masp::utils::{
     IndexedNoteEntry, MaspClient, MaspClientCapabilities,
@@ -427,7 +427,7 @@ impl MaspClient for TestingMaspClient {
     async fn fetch_note_index(
         &self,
         _: BlockHeight,
-    ) -> Result<BTreeMap<IndexedTx, usize>, Self::Error> {
+    ) -> Result<BTreeMap<MaspIndexedTx, usize>, Self::Error> {
         unimplemented!(
             "Transaction notes map fetching is not implemented by this client"
         )

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -37,7 +37,6 @@ use sha2::{Digest, Sha256};
 pub use wrapper::*;
 
 use crate::data::protocol::ProtocolTx;
-use crate::event::MaspTxRefs;
 use crate::TxCommitments;
 
 /// The different result codes that the ledger may send back to a client
@@ -216,34 +215,6 @@ impl InnerTxId<'_> {
     }
 }
 
-/// The extended transaction result, containing the references to masp
-/// sections (if any)
-pub struct ExtendedTxResult<T> {
-    /// The transaction result
-    pub tx_result: TxResult<T>,
-    /// The optional references to masp data (either MASP sections or tx Data
-    /// for shielded actions)
-    // FIXME: review this note
-    // NOTE: it's paramount to enforce a single, ordered collection for all the
-    // masp transactions to ensure that the exact view on the tx sequence is
-    // preserved in the events. Also, it is possible for two refs to be exactly
-    // the same, we must make sure to emit events for both so that the
-    // client/indexer can properly construct their internal state
-    // FIXME: I don't think we need this anymore? We can just push the events
-    // to the events themselves and then commit them as usual when evaluating
-    // the tx results
-    pub masp_tx_refs: MaspTxRefs,
-}
-
-impl<T> Default for ExtendedTxResult<T> {
-    fn default() -> Self {
-        Self {
-            tx_result: Default::default(),
-            masp_tx_refs: Default::default(),
-        }
-    }
-}
-
 #[derive(Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 /// The result of a dry run, included the actual transaction result and the gas
 /// used
@@ -341,17 +312,6 @@ impl<T: Display> TxResult<T> {
         }
 
         TxResult(batch_results)
-    }
-
-    /// Converts this result to [`ExtendedTxResult`]
-    pub fn to_extended_result(
-        self,
-        masp_tx_refs: Option<MaspTxRefs>,
-    ) -> ExtendedTxResult<T> {
-        ExtendedTxResult {
-            tx_result: self,
-            masp_tx_refs: masp_tx_refs.unwrap_or_default(),
-        }
     }
 }
 

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -24,7 +24,6 @@ use namada_core::borsh::{
 };
 use namada_core::hash::Hash;
 use namada_core::storage;
-use namada_events::extend::MaspTxRefs;
 use namada_events::Event;
 use namada_gas::WholeGas;
 use namada_macros::BorshDeserializer;
@@ -38,6 +37,7 @@ use sha2::{Digest, Sha256};
 pub use wrapper::*;
 
 use crate::data::protocol::ProtocolTx;
+use crate::event::MaspTxRefs;
 use crate::TxCommitments;
 
 /// The different result codes that the ledger may send back to a client
@@ -223,11 +223,15 @@ pub struct ExtendedTxResult<T> {
     pub tx_result: TxResult<T>,
     /// The optional references to masp data (either MASP sections or tx Data
     /// for shielded actions)
+    // FIXME: review this note
     // NOTE: it's paramount to enforce a single, ordered collection for all the
     // masp transactions to ensure that the exact view on the tx sequence is
     // preserved in the events. Also, it is possible for two refs to be exactly
     // the same, we must make sure to emit events for both so that the
     // client/indexer can properly construct their internal state
+    // FIXME: I don't think we need this anymore? We can just push the events
+    // to the events themselves and then commit them as usual when evaluating
+    // the tx results
     pub masp_tx_refs: MaspTxRefs,
 }
 

--- a/crates/tx/src/event.rs
+++ b/crates/tx/src/event.rs
@@ -172,7 +172,6 @@ pub struct MaspEvent {
     /// A flag signaling the type of the masp transaction
     pub kind: MaspEventKind,
     /// The reference to the masp data
-    // FIXME: rename this field?
     pub data: MaspTxRef,
 }
 
@@ -193,7 +192,6 @@ impl EventAttributeEntry<'static> for MaspTxRef {
     type Value = MaspTxRef;
     type ValueOwned = Self::Value;
 
-    // FIXME: rename this?
     const KEY: &'static str = "section";
 
     fn into_value(self) -> Self::Value {

--- a/crates/tx/src/event.rs
+++ b/crates/tx/src/event.rs
@@ -115,10 +115,24 @@ pub mod masp_types {
 }
 
 /// MASP event kind
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialOrd,
+    PartialEq,
+    Eq,
+    Ord,
+    Serialize,
+    Deserialize,
+)]
 pub enum MaspEventKind {
     /// A MASP transaction used for fee payment
     FeePayment,
     /// A general MASP transfer
+    #[default]
     Transfer,
 }
 

--- a/crates/tx/src/event.rs
+++ b/crates/tx/src/event.rs
@@ -119,6 +119,7 @@ pub mod masp_types {
     Debug,
     Default,
     Clone,
+    Copy,
     BorshSerialize,
     BorshDeserialize,
     PartialOrd,
@@ -127,6 +128,7 @@ pub mod masp_types {
     Ord,
     Serialize,
     Deserialize,
+    Hash,
 )]
 pub enum MaspEventKind {
     /// A MASP transaction used for fee payment

--- a/crates/tx/src/event.rs
+++ b/crates/tx/src/event.rs
@@ -1,17 +1,23 @@
 //! Transaction events.
 
+use std::fmt::Display;
+use std::str::FromStr;
+
 use namada_core::borsh::{BorshDeserialize, BorshSerialize};
+use namada_core::ibc::IbcTxDataHash;
+use namada_core::masp::MaspTxId;
 use namada_events::extend::{
     ComposeEvent, EventAttributeEntry, Height, Log, TxHash,
 };
-use namada_events::{Event, EventLevel, EventToEmit};
+use namada_events::{Event, EventLevel, EventToEmit, EventType};
 use namada_macros::BorshDeserializer;
 #[cfg(feature = "migrations")]
 use namada_migrations::*;
+use serde::{Deserialize, Serialize};
 
 use super::Tx;
 use crate::data::{ResultCode, TxResult};
-use crate::TxType;
+use crate::{IndexedTx, TxType};
 
 /// Transaction event.
 #[derive(
@@ -89,5 +95,119 @@ impl<'result> EventAttributeEntry<'result> for Batch<'result> {
 
     fn into_value(self) -> Self::Value {
         self.0
+    }
+}
+
+pub mod masp_types {
+    //! MASP event types
+
+    use namada_events::EventType;
+
+    use super::MaspEvent;
+
+    /// MASP fee payment event
+    pub const FEE_PAYMENT: EventType =
+        namada_events::event_type!(MaspEvent, "fee-payment");
+
+    /// General MASP transfer event
+    pub const TRANSFER: EventType =
+        namada_events::event_type!(MaspEvent, "transfer");
+}
+
+/// MASP event kind
+pub enum MaspEventKind {
+    /// A MASP transaction used for fee payment
+    FeePayment,
+    /// A general MASP transfer
+    Transfer,
+}
+
+impl From<&MaspEventKind> for EventType {
+    fn from(masp_event_kind: &MaspEventKind) -> Self {
+        match masp_event_kind {
+            MaspEventKind::FeePayment => masp_types::FEE_PAYMENT,
+            MaspEventKind::Transfer => masp_types::TRANSFER,
+        }
+    }
+}
+
+impl From<MaspEventKind> for EventType {
+    fn from(masp_event_kind: MaspEventKind) -> Self {
+        (&masp_event_kind).into()
+    }
+}
+
+/// A type representing the possible reference to some MASP data, either a masp
+/// section or ibc tx data
+#[derive(Clone, Serialize, Deserialize)]
+pub enum MaspTxRef {
+    /// Reference to a MASP section
+    MaspSection(MaspTxId),
+    /// Reference to an ibc tx data section
+    IbcData(IbcTxDataHash),
+}
+
+impl Display for MaspTxRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
+}
+
+impl FromStr for MaspTxRef {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+/// A list of MASP tx references
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct MaspTxRefs(pub Vec<(IndexedTx, MaspTxRef)>);
+
+/// MASP transaction event
+pub struct MaspEvent {
+    /// The indexed transaction that generated this event
+    pub tx_index: IndexedTx,
+    /// A flag signaling the type of the masp transaction
+    pub kind: MaspEventKind,
+    /// The reference to the masp data
+    // FIXME: rename this field?
+    pub data: MaspTxRef,
+}
+
+impl EventToEmit for MaspEvent {
+    const DOMAIN: &'static str = "masp";
+}
+
+impl From<MaspEvent> for Event {
+    fn from(masp_event: MaspEvent) -> Self {
+        Self::new(masp_event.kind.into(), EventLevel::Tx)
+            .with(masp_event.data)
+            .with(masp_event.tx_index)
+            .into()
+    }
+}
+
+impl EventAttributeEntry<'static> for MaspTxRef {
+    type Value = MaspTxRef;
+    type ValueOwned = Self::Value;
+
+    // FIXME: rename this?
+    const KEY: &'static str = "section";
+
+    fn into_value(self) -> Self::Value {
+        self
+    }
+}
+
+impl EventAttributeEntry<'static> for IndexedTx {
+    type Value = IndexedTx;
+    type ValueOwned = Self::Value;
+
+    const KEY: &'static str = "indexed-tx";
+
+    fn into_value(self) -> Self::Value {
+        self
     }
 }

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -977,7 +977,7 @@ impl IndexedTxRange {
             IndexedTx {
                 block_height: to,
                 block_index: TxIndex(u32::MAX),
-                batch_index: None,
+                batch_index: Some(u32::MAX),
             },
         )
     }


### PR DESCRIPTION
## Describe your changes

Supersedes #4449.
Partially addresses #3824 (removes `ExtendedTxResult`).
Partially addresses #3827 as we take events out of `BatchedTxResult` in case of masp fee payment.

Ensures that events for masp fee payment txs are emitted as soon as the storage changes are committed

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [x] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
        - ~https://github.com/anoma/namada-masp-indexer/pull/50~ ->https://github.com/anoma/namada-masp-indexer/pull/64
        - https://github.com/anoma/namada-indexer/pull/331
