### PR TITLE
Murisi/native token migrations

### DIFF
--- a/.changelog/unreleased/improvements/4543-native-token-migrations.md
+++ b/.changelog/unreleased/improvements/4543-native-token-migrations.md
@@ -1,0 +1,2 @@
+- Extended migration to allow the rewards for the native token and other Namada
+  addresses to be reset. ([\#4543](https://github.com/anoma/namada/pull/4543))

--- a/.changelog/unreleased/testing/4540-migrate-wasms.md
+++ b/.changelog/unreleased/testing/4540-migrate-wasms.md
@@ -1,0 +1,2 @@
+- Implemented an example hard-fork migration for transaction WASM code.
+  ([\#4540](https://github.com/anoma/namada/pull/4540))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5760,6 +5760,7 @@ dependencies = [
  "namada_trans_token",
  "proptest",
  "serde_json",
+ "sha2 0.10.8",
  "tokio",
 ]
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,4 +53,5 @@ data-encoding.workspace = true
 linkme.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tokio = { workspace = true, default-features = false }

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -9,8 +9,10 @@ use masp_primitives::transaction::components::I128Sum;
 use namada_core::borsh::BorshSerializeExt;
 use namada_core::hash::Hash;
 use namada_core::masp::{Precision, encode_asset_type};
+use namada_core::storage::Key;
 use namada_macros::BorshDeserializer;
 use namada_migrations::REGISTER_DESERIALIZERS;
+use namada_parameters::storage::get_tx_allowlist_storage_key;
 use namada_sdk::address::Address;
 use namada_sdk::ibc::trace::ibc_token;
 use namada_sdk::masp_primitives::asset_type::AssetType;
@@ -25,6 +27,7 @@ use namada_shielded_token::storage_key::{
 use namada_shielded_token::{ConversionLeaf, ConversionState, MaspEpoch};
 use namada_trans_token::storage_key::{balance_key, minted_balance_key};
 use namada_trans_token::{Amount, Denomination, MaspDigitPos, Store};
+use sha2::{Digest, Sha256};
 
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -54,7 +57,7 @@ impl From<ConversionState> for NewConversionState {
 }
 
 // Demonstrate how to set the minted balance using a migration
-fn minted_balance_migration() {
+fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     let person =
         Address::decode("tnam1q9rhgyv3ydq0zu3whnftvllqnvhvhm270qxay5tn")
             .unwrap();
@@ -65,34 +68,29 @@ fn minted_balance_migration() {
     let minted_key = minted_balance_key(&nam);
     let minted_value = Amount::from(117600000504441u64);
 
-    let updates = [
-        migrations::DbUpdateType::Add {
-            key: balance_key(&nam, &person),
-            cf: DbColFam::SUBSPACE,
-            value: amount.into(),
-            force: false,
-        },
-        migrations::DbUpdateType::Add {
-            key: minted_key,
-            cf: DbColFam::SUBSPACE,
-            value: minted_value.into(),
-            force: false,
-        },
-        migrations::DbUpdateType::RepeatDelete(apfel, DbColFam::SUBSPACE),
-    ];
-    let changes = migrations::DbChanges {
-        changes: updates.into_iter().collect(),
-    };
-    std::fs::write(
-        "minted_balance_migration.json",
-        serde_json::to_string(&changes).unwrap(),
-    )
-    .unwrap();
+    updates.push(migrations::DbUpdateType::Add {
+        key: balance_key(&nam, &person),
+        cf: DbColFam::SUBSPACE,
+        value: amount.into(),
+        force: false,
+    });
+    updates.push(migrations::DbUpdateType::Add {
+        key: minted_key,
+        cf: DbColFam::SUBSPACE,
+        value: minted_value.into(),
+        force: false,
+    });
+    updates.push(migrations::DbUpdateType::RepeatDelete(
+        apfel,
+        DbColFam::SUBSPACE,
+    ));
 }
 
 // Demonstrate how to set the shielded reward precision of IBC tokens using a
 // migration
-fn shielded_reward_precision_migration() {
+fn shielded_reward_precision_migration(
+    updates: &mut Vec<migrations::DbUpdateType>,
+) {
     pub type ChannelId = &'static str;
     pub type BaseToken = &'static str;
 
@@ -105,7 +103,6 @@ fn shielded_reward_precision_migration() {
         ("channel-0", "stutia", 1000u128),
     ];
 
-    let mut updates = Vec::new();
     // Set IBC token shielded reward precisions
     for (channel_id, base_token, precision) in IBC_TOKENS {
         let ibc_denom = format!("transfer/{channel_id}/{base_token}");
@@ -122,20 +119,13 @@ fn shielded_reward_precision_migration() {
             force: false,
         });
     }
-
-    let changes = migrations::DbChanges {
-        changes: updates.into_iter().collect(),
-    };
-    std::fs::write(
-        "shielded_reward_precision_migration.json",
-        serde_json::to_string(&changes).unwrap(),
-    )
-    .unwrap();
 }
 
 // Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
 // their allowed conversions with conversions that do not contain rewards.
-fn shielded_reward_reset_migration() {
+fn shielded_reward_reset_migration(
+    updates: &mut Vec<migrations::DbUpdateType>,
+) {
     pub type ChannelId = &'static str;
     pub type BaseToken = &'static str;
 
@@ -155,7 +145,6 @@ fn shielded_reward_reset_migration() {
         ("channel-0", "stutia", 1000u128),
     ];
 
-    let mut updates = Vec::new();
     // Reset the allowed conversions for the above tokens
     for (channel_id, base_token, precision) in IBC_TOKENS {
         let ibc_denom = format!("transfer/{channel_id}/{base_token}");
@@ -241,20 +230,11 @@ fn shielded_reward_reset_migration() {
             }
         }
     }
-
-    let changes = migrations::DbChanges {
-        changes: updates.into_iter().collect(),
-    };
-    std::fs::write(
-        "shielded_reward_reset_migration.json",
-        serde_json::to_string(&changes).unwrap(),
-    )
-    .unwrap();
 }
 
 // Demonstrate replacing the entire conversion state with a new state that does
 // not contain rewards.
-fn conversion_state_migration() {
+fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     // Valid precisions must be in the intersection of i128 and u128
     pub type Precision = u128;
 
@@ -309,7 +289,6 @@ fn conversion_state_migration() {
         ),
     ];
 
-    let mut updates = Vec::new();
     let mut assets = BTreeMap::new();
     let mut conv_notes = Vec::new();
     // Reset the allowed conversions for the above tokens
@@ -430,21 +409,177 @@ fn conversion_state_migration() {
         value: assets_hash.into(),
         force: false,
     });
+}
 
-    let changes = migrations::DbChanges {
-        changes: updates.into_iter().collect(),
-    };
-    std::fs::write(
-        "conversion_state_migration.json",
-        serde_json::to_string(&changes).unwrap(),
-    )
-    .unwrap();
+// Demonstrate upgrading the transaction WASM code and hashes in storage
+fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+    // wasm_updates[x].0) The WASM hash that is being replaced
+    // wasm_updates[x].1) The name of WASM being updated
+    // wasm_updates[x].2) The bytes of the new WASM code
+    let wasm_updates: Vec<(&str, &str, &[u8])> =
+        vec![
+        (
+            "83afcbf97c35188991ae2e73db2f48cb8d019c4295fe5323d9c3dfebcd5dbec0",
+            "tx_transfer.wasm",
+            //include_bytes!("tx_transfer.5c7e44e61c00df351fa7c497cd2e186d71909f1a18db0c8d362dff36057e0fbf.wasm"),
+            &[0xDE, 0xAD, 0xBE, 0xEF],
+        ),
+        (
+            "6ff3c2a2ebc65061a9b89abd15fb37851ca77e162b42b7989889bd537e802b09",
+            "tx_ibc.wasm",
+            //include_bytes!("tx_ibc.ae9b900edd6437461addd1fe1c723c4b1a8ac8d2fce30e1e4c417ef34f299f73.wasm"),
+            &[0xDE, 0xAD, 0xBE, 0xEF],
+        ),
+    ];
+
+    // Update the tx allowlist parameter
+    let tx_allowlist_key = get_tx_allowlist_storage_key();
+    let tx_allowlist: Vec<&str> = vec![
+        "ec357c39e05677da3d8da359fee6e3a8b9012dd1a7e7def51f4e484132f68c77",
+        "a324288bdc7a7d3cb15ca5ef3ebb04b9121b1d5804478dabd1ef4533459d7069",
+        "6012fff1d191a545d6f7960f1dd9b2df5fcdfc9dbb8dfd22bb1458f3983144b9",
+        "4fe1bb1e76c21eacd5eb84782c51aebd683643eefbd1034e4e13aa7284f508f8",
+        "23eec5e1bad79387e57d052840b86ff061aa3182638f690a642126183788f0e3",
+        "5a31f468d03207a8e566a55072ddad7aad018fc635621564fb1c105b0f089f4d",
+        "9eb40c4b40b5af540f9a32f8bd377a53cd3b5e0c3c799b4381ef6475f333e33d",
+        "2b3cf66f49093f674793fcdba72d45f1d7c0e34556800f597d3d5242d97091e0",
+        "6ff3c2a2ebc65061a9b89abd15fb37851ca77e162b42b7989889bd537e802b09",
+        "31a7199befce4226faad7fe1744895fb6845ee0749016c3a2a0a31b26088aff9",
+        "f0d270cab3357124eb8894c1e7cb0e775056ed613e41d075e23467bcaa36a1f7",
+        "51c4d0149807597c1c7981cf28cb8b078c93843b7ae91a6cd9e6b422f343e9a3",
+        "a07d722db5d3d06b0c65cb0c20811ce2a95105cebe2456a3ea6334eb2438fbab",
+        "f1cdb278dae8b7ab28fd850dcf9746b03aee2b42444ec9e39ae3a0bd46f3e17c",
+        "b48de32b91a58d8e63cd283bd96276f38736822ca8f90bfec2093eefdcdf5148",
+        "83afcbf97c35188991ae2e73db2f48cb8d019c4295fe5323d9c3dfebcd5dbec0",
+        "8293cecc00c63bb4b6216eec912c57c72544f42203ba1ff5a42ae098c9e921e4",
+        "f0e37af0417f5d54f20c81c2cf1b9301bd13ce79695b78c85d11b2ba187fa86d",
+        "0c650c7869da1ac3e734a4367557a499c937962effde4f7e7cc609278000ebd1",
+        "dbb6f005883075ab4133d8bd367af914a899946e7ae532f816be48c77044a512",
+        "bf4716b590b68562ee2c872757a0c370daf1504596d4350fffc0b94a566072ca",
+        "f6330d8c8bc92d9f8ea0f023688873722b65291bc6db9bb11ab3a0836e1be86b",
+        "c4357f5548c43086e56f22ac2e951ee2500368d8ed2479c0d0046b6e59f8a8e5",
+        "b4261ecafcfb0254efb39165311268d99bb5aa85ac47514913317d20f1791790",
+    ];
+    let mut tx_allowlist: Vec<String> = tx_allowlist
+        .into_iter()
+        .map(|hash_str| {
+            Hash::from_str(hash_str).unwrap().to_string().to_lowercase()
+        })
+        .collect();
+    // Replace the targetted old hashes
+    for (old_code_hash, name, code) in wasm_updates {
+        let old_code_hash = Hash::from_str(old_code_hash).unwrap();
+        let new_code_hash = Hash(*Sha256::digest(code).as_ref());
+        let new_code_len = u64::try_from(code.len()).unwrap();
+        let pos = tx_allowlist
+            .iter()
+            .position(|x| Hash::from_str(x).unwrap() == old_code_hash)
+            .expect("old tx code hash not found");
+        tx_allowlist[pos] = new_code_hash.to_string().to_lowercase();
+
+        // Delete the old tx code
+        let old_code_key = Key::wasm_code(&old_code_hash);
+        let old_code_len_key = Key::wasm_code_len(&old_code_hash);
+        updates.push(migrations::DbUpdateType::Delete(
+            old_code_key,
+            DbColFam::SUBSPACE,
+        ));
+        updates.push(migrations::DbUpdateType::Delete(
+            old_code_len_key,
+            DbColFam::SUBSPACE,
+        ));
+
+        // Write the new tx code into storage
+        let code_key = Key::wasm_code(&new_code_hash);
+        let code_len_key = Key::wasm_code_len(&new_code_hash);
+        let hash_key = Key::wasm_hash(name);
+        let code_name_key = Key::wasm_code_name(name.to_owned());
+
+        updates.push(migrations::DbUpdateType::Add {
+            key: code_key,
+            cf: DbColFam::SUBSPACE,
+            value: code.to_vec().into(),
+            force: false,
+        });
+        updates.push(migrations::DbUpdateType::Add {
+            key: code_len_key,
+            cf: DbColFam::SUBSPACE,
+            value: new_code_len.into(),
+            force: false,
+        });
+        updates.push(migrations::DbUpdateType::Add {
+            key: hash_key,
+            cf: DbColFam::SUBSPACE,
+            value: new_code_hash.into(),
+            force: false,
+        });
+        updates.push(migrations::DbUpdateType::Add {
+            key: code_name_key,
+            cf: DbColFam::SUBSPACE,
+            value: new_code_hash.into(),
+            force: false,
+        });
+    }
+    // Put the allow list in storage
+    updates.push(migrations::DbUpdateType::Add {
+        key: tx_allowlist_key,
+        cf: DbColFam::SUBSPACE,
+        value: tx_allowlist.into(),
+        force: false,
+    });
 }
 
 // Generate various migrations
 fn main() {
-    minted_balance_migration();
-    shielded_reward_precision_migration();
-    shielded_reward_reset_migration();
-    conversion_state_migration();
+    // Write an example migration that updates minted balances
+    let mut minted_balance_changes = migrations::DbChanges { changes: vec![] };
+    minted_balance_migration(&mut minted_balance_changes.changes);
+    std::fs::write(
+        "minted_balance_migration.json",
+        serde_json::to_string(&minted_balance_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that updates token precision
+    let mut reward_precision_changes =
+        migrations::DbChanges { changes: vec![] };
+    shielded_reward_precision_migration(&mut reward_precision_changes.changes);
+    std::fs::write(
+        "reward_precision_migration.json",
+        serde_json::to_string(&reward_precision_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that resets shielded rewards
+    let mut reward_reset_changes = migrations::DbChanges { changes: vec![] };
+    shielded_reward_reset_migration(&mut reward_reset_changes.changes);
+    std::fs::write(
+        "reward_reset_migration.json",
+        serde_json::to_string(&reward_reset_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that directly updates conversion state
+    let mut conversion_state_changes =
+        migrations::DbChanges { changes: vec![] };
+    conversion_state_migration(&mut conversion_state_changes.changes);
+    std::fs::write(
+        "conversion_state_migration.json",
+        serde_json::to_string(&conversion_state_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that just updates WASMs
+    let mut wasm_changes = migrations::DbChanges { changes: vec![] };
+    wasm_migration(&mut wasm_changes.changes);
+    std::fs::write(
+        "wasm_migration.json",
+        serde_json::to_string(&wasm_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that updates WASMs and resets shielded rewards
+    let mut pre_phase4_changes = migrations::DbChanges { changes: vec![] };
+    shielded_reward_reset_migration(&mut pre_phase4_changes.changes);
+    wasm_migration(&mut pre_phase4_changes.changes);
+    std::fs::write(
+        "pre_phase4_migration.json",
+        serde_json::to_string(&pre_phase4_changes).unwrap(),
+    )
+    .unwrap();
 }

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -30,12 +30,15 @@ use namada_trans_token::storage_key::{balance_key, minted_balance_key};
 use namada_trans_token::{Amount, Denomination, MaspDigitPos, Store};
 use sha2::{Digest, Sha256};
 
+/// Represents the channel ID of an IBC token
 pub type ChannelId = &'static str;
+/// Represents the base token of an IBC token
 pub type BaseToken = &'static str;
-
+/// The type hash of the conversion state structure in v0.31.9
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
 
+/// The new conversion state structure after the v0.32.0 upgrade
 #[derive(
     Debug, Default, BorshSerialize, BorshDeserialize, BorshDeserializer,
 )]
@@ -60,8 +63,8 @@ impl From<ConversionState> for NewConversionState {
     }
 }
 
-// Demonstrate how to set the minted balance using a migration
-fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+/// Demonstrate how to set the minted balance using a migration
+pub fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     let person =
         Address::decode("tnam1q9rhgyv3ydq0zu3whnftvllqnvhvhm270qxay5tn")
             .unwrap();
@@ -90,9 +93,9 @@ fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     ));
 }
 
-// Demonstrate how to set the shielded reward precision of IBC tokens using a
-// migration
-fn shielded_reward_precision_migration(
+/// Demonstrate how to set the shielded reward precision of IBC tokens using a
+/// migration
+pub fn shielded_reward_precision_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
     const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
@@ -122,8 +125,8 @@ fn shielded_reward_precision_migration(
     }
 }
 
-// A convenience data structure to allow token addresses to be more readably
-// expressed as a channel ID and base token instead of a raw Namada address.
+/// A convenience data structure to allow token addresses to be more readably
+/// expressed as a channel ID and base token instead of a raw Namada address.
 pub enum TokenAddress {
     // Specify an IBC address. This can also be done more directly using the
     // Self::Address variant.
@@ -132,15 +135,16 @@ pub enum TokenAddress {
     Address(Address),
 }
 
-// Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
-// their allowed conversions with conversions that do not contain rewards.
-fn shielded_reward_reset_migration(
+/// Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
+/// their allowed conversions with conversions that do not contain rewards.
+pub fn shielded_reward_reset_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
     // The address of the native token. This is what rewards are denominated in.
-    let native_token =
-        Address::from_str("tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e")
-            .expect("unable to construct native token address");
+    const NATIVE_TOKEN_BECH32M: &str =
+        "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e";
+    let native_token = Address::from_str(NATIVE_TOKEN_BECH32M)
+        .expect("unable to construct native token address");
     // The MASP epoch in which this migration will be applied. This number
     // controls the number of epochs of conversions created.
     const TARGET_MASP_EPOCH: MaspEpoch = MaspEpoch::new(2000);
@@ -262,9 +266,9 @@ fn shielded_reward_reset_migration(
     }
 }
 
-// Demonstrate replacing the entire conversion state with a new state that does
-// not contain rewards.
-fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+/// Demonstrate replacing the entire conversion state with a new state that does
+/// not contain rewards.
+pub fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     // Valid precisions must be in the intersection of i128 and u128
     pub type Precision = u128;
 
@@ -441,8 +445,8 @@ fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
 }
 
-// Demonstrate upgrading the transaction WASM code and hashes in storage
-fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+/// Demonstrate upgrading the transaction WASM code and hashes in storage
+pub fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     // wasm_updates[x].0) The WASM hash that is being replaced
     // wasm_updates[x].1) The name of WASM being updated
     // wasm_updates[x].2) The bytes of the new WASM code
@@ -559,8 +563,8 @@ fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
 }
 
-// Generate various migrations
-fn main() {
+/// Generate various migrations
+pub fn main() {
     // Write an example migration that updates minted balances
     let mut minted_balance_changes = migrations::DbChanges { changes: vec![] };
     minted_balance_migration(&mut minted_balance_changes.changes);

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -22,12 +22,16 @@ use namada_sdk::migrations;
 use namada_sdk::storage::DbColFam;
 use namada_shielded_token::storage_key::{
     masp_assets_hash_key, masp_conversion_key, masp_reward_precision_key,
+    masp_scheduled_base_native_precision_key,
     masp_scheduled_reward_precision_key,
 };
 use namada_shielded_token::{ConversionLeaf, ConversionState, MaspEpoch};
 use namada_trans_token::storage_key::{balance_key, minted_balance_key};
 use namada_trans_token::{Amount, Denomination, MaspDigitPos, Store};
 use sha2::{Digest, Sha256};
+
+pub type ChannelId = &'static str;
+pub type BaseToken = &'static str;
 
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -91,9 +95,6 @@ fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
 fn shielded_reward_precision_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
-    pub type ChannelId = &'static str;
-    pub type BaseToken = &'static str;
-
     const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
         ("channel-1", "uosmo", 1000u128),
         ("channel-2", "uatom", 1000u128),
@@ -121,14 +122,25 @@ fn shielded_reward_precision_migration(
     }
 }
 
+// A convenience data structure to allow token addresses to be more readably
+// expressed as a channel ID and base token instead of a raw Namada address.
+pub enum TokenAddress {
+    // Specify an IBC address. This can also be done more directly using the
+    // Self::Address variant.
+    Ibc(ChannelId, BaseToken),
+    // Directly specify a Namada address
+    Address(Address),
+}
+
 // Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
 // their allowed conversions with conversions that do not contain rewards.
 fn shielded_reward_reset_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
-    pub type ChannelId = &'static str;
-    pub type BaseToken = &'static str;
-
+    // The address of the native token. This is what rewards are denominated in.
+    let native_token =
+        Address::from_str("tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e")
+            .expect("unable to construct native token address");
     // The MASP epoch in which this migration will be applied. This number
     // controls the number of epochs of conversions created.
     const TARGET_MASP_EPOCH: MaspEpoch = MaspEpoch::new(2000);
@@ -136,20 +148,25 @@ fn shielded_reward_reset_migration(
     // tokens, this is 0.
     const DENOMINATION: Denomination = Denomination(0u8);
     // The tokens whose rewarrds will be reset.
-    const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
-        ("channel-1", "uosmo", 1000u128),
-        ("channel-2", "uatom", 1000u128),
-        ("channel-3", "utia", 1000u128),
-        ("channel-0", "stuosmo", 1000u128),
-        ("channel-0", "stuatom", 1000u128),
-        ("channel-0", "stutia", 1000u128),
+    const TOKENS: [(TokenAddress, Precision); 6] = [
+        (TokenAddress::Ibc("channel-1", "uosmo"), 1000u128),
+        (TokenAddress::Ibc("channel-2", "uatom"), 1000u128),
+        (TokenAddress::Ibc("channel-3", "utia"), 1000u128),
+        (TokenAddress::Ibc("channel-0", "stuosmo"), 1000u128),
+        (TokenAddress::Ibc("channel-0", "stuatom"), 1000u128),
+        (TokenAddress::Ibc("channel-0", "stutia"), 1000u128),
     ];
 
     // Reset the allowed conversions for the above tokens
-    for (channel_id, base_token, precision) in IBC_TOKENS {
-        let ibc_denom = format!("transfer/{channel_id}/{base_token}");
-        let token_address = ibc_token(&ibc_denom).clone();
-
+    for (token_address, precision) in TOKENS {
+        // Compute the Namada address
+        let token_address = match token_address {
+            TokenAddress::Ibc(channel_id, base_token) => {
+                let ibc_denom = format!("transfer/{channel_id}/{base_token}");
+                ibc_token(&ibc_denom).clone()
+            }
+            TokenAddress::Address(addr) => addr,
+        };
         // Erase the TOK rewards that have been distributed so far
         let mut asset_types = BTreeMap::new();
         let mut precision_toks = BTreeMap::new();
@@ -201,6 +218,19 @@ fn shielded_reward_reset_migration(
             value: precision.into(),
             force: false,
         });
+        // If the current token is the native token, then also update the base
+        // native precision
+        if token_address == native_token {
+            let shielded_token_base_native_precision_key =
+                masp_scheduled_base_native_precision_key(&TARGET_MASP_EPOCH);
+
+            updates.push(migrations::DbUpdateType::Add {
+                key: shielded_token_base_native_precision_key,
+                cf: DbColFam::SUBSPACE,
+                value: precision.into(),
+                force: false,
+            });
+        }
         // Write the new TOK conversions to memory
         for digit in MaspDigitPos::iter() {
             // -PRECISION TOK[ep, digit] + PRECISION TOK[current_ep, digit]


### PR DESCRIPTION
## Describe your changes
Based on https://github.com/anoma/namada/pull/4540 . Extended the migration code to allow the conversions for arbitrary Namada addresses to be reset. If the token being reset happens to be the native token, then the scheduled base native precision key will also be set. This functionality might be useful if we determine that we need to change the native token's precision in order to actually realize rewards for ordinary end-users.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
