### PR TITLE
Test masp events

### DIFF
--- a/.changelog/unreleased/testing/4566-test-masp-events.md
+++ b/.changelog/unreleased/testing/4566-test-masp-events.md
@@ -1,0 +1,2 @@
+- Added integration tests to cover the new MASP events and masp fee payments in
+  a failing atomic batch. ([\#4566](https://github.com/anoma/namada/pull/4566))

--- a/crates/node/src/shell/testing/node.rs
+++ b/crates/node/src/shell/testing/node.rs
@@ -530,16 +530,16 @@ impl MockNode {
         let mut result_codes = resp
             .events
             .iter()
-            .map(|e| {
-                let code = e
-                    .read_attribute_opt::<CodeAttr>()
+            .filter_map(|e| {
+                e.read_attribute_opt::<CodeAttr>()
                     .unwrap()
-                    .unwrap_or_default();
-                if code == ResultCode::Ok {
-                    NodeResults::Ok
-                } else {
-                    NodeResults::Failed(code)
-                }
+                    .map(|result_code| {
+                        if result_code == ResultCode::Ok {
+                            NodeResults::Ok
+                        } else {
+                            NodeResults::Failed(result_code)
+                        }
+                    })
             })
             .collect::<Vec<_>>();
         let mut tx_results = resp
@@ -675,16 +675,16 @@ impl MockNode {
         let mut error_codes = resp
             .events
             .iter()
-            .map(|e| {
-                let code = e
-                    .read_attribute_opt::<CodeAttr>()
+            .filter_map(|e| {
+                e.read_attribute_opt::<CodeAttr>()
                     .unwrap()
-                    .unwrap_or_default();
-                if code == ResultCode::Ok {
-                    NodeResults::Ok
-                } else {
-                    NodeResults::Failed(code)
-                }
+                    .map(|result_code| {
+                        if result_code == ResultCode::Ok {
+                            NodeResults::Ok
+                        } else {
+                            NodeResults::Failed(result_code)
+                        }
+                    })
             })
             .collect::<Vec<_>>();
         let mut txs_results = resp


### PR DESCRIPTION
## Describe your changes

Adds an integration test to check the new masp events: it verifies that the protocol emits these events correctly and that the client can reconstruct the correct shielded state (specifically, the correct order in which the output notes were committed).

Adds an integration test to verify that even in a failing atomic batch the masp fee paying transaction is guaranteed to be committed.

Fixes a minor bug in the integration tests for which arbitrary events were casted to `tx/applied` events.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
