### PR TITLE
test/e2e: hw-wallet-automation improvements

### DIFF
--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -52,8 +52,9 @@ use crate::e2e::helpers::{
 };
 use crate::e2e::setup::{
     self, Bin, Who, allow_duplicate_ips, apply_use_device, default_port_offset,
-    sleep, speculos_app_elf, speculos_path,
+    sleep,
 };
+use crate::hw_wallet_automation::Speculos;
 use crate::strings::{
     LEDGER_SHUTDOWN, LEDGER_STARTED, NON_VALIDATOR_NODE, TX_APPLIED_SUCCESS,
     TX_REJECTED, VALIDATOR_NODE,
@@ -582,8 +583,7 @@ fn pos_bonds() -> Result<()> {
     );
 
     // If used, keep Speculos alive for duration of the test
-    let mut speculos: Option<std::process::Child> = None;
-    if hw_wallet_automation::uses_automation() {
+    let _speculos = if hw_wallet_automation::uses_automation() {
         // Gen automation for Speculos
         let automation = hw_wallet_automation::gen_automation_e2e_pos_bonds();
         let json = serde_json::to_vec_pretty(&automation).unwrap();
@@ -591,23 +591,10 @@ fn pos_bonds() -> Result<()> {
         std::fs::write(&path, json).unwrap();
 
         // Start Speculos with the automation
-        speculos = Some(
-            Command::new(speculos_path())
-                .args([
-                    &speculos_app_elf(),
-                    "--seed",
-                    hw_wallet_automation::SEED,
-                    "--automation",
-                    &format!("file:{}", path.to_string_lossy()),
-                    "--log-level",
-                    "automation:DEBUG",
-                    "--display",
-                    "headless",
-                ])
-                .spawn()
-                .unwrap(),
-        );
-    }
+        Some(Speculos::spawn(&path))
+    } else {
+        None
+    };
 
     // 1. Run the ledger node
     let _bg_validator_0 =
@@ -808,10 +795,6 @@ fn pos_bonds() -> Result<()> {
     let mut client = run!(test, Bin::Client, tx_args, Some(40))?;
     client.exp_string(TX_APPLIED_SUCCESS)?;
     client.assert_success();
-
-    if let Some(mut process) = speculos {
-        process.kill().unwrap()
-    }
 
     Ok(())
 }
@@ -2507,8 +2490,7 @@ fn masp_txs_and_queries() -> Result<()> {
     )?;
 
     // If used, keep Speculos alive for duration of the test
-    let mut speculos: Option<std::process::Child> = None;
-    if hw_wallet_automation::uses_automation() {
+    let _speculos = if hw_wallet_automation::uses_automation() {
         // Gen automation for Speculos
         let automation =
             hw_wallet_automation::gen_automation_e2e_masp_tx_and_queries();
@@ -2517,25 +2499,10 @@ fn masp_txs_and_queries() -> Result<()> {
         std::fs::write(&path, json).unwrap();
 
         // Start Speculos with the automation
-        speculos = Some(
-            Command::new(speculos_path())
-                .args([
-                    &speculos_app_elf(),
-                    "--seed",
-                    hw_wallet_automation::SEED,
-                    "--automation",
-                    &format!("file:{}", path.to_string_lossy()),
-                    "--log-level",
-                    "automation:DEBUG",
-                    "--display",
-                    "headless",
-                    "--api-port",
-                    "0" // Disables REST API
-                ])
-                .spawn()
-                .unwrap(),
-        );
-    }
+        Some(Speculos::spawn(&path))
+    } else {
+        None
+    };
 
     // Run all cmds on the first validator
     let who = Who::Validator(0);
@@ -2661,10 +2628,6 @@ fn masp_txs_and_queries() -> Result<()> {
 
             client.exp_string(tx_result)?;
         }
-    }
-
-    if let Some(mut process) = speculos {
-        process.kill().unwrap()
     }
 
     Ok(())

--- a/crates/tests/src/e2e/ledger_tests.rs
+++ b/crates/tests/src/e2e/ledger_tests.rs
@@ -2529,6 +2529,8 @@ fn masp_txs_and_queries() -> Result<()> {
                     "automation:DEBUG",
                     "--display",
                     "headless",
+                    "--api-port",
+                    "0" // Disables REST API
                 ])
                 .spawn()
                 .unwrap(),

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -9,6 +9,7 @@ mod vm_host_env;
 pub use vm_host_env::{tx, vp};
 #[cfg(test)]
 mod e2e;
+#[cfg(test)]
 pub mod hw_wallet_automation;
 #[cfg(test)]
 mod integration;


### PR DESCRIPTION
## Describe your changes

Trying to see if it has any effect on the flakey test failures:
 - disabled unused speculos REST API
 - added a speculos cmd wrapper with process clean-up on drop

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
