### PR TITLE
Removes `TxResult`'s methods in favor of `Deref`

### DIFF
--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -354,7 +354,7 @@ where
         .filter(|cmt| {
             let inner_tx_hash =
                 compute_inner_tx_hash(wrapper_hash, Either::Right(cmt));
-            !tx_result.0.contains_key(&inner_tx_hash)
+            !tx_result.contains_key(&inner_tx_hash)
         })
         .collect::<HashSet<_>>()
         .into_iter();

--- a/crates/node/src/shell/finalize_block.rs
+++ b/crates/node/src/shell/finalize_block.rs
@@ -364,7 +364,7 @@ where
                             Either::Right(cmt),
                         );
                         if let Some(Ok(batched_result)) =
-                            tx_result.0.get_mut(&inner_tx_hash)
+                            tx_result.get_mut(&inner_tx_hash)
                         {
                             if batched_result.is_accepted() {
                                 // Take the events from the batch result to

--- a/crates/tests/src/integration/ledger_tests.rs
+++ b/crates/tests/src/integration/ledger_tests.rs
@@ -2009,8 +2009,8 @@ fn enforce_fee_payment() -> Result<()> {
     let second_result = &results[1];
 
     // The batches should contain a single inner tx each
-    assert_eq!(first_result.0.len(), 1);
-    assert_eq!(second_result.0.len(), 1);
+    assert_eq!(first_result.len(), 1);
+    assert_eq!(second_result.len(), 1);
 
     // First transaction pay fees but then fails on the token transfer because
     // of a lack of funds

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -4203,7 +4203,7 @@ fn expired_masp_tx() -> Result<()> {
 
         for result in results.iter() {
             // The batch should contain a single inner tx
-            assert_eq!(result.0.len(), 1);
+            assert_eq!(result.len(), 1);
 
             let inner_tx_result = result
                 .get_inner_tx_result(
@@ -6117,7 +6117,7 @@ fn identical_output_descriptions() -> Result<()> {
 
         for result in results.iter() {
             // The batch should contain two inner txs
-            assert_eq!(result.0.len(), 2);
+            assert_eq!(result.len(), 2);
 
             for inner_cmt in inner_cmts {
                 let inner_tx_result = result

--- a/crates/tx/src/data/mod.rs
+++ b/crates/tx/src/data/mod.rs
@@ -14,6 +14,7 @@ use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::fmt::{self, Display};
 use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
 use bitflags::bitflags;
@@ -228,7 +229,7 @@ pub struct DryRunResult(pub TxResult<String>, pub WholeGas);
 // strings
 // TODO derive BorshSchema after <https://github.com/near/borsh-rs/issues/82>
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
-pub struct TxResult<T>(pub HashMap<Hash, Result<BatchedTxResult, T>>);
+pub struct TxResult<T>(HashMap<Hash, Result<BatchedTxResult, T>>);
 
 impl<T> Default for TxResult<T> {
     fn default() -> Self {
@@ -316,6 +317,20 @@ impl<T: Display> TxResult<T> {
     }
 }
 
+impl<T> Deref for TxResult<T> {
+    type Target = HashMap<Hash, Result<BatchedTxResult, T>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for TxResult<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl<T> TxResult<T> {
     /// Return a new set of tx results.
     pub fn new() -> Self {
@@ -343,26 +358,6 @@ impl<T> TxResult<T> {
     ) -> Option<&Result<BatchedTxResult, T>> {
         self.0
             .get(&compute_inner_tx_hash(wrapper_hash, commitments))
-    }
-
-    /// Iterate over all the inner tx results.
-    #[inline]
-    pub fn iter(
-        &self,
-    ) -> impl Iterator<Item = (&Hash, &Result<BatchedTxResult, T>)> + '_ {
-        self.0.iter()
-    }
-
-    /// Return the length of the collection of inner tx results.
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Check if the collection of inner tx results is empty.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
     }
 
     /// Check if all the inner txs in the collection have been successfully


### PR DESCRIPTION
## Describe your changes

Removes some trivial `TxResult`'s methods in favor of `Deref`

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
