### PR TITLE
fix core release by symlinking CONSENSUS_VERSION

### DIFF
--- a/crates/core/CONSENSUS_VERSION
+++ b/crates/core/CONSENSUS_VERSION
@@ -1,0 +1,1 @@
+../../CONSENSUS_VERSION

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -7,9 +7,8 @@ use std::str::FromStr;
 fn main() {
     println!("cargo:rerun-if-changed=CONSENSUS_VERSION");
     let out_dir = env::var("OUT_DIR").unwrap();
-    let raw_consensus_version =
-        std::fs::read_to_string("../../CONSENSUS_VERSION")
-            .expect("Read CONSENSUS_VERSION file");
+    let raw_consensus_version = std::fs::read_to_string("./CONSENSUS_VERSION")
+        .expect("Read CONSENSUS_VERSION file");
     let consensus_version = u64::from_str(raw_consensus_version.trim())
         .expect("CONSENSUS_VERSION contains a u64");
     let mut consensus_version_rs =


### PR DESCRIPTION
## Describe your changes

Adds symlink to `CONSENSUS_VERSION` from workspace root to `crates/core`. This change is needed for publishing `namada_core` to crates.io (I published libs-v0.149.1 using this patch)

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
