### PR TITLE
Murisi/accelerate epochs

### DIFF
--- a/.changelog/unreleased/testing/4555-accelerate-epochs.md
+++ b/.changelog/unreleased/testing/4555-accelerate-epochs.md
@@ -1,0 +1,2 @@
+- Added an example migration that immediately changes epoch durations.
+  ([\#4555](https://github.com/anoma/namada/pull/4555))

--- a/.changelog/unreleased/testing/4589-set-masp-params-migration.md
+++ b/.changelog/unreleased/testing/4589-set-masp-params-migration.md
@@ -1,0 +1,2 @@
+- Implemented a migration that sets shielded reward parameters.
+  ([\#4589](https://github.com/anoma/namada/pull/4589))

--- a/crates/migrations/src/foreign_types.rs
+++ b/crates/migrations/src/foreign_types.rs
@@ -12,5 +12,6 @@ derive_typehash!(Vec::<u8>);
 derive_typehash!(Vec::<String>);
 derive_typehash!(u64);
 derive_typehash!(u128);
+derive_typehash!(Option::<u32>);
 #[cfg(feature = "masp")]
 derive_typehash!(masp_primitives::convert::AllowedConversion);

--- a/crates/sdk/src/migrations.rs
+++ b/crates/sdk/src/migrations.rs
@@ -26,6 +26,12 @@ const PRINTLN_CUTOFF: usize = 300;
 
 /// For migrations involving the conversion state
 pub const CONVERSION_STATE_KEY: &str = "conversion_state";
+/// Key holding minimum start height for next epoch
+pub const NEXT_EPOCH_MIN_START_HEIGHT_KEY: &str = "next_epoch_min_start_height";
+/// Key holding minimum start time for next epoch
+pub const NEXT_EPOCH_MIN_START_TIME_KEY: &str = "next_epoch_min_start_time";
+/// Key holding number of blocks till next epoch
+pub const UPDATE_EPOCH_BLOCKS_DELAY_KEY: &str = "update_epoch_blocks_delay";
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 enum UpdateBytes {
@@ -319,6 +325,51 @@ impl DbUpdateType {
                         })?;
                     // Make sure to put the conversion state into memory too
                     state.in_mem_mut().conversion_state = conversion_state;
+                } else if DbColFam::STATE == *cf
+                    && NEXT_EPOCH_MIN_START_HEIGHT_KEY == key.to_string()
+                {
+                    let next_epoch_min_start_height = crate::decode(value)
+                        .map_err(|_| {
+                            eyre::eyre!(
+                                "The value provided for the key {} is not a \
+                                 valid BlockHeight",
+                                key,
+                            )
+                        })?;
+                    // Make sure to put the next epoch minimum start height into
+                    // memory too
+                    state.in_mem_mut().next_epoch_min_start_height =
+                        next_epoch_min_start_height;
+                } else if DbColFam::STATE == *cf
+                    && NEXT_EPOCH_MIN_START_TIME_KEY == key.to_string()
+                {
+                    let next_epoch_min_start_time = crate::decode(value)
+                        .map_err(|_| {
+                            eyre::eyre!(
+                                "The value provided for the key {} is not a \
+                                 valid DateTimeUtc",
+                                key,
+                            )
+                        })?;
+                    // Make sure to put the next epoch minimum start time into
+                    // memory too
+                    state.in_mem_mut().next_epoch_min_start_time =
+                        next_epoch_min_start_time;
+                } else if DbColFam::STATE == *cf
+                    && UPDATE_EPOCH_BLOCKS_DELAY_KEY == key.to_string()
+                {
+                    let update_epoch_blocks_delay = crate::decode(value)
+                        .map_err(|_| {
+                            eyre::eyre!(
+                                "The value provided for the key {} is not a \
+                                 valid Option<u32>",
+                                key,
+                            )
+                        })?;
+                    // Make sure to put the update epoch blocks delay into
+                    // memory too
+                    state.in_mem_mut().update_epoch_blocks_delay =
+                        update_epoch_blocks_delay;
                 }
 
                 migrator.write(state.db(), key, cf, value, persist_diffs);

--- a/crates/sdk/src/migrations.rs
+++ b/crates/sdk/src/migrations.rs
@@ -609,6 +609,7 @@ derive_borshdeserializer!(Vec::<String>);
 derive_borshdeserializer!(u64);
 derive_borshdeserializer!(u128);
 derive_borshdeserializer!(namada_core::hash::Hash);
+derive_borshdeserializer!(Option::<u32>);
 derive_borshdeserializer!(masp_primitives::convert::AllowedConversion);
 
 #[derive(BorshSerialize, BorshDeserialize)]

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -59,12 +59,6 @@ pub type KdGain = &'static str;
 /// The type hash of the conversion state structure in v0.31.9
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
-/// Key holding minimum start height for next epoch
-pub const NEXT_EPOCH_MIN_START_HEIGHT_KEY: &str = "next_epoch_min_start_height";
-/// Key holding minimum start time for next epoch
-pub const NEXT_EPOCH_MIN_START_TIME_KEY: &str = "next_epoch_min_start_time";
-/// Key holding number of blocks till next epoch
-pub const UPDATE_EPOCH_BLOCKS_DELAY_KEY: &str = "update_epoch_blocks_delay";
 
 /// The new conversion state structure after the v0.32.0 upgrade
 #[derive(
@@ -785,7 +779,7 @@ pub fn accelerate_epoch_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
     // Set the next epoch's block height to zero in order to force transition
     updates.push(migrations::DbUpdateType::Add {
-        key: NEXT_EPOCH_MIN_START_HEIGHT_KEY
+        key: migrations::NEXT_EPOCH_MIN_START_HEIGHT_KEY
             .parse()
             .expect("unable to construct conversion state key"),
         cf: DbColFam::STATE,
@@ -794,7 +788,7 @@ pub fn accelerate_epoch_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
     // Set the next epoch's start time to a minimum in order to force transition
     updates.push(migrations::DbUpdateType::Add {
-        key: NEXT_EPOCH_MIN_START_TIME_KEY
+        key: migrations::NEXT_EPOCH_MIN_START_TIME_KEY
             .parse()
             .expect("unable to construct conversion state key"),
         cf: DbColFam::STATE,

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -7,13 +7,19 @@ use masp_primitives::ff::PrimeField;
 use masp_primitives::sapling::Node;
 use masp_primitives::transaction::components::I128Sum;
 use namada_core::borsh::BorshSerializeExt;
+use namada_core::chain::BlockHeight;
 use namada_core::dec::Dec;
 use namada_core::hash::Hash;
 use namada_core::masp::{Precision, encode_asset_type};
 use namada_core::storage::Key;
+use namada_core::time::MIN_UTC;
 use namada_macros::BorshDeserializer;
 use namada_migrations::REGISTER_DESERIALIZERS;
-use namada_parameters::storage::get_tx_allowlist_storage_key;
+use namada_parameters::EpochDuration;
+use namada_parameters::storage::{
+    get_epoch_duration_storage_key, get_epochs_per_year_key,
+    get_masp_epoch_multiplier_key, get_tx_allowlist_storage_key,
+};
 use namada_sdk::address::Address;
 use namada_sdk::ibc::trace::ibc_token;
 use namada_sdk::masp_primitives::asset_type::AssetType;
@@ -53,6 +59,12 @@ pub type KdGain = &'static str;
 /// The type hash of the conversion state structure in v0.31.9
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
+/// Key holding minimum start height for next epoch
+pub const NEXT_EPOCH_MIN_START_HEIGHT_KEY: &str = "next_epoch_min_start_height";
+/// Key holding minimum start time for next epoch
+pub const NEXT_EPOCH_MIN_START_TIME_KEY: &str = "next_epoch_min_start_time";
+/// Key holding number of blocks till next epoch
+pub const UPDATE_EPOCH_BLOCKS_DELAY_KEY: &str = "update_epoch_blocks_delay";
 
 /// The new conversion state structure after the v0.32.0 upgrade
 #[derive(
@@ -734,6 +746,63 @@ pub fn shielded_reward_parameters_migration(
     }
 }
 
+/// Demonstrate accelerating epochs
+pub fn accelerate_epoch_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+    // Set the number of epochs per year to the specified constant
+    const EPOCHS_PER_YEAR: u64 = 175200;
+    let epochs_per_year_key = get_epochs_per_year_key();
+    updates.push(migrations::DbUpdateType::Add {
+        key: epochs_per_year_key,
+        cf: DbColFam::SUBSPACE,
+        value: EPOCHS_PER_YEAR.into(),
+        force: false,
+    });
+    // Set the MASP epoch multiplier to the specified constant
+    const MASP_EPOCH_MULTIPLIER: u64 = 2;
+    let masp_epoch_multiplier_key = get_masp_epoch_multiplier_key();
+    updates.push(migrations::DbUpdateType::Add {
+        key: masp_epoch_multiplier_key,
+        cf: DbColFam::SUBSPACE,
+        value: MASP_EPOCH_MULTIPLIER.into(),
+        force: false,
+    });
+    // Set the epoch duration to the specified constant
+    const MIN_NUM_OF_BLOCKS: u64 = 4;
+    let epy_i64 = i64::try_from(EPOCHS_PER_YEAR)
+        .expect("`epochs_per_year` must not exceed `i64::MAX`");
+    #[allow(clippy::arithmetic_side_effects)]
+    let min_duration: i64 = 60 * 60 * 24 * 365 / epy_i64;
+    let epoch_duration = EpochDuration {
+        min_num_of_blocks: MIN_NUM_OF_BLOCKS,
+        min_duration: namada_sdk::time::Duration::seconds(min_duration).into(),
+    };
+    let epoch_duration_key = get_epoch_duration_storage_key();
+    updates.push(migrations::DbUpdateType::Add {
+        key: epoch_duration_key,
+        cf: DbColFam::SUBSPACE,
+        value: epoch_duration.into(),
+        force: false,
+    });
+    // Set the next epoch's block height to zero in order to force transition
+    updates.push(migrations::DbUpdateType::Add {
+        key: NEXT_EPOCH_MIN_START_HEIGHT_KEY
+            .parse()
+            .expect("unable to construct conversion state key"),
+        cf: DbColFam::STATE,
+        value: BlockHeight(0).into(),
+        force: false,
+    });
+    // Set the next epoch's start time to a minimum in order to force transition
+    updates.push(migrations::DbUpdateType::Add {
+        key: NEXT_EPOCH_MIN_START_TIME_KEY
+            .parse()
+            .expect("unable to construct conversion state key"),
+        cf: DbColFam::STATE,
+        value: MIN_UTC.into(),
+        force: false,
+    });
+}
+
 /// Generate various migrations
 pub fn main() {
     // Write an example migration that updates minted balances
@@ -794,6 +863,15 @@ pub fn main() {
     std::fs::write(
         "reward_parameters_migration.json",
         serde_json::to_string(&reward_parameter_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that accelerates epochs
+    let mut accelerate_epochs_changes =
+        migrations::DbChanges { changes: vec![] };
+    accelerate_epoch_migration(&mut accelerate_epochs_changes.changes);
+    std::fs::write(
+        "accelerate_epochs_migration.json",
+        serde_json::to_string(&accelerate_epochs_changes).unwrap(),
     )
     .unwrap();
 }


### PR DESCRIPTION
## Describe your changes
This PR is based on #4589 . It demonstrates how to use migrations to change epoch durations and multipliers, and also force nodes to immediately respect the new values. This PR is useful when conducting tests atop of the state of real chains that probably have longer epochs.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
