### PR TITLE
Make the control coefficient the inverse of the epochs per year.

### DIFF
--- a/.changelog/unreleased/improvements/4542-simplify-masp-inflation.md
+++ b/.changelog/unreleased/improvements/4542-simplify-masp-inflation.md
@@ -1,0 +1,2 @@
+- Simply the MASP inflattion PD-controller formula to increase clarity and
+  reduce redundancy. ([\#4542](https://github.com/anoma/namada/pull/4542))

--- a/crates/controller/src/lib.rs
+++ b/crates/controller/src/lib.rs
@@ -125,10 +125,10 @@ impl PDController {
         current_metric: Dec,
     ) -> Result<Dec, arith::Error> {
         let val: Dec = checked!(
-            current_metric * (self.d_gain_nom - self.p_gain_nom)
-                + (self.target_metric * self.p_gain_nom)
-                - (self.last_metric * self.d_gain_nom)
+            (coeff * current_metric) * (self.d_gain_nom - self.p_gain_nom)
+                + ((coeff * self.target_metric) * self.p_gain_nom)
+                - ((coeff * self.last_metric) * self.d_gain_nom)
         )?;
-        checked!(coeff * val)
+        checked!(val)
     }
 }

--- a/crates/shielded_token/src/conversion.rs
+++ b/crates/shielded_token/src/conversion.rs
@@ -73,7 +73,7 @@ pub fn compute_inflation(
 
     let metric = Dec::try_from(locked_amount)
         .expect("Should not fail to convert Uint to Dec");
-    let control_coeff = max_reward_rate
+    let control_coeff = Dec::one()
         .checked_div(controller.get_epochs_per_year())
         .expect("Control coefficient overflow");
 
@@ -991,8 +991,8 @@ mod tests {
             // Tokens
             let token_params = ShieldedParams {
                 max_reward_rate: Dec::from_str("0.1").unwrap(),
-                kp_gain_nom: Dec::from_str("0.1").unwrap(),
-                kd_gain_nom: Dec::from_str("0.1").unwrap(),
+                kp_gain_nom: Dec::from_str("0.01").unwrap(),
+                kd_gain_nom: Dec::from_str("0.01").unwrap(),
                 locked_amount_target: 10_000_u64,
             };
 

--- a/crates/shielded_token/src/lib.rs
+++ b/crates/shielded_token/src/lib.rs
@@ -73,8 +73,8 @@ impl Default for ShieldedParams {
     fn default() -> Self {
         Self {
             max_reward_rate: Dec::from_str("0.1").unwrap(),
-            kp_gain_nom: Dec::from_str("0.25").unwrap(),
-            kd_gain_nom: Dec::from_str("0.25").unwrap(),
+            kp_gain_nom: Dec::from_str("0.025").unwrap(),
+            kd_gain_nom: Dec::from_str("0.025").unwrap(),
             locked_amount_target: 10_000_u64,
         }
     }

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -623,8 +623,10 @@ fn values_spanning_multiple_masp_digits() -> Result<()> {
             // the inflation being computed by the pd controller to
             // exceed the amount of test tokens in the masp
             max_reward_rate: Dec::from_str("999999999999999.0").unwrap(),
-            kp_gain_nom: Dec::from_str("99999999999999999999").unwrap(),
-            kd_gain_nom: Dec::from_str("99999999999999999999").unwrap(),
+            kp_gain_nom: Dec::from_str("99999999999999899999000000000000001")
+                .unwrap(),
+            kd_gain_nom: Dec::from_str("99999999999999899999000000000000001")
+                .unwrap(),
             locked_amount_target: u64::MAX,
         }),
         &mut node.shell.lock().unwrap().state,

--- a/crates/tests/src/integration/setup.rs
+++ b/crates/tests/src/integration/setup.rs
@@ -58,8 +58,8 @@ pub fn initialize_genesis(
     for (_, config) in templates.tokens.token.iter_mut() {
         config.masp_params = Some(token::ShieldedParams {
             max_reward_rate: Dec::from_str("0.1").unwrap(),
-            kp_gain_nom: Dec::from_str("0.1").unwrap(),
-            kd_gain_nom: Dec::from_str("0.1").unwrap(),
+            kp_gain_nom: Dec::from_str("0.01").unwrap(),
+            kd_gain_nom: Dec::from_str("0.01").unwrap(),
             locked_amount_target: 1_000_000u64,
         });
     }

--- a/genesis/hardware/tokens.toml
+++ b/genesis/hardware/tokens.toml
@@ -5,8 +5,8 @@ denom = 6
 
 [token.NAM.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.BTC]
@@ -14,8 +14,8 @@ denom = 8
 
 [token.BTC.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.ETH]
@@ -23,8 +23,8 @@ denom = 18
 
 [token.ETH.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.DOT]
@@ -32,8 +32,8 @@ denom = 10
 
 [token.DOT.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.Schnitzel]
@@ -41,8 +41,8 @@ denom = 6
 
 [token.Schnitzel.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.Apfel]
@@ -50,8 +50,8 @@ denom = 6
 
 [token.Apfel.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.Kartoffel]
@@ -59,6 +59,6 @@ denom = 6
 
 [token.Kartoffel.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000

--- a/genesis/localnet/tokens.toml
+++ b/genesis/localnet/tokens.toml
@@ -5,8 +5,8 @@ denom = 6
 
 [token.NAM.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.BTC]
@@ -14,8 +14,8 @@ denom = 8
 
 [token.BTC.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.ETH]
@@ -23,8 +23,8 @@ denom = 18
 
 [token.ETH.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.DOT]
@@ -32,8 +32,8 @@ denom = 10
 
 [token.DOT.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.Schnitzel]
@@ -41,8 +41,8 @@ denom = 6
 
 [token.Schnitzel.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.Apfel]
@@ -50,8 +50,8 @@ denom = 6
 
 [token.Apfel.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000
 
 [token.Kartoffel]
@@ -59,6 +59,6 @@ denom = 6
 
 [token.Kartoffel.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000

--- a/genesis/starter/tokens.toml
+++ b/genesis/starter/tokens.toml
@@ -6,6 +6,6 @@ denom = 6
 
 [token.NAM.masp_params]
 max_reward_rate = "0.01"
-kd_gain_nom = "0.25"
-kp_gain_nom = "0.25"
+kd_gain_nom = "0.0025"
+kp_gain_nom = "0.0025"
 locked_amount_target = 10000


### PR DESCRIPTION
## Describe your changes
Currently the MASP inflation control coefficient is `max_reward_rate/epochs_per_year`. This is not problematic for the running of the rewards system, but it potentially complicates the semantics of the formula and unnecessarily makes the numerical bounds for desirable nominal proportional gain values dependent upon the selection of the maximum reward rate. This PR removes the factor `max_reward_rate` from the control value and adjusts the nominal proportional gain and nominal derivative gain values in tests so that the same result is achieved.

In more detail, the minor problems with the including the maximum reward rate in the control coefficient are:
1) it's somewhat redundant because the maximum reward rate is already being used to clamp the control value since it's a factor of the other argument to the `min` function. Arguably people might expect the maximum reward rate to behave more like a clamp on reward rates (or the control value specifically) rather than a general scaling factor.
2) it's harder to understand what's being computed because the control value computation involves the maximum reward rate in a way that does not eventually multiply it by the current supply of NAM - had this been the case, then their product could have been understood to be the maximum reward
3) it makes the numerical bounds on the set of nominal proportional gain values that make the PD-controller yield non-zero inflation dependent upon the chosen maximum reward rate value (which too has its own selection constraints). It might be simpler if these values can be set independently. See: https://hackmd.io/oqLHjyvwRMaxSD5JJNrB2w?both#Notes

Applying this PR would require the nominal proportional gain and nominal derivative gain parameters in the target network to be modified. So it may not be worth trying to address this issue at this point.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
