### PR TITLE
Change ABI to C-unwind in vm_env when running natively

### DIFF
--- a/.changelog/unreleased/bug-fixes/4580-fix-vm-env-tests.md
+++ b/.changelog/unreleased/bug-fixes/4580-fix-vm-env-tests.md
@@ -1,0 +1,2 @@
+- Change ABI to `C-unwind` in `vm_env` when running natively.
+  ([\#4580](https://github.com/anoma/namada/pull/4580))

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -67,7 +67,7 @@ namada_sdk = { path = "../sdk", default-features = false, features = [
   "testing",
   "migrations",
 ] }
-namada_vm_env.path = "../vm_env"
+namada_vm_env = { path = "../vm_env", features = ["c_unwind"] }
 
 assert_cmd.workspace = true
 assert_matches.workspace = true

--- a/crates/vm_env/Cargo.toml
+++ b/crates/vm_env/Cargo.toml
@@ -15,6 +15,7 @@ rust-version.workspace = true
 
 [features]
 default = []
+c_unwind = []
 
 [dependencies]
 namada_core.workspace = true


### PR DESCRIPTION
## Describe your changes

Change ABI to `C-unwind` in `vm_env` when running natively. This fixes tests aborting, instead of unwinding the stack.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
