### PR TITLE
Changelog: Release libs 0.48.3

### DIFF
--- a/.changelog/libs-v0.48.3/miscellaneous/4561-ci-workflow-fixes.md
+++ b/.changelog/libs-v0.48.3/miscellaneous/4561-ci-workflow-fixes.md
@@ -1,0 +1,2 @@
+- Fix CI release workflow file.
+  ([\#4561](https://github.com/anoma/namada/pull/4561))

--- a/.changelog/libs-v0.48.3/summary.md
+++ b/.changelog/libs-v0.48.3/summary.md
@@ -1,0 +1,1 @@
+Namada libs 0.48.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,15 @@ Namada libs 0.149.0 is a consensus and major breaking release.
 - Demonstrate direct conversion state migrations.
   ([\#4513](https://github.com/anoma/namada/pull/4513))
 
+## libs-v0.48.3
+
+Namada libs 0.48.3
+
+### MISCELLANEOUS
+
+- Fix CI release workflow file.
+  ([\#4561](https://github.com/anoma/namada/pull/4561))
+
 ## libs-v0.48.2
 
 Namada libs 0.48.2


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
