### PR TITLE
Improve MASP fee payment errors

### DIFF
--- a/.changelog/unreleased/improvements/4541-better-masp-fee-payment-vp-err.md
+++ b/.changelog/unreleased/improvements/4541-better-masp-fee-payment-vp-err.md
@@ -1,0 +1,2 @@
+- Include the address and error messages of rejecting VPs in MASP fee payments.
+  ([\#4541](https://github.com/anoma/namada/pull/4541))

--- a/crates/node/src/protocol.rs
+++ b/crates/node/src/protocol.rs
@@ -861,8 +861,8 @@ where
                         "Not a MASP transaction.".to_string()
                     } else {
                         format!(
-                            "Some VPs rejected it: {:#?}",
-                            result.vps_result.rejected_vps
+                            "Some VPs rejected it: {:?}",
+                            result.vps_result.errors
                         )
                     };
                     tracing::error!(error_msg);


### PR DESCRIPTION
## Describe your changes

Rather than just including the address of the VP rejecting a MASP fee payment, the address and error messages are returned, which are helpful both for users and devs alike.

**This change shouldn't be consensus breaking.**

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
