### PR TITLE
Unique public keys for signing

### DIFF
--- a/.changelog/unreleased/SDK/4579-map-signing-tx-data.md
+++ b/.changelog/unreleased/SDK/4579-map-signing-tx-data.md
@@ -1,0 +1,2 @@
+- The public keys for signing are now enforced to be unique.
+  ([\#4579](https://github.com/anoma/namada/pull/4579))

--- a/crates/apps_lib/src/config/genesis/transactions.rs
+++ b/crates/apps_lib/src/config/genesis/transactions.rs
@@ -57,7 +57,7 @@ pub trait TxToSign {
     fn get_pks(
         &self,
         accounts: &[EstablishedAccountTx],
-    ) -> (Vec<common::PublicKey>, u8);
+    ) -> (HashSet<common::PublicKey>, u8);
 
     fn get_owner(&self) -> GenesisAddress;
 }
@@ -658,7 +658,7 @@ impl TxToSign for ValidatorAccountTx<SignedPk> {
     fn get_pks(
         &self,
         established_accounts: &[EstablishedAccountTx],
-    ) -> (Vec<PublicKey>, u8) {
+    ) -> (HashSet<PublicKey>, u8) {
         established_accounts
             .iter()
             .find_map(|account| {
@@ -668,7 +668,7 @@ impl TxToSign for ValidatorAccountTx<SignedPk> {
                             .public_keys
                             .iter()
                             .map(|pk| pk.raw.clone())
-                            .collect::<Vec<_>>(),
+                            .collect::<HashSet<_>>(),
                         account.threshold,
                     ))
                 } else {
@@ -924,9 +924,9 @@ where
     fn get_pks(
         &self,
         established_accounts: &[EstablishedAccountTx],
-    ) -> (Vec<PublicKey>, u8) {
+    ) -> (HashSet<PublicKey>, u8) {
         match &self.source {
-            GenesisAddress::PublicKey(pk) => (vec![pk.raw.clone()], 1),
+            GenesisAddress::PublicKey(pk) => ([pk.raw.clone()].into(), 1),
             GenesisAddress::EstablishedAddress(owner) => established_accounts
                 .iter()
                 .find_map(|account| {
@@ -936,7 +936,7 @@ where
                                 .public_keys
                                 .iter()
                                 .map(|pk| pk.raw.clone())
-                                .collect::<Vec<_>>(),
+                                .collect::<HashSet<_>>(),
                             account.threshold,
                         ))
                     } else {

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -66,7 +66,7 @@ use crate::wallet::{Wallet, WalletIo};
 use crate::{Namada, args, rpc};
 
 /// A structure holding the signing data to craft a transaction
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct SigningTxData {
     /// The address owning the transaction
     pub owner: Option<Address>,
@@ -80,35 +80,6 @@ pub struct SigningTxData {
     pub fee_payer: common::PublicKey,
     /// ID of the Transaction needing signing
     pub shielded_hash: Option<MaspTxId>,
-}
-
-impl PartialEq for SigningTxData {
-    fn eq(&self, other: &Self) -> bool {
-        // Deconstruct the two instances to ensure we don't forget any new field
-        let SigningTxData {
-            owner,
-            public_keys,
-            threshold,
-            account_public_keys_map,
-            fee_payer,
-            shielded_hash,
-        } = self;
-        let SigningTxData {
-            owner: other_owner,
-            public_keys: other_public_keys,
-            threshold: other_threshold,
-            account_public_keys_map: other_account_public_keys_map,
-            fee_payer: other_fee_payer,
-            shielded_hash: other_shielded_hash,
-        } = other;
-
-        owner == other_owner
-            && threshold == other_threshold
-            && account_public_keys_map == other_account_public_keys_map
-            && fee_payer == other_fee_payer
-            && shielded_hash == other_shielded_hash
-            && public_keys == other_public_keys
-    }
 }
 
 /// Find the public key for the given address and try to load the keypair

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -6609,7 +6609,7 @@ fn identical_output_descriptions() -> Result<()> {
 
     let signing_data = SigningTxData {
         owner: None,
-        public_keys: vec![adam_key.to_public()],
+        public_keys: [adam_key.to_public()].into(),
         threshold: 1,
         account_public_keys_map: None,
         fee_payer: adam_key.to_public(),
@@ -6913,7 +6913,7 @@ fn masp_batch() -> Result<()> {
 
     let signing_data = SigningTxData {
         owner: None,
-        public_keys: vec![adam_key.to_public()],
+        public_keys: [adam_key.to_public()].into(),
         threshold: 1,
         account_public_keys_map: None,
         fee_payer: adam_key.to_public(),
@@ -7168,7 +7168,7 @@ fn masp_atomic_batch() -> Result<()> {
 
     let signing_data = SigningTxData {
         owner: None,
-        public_keys: vec![adam_key.to_public()],
+        public_keys: [adam_key.to_public()].into(),
         threshold: 1,
         account_public_keys_map: None,
         fee_payer: adam_key.to_public(),
@@ -7511,7 +7511,7 @@ fn masp_failing_atomic_batch() -> Result<()> {
 
     let signing_data = SigningTxData {
         owner: None,
-        public_keys: vec![adam_key.to_public()],
+        public_keys: [adam_key.to_public()].into(),
         threshold: 1,
         account_public_keys_map: None,
         fee_payer: adam_key.to_public(),
@@ -8414,7 +8414,7 @@ fn masp_events() -> Result<()> {
 
     let signing_data = SigningTxData {
         owner: None,
-        public_keys: vec![cooper_pk.clone()],
+        public_keys: [cooper_pk.clone()].into(),
         threshold: 1,
         account_public_keys_map: None,
         fee_payer: cooper_pk.clone(),


### PR DESCRIPTION
## Describe your changes

Closes #4238.

Makes the `public_keys` field of `SigningTxData` a map instead of a vector to ensure uniqueness and simplify some of the logic.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
