### PR TITLE
Remove duplicated events

### DIFF
--- a/.changelog/unreleased/improvements/4497-no-duplicated-events.md
+++ b/.changelog/unreleased/improvements/4497-no-duplicated-events.md
@@ -1,0 +1,3 @@
+- Fixed the handling of events so that we don't emit
+  duplicated events inside the `tx/applied` one anymore.
+  ([\#4497](https://github.com/anoma/namada/pull/4497))

--- a/.github/workflows/scripts/hermes.txt
+++ b/.github/workflows/scripts/hermes.txt
@@ -1,1 +1,1 @@
-1.10.4-namada-beta18-test3
+1.12.0-namada-test1

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -69,7 +69,7 @@ pub async fn query_tx_status(
     namada: &impl Namada,
     status: namada_sdk::rpc::TxEventQuery<'_>,
     deadline: Instant,
-) -> Event {
+) -> (Event, Vec<Event>) {
     rpc::query_tx_status(namada, status, deadline)
         .await
         .unwrap()
@@ -2273,7 +2273,7 @@ pub async fn query_has_storage_key<C: Client + Sync>(
 pub async fn query_tx_events<C: Client + Sync>(
     client: &C,
     tx_event_query: namada_sdk::rpc::TxEventQuery<'_>,
-) -> std::result::Result<Option<Event>, <C as Client>::Error> {
+) -> std::result::Result<Option<(Event, Vec<Event>)>, <C as Client>::Error> {
     namada_sdk::rpc::query_tx_events(client, tx_event_query).await
 }
 
@@ -2293,8 +2293,8 @@ pub async fn query_result(context: &impl Namada, args: args::QueryResult) {
     )
     .await
     {
-        Ok(resp) => {
-            let resp = match TxResponse::try_from(resp) {
+        Ok(events) => {
+            let resp = match TxResponse::try_from(events) {
                 Ok(resp) => resp,
                 Err(err) => {
                     edisplay_line!(context.io(), "{err}");

--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -19,7 +19,6 @@ use namada_sdk::chain::{BlockHeight, Epoch};
 use namada_sdk::collections::{HashMap, HashSet};
 use namada_sdk::control_flow::time::{Duration, Instant};
 use namada_sdk::dec::Dec;
-use namada_sdk::events::Event;
 use namada_sdk::governance::ProposalVote;
 use namada_sdk::governance::parameters::GovernanceParameters;
 use namada_sdk::governance::pgf::parameters::PgfParameters;
@@ -46,8 +45,8 @@ use namada_sdk::proof_of_stake::types::{
 use namada_sdk::proof_of_stake::{self, OwnedPosParams, PosParams};
 use namada_sdk::queries::RPC;
 use namada_sdk::rpc::{
-    self, TxResponse, enriched_bonds_and_unbonds, format_denominated_amount,
-    query_epoch, query_ibc_params,
+    self, TxAppliedEvents, TxResponse, enriched_bonds_and_unbonds,
+    format_denominated_amount, query_epoch, query_ibc_params,
 };
 use namada_sdk::state::LastBlock;
 use namada_sdk::storage::BlockResults;
@@ -69,7 +68,7 @@ pub async fn query_tx_status(
     namada: &impl Namada,
     status: namada_sdk::rpc::TxEventQuery<'_>,
     deadline: Instant,
-) -> (Event, Vec<Event>) {
+) -> TxAppliedEvents {
     rpc::query_tx_status(namada, status, deadline)
         .await
         .unwrap()
@@ -2273,7 +2272,7 @@ pub async fn query_has_storage_key<C: Client + Sync>(
 pub async fn query_tx_events<C: Client + Sync>(
     client: &C,
     tx_event_query: namada_sdk::rpc::TxEventQuery<'_>,
-) -> std::result::Result<Option<(Event, Vec<Event>)>, <C as Client>::Error> {
+) -> std::result::Result<Option<TxAppliedEvents>, <C as Client>::Error> {
     namada_sdk::rpc::query_tx_events(client, tx_event_query).await
 }
 

--- a/crates/light_sdk/src/reading/asynchronous/tx.rs
+++ b/crates/light_sdk/src/reading/asynchronous/tx.rs
@@ -1,5 +1,4 @@
-use namada_sdk::events::Event;
-use namada_sdk::rpc::{TxEventQuery, TxResponse};
+use namada_sdk::rpc::{TxAppliedEvents, TxEventQuery, TxResponse};
 use namada_sdk::tx::data::DryRunResult;
 
 use super::*;
@@ -9,7 +8,7 @@ use super::*;
 pub async fn query_tx_events(
     tendermint_addr: &str,
     tx_hash: &str,
-) -> Result<Option<(Event, Vec<Event>)>, Error> {
+) -> Result<Option<TxAppliedEvents>, Error> {
     let client = HttpClient::new(
         TendermintAddress::from_str(tendermint_addr)
             .map_err(|e| Error::Other(e.to_string()))?,
@@ -58,7 +57,7 @@ pub async fn query_tx_response(
 pub async fn query_tx_status(
     tendermint_addr: &str,
     tx_hash: &str,
-) -> Result<(Event, Vec<Event>), Error> {
+) -> Result<TxAppliedEvents, Error> {
     let maybe_event = query_tx_events(tendermint_addr, tx_hash).await?;
     if let Some(e) = maybe_event {
         Ok(e)

--- a/crates/light_sdk/src/reading/asynchronous/tx.rs
+++ b/crates/light_sdk/src/reading/asynchronous/tx.rs
@@ -9,7 +9,7 @@ use super::*;
 pub async fn query_tx_events(
     tendermint_addr: &str,
     tx_hash: &str,
-) -> Result<Option<Event>, Error> {
+) -> Result<Option<(Event, Vec<Event>)>, Error> {
     let client = HttpClient::new(
         TendermintAddress::from_str(tendermint_addr)
             .map_err(|e| Error::Other(e.to_string()))?,
@@ -50,15 +50,15 @@ pub async fn query_tx_response(
     tendermint_addr: &str,
     tx_hash: &str,
 ) -> Result<TxResponse, Error> {
-    let event = query_tx_status(tendermint_addr, tx_hash).await?;
-    event.try_into().map_err(Error::Other)
+    let events = query_tx_status(tendermint_addr, tx_hash).await?;
+    events.try_into().map_err(Error::Other)
 }
 
 /// Query the status of a given transaction.
 pub async fn query_tx_status(
     tendermint_addr: &str,
     tx_hash: &str,
-) -> Result<Event, Error> {
+) -> Result<(Event, Vec<Event>), Error> {
     let maybe_event = query_tx_events(tendermint_addr, tx_hash).await?;
     if let Some(e) = maybe_event {
         Ok(e)

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -11,7 +11,8 @@ use namada_sdk::chain::BlockHeight;
 use namada_sdk::collections::HashSet;
 use namada_sdk::events::EventLevel;
 use namada_sdk::events::extend::{
-    ComposeEvent, Height as HeightAttr, TxHash as TxHashAttr, UserAccount,
+    ComposeEvent, Height as HeightAttr, InnerTxHash as InnerTxHashAttr,
+    TxHash as TxHashAttr, UserAccount,
 };
 use namada_sdk::gas::{self, Gas, GasMetering, TxGasMeter, VpGasMeter};
 use namada_sdk::hash::Hash;
@@ -401,6 +402,8 @@ where
                 )
                 .map_err(|e| Box::new(DispatchError::from(e)))?
                 {
+                    let inner_tx_hash =
+                        compute_inner_tx_hash(wrapper_hash, Either::Right(cmt));
                     batched_tx_result.events.insert(
                         MaspEvent {
                             tx_index: IndexedTx {
@@ -417,6 +420,12 @@ where
                             kind: MaspEventKind::Transfer,
                             data: masp_ref,
                         }
+                        .with(TxHashAttr(
+                            // Zero hash if the wrapper is not provided
+                            // (governance proposal)
+                            wrapper_hash.cloned().unwrap_or_default(),
+                        ))
+                        .with(InnerTxHashAttr(inner_tx_hash))
                         .into(),
                     );
                 }
@@ -512,6 +521,12 @@ where
 
     let batch_results =
         payment_result.map_or_else(TxResult::default, |mut masp_tx_result| {
+            let first_inner_tx_hash = compute_inner_tx_hash(
+                tx.wrapper_hash().as_ref(),
+                // Ok to unwrap cause if we have a batched result it means
+                // we've executed the first tx in the batch
+                Either::Right(tx.first_commitments().unwrap()),
+            );
             let mut batch = TxResult::default();
             // Generate Masp event if needed
             masp_tx_result.tx_result.events.insert(
@@ -524,14 +539,14 @@ where
                     kind: MaspEventKind::FeePayment,
                     data: masp_tx_result.masp_section_ref,
                 }
+                .with(TxHashAttr(tx.header_hash()))
+                .with(InnerTxHashAttr(first_inner_tx_hash))
                 .into(),
             );
 
             batch.insert_inner_tx_result(
-                // Ok to unwrap cause if we have a batched result it means
-                // we've executed the first tx in the batch
                 tx.wrapper_hash().as_ref(),
-                either::Right(tx.first_commitments().unwrap()),
+                either::Left(&first_inner_tx_hash),
                 Ok(masp_tx_result.tx_result),
             );
 

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -999,7 +999,7 @@ impl<'finalize> TempTxLogs {
     ) -> ValidityFlags {
         let mut flags = ValidityFlags::default();
 
-        for (cmt_hash, batched_result) in tx_result.0.iter_mut() {
+        for (cmt_hash, batched_result) in tx_result.iter_mut() {
             match batched_result {
                 Ok(result) => {
                     if result.is_accepted() {
@@ -1015,10 +1015,6 @@ impl<'finalize> TempTxLogs {
                         self.stats.increment_successful_txs();
                         flags.commit_batch_hash = true;
 
-                        // FIXME: let's start by taking the events here and then
-                        // do another commit where maybe we rework TxResult?
-                        // Need to see if it brakes compatibility with external
-                        // tools
                         self.response_events.emit_many(
                             // Take the events to avoid replicating them when
                             // emitting the transaction's result event

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -475,7 +475,7 @@ where
     fn handle_inner_tx_results(
         &mut self,
         response: &mut shim::response::FinalizeBlock,
-        tx_result: namada_sdk::tx::data::TxResult<protocol::Error>,
+        mut tx_result: namada_sdk::tx::data::TxResult<protocol::Error>,
         tx_data: TxData<'_>,
         tx_logs: &mut TxLogs<'_>,
     ) {
@@ -484,7 +484,7 @@ where
         let ValidityFlags {
             commit_batch_hash,
             is_any_tx_invalid,
-        } = temp_log.check_inner_results(&tx_result, tx_data.height);
+        } = temp_log.check_inner_results(&mut tx_result, tx_data.height);
 
         if tx_data.is_atomic_batch && is_any_tx_invalid {
             // Atomic batches need custom handling when even a single tx fails,
@@ -537,7 +537,7 @@ where
         &mut self,
         response: &mut shim::response::FinalizeBlock,
         msg: &Error,
-        tx_result: namada_sdk::tx::data::TxResult<protocol::Error>,
+        mut tx_result: namada_sdk::tx::data::TxResult<protocol::Error>,
         tx_data: TxData<'_>,
         tx_logs: &mut TxLogs<'_>,
     ) {
@@ -546,7 +546,7 @@ where
         let ValidityFlags {
             commit_batch_hash,
             is_any_tx_invalid: _,
-        } = temp_log.check_inner_results(&tx_result, tx_data.height);
+        } = temp_log.check_inner_results(&mut tx_result, tx_data.height);
 
         let unrun_txs = tx_data
             .commitments_len
@@ -994,12 +994,12 @@ impl<'finalize> TempTxLogs {
 
     fn check_inner_results(
         &mut self,
-        tx_result: &namada_sdk::tx::data::TxResult<protocol::Error>,
+        tx_result: &mut namada_sdk::tx::data::TxResult<protocol::Error>,
         height: BlockHeight,
     ) -> ValidityFlags {
         let mut flags = ValidityFlags::default();
 
-        for (cmt_hash, batched_result) in tx_result.iter() {
+        for (cmt_hash, batched_result) in tx_result.0.iter_mut() {
             match batched_result {
                 Ok(result) => {
                     if result.is_accepted() {
@@ -1015,11 +1015,16 @@ impl<'finalize> TempTxLogs {
                         self.stats.increment_successful_txs();
                         flags.commit_batch_hash = true;
 
-                        // events from other sources
+                        // FIXME: let's start by taking the events here and then
+                        // do another commit where maybe we rework TxResult?
+                        // Need to see if it brakes compatibility with external
+                        // tools
                         self.response_events.emit_many(
-                            result.events.iter().map(|event| {
-                                event.clone().with(Height(height))
-                            }),
+                            // Take the events to avoid replicating them when
+                            // emitting the transaction's result event
+                            std::mem::take(&mut result.events)
+                                .into_iter()
+                                .map(|event| event.with(Height(height))),
                         );
                     } else {
                         // VPs rejected, this branch can only be reached by

--- a/crates/sdk/src/events/log/dumb_queries.rs
+++ b/crates/sdk/src/events/log/dumb_queries.rs
@@ -246,9 +246,8 @@ mod tests {
         for ev in [event_1, event_2, event_3] {
             assert!(matcher.matches(&ev))
         }
-        // FIXME: need a higher level test to check that we can reconstruct
-        // events for the specific inner txs Check that the event
-        // missing the transaction hash attribute is not captured by the matcher
+        // Check that the event missing the transaction hash attribute is not
+        // captured by the matcher
         assert!(!matcher.matches(&event_4))
     }
 

--- a/crates/sdk/src/events/log/dumb_queries.rs
+++ b/crates/sdk/src/events/log/dumb_queries.rs
@@ -165,6 +165,12 @@ impl QueryMatcher {
         .and_attribute(PacketDstChannel(destination_channel))
         .and_attribute(PacketSequence(sequence))
     }
+
+    /// Returns all the events associated with the provided transaction's hash
+    pub fn tx_events(tx_hash: Hash) -> Self {
+        // FIXME: does this prefix work?
+        Self::with_prefix(EventType::new("")).and_attribute(TxHashAttr(tx_hash))
+    }
 }
 
 #[cfg(test)]

--- a/crates/sdk/src/queries/shell.rs
+++ b/crates/sdk/src/queries/shell.rs
@@ -24,6 +24,7 @@ use namada_storage::{ResultExt, StorageRead};
 use namada_token::masp::MaspTokenRewardData;
 use namada_token::storage_key::masp_token_map_key;
 use namada_tx::data::DryRunResult;
+use namada_tx::event::types::APPLIED;
 
 use self::eth_bridge::{ETH_BRIDGE, EthBridge};
 use crate::borsh::BorshSerializeExt;
@@ -589,12 +590,15 @@ where
         .cloned();
 
     if let Some(applied_event) = tx_applied_event {
-        // Look for all the other events relative to this transaction
+        // Look for all the other events relative to this transaction (expect
+        // for the tx/applied one) FIXME: actually, instead of removing
+        // the applied event do a single query and extract it
         let matcher_events = dumb_queries::QueryMatcher::tx_events(tx_hash);
         let other_events = ctx
             .event_log
             .with_matcher(matcher_events)
             .iter()
+            .filter(|event| event.kind() != &APPLIED)
             .cloned()
             .collect();
 

--- a/crates/sdk/src/queries/shell.rs
+++ b/crates/sdk/src/queries/shell.rs
@@ -579,8 +579,6 @@ where
     D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
     H: 'static + StorageHasher + Sync,
 {
-    // FIXME: at this point it's probably better to add the tx hash to masp
-    // events too
     let matcher_applied = dumb_queries::QueryMatcher::applied(tx_hash);
     let applied_event = ctx
         .event_log

--- a/crates/sdk/src/rpc.rs
+++ b/crates/sdk/src/rpc.rs
@@ -755,7 +755,7 @@ impl TryFrom<TxAppliedEvents> for TxResponse {
                 let inner_tx_result =
                     batch.get_mut(&inner_tx_hash).ok_or_else(|| {
                         format!(
-                            "MIssing result of inner transaction {}",
+                            "Missing result of inner transaction {}",
                             inner_tx_hash
                         )
                     })?;

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -431,9 +431,8 @@ pub async fn submit_tx(
 
     // The transaction is now on chain. We wait for it to be applied
     let tx_query = rpc::TxEventQuery::Applied(tx_hash.as_str());
-    let (applied_event, tx_events) =
-        rpc::query_tx_status(context, tx_query, deadline).await?;
-    let response = TxResponse::from_events(applied_event, tx_events);
+    let tx_events = rpc::query_tx_status(context, tx_query, deadline).await?;
+    let response = TxResponse::from_events(tx_events);
     display_batch_resp(context, &response);
     Ok(response)
 }

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -161,8 +161,9 @@ pub enum ProcessTxResponse {
 }
 
 impl ProcessTxResponse {
-    /// Returns a `TxResult` if the transaction was applied and accepted by
-    /// all VPs. Note that this always returns false for dry-run transactions.
+    /// Returns a `BatchedTxResult` if the transaction was applied and accepted
+    /// by all VPs. Note that this always returns false for dry-run
+    /// transactions.
     pub fn is_applied_and_valid(
         &self,
         wrapper_hash: Option<&Hash>,
@@ -430,8 +431,9 @@ pub async fn submit_tx(
 
     // The transaction is now on chain. We wait for it to be applied
     let tx_query = rpc::TxEventQuery::Applied(tx_hash.as_str());
-    let event = rpc::query_tx_status(context, tx_query, deadline).await?;
-    let response = TxResponse::from_event(event);
+    let (applied_event, tx_events) =
+        rpc::query_tx_status(context, tx_query, deadline).await?;
+    let response = TxResponse::from_events(applied_event, tx_events);
     display_batch_resp(context, &response);
     Ok(response)
 }

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -3153,6 +3153,41 @@ fn pos_validator_metadata_validation() -> Result<()> {
     Ok(())
 }
 
+// Test that a client can reconstruct the events associated with a transaction
+#[test]
+fn client_events_reconstruction() -> Result<()> {
+    // This address doesn't matter for tests. But an argument is required.
+    let validator_one_rpc = "http://127.0.0.1:26567";
+    let (node, _services) = setup::setup()?;
+
+    // Submit a transfer transaction that will emit a transfer event
+    let tx_args = apply_use_device(vec![
+        "transparent-transfer",
+        "--source",
+        BERTHA_KEY,
+        "--target",
+        ALBERT_KEY,
+        "--token",
+        NAM,
+        "--amount",
+        "1",
+        "--node",
+        &validator_one_rpc,
+        "--force",
+    ]);
+
+    let captured = CapturedOutput::of(|| run(&node, Bin::Client, tx_args));
+    assert_matches!(captured.result, Ok(_));
+    assert!(captured.contains(TX_APPLIED_SUCCESS));
+    // Check that, even if we don't serialize the events within the tx/applied
+    // event, the client can recover the events associated with this transaction
+    // from the block and reconstruct a complete log for the user
+    assert!(captured.contains("Events:"));
+    assert!(captured.contains("- tx - token/transfer:"));
+
+    Ok(())
+}
+
 fn make_migration_json() -> (Hash, tempfile::NamedTempFile) {
     let file = tempfile::Builder::new().tempfile().expect("Test failed");
     let updates = [migrations::DbUpdateType::Add {

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -228,6 +228,9 @@ pub struct DryRunResult(pub TxResult<String>, pub WholeGas);
 // management with regards to replay protection, whereas for logging we use
 // strings
 // TODO derive BorshSchema after <https://github.com/near/borsh-rs/issues/82>
+// FIXME: if we change the type we serialize in the events maybe we don't need
+// the generic on this one anymore
+// FIXME: should we try removing this generic?
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct TxResult<T>(HashMap<Hash, Result<BatchedTxResult, T>>);
 
@@ -237,6 +240,7 @@ impl<T> Default for TxResult<T> {
     }
 }
 
+// FIXME: if we remove the generic can we also remove this?
 impl<T: Serialize> Serialize for TxResult<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -403,6 +407,8 @@ pub struct BatchedTxResult {
     /// New established addresses created by the transaction
     pub initialized_accounts: Vec<Address>,
     /// Events emitted by the transaction
+    // FIXME: also need to skip borsh serialization?
+    #[serde(skip_serializing, skip_deserializing)]
     pub events: BTreeSet<Event>,
 }
 
@@ -476,6 +482,7 @@ pub struct VpsResult {
     pub status_flags: VpStatusFlags,
 }
 
+// FIXME: maybe no need for these display and from str anymore
 impl<T: Serialize> fmt::Display for TxResult<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {


### PR DESCRIPTION
## Describe your changes

Closes #3827.

Avoid serializing the `events` field of `BatchedTxResult` so that we don't get the same events that we can find in the block results inside every `tx/applied` event.

To achieve this we now attach the tx hash and inner tx hash attribute (introduced in #4454) to the new masp events introduced in #4475: without this change the retrieval of these events based on the transaction's hash alone would be quite convoluted (if not impossible). This change also goes into the direction of #3824: if in the future we were to produce the masp events directly in wasm, we would perfectly match the current structure of the events emitted in protocol (no need for a migration of the events).

The rpc code has also been updated to reconstruct the complete `BatchedTxResult` (with `events`) so that we keep the current behavior of providing the clients with complete data about the execution of a transaction.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
