### PR TITLE
Added integration test for auto-compounding.

### DIFF
--- a/.changelog/unreleased/testing/4491-test-auto-compounding.md
+++ b/.changelog/unreleased/testing/4491-test-auto-compounding.md
@@ -1,0 +1,2 @@
+- Test that the auto-compounding of shielded balances is equivalent to manual
+  compounding. ([\#4491](https://github.com/anoma/namada/pull/4491))

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -1523,1039 +1523,252 @@ fn auto_compounding() -> Result<()> {
         ],
     )?;
 
-    // Assert BTC balance at Albert's shielded key is 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
+    // Assert that the actual and estimated balances are equal to the parameters
+    // of this closure. Also assert that the total MASP balance is equal to the
+    // last parameter. Then unshield, reshield, synchronize, and jump to the
+    // next epoch.
+    let mut check_balance_and_reshield =
+        |bal_a, bal_b, est_a, est_b, total| -> Result<()> {
+            // Assert BTC balance at ALbert's shielded key is still 0.1
+            let captured = CapturedOutput::of(|| {
+                run(
+                    &node,
+                    Bin::Client,
+                    vec![
+                        "balance",
+                        "--owner",
+                        AA_VIEWING_KEY,
+                        "--token",
+                        BTC,
+                        "--node",
+                        validator_one_rpc,
+                    ],
+                )
+            });
+            assert!(captured.result.is_ok());
+            assert!(captured.contains("btc: 0.1"));
 
-    // Assert BTC balance at Bertha's shielded key is 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
+            // Assert BTC balance at Bertha's shielded key is still 0.1
+            let captured = CapturedOutput::of(|| {
+                run(
+                    &node,
+                    Bin::Client,
+                    vec![
+                        "balance",
+                        "--owner",
+                        AB_VIEWING_KEY,
+                        "--token",
+                        BTC,
+                        "--node",
+                        validator_one_rpc,
+                    ],
+                )
+            });
+            assert!(captured.result.is_ok());
+            assert!(captured.contains("btc: 0.1"));
 
-    // Assert NAM balance at Albert's shielded key is 0
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0"));
+            // Assert NAM balance at Albert's shielded key is bal_a
+            let captured = CapturedOutput::of(|| {
+                run(
+                    &node,
+                    Bin::Client,
+                    vec![
+                        "balance",
+                        "--owner",
+                        AA_VIEWING_KEY,
+                        "--token",
+                        NAM,
+                        "--node",
+                        validator_one_rpc,
+                    ],
+                )
+            });
 
-    // Assert NAM balance at Bertha's shielded key is 0
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0"));
+            assert!(captured.result.is_ok());
+            assert!(captured.contains(&format!("nam: {}", bal_a)));
 
-    // Assert the rewards estimate for Albert's shielded key is also zero
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AA_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(
-        captured.contains(
-            "Estimated native token rewards for the next MASP epoch: 0"
-        )
-    );
+            // Assert NAM balance at Bertha's shielded key is bal_b
+            let captured = CapturedOutput::of(|| {
+                run(
+                    &node,
+                    Bin::Client,
+                    vec![
+                        "balance",
+                        "--owner",
+                        AB_VIEWING_KEY,
+                        "--token",
+                        NAM,
+                        "--node",
+                        validator_one_rpc,
+                    ],
+                )
+            });
 
-    // Assert the rewards estimate for Bertha's shielded key is also zero
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AB_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(
-        captured.contains(
-            "Estimated native token rewards for the next MASP epoch: 0"
-        )
-    );
+            assert!(captured.result.is_ok());
+            assert!(captured.contains(&format!("nam: {}", bal_b)));
 
-    // Wait till epoch boundary
-    node.next_masp_epoch();
+            // Assert the rewards estimate at Albert's shielded key matches
+            // est_a
+            let captured = CapturedOutput::of(|| {
+                run(
+                    &node,
+                    Bin::Client,
+                    vec![
+                        "estimate-shielding-rewards",
+                        "--key",
+                        AA_VIEWING_KEY,
+                        "--node",
+                        validator_one_rpc,
+                    ],
+                )
+            });
+            assert!(captured.result.is_ok());
+            assert!(captured.contains(&format!(
+                "Estimated native token rewards for the next MASP epoch: {}",
+                est_a
+            )));
 
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec!["shielded-sync", "--node", validator_one_rpc],
+            // Assert the rewards estimate at Bertha's shielded key matches
+            // est_b
+            let captured = CapturedOutput::of(|| {
+                run(
+                    &node,
+                    Bin::Client,
+                    vec![
+                        "estimate-shielding-rewards",
+                        "--key",
+                        AB_VIEWING_KEY,
+                        "--node",
+                        validator_one_rpc,
+                    ],
+                )
+            });
+            assert!(captured.result.is_ok());
+            assert!(captured.contains(&format!(
+                "Estimated native token rewards for the next MASP epoch: {}",
+                est_b
+            )));
+
+            // Assert NAM balance at MASP pool is exclusively the
+            // rewards from the shielded BTC
+            let captured = CapturedOutput::of(|| {
+                run(
+                    &node,
+                    Bin::Client,
+                    vec![
+                        "balance",
+                        "--owner",
+                        MASP,
+                        "--token",
+                        NAM,
+                        "--node",
+                        validator_one_rpc,
+                    ],
+                )
+            });
+            assert!(captured.result.is_ok());
+            assert!(captured.contains(&format!("nam: {}", total)));
+
+            // Send bal_b NAM from Bertha's shielded key to Albert
+            let captured = CapturedOutput::of(|| {
+                run(
+                    &node,
+                    Bin::Client,
+                    apply_use_device(vec![
+                        "unshield",
+                        "--source",
+                        B_SPENDING_KEY,
+                        "--target",
+                        ALBERT,
+                        "--token",
+                        NAM,
+                        "--amount",
+                        bal_b,
+                        "--gas-limit",
+                        "70000",
+                        "--signing-keys",
+                        ALBERT_KEY,
+                        "--node",
+                        validator_one_rpc,
+                    ]),
+                )
+            });
+            assert!(captured.result.is_ok());
+            assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+            // sync the shielded context
+            run(
+                &node,
+                Bin::Client,
+                vec![
+                    "shielded-sync",
+                    "--viewing-keys",
+                    AA_VIEWING_KEY,
+                    AB_VIEWING_KEY,
+                    "--node",
+                    validator_one_rpc,
+                ],
+            )?;
+
+            // Send bal_b NAM from Albert to Bertha's shielded key
+            let captured = CapturedOutput::of(|| {
+                run(
+                    &node,
+                    Bin::Client,
+                    apply_use_device(vec![
+                        "shield",
+                        "--source",
+                        ALBERT,
+                        "--target",
+                        AB_PAYMENT_ADDRESS,
+                        "--token",
+                        NAM,
+                        "--amount",
+                        bal_b,
+                        "--signing-keys",
+                        ALBERT_KEY,
+                        "--node",
+                        validator_one_rpc,
+                    ]),
+                )
+            });
+            assert!(captured.result.is_ok());
+            assert!(captured.contains(TX_APPLIED_SUCCESS));
+
+            // sync the shielded context
+            run(
+                &node,
+                Bin::Client,
+                vec![
+                    "shielded-sync",
+                    "--viewing-keys",
+                    AA_VIEWING_KEY,
+                    AB_VIEWING_KEY,
+                    "--node",
+                    validator_one_rpc,
+                ],
+            )?;
+
+            // Wait till epoch boundary
+            node.next_masp_epoch();
+
+            Ok(())
+        };
+
+    // Now check that the principal amount compounds correctly over a few epochs
+    check_balance_and_reshield("0", "0", "0", "0", "0")?;
+    check_balance_and_reshield(
+        "0.0317", "0.0317", "0.0317", "0.0317", "0.0634",
     )?;
-
-    // Assert BTC balance at ALbert's shielded key is still 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
-
-    // Assert BTC balance at Bertha's shielded key is still 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
-
-    // Assert NAM balance at Albert's shielded key is a non-zero number (rewards
-    // have been dispensed)
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.0317"));
-
-    // Assert NAM balance at Bertha's shielded key is a non-zero number (rewards
-    // have been dispensed)
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.0317"));
-
-    // Assert the rewards estimate at Albert's shielded key matches the actual
-    // rewards
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AA_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.0317"
-    ));
-
-    // Assert the rewards estimate at Bertha's shielded key matches the actual
-    // rewards
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AB_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.0317"
-    ));
-
-    // Assert NAM balance at MASP pool is exclusively the
-    // rewards from the shielded BTC
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                MASP,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.0634"));
-
-    // Send 0.0317 NAM from Bertha's shielded key to Albert
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            apply_use_device(vec![
-                "unshield",
-                "--source",
-                B_SPENDING_KEY,
-                "--target",
-                ALBERT,
-                "--token",
-                NAM,
-                "--amount",
-                "0.0317",
-                "--signing-keys",
-                ALBERT_KEY,
-                "--node",
-                validator_one_rpc,
-            ]),
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(TX_APPLIED_SUCCESS));
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec![
-            "shielded-sync",
-            "--viewing-keys",
-            AA_VIEWING_KEY,
-            AB_VIEWING_KEY,
-            "--node",
-            validator_one_rpc,
-        ],
+    check_balance_and_reshield(
+        "0.09534", "0.09533", "0.06491", "0.0649", "0.190688",
     )?;
-
-    // Send 0.0317 NAM from Albert to Bertha's shielded key
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            apply_use_device(vec![
-                "shield",
-                "--source",
-                ALBERT,
-                "--target",
-                AB_PAYMENT_ADDRESS,
-                "--token",
-                NAM,
-                "--amount",
-                "0.0317",
-                "--signing-keys",
-                ALBERT_KEY,
-                "--node",
-                validator_one_rpc,
-            ]),
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(TX_APPLIED_SUCCESS));
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec![
-            "shielded-sync",
-            "--viewing-keys",
-            AA_VIEWING_KEY,
-            AB_VIEWING_KEY,
-            "--node",
-            validator_one_rpc,
-        ],
+    check_balance_and_reshield(
+        "0.191008", "0.190982", "0.09678", "0.096796", "0.382016",
     )?;
-
-    // Wait till epoch boundary
-    node.next_masp_epoch();
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec!["shielded-sync", "--node", validator_one_rpc],
+    check_balance_and_reshield(
+        "0.31854", "0.31851", "0.128528", "0.128524", "0.637092",
     )?;
-
-    // Assert BTC balance at Albert's shielded key is still 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
-
-    // Assert BTC balance at Bertha's shielded key is still 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
-
-    // Assert NAM balance at Albert's shielded key is a number greater than the
-    // last epoch's balance (more rewards have been dispensed)
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.09534"));
-
-    // Assert NAM balance at Bertha's shielded key is a number greater than the
-    // last epoch's balance (more rewards have been dispensed)
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.09533"));
-
-    // Assert the rewards estimate at Albert's shielded key is 0 since we
-    // haven't shielded any more tokens
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AA_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.06491"
-    ));
-
-    // Assert the rewards estimate at Bertha's shielded key is 0 since we
-    // haven't shielded any more tokens
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AB_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.0649"
-    ));
-
-    // Assert NAM balance at MASP pool is exclusively the
-    // rewards from the shielded BTC
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                MASP,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.190688"));
-
-    // Send 0.09533 NAM from Bertha's shielded key to Albert
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            apply_use_device(vec![
-                "unshield",
-                "--source",
-                B_SPENDING_KEY,
-                "--target",
-                ALBERT,
-                "--token",
-                NAM,
-                "--amount",
-                "0.09533",
-                "--gas-limit",
-                "70000",
-                "--signing-keys",
-                ALBERT_KEY,
-                "--node",
-                validator_one_rpc,
-            ]),
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(TX_APPLIED_SUCCESS));
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec![
-            "shielded-sync",
-            "--viewing-keys",
-            AA_VIEWING_KEY,
-            AB_VIEWING_KEY,
-            "--node",
-            validator_one_rpc,
-        ],
-    )?;
-
-    // Send 0.09533 NAM from Albert to Bertha's shielded key
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            apply_use_device(vec![
-                "shield",
-                "--source",
-                ALBERT,
-                "--target",
-                AB_PAYMENT_ADDRESS,
-                "--token",
-                NAM,
-                "--amount",
-                "0.09533",
-                "--signing-keys",
-                ALBERT_KEY,
-                "--node",
-                validator_one_rpc,
-            ]),
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(TX_APPLIED_SUCCESS));
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec![
-            "shielded-sync",
-            "--viewing-keys",
-            AA_VIEWING_KEY,
-            AB_VIEWING_KEY,
-            "--node",
-            validator_one_rpc,
-        ],
-    )?;
-
-    // Wait till epoch boundary
-    node.next_masp_epoch();
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec!["shielded-sync", "--node", validator_one_rpc],
-    )?;
-
-    // Assert BTC balance at Albert's shielded key is still 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
-
-    // Assert BTC balance at Bertha's shielded key is still 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
-
-    // Assert NAM balance at Albert's shielded key is a number greater than the
-    // last epoch's balance (more rewards have been dispensed)
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.191008"));
-
-    // Assert NAM balance at Bertha's shielded key is a number greater than the
-    // last epoch's balance (more rewards have been dispensed)
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.190982"));
-
-    // Assert the rewards estimate at Albert's shielded key is 0 since we
-    // haven't shielded any more tokens
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AA_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.09678"
-    ));
-
-    // Assert the rewards estimate at Bertha's shielded key are 0 since we
-    // haven't shielded any more tokens
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AB_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.096796"
-    ));
-
-    // Assert NAM balance at MASP pool is exclusively the
-    // rewards from the shielded BTC
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                MASP,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.382016"));
-
-    // Send 0.190982 NAM from Bertha's shielded key to Albert
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            apply_use_device(vec![
-                "unshield",
-                "--source",
-                B_SPENDING_KEY,
-                "--target",
-                ALBERT,
-                "--token",
-                NAM,
-                "--amount",
-                "0.190982",
-                "--gas-limit",
-                "70000",
-                "--signing-keys",
-                ALBERT_KEY,
-                "--node",
-                validator_one_rpc,
-            ]),
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(TX_APPLIED_SUCCESS));
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec![
-            "shielded-sync",
-            "--viewing-keys",
-            AA_VIEWING_KEY,
-            AB_VIEWING_KEY,
-            "--node",
-            validator_one_rpc,
-        ],
-    )?;
-
-    // Send 0.190982 NAM from Albert to Bertha's shielded key
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            apply_use_device(vec![
-                "shield",
-                "--source",
-                ALBERT,
-                "--target",
-                AB_PAYMENT_ADDRESS,
-                "--token",
-                NAM,
-                "--amount",
-                "0.190982",
-                "--signing-keys",
-                ALBERT_KEY,
-                "--node",
-                validator_one_rpc,
-            ]),
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(TX_APPLIED_SUCCESS));
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec![
-            "shielded-sync",
-            "--viewing-keys",
-            AA_VIEWING_KEY,
-            AB_VIEWING_KEY,
-            "--node",
-            validator_one_rpc,
-        ],
-    )?;
-
-    // Wait till epoch boundary
-    node.next_masp_epoch();
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec!["shielded-sync", "--node", validator_one_rpc],
-    )?;
-
-    // Assert BTC balance at Albert's shielded key is still 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
-
-    // Assert BTC balance at Bertha's shielded key is still 0.1
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                BTC,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("btc: 0.1"));
-
-    // Assert NAM balance at Albert's shielded key is a number greater than the
-    // last epoch's balance (more rewards have been dispensed)
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AA_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.31854"));
-
-    // Assert NAM balance at Bertha's shielded key is a number greater than the
-    // last epoch's balance (more rewards have been dispensed)
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                AB_VIEWING_KEY,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.31851"));
-
-    // Assert the rewards estimate at Albert's shielded key is 0 since we
-    // haven't shielded any more tokens
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AA_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.128528"
-    ));
-
-    // Assert the rewards estimate at Bertha's shielded key is 0 since we
-    // haven't shielded any more tokens
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "estimate-shielding-rewards",
-                "--key",
-                AB_VIEWING_KEY,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(
-        "Estimated native token rewards for the next MASP epoch: 0.128524"
-    ));
-
-    // Assert NAM balance at MASP pool is exclusively the
-    // rewards from the shielded BTC
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            vec![
-                "balance",
-                "--owner",
-                MASP,
-                "--token",
-                NAM,
-                "--node",
-                validator_one_rpc,
-            ],
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains("nam: 0.637092"));
-
-    // Send 0.31851 NAM from Bertha's shielded key to Albert
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            apply_use_device(vec![
-                "unshield",
-                "--source",
-                B_SPENDING_KEY,
-                "--target",
-                ALBERT,
-                "--token",
-                NAM,
-                "--amount",
-                "0.31851",
-                "--gas-limit",
-                "70000",
-                "--signing-keys",
-                ALBERT_KEY,
-                "--node",
-                validator_one_rpc,
-            ]),
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(TX_APPLIED_SUCCESS));
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec![
-            "shielded-sync",
-            "--viewing-keys",
-            AA_VIEWING_KEY,
-            AB_VIEWING_KEY,
-            "--node",
-            validator_one_rpc,
-        ],
-    )?;
-
-    // Send 0.31851 NAM from Albert to Bertha's shielded key
-    let captured = CapturedOutput::of(|| {
-        run(
-            &node,
-            Bin::Client,
-            apply_use_device(vec![
-                "shield",
-                "--source",
-                ALBERT,
-                "--target",
-                AB_PAYMENT_ADDRESS,
-                "--token",
-                NAM,
-                "--amount",
-                "0.31851",
-                "--signing-keys",
-                ALBERT_KEY,
-                "--node",
-                validator_one_rpc,
-            ]),
-        )
-    });
-    assert!(captured.result.is_ok());
-    assert!(captured.contains(TX_APPLIED_SUCCESS));
-
-    // sync the shielded context
-    run(
-        &node,
-        Bin::Client,
-        vec![
-            "shielded-sync",
-            "--viewing-keys",
-            AA_VIEWING_KEY,
-            AB_VIEWING_KEY,
-            "--node",
-            validator_one_rpc,
-        ],
-    )?;
-
-    // Wait till epoch boundary
-    node.next_masp_epoch();
-
     Ok(())
 }
 


### PR DESCRIPTION
## Describe your changes
Added an integration test to check that the automatic compounding of a shielded account balance is the same as manually compounding a shielded account balance. Here, manual compounding refers to a shielded pool user immediately unshielding shielded rewards they receive (thereby applying/realizing rewards at that point in time) and then reshielding them (with the timestamp of the current MASP epoch). Though this means that different allowed conversions (from the protocol) are now applied onto the automatically and manually compounded accounts, the results of shielded balance queries are expected to be the approximately the same for all MASP epochs.

See the results of compounding a principal amount of 0.1 BTC below:
| Ep.| Auto Compounding | Manual Compounding | Claimable | MASP Balance |
|---|---|---|---|---|
|0| 0.1 BTC | 0.1 BTC | 0.2 BTC |
|1| 0.1 BTC + 0.0317 NAM | 0.1 BTC + 0.0317 NAM | 0.2 BTC + 0.0634 NAM | 0.2 BTC + 0.0634 NAM |
|2| 0.1 BTC + 0.09534 NAM | 0.1 BTC + 0.09533 NAM | 0.2 BTC + 0.19067 NAM | 0.2 BTC + 0.190688 NAM |
|3| 0.1 BTC + 0.191008 NAM | 0.1 BTC + 0.190982 NAM | 0.2 BTC + 0.38199 NAM | 0.2 BTC + 0.382016 NAM |
|4| 0.1 BTC + 0.31854 NAM | 0.1 BTC + 0.31851 NAM | 0.2 BTC + 0.63705 NAM | 0.2 BTC + 0.637092 NAM |

Note that auto-compounding gives slightly higher balances than manual compounding. This is probably because NAM  conversions to the latest epoch have ever higher thresholds which means that the dust that doesn't get converted will also get higher. Also note that the MASP balance is slightly higher than the claimable amount, which is the sum of the shielded balances held by all the shielded key holders. This is due to rounding errors in the deflation process as explained in https://github.com/anoma/namada/issues/4372 . The growth of the gap between what is claimable and the MASP balance will depend on the inflation rate of NAM, and the relative precisions of NAM and the token being rewarded.
## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
