### PR TITLE
Fix setuptools bug.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,8 +604,10 @@ jobs:
           cd ../ledger-namada
           git checkout "v$LEDGER_APP_VERSION"
           git submodule update --init --recursive
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
           sudo apt-get update
+          sudo apt-get upgrade
+          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+          pip install --upgrade setuptools
           make deps
       - name: Install rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Describe your changes
Attempt to fix the error `ERROR: Can not execute `setup.py` since setuptools is not available in the build environment.` in the CI.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
