### PR TITLE
Murisi/mainnet native token migration

### DIFF
--- a/.changelog/unreleased/improvements/4543-native-token-migrations.md
+++ b/.changelog/unreleased/improvements/4543-native-token-migrations.md
@@ -1,0 +1,2 @@
+- Extended migration to allow the rewards for the native token and other Namada
+  addresses to be reset. ([\#4543](https://github.com/anoma/namada/pull/4543))

--- a/.changelog/unreleased/testing/4540-migrate-wasms.md
+++ b/.changelog/unreleased/testing/4540-migrate-wasms.md
@@ -1,0 +1,2 @@
+- Implemented an example hard-fork migration for transaction WASM code.
+  ([\#4540](https://github.com/anoma/namada/pull/4540))

--- a/.changelog/unreleased/testing/4555-accelerate-epochs.md
+++ b/.changelog/unreleased/testing/4555-accelerate-epochs.md
@@ -1,0 +1,2 @@
+- Added an example migration that immediately changes epoch durations.
+  ([\#4555](https://github.com/anoma/namada/pull/4555))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5760,6 +5760,7 @@ dependencies = [
  "namada_trans_token",
  "proptest",
  "serde_json",
+ "sha2 0.10.8",
  "tokio",
 ]
 

--- a/crates/migrations/src/foreign_types.rs
+++ b/crates/migrations/src/foreign_types.rs
@@ -12,5 +12,6 @@ derive_typehash!(Vec::<u8>);
 derive_typehash!(Vec::<String>);
 derive_typehash!(u64);
 derive_typehash!(u128);
+derive_typehash!(Option::<u32>);
 #[cfg(feature = "masp")]
 derive_typehash!(masp_primitives::convert::AllowedConversion);

--- a/crates/sdk/src/migrations.rs
+++ b/crates/sdk/src/migrations.rs
@@ -26,6 +26,12 @@ const PRINTLN_CUTOFF: usize = 300;
 
 /// For migrations involving the conversion state
 pub const CONVERSION_STATE_KEY: &str = "conversion_state";
+/// Key holding minimum start height for next epoch
+pub const NEXT_EPOCH_MIN_START_HEIGHT_KEY: &str = "next_epoch_min_start_height";
+/// Key holding minimum start time for next epoch
+pub const NEXT_EPOCH_MIN_START_TIME_KEY: &str = "next_epoch_min_start_time";
+/// Key holding number of blocks till next epoch
+pub const UPDATE_EPOCH_BLOCKS_DELAY_KEY: &str = "update_epoch_blocks_delay";
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 enum UpdateBytes {
@@ -319,6 +325,51 @@ impl DbUpdateType {
                         })?;
                     // Make sure to put the conversion state into memory too
                     state.in_mem_mut().conversion_state = conversion_state;
+                } else if DbColFam::STATE == *cf
+                    && NEXT_EPOCH_MIN_START_HEIGHT_KEY == key.to_string()
+                {
+                    let next_epoch_min_start_height = crate::decode(value)
+                        .map_err(|_| {
+                            eyre::eyre!(
+                                "The value provided for the key {} is not a \
+                                 valid BlockHeight",
+                                key,
+                            )
+                        })?;
+                    // Make sure to put the next epoch minimum start height into
+                    // memory too
+                    state.in_mem_mut().next_epoch_min_start_height =
+                        next_epoch_min_start_height;
+                } else if DbColFam::STATE == *cf
+                    && NEXT_EPOCH_MIN_START_TIME_KEY == key.to_string()
+                {
+                    let next_epoch_min_start_time = crate::decode(value)
+                        .map_err(|_| {
+                            eyre::eyre!(
+                                "The value provided for the key {} is not a \
+                                 valid DateTimeUtc",
+                                key,
+                            )
+                        })?;
+                    // Make sure to put the next epoch minimum start time into
+                    // memory too
+                    state.in_mem_mut().next_epoch_min_start_time =
+                        next_epoch_min_start_time;
+                } else if DbColFam::STATE == *cf
+                    && UPDATE_EPOCH_BLOCKS_DELAY_KEY == key.to_string()
+                {
+                    let update_epoch_blocks_delay = crate::decode(value)
+                        .map_err(|_| {
+                            eyre::eyre!(
+                                "The value provided for the key {} is not a \
+                                 valid Option<u32>",
+                                key,
+                            )
+                        })?;
+                    // Make sure to put the update epoch blocks delay into
+                    // memory too
+                    state.in_mem_mut().update_epoch_blocks_delay =
+                        update_epoch_blocks_delay;
                 }
 
                 migrator.write(state.db(), key, cf, value, persist_diffs);

--- a/crates/sdk/src/migrations.rs
+++ b/crates/sdk/src/migrations.rs
@@ -609,6 +609,7 @@ derive_borshdeserializer!(Vec::<String>);
 derive_borshdeserializer!(u64);
 derive_borshdeserializer!(u128);
 derive_borshdeserializer!(namada_core::hash::Hash);
+derive_borshdeserializer!(Option::<u32>);
 derive_borshdeserializer!(masp_primitives::convert::AllowedConversion);
 
 #[derive(BorshSerialize, BorshDeserialize)]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,4 +53,5 @@ data-encoding.workspace = true
 linkme.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tokio = { workspace = true, default-features = false }

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -9,8 +9,10 @@ use masp_primitives::transaction::components::I128Sum;
 use namada_core::borsh::BorshSerializeExt;
 use namada_core::hash::Hash;
 use namada_core::masp::{Precision, encode_asset_type};
+use namada_core::storage::Key;
 use namada_macros::BorshDeserializer;
 use namada_migrations::REGISTER_DESERIALIZERS;
+use namada_parameters::storage::get_tx_allowlist_storage_key;
 use namada_sdk::address::Address;
 use namada_sdk::ibc::trace::ibc_token;
 use namada_sdk::masp_primitives::asset_type::AssetType;
@@ -25,6 +27,7 @@ use namada_shielded_token::storage_key::{
 use namada_shielded_token::{ConversionLeaf, ConversionState, MaspEpoch};
 use namada_trans_token::storage_key::{balance_key, minted_balance_key};
 use namada_trans_token::{Amount, Denomination, MaspDigitPos, Store};
+use sha2::{Digest, Sha256};
 
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -54,7 +57,7 @@ impl From<ConversionState> for NewConversionState {
 }
 
 // Demonstrate how to set the minted balance using a migration
-fn minted_balance_migration() {
+fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     let person =
         Address::decode("tnam1q9rhgyv3ydq0zu3whnftvllqnvhvhm270qxay5tn")
             .unwrap();
@@ -65,34 +68,29 @@ fn minted_balance_migration() {
     let minted_key = minted_balance_key(&nam);
     let minted_value = Amount::from(117600000504441u64);
 
-    let updates = [
-        migrations::DbUpdateType::Add {
-            key: balance_key(&nam, &person),
-            cf: DbColFam::SUBSPACE,
-            value: amount.into(),
-            force: false,
-        },
-        migrations::DbUpdateType::Add {
-            key: minted_key,
-            cf: DbColFam::SUBSPACE,
-            value: minted_value.into(),
-            force: false,
-        },
-        migrations::DbUpdateType::RepeatDelete(apfel, DbColFam::SUBSPACE),
-    ];
-    let changes = migrations::DbChanges {
-        changes: updates.into_iter().collect(),
-    };
-    std::fs::write(
-        "minted_balance_migration.json",
-        serde_json::to_string(&changes).unwrap(),
-    )
-    .unwrap();
+    updates.push(migrations::DbUpdateType::Add {
+        key: balance_key(&nam, &person),
+        cf: DbColFam::SUBSPACE,
+        value: amount.into(),
+        force: false,
+    });
+    updates.push(migrations::DbUpdateType::Add {
+        key: minted_key,
+        cf: DbColFam::SUBSPACE,
+        value: minted_value.into(),
+        force: false,
+    });
+    updates.push(migrations::DbUpdateType::RepeatDelete(
+        apfel,
+        DbColFam::SUBSPACE,
+    ));
 }
 
 // Demonstrate how to set the shielded reward precision of IBC tokens using a
 // migration
-fn shielded_reward_precision_migration() {
+fn shielded_reward_precision_migration(
+    updates: &mut Vec<migrations::DbUpdateType>,
+) {
     pub type ChannelId = &'static str;
     pub type BaseToken = &'static str;
 
@@ -105,7 +103,6 @@ fn shielded_reward_precision_migration() {
         ("channel-0", "stutia", 1000u128),
     ];
 
-    let mut updates = Vec::new();
     // Set IBC token shielded reward precisions
     for (channel_id, base_token, precision) in IBC_TOKENS {
         let ibc_denom = format!("transfer/{channel_id}/{base_token}");
@@ -122,20 +119,13 @@ fn shielded_reward_precision_migration() {
             force: false,
         });
     }
-
-    let changes = migrations::DbChanges {
-        changes: updates.into_iter().collect(),
-    };
-    std::fs::write(
-        "shielded_reward_precision_migration.json",
-        serde_json::to_string(&changes).unwrap(),
-    )
-    .unwrap();
 }
 
 // Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
 // their allowed conversions with conversions that do not contain rewards.
-fn shielded_reward_reset_migration() {
+fn shielded_reward_reset_migration(
+    updates: &mut Vec<migrations::DbUpdateType>,
+) {
     pub type ChannelId = &'static str;
     pub type BaseToken = &'static str;
 
@@ -155,7 +145,6 @@ fn shielded_reward_reset_migration() {
         ("channel-0", "stutia", 1000u128),
     ];
 
-    let mut updates = Vec::new();
     // Reset the allowed conversions for the above tokens
     for (channel_id, base_token, precision) in IBC_TOKENS {
         let ibc_denom = format!("transfer/{channel_id}/{base_token}");
@@ -241,20 +230,11 @@ fn shielded_reward_reset_migration() {
             }
         }
     }
-
-    let changes = migrations::DbChanges {
-        changes: updates.into_iter().collect(),
-    };
-    std::fs::write(
-        "shielded_reward_reset_migration.json",
-        serde_json::to_string(&changes).unwrap(),
-    )
-    .unwrap();
 }
 
 // Demonstrate replacing the entire conversion state with a new state that does
 // not contain rewards.
-fn conversion_state_migration() {
+fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     // Valid precisions must be in the intersection of i128 and u128
     pub type Precision = u128;
 
@@ -309,7 +289,6 @@ fn conversion_state_migration() {
         ),
     ];
 
-    let mut updates = Vec::new();
     let mut assets = BTreeMap::new();
     let mut conv_notes = Vec::new();
     // Reset the allowed conversions for the above tokens
@@ -430,21 +409,177 @@ fn conversion_state_migration() {
         value: assets_hash.into(),
         force: false,
     });
+}
 
-    let changes = migrations::DbChanges {
-        changes: updates.into_iter().collect(),
-    };
-    std::fs::write(
-        "conversion_state_migration.json",
-        serde_json::to_string(&changes).unwrap(),
-    )
-    .unwrap();
+// Demonstrate upgrading the transaction WASM code and hashes in storage
+fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+    // wasm_updates[x].0) The WASM hash that is being replaced
+    // wasm_updates[x].1) The name of WASM being updated
+    // wasm_updates[x].2) The bytes of the new WASM code
+    let wasm_updates: Vec<(&str, &str, &[u8])> =
+        vec![
+        (
+            "83afcbf97c35188991ae2e73db2f48cb8d019c4295fe5323d9c3dfebcd5dbec0",
+            "tx_transfer.wasm",
+            //include_bytes!("tx_transfer.5c7e44e61c00df351fa7c497cd2e186d71909f1a18db0c8d362dff36057e0fbf.wasm"),
+            &[0xDE, 0xAD, 0xBE, 0xEF],
+        ),
+        (
+            "6ff3c2a2ebc65061a9b89abd15fb37851ca77e162b42b7989889bd537e802b09",
+            "tx_ibc.wasm",
+            //include_bytes!("tx_ibc.ae9b900edd6437461addd1fe1c723c4b1a8ac8d2fce30e1e4c417ef34f299f73.wasm"),
+            &[0xDE, 0xAD, 0xBE, 0xEF],
+        ),
+    ];
+
+    // Update the tx allowlist parameter
+    let tx_allowlist_key = get_tx_allowlist_storage_key();
+    let tx_allowlist: Vec<&str> = vec![
+        "ec357c39e05677da3d8da359fee6e3a8b9012dd1a7e7def51f4e484132f68c77",
+        "a324288bdc7a7d3cb15ca5ef3ebb04b9121b1d5804478dabd1ef4533459d7069",
+        "6012fff1d191a545d6f7960f1dd9b2df5fcdfc9dbb8dfd22bb1458f3983144b9",
+        "4fe1bb1e76c21eacd5eb84782c51aebd683643eefbd1034e4e13aa7284f508f8",
+        "23eec5e1bad79387e57d052840b86ff061aa3182638f690a642126183788f0e3",
+        "5a31f468d03207a8e566a55072ddad7aad018fc635621564fb1c105b0f089f4d",
+        "9eb40c4b40b5af540f9a32f8bd377a53cd3b5e0c3c799b4381ef6475f333e33d",
+        "2b3cf66f49093f674793fcdba72d45f1d7c0e34556800f597d3d5242d97091e0",
+        "6ff3c2a2ebc65061a9b89abd15fb37851ca77e162b42b7989889bd537e802b09",
+        "31a7199befce4226faad7fe1744895fb6845ee0749016c3a2a0a31b26088aff9",
+        "f0d270cab3357124eb8894c1e7cb0e775056ed613e41d075e23467bcaa36a1f7",
+        "51c4d0149807597c1c7981cf28cb8b078c93843b7ae91a6cd9e6b422f343e9a3",
+        "a07d722db5d3d06b0c65cb0c20811ce2a95105cebe2456a3ea6334eb2438fbab",
+        "f1cdb278dae8b7ab28fd850dcf9746b03aee2b42444ec9e39ae3a0bd46f3e17c",
+        "b48de32b91a58d8e63cd283bd96276f38736822ca8f90bfec2093eefdcdf5148",
+        "83afcbf97c35188991ae2e73db2f48cb8d019c4295fe5323d9c3dfebcd5dbec0",
+        "8293cecc00c63bb4b6216eec912c57c72544f42203ba1ff5a42ae098c9e921e4",
+        "f0e37af0417f5d54f20c81c2cf1b9301bd13ce79695b78c85d11b2ba187fa86d",
+        "0c650c7869da1ac3e734a4367557a499c937962effde4f7e7cc609278000ebd1",
+        "dbb6f005883075ab4133d8bd367af914a899946e7ae532f816be48c77044a512",
+        "bf4716b590b68562ee2c872757a0c370daf1504596d4350fffc0b94a566072ca",
+        "f6330d8c8bc92d9f8ea0f023688873722b65291bc6db9bb11ab3a0836e1be86b",
+        "c4357f5548c43086e56f22ac2e951ee2500368d8ed2479c0d0046b6e59f8a8e5",
+        "b4261ecafcfb0254efb39165311268d99bb5aa85ac47514913317d20f1791790",
+    ];
+    let mut tx_allowlist: Vec<String> = tx_allowlist
+        .into_iter()
+        .map(|hash_str| {
+            Hash::from_str(hash_str).unwrap().to_string().to_lowercase()
+        })
+        .collect();
+    // Replace the targetted old hashes
+    for (old_code_hash, name, code) in wasm_updates {
+        let old_code_hash = Hash::from_str(old_code_hash).unwrap();
+        let new_code_hash = Hash(*Sha256::digest(code).as_ref());
+        let new_code_len = u64::try_from(code.len()).unwrap();
+        let pos = tx_allowlist
+            .iter()
+            .position(|x| Hash::from_str(x).unwrap() == old_code_hash)
+            .expect("old tx code hash not found");
+        tx_allowlist[pos] = new_code_hash.to_string().to_lowercase();
+
+        // Delete the old tx code
+        let old_code_key = Key::wasm_code(&old_code_hash);
+        let old_code_len_key = Key::wasm_code_len(&old_code_hash);
+        updates.push(migrations::DbUpdateType::Delete(
+            old_code_key,
+            DbColFam::SUBSPACE,
+        ));
+        updates.push(migrations::DbUpdateType::Delete(
+            old_code_len_key,
+            DbColFam::SUBSPACE,
+        ));
+
+        // Write the new tx code into storage
+        let code_key = Key::wasm_code(&new_code_hash);
+        let code_len_key = Key::wasm_code_len(&new_code_hash);
+        let hash_key = Key::wasm_hash(name);
+        let code_name_key = Key::wasm_code_name(name.to_owned());
+
+        updates.push(migrations::DbUpdateType::Add {
+            key: code_key,
+            cf: DbColFam::SUBSPACE,
+            value: code.to_vec().into(),
+            force: false,
+        });
+        updates.push(migrations::DbUpdateType::Add {
+            key: code_len_key,
+            cf: DbColFam::SUBSPACE,
+            value: new_code_len.into(),
+            force: false,
+        });
+        updates.push(migrations::DbUpdateType::Add {
+            key: hash_key,
+            cf: DbColFam::SUBSPACE,
+            value: new_code_hash.into(),
+            force: false,
+        });
+        updates.push(migrations::DbUpdateType::Add {
+            key: code_name_key,
+            cf: DbColFam::SUBSPACE,
+            value: new_code_hash.into(),
+            force: false,
+        });
+    }
+    // Put the allow list in storage
+    updates.push(migrations::DbUpdateType::Add {
+        key: tx_allowlist_key,
+        cf: DbColFam::SUBSPACE,
+        value: tx_allowlist.into(),
+        force: false,
+    });
 }
 
 // Generate various migrations
 fn main() {
-    minted_balance_migration();
-    shielded_reward_precision_migration();
-    shielded_reward_reset_migration();
-    conversion_state_migration();
+    // Write an example migration that updates minted balances
+    let mut minted_balance_changes = migrations::DbChanges { changes: vec![] };
+    minted_balance_migration(&mut minted_balance_changes.changes);
+    std::fs::write(
+        "minted_balance_migration.json",
+        serde_json::to_string(&minted_balance_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that updates token precision
+    let mut reward_precision_changes =
+        migrations::DbChanges { changes: vec![] };
+    shielded_reward_precision_migration(&mut reward_precision_changes.changes);
+    std::fs::write(
+        "reward_precision_migration.json",
+        serde_json::to_string(&reward_precision_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that resets shielded rewards
+    let mut reward_reset_changes = migrations::DbChanges { changes: vec![] };
+    shielded_reward_reset_migration(&mut reward_reset_changes.changes);
+    std::fs::write(
+        "reward_reset_migration.json",
+        serde_json::to_string(&reward_reset_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that directly updates conversion state
+    let mut conversion_state_changes =
+        migrations::DbChanges { changes: vec![] };
+    conversion_state_migration(&mut conversion_state_changes.changes);
+    std::fs::write(
+        "conversion_state_migration.json",
+        serde_json::to_string(&conversion_state_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that just updates WASMs
+    let mut wasm_changes = migrations::DbChanges { changes: vec![] };
+    wasm_migration(&mut wasm_changes.changes);
+    std::fs::write(
+        "wasm_migration.json",
+        serde_json::to_string(&wasm_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that updates WASMs and resets shielded rewards
+    let mut pre_phase4_changes = migrations::DbChanges { changes: vec![] };
+    shielded_reward_reset_migration(&mut pre_phase4_changes.changes);
+    wasm_migration(&mut pre_phase4_changes.changes);
+    std::fs::write(
+        "pre_phase4_migration.json",
+        serde_json::to_string(&pre_phase4_changes).unwrap(),
+    )
+    .unwrap();
 }

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -30,12 +30,15 @@ use namada_trans_token::storage_key::{balance_key, minted_balance_key};
 use namada_trans_token::{Amount, Denomination, MaspDigitPos, Store};
 use sha2::{Digest, Sha256};
 
+/// Represents the channel ID of an IBC token
 pub type ChannelId = &'static str;
+/// Represents the base token of an IBC token
 pub type BaseToken = &'static str;
-
+/// The type hash of the conversion state structure in v0.31.9
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
 
+/// The new conversion state structure after the v0.32.0 upgrade
 #[derive(
     Debug, Default, BorshSerialize, BorshDeserialize, BorshDeserializer,
 )]
@@ -60,8 +63,8 @@ impl From<ConversionState> for NewConversionState {
     }
 }
 
-// Demonstrate how to set the minted balance using a migration
-fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+/// Demonstrate how to set the minted balance using a migration
+pub fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     let person =
         Address::decode("tnam1q9rhgyv3ydq0zu3whnftvllqnvhvhm270qxay5tn")
             .unwrap();
@@ -90,9 +93,9 @@ fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     ));
 }
 
-// Demonstrate how to set the shielded reward precision of IBC tokens using a
-// migration
-fn shielded_reward_precision_migration(
+/// Demonstrate how to set the shielded reward precision of IBC tokens using a
+/// migration
+pub fn shielded_reward_precision_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
     const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
@@ -122,8 +125,8 @@ fn shielded_reward_precision_migration(
     }
 }
 
-// A convenience data structure to allow token addresses to be more readably
-// expressed as a channel ID and base token instead of a raw Namada address.
+/// A convenience data structure to allow token addresses to be more readably
+/// expressed as a channel ID and base token instead of a raw Namada address.
 pub enum TokenAddress {
     // Specify an IBC address. This can also be done more directly using the
     // Self::Address variant.
@@ -132,15 +135,16 @@ pub enum TokenAddress {
     Address(Address),
 }
 
-// Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
-// their allowed conversions with conversions that do not contain rewards.
-fn shielded_reward_reset_migration(
+/// Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
+/// their allowed conversions with conversions that do not contain rewards.
+pub fn shielded_reward_reset_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
     // The address of the native token. This is what rewards are denominated in.
-    let native_token =
-        Address::from_str("tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e")
-            .expect("unable to construct native token address");
+    const NATIVE_TOKEN_BECH32M: &str =
+        "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e";
+    let native_token = Address::from_str(NATIVE_TOKEN_BECH32M)
+        .expect("unable to construct native token address");
     // The MASP epoch in which this migration will be applied. This number
     // controls the number of epochs of conversions created.
     const TARGET_MASP_EPOCH: MaspEpoch = MaspEpoch::new(2000);
@@ -262,9 +266,9 @@ fn shielded_reward_reset_migration(
     }
 }
 
-// Demonstrate replacing the entire conversion state with a new state that does
-// not contain rewards.
-fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+/// Demonstrate replacing the entire conversion state with a new state that does
+/// not contain rewards.
+pub fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     // Valid precisions must be in the intersection of i128 and u128
     pub type Precision = u128;
 
@@ -441,8 +445,8 @@ fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
 }
 
-// Demonstrate upgrading the transaction WASM code and hashes in storage
-fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+/// Demonstrate upgrading the transaction WASM code and hashes in storage
+pub fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     // wasm_updates[x].0) The WASM hash that is being replaced
     // wasm_updates[x].1) The name of WASM being updated
     // wasm_updates[x].2) The bytes of the new WASM code
@@ -559,8 +563,8 @@ fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
 }
 
-// Generate various migrations
-fn main() {
+/// Generate various migrations
+pub fn main() {
     // Write an example migration that updates minted balances
     let mut minted_balance_changes = migrations::DbChanges { changes: vec![] };
     minted_balance_migration(&mut minted_balance_changes.changes);

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -22,12 +22,16 @@ use namada_sdk::migrations;
 use namada_sdk::storage::DbColFam;
 use namada_shielded_token::storage_key::{
     masp_assets_hash_key, masp_conversion_key, masp_reward_precision_key,
+    masp_scheduled_base_native_precision_key,
     masp_scheduled_reward_precision_key,
 };
 use namada_shielded_token::{ConversionLeaf, ConversionState, MaspEpoch};
 use namada_trans_token::storage_key::{balance_key, minted_balance_key};
 use namada_trans_token::{Amount, Denomination, MaspDigitPos, Store};
 use sha2::{Digest, Sha256};
+
+pub type ChannelId = &'static str;
+pub type BaseToken = &'static str;
 
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -91,9 +95,6 @@ fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
 fn shielded_reward_precision_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
-    pub type ChannelId = &'static str;
-    pub type BaseToken = &'static str;
-
     const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
         ("channel-1", "uosmo", 1000u128),
         ("channel-2", "uatom", 1000u128),
@@ -121,14 +122,25 @@ fn shielded_reward_precision_migration(
     }
 }
 
+// A convenience data structure to allow token addresses to be more readably
+// expressed as a channel ID and base token instead of a raw Namada address.
+pub enum TokenAddress {
+    // Specify an IBC address. This can also be done more directly using the
+    // Self::Address variant.
+    Ibc(ChannelId, BaseToken),
+    // Directly specify a Namada address
+    Address(Address),
+}
+
 // Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
 // their allowed conversions with conversions that do not contain rewards.
 fn shielded_reward_reset_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
-    pub type ChannelId = &'static str;
-    pub type BaseToken = &'static str;
-
+    // The address of the native token. This is what rewards are denominated in.
+    let native_token =
+        Address::from_str("tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e")
+            .expect("unable to construct native token address");
     // The MASP epoch in which this migration will be applied. This number
     // controls the number of epochs of conversions created.
     const TARGET_MASP_EPOCH: MaspEpoch = MaspEpoch::new(2000);
@@ -136,20 +148,25 @@ fn shielded_reward_reset_migration(
     // tokens, this is 0.
     const DENOMINATION: Denomination = Denomination(0u8);
     // The tokens whose rewarrds will be reset.
-    const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
-        ("channel-1", "uosmo", 1000u128),
-        ("channel-2", "uatom", 1000u128),
-        ("channel-3", "utia", 1000u128),
-        ("channel-0", "stuosmo", 1000u128),
-        ("channel-0", "stuatom", 1000u128),
-        ("channel-0", "stutia", 1000u128),
+    const TOKENS: [(TokenAddress, Precision); 6] = [
+        (TokenAddress::Ibc("channel-1", "uosmo"), 1000u128),
+        (TokenAddress::Ibc("channel-2", "uatom"), 1000u128),
+        (TokenAddress::Ibc("channel-3", "utia"), 1000u128),
+        (TokenAddress::Ibc("channel-0", "stuosmo"), 1000u128),
+        (TokenAddress::Ibc("channel-0", "stuatom"), 1000u128),
+        (TokenAddress::Ibc("channel-0", "stutia"), 1000u128),
     ];
 
     // Reset the allowed conversions for the above tokens
-    for (channel_id, base_token, precision) in IBC_TOKENS {
-        let ibc_denom = format!("transfer/{channel_id}/{base_token}");
-        let token_address = ibc_token(&ibc_denom).clone();
-
+    for (token_address, precision) in TOKENS {
+        // Compute the Namada address
+        let token_address = match token_address {
+            TokenAddress::Ibc(channel_id, base_token) => {
+                let ibc_denom = format!("transfer/{channel_id}/{base_token}");
+                ibc_token(&ibc_denom).clone()
+            }
+            TokenAddress::Address(addr) => addr,
+        };
         // Erase the TOK rewards that have been distributed so far
         let mut asset_types = BTreeMap::new();
         let mut precision_toks = BTreeMap::new();
@@ -201,6 +218,19 @@ fn shielded_reward_reset_migration(
             value: precision.into(),
             force: false,
         });
+        // If the current token is the native token, then also update the base
+        // native precision
+        if token_address == native_token {
+            let shielded_token_base_native_precision_key =
+                masp_scheduled_base_native_precision_key(&TARGET_MASP_EPOCH);
+
+            updates.push(migrations::DbUpdateType::Add {
+                key: shielded_token_base_native_precision_key,
+                cf: DbColFam::SUBSPACE,
+                value: precision.into(),
+                force: false,
+            });
+        }
         // Write the new TOK conversions to memory
         for digit in MaspDigitPos::iter() {
             // -PRECISION TOK[ep, digit] + PRECISION TOK[current_ep, digit]

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -42,6 +42,10 @@ pub type ChannelId = &'static str;
 pub type BaseToken = &'static str;
 /// Represents a Namada address in Bech32m encoding
 pub type AddressBech32m = &'static str;
+/// Represents the hash of a WASM binary
+pub type WasmHash = &'static str;
+/// Represents the bytes of a WASM binary
+pub type WasmBytes = &'static [u8];
 /// The type hash of the conversion state structure in v0.31.9
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -299,56 +303,60 @@ pub fn shielded_reward_reset_migration(
 /// Demonstrate replacing the entire conversion state with a new state that does
 /// not contain rewards.
 pub fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
-    // Valid precisions must be in the intersection of i128 and u128
-    pub type Precision = u128;
-
     // The MASP epoch in which this migration will be applied. This number
     // controls the number of epochs of conversions created.
     const TARGET_MASP_EPOCH: MaspEpoch = MaspEpoch::new(4);
     // Precision to use for the native token
     const NATIVE_PRECISION: Precision = 1000;
     // The tokens whose rewarrds will be reset.
-    let tokens: [(Address, Denomination, Precision); 7] = [
+    const TOKENS: [(TokenAddress, Denomination, Precision); 7] = [
         (
-            Address::from_str("tnam1qyvfwdkz8zgs9n3qn9xhp8scyf8crrxwuq26r6gy")
-                .unwrap(),
-            6.into(),
+            TokenAddress::Address(
+                "tnam1qyvfwdkz8zgs9n3qn9xhp8scyf8crrxwuq26r6gy",
+            ),
+            Denomination(6),
             1000u128,
         ),
         (
-            Address::from_str("tnam1qy8qgxlcteehlk70sn8wx2pdlavtayp38vvrnkhq")
-                .unwrap(),
-            8.into(),
+            TokenAddress::Address(
+                "tnam1qy8qgxlcteehlk70sn8wx2pdlavtayp38vvrnkhq",
+            ),
+            Denomination(8),
             10000u128,
         ),
         (
-            Address::from_str("tnam1qyfl072lhaazfj05m7ydz8cr57zdygk375jxjfwx")
-                .unwrap(),
-            10.into(),
+            TokenAddress::Address(
+                "tnam1qyfl072lhaazfj05m7ydz8cr57zdygk375jxjfwx",
+            ),
+            Denomination(10),
             10000000u128,
         ),
         (
-            Address::from_str("tnam1qxvnvm2t9xpceu8rup0n6espxyj2ke36yv4dw6q5")
-                .unwrap(),
-            18.into(),
+            TokenAddress::Address(
+                "tnam1qxvnvm2t9xpceu8rup0n6espxyj2ke36yv4dw6q5",
+            ),
+            Denomination(18),
             10000u128,
         ),
         (
-            Address::from_str("tnam1qyx93z5ma43jjmvl0xhwz4rzn05t697f3vfv8yuj")
-                .unwrap(),
-            6.into(),
+            TokenAddress::Address(
+                "tnam1qyx93z5ma43jjmvl0xhwz4rzn05t697f3vfv8yuj",
+            ),
+            Denomination(6),
             1000u128,
         ),
         (
-            Address::from_str("tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e")
-                .unwrap(),
-            6.into(),
+            TokenAddress::Address(
+                "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e",
+            ),
+            Denomination(6),
             NATIVE_PRECISION,
         ),
         (
-            Address::from_str("tnam1q9f5yynt5qfxe28ae78xxp7wcgj50fn4syetyrj6")
-                .unwrap(),
-            6.into(),
+            TokenAddress::Address(
+                "tnam1q9f5yynt5qfxe28ae78xxp7wcgj50fn4syetyrj6",
+            ),
+            Denomination(6),
             1000u128,
         ),
     ];
@@ -356,7 +364,16 @@ pub fn conversion_state_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     let mut assets = BTreeMap::new();
     let mut conv_notes = Vec::new();
     // Reset the allowed conversions for the above tokens
-    for (token_address, denomination, precision) in tokens {
+    for (token_address, denomination, precision) in TOKENS {
+        // Compute the Namada address
+        let token_address = match token_address {
+            TokenAddress::Ibc(channel_id, base_token) => {
+                let ibc_denom = format!("transfer/{channel_id}/{base_token}");
+                ibc_token(&ibc_denom).clone()
+            }
+            TokenAddress::Address(addr) => Address::from_str(addr)
+                .expect("unable to construct token address"),
+        };
         // Erase the TOK rewards that have been distributed so far
         let mut asset_types = BTreeMap::new();
         let mut precision_toks = BTreeMap::new();
@@ -480,25 +497,28 @@ pub fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     // wasm_updates[x].0) The WASM hash that is being replaced
     // wasm_updates[x].1) The name of WASM being updated
     // wasm_updates[x].2) The bytes of the new WASM code
-    let wasm_updates: Vec<(&str, &str, &[u8])> =
-        vec![
+    const WASM_UPDATES: [(WasmHash, &str, WasmBytes); 2] = [
         (
             "83afcbf97c35188991ae2e73db2f48cb8d019c4295fe5323d9c3dfebcd5dbec0",
             "tx_transfer.wasm",
-            //include_bytes!("tx_transfer.5c7e44e61c00df351fa7c497cd2e186d71909f1a18db0c8d362dff36057e0fbf.wasm"),
+            // include_bytes!("tx_transfer.
+            // 5c7e44e61c00df351fa7c497cd2e186d71909f1a18db0c8d362dff36057e0fbf.
+            // wasm"),
             &[0xDE, 0xAD, 0xBE, 0xEF],
         ),
         (
             "6ff3c2a2ebc65061a9b89abd15fb37851ca77e162b42b7989889bd537e802b09",
             "tx_ibc.wasm",
-            //include_bytes!("tx_ibc.ae9b900edd6437461addd1fe1c723c4b1a8ac8d2fce30e1e4c417ef34f299f73.wasm"),
+            // include_bytes!("tx_ibc.
+            // ae9b900edd6437461addd1fe1c723c4b1a8ac8d2fce30e1e4c417ef34f299f73.
+            // wasm"),
             &[0xDE, 0xAD, 0xBE, 0xEF],
         ),
     ];
 
     // Update the tx allowlist parameter
     let tx_allowlist_key = get_tx_allowlist_storage_key();
-    let tx_allowlist: Vec<&str> = vec![
+    const TX_ALLOWLIST: [WasmHash; 24] = [
         "ec357c39e05677da3d8da359fee6e3a8b9012dd1a7e7def51f4e484132f68c77",
         "a324288bdc7a7d3cb15ca5ef3ebb04b9121b1d5804478dabd1ef4533459d7069",
         "6012fff1d191a545d6f7960f1dd9b2df5fcdfc9dbb8dfd22bb1458f3983144b9",
@@ -524,14 +544,14 @@ pub fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
         "c4357f5548c43086e56f22ac2e951ee2500368d8ed2479c0d0046b6e59f8a8e5",
         "b4261ecafcfb0254efb39165311268d99bb5aa85ac47514913317d20f1791790",
     ];
-    let mut tx_allowlist: Vec<String> = tx_allowlist
+    let mut tx_allowlist: Vec<String> = TX_ALLOWLIST
         .into_iter()
         .map(|hash_str| {
             Hash::from_str(hash_str).unwrap().to_string().to_lowercase()
         })
         .collect();
     // Replace the targetted old hashes
-    for (old_code_hash, name, code) in wasm_updates {
+    for (old_code_hash, name, code) in WASM_UPDATES {
         let old_code_hash = Hash::from_str(old_code_hash).unwrap();
         let new_code_hash = Hash(*Sha256::digest(code).as_ref());
         let new_code_len = u64::try_from(code.len()).unwrap();

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -171,43 +171,48 @@ pub fn shielded_reward_reset_migration(
 ) {
     // The address of the native token. This is what rewards are denominated in.
     const NATIVE_TOKEN_BECH32M: AddressBech32m =
-        "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e";
+        "tnam1q9gr66cvu4hrzm0sd5kmlnjje82gs3xlfg3v6nu7";
     let native_token = Address::from_str(NATIVE_TOKEN_BECH32M)
         .expect("unable to construct native token address");
     // The MASP epoch in which this migration will be applied. This number
     // controls the number of epochs of conversions created.
-    const TARGET_MASP_EPOCH: MaspEpoch = MaspEpoch::new(2000);
-    // The tokens whose rewarrds will be reset.
-    const TOKENS: [(TokenAddress, Denomination, Precision); 6] = [
+    const TARGET_MASP_EPOCH: MaspEpoch = MaspEpoch::new(255);
+    // The tokens whose rewards will be reset.
+    const TOKENS: [(TokenAddress, Denomination, Precision); 7] = [
         (
             TokenAddress::Ibc("channel-1", "uosmo"),
             Denomination(0u8),
-            1000u128,
+            1010u128,
         ),
         (
             TokenAddress::Ibc("channel-2", "uatom"),
             Denomination(0u8),
-            1000u128,
+            1020u128,
         ),
         (
             TokenAddress::Ibc("channel-3", "utia"),
             Denomination(0u8),
-            1000u128,
+            1030u128,
         ),
         (
             TokenAddress::Ibc("channel-0", "stuosmo"),
             Denomination(0u8),
-            1000u128,
+            1040u128,
         ),
         (
             TokenAddress::Ibc("channel-0", "stuatom"),
             Denomination(0u8),
-            1000u128,
+            1050u128,
         ),
         (
             TokenAddress::Ibc("channel-0", "stutia"),
             Denomination(0u8),
-            1000u128,
+            1060u128,
+        ),
+        (
+            TokenAddress::Address(NATIVE_TOKEN_BECH32M),
+            Denomination(6u8),
+            1070u128,
         ),
     ];
 
@@ -516,50 +521,44 @@ pub fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     // wasm_updates[x].2) The bytes of the new WASM code
     const WASM_UPDATES: [(WasmHash, &str, WasmBytes); 2] = [
         (
-            "83afcbf97c35188991ae2e73db2f48cb8d019c4295fe5323d9c3dfebcd5dbec0",
+            "6d753db0390e7cec16729fc405bfe41384c93bd79f42b8b8be41b22edbbf1b7c",
             "tx_transfer.wasm",
-            // include_bytes!("tx_transfer.
-            // 5c7e44e61c00df351fa7c497cd2e186d71909f1a18db0c8d362dff36057e0fbf.
-            // wasm"),
-            &[0xDE, 0xAD, 0xBE, 0xEF],
+            include_bytes!("../wasm/tx_transfer.5c7e44e61c00df351fa7c497cd2e186d71909f1a18db0c8d362dff36057e0fbf.wasm"),
         ),
         (
-            "6ff3c2a2ebc65061a9b89abd15fb37851ca77e162b42b7989889bd537e802b09",
+            "cecb1f1b75cd649915423c5e68be20c5232f94ab57a11a908dc66751bbdc4f72",
             "tx_ibc.wasm",
-            // include_bytes!("tx_ibc.
-            // ae9b900edd6437461addd1fe1c723c4b1a8ac8d2fce30e1e4c417ef34f299f73.
-            // wasm"),
-            &[0xDE, 0xAD, 0xBE, 0xEF],
+            include_bytes!("../wasm/tx_ibc.ae9b900edd6437461addd1fe1c723c4b1a8ac8d2fce30e1e4c417ef34f299f73.wasm"),
         ),
     ];
 
     // Update the tx allowlist parameter
     let tx_allowlist_key = get_tx_allowlist_storage_key();
     const TX_ALLOWLIST: [WasmHash; 24] = [
-        "ec357c39e05677da3d8da359fee6e3a8b9012dd1a7e7def51f4e484132f68c77",
-        "a324288bdc7a7d3cb15ca5ef3ebb04b9121b1d5804478dabd1ef4533459d7069",
-        "6012fff1d191a545d6f7960f1dd9b2df5fcdfc9dbb8dfd22bb1458f3983144b9",
-        "4fe1bb1e76c21eacd5eb84782c51aebd683643eefbd1034e4e13aa7284f508f8",
-        "23eec5e1bad79387e57d052840b86ff061aa3182638f690a642126183788f0e3",
-        "5a31f468d03207a8e566a55072ddad7aad018fc635621564fb1c105b0f089f4d",
-        "9eb40c4b40b5af540f9a32f8bd377a53cd3b5e0c3c799b4381ef6475f333e33d",
-        "2b3cf66f49093f674793fcdba72d45f1d7c0e34556800f597d3d5242d97091e0",
-        "6ff3c2a2ebc65061a9b89abd15fb37851ca77e162b42b7989889bd537e802b09",
-        "31a7199befce4226faad7fe1744895fb6845ee0749016c3a2a0a31b26088aff9",
-        "f0d270cab3357124eb8894c1e7cb0e775056ed613e41d075e23467bcaa36a1f7",
-        "51c4d0149807597c1c7981cf28cb8b078c93843b7ae91a6cd9e6b422f343e9a3",
-        "a07d722db5d3d06b0c65cb0c20811ce2a95105cebe2456a3ea6334eb2438fbab",
-        "f1cdb278dae8b7ab28fd850dcf9746b03aee2b42444ec9e39ae3a0bd46f3e17c",
-        "b48de32b91a58d8e63cd283bd96276f38736822ca8f90bfec2093eefdcdf5148",
-        "83afcbf97c35188991ae2e73db2f48cb8d019c4295fe5323d9c3dfebcd5dbec0",
-        "8293cecc00c63bb4b6216eec912c57c72544f42203ba1ff5a42ae098c9e921e4",
-        "f0e37af0417f5d54f20c81c2cf1b9301bd13ce79695b78c85d11b2ba187fa86d",
-        "0c650c7869da1ac3e734a4367557a499c937962effde4f7e7cc609278000ebd1",
-        "dbb6f005883075ab4133d8bd367af914a899946e7ae532f816be48c77044a512",
-        "bf4716b590b68562ee2c872757a0c370daf1504596d4350fffc0b94a566072ca",
-        "f6330d8c8bc92d9f8ea0f023688873722b65291bc6db9bb11ab3a0836e1be86b",
-        "c4357f5548c43086e56f22ac2e951ee2500368d8ed2479c0d0046b6e59f8a8e5",
-        "b4261ecafcfb0254efb39165311268d99bb5aa85ac47514913317d20f1791790",
+        "c6629064a1c3bde8503212cfa5e9b954169a7f162ad411b63a71db782fe909d7",
+        "490cf419bdbffe616c6aa6c72d38064e350ee65fb04d92472ccf285aec6844b6",
+        "473ee80e6e714f6097ec713c88f527b38da6479354075c879b66b9f53e813cb0",
+        "0295796e5ff47aeecb95b68c2fe308693e5f84b251126f26d03309e5f4f5da55",
+        "b745bc2b87bf8acd07e2f3409c77eee06c9b5206d2a77a2f23bb8e593c70cbfe",
+        "1b5a323c140b54700f280cde8b9aac1c12555f9c119e936432ddfa8f194d23ac",
+        "b74104949ac0c35ee922fdc3f3db454627742e2483d79550c12fcf31755c6d01",
+        "5120581194f1e6a122d2eec3f886e9cf5f079f56540d96193d3c1f9804c4d936",
+        "cecb1f1b75cd649915423c5e68be20c5232f94ab57a11a908dc66751bbdc4f72",
+        "26f90ec6676444cd6191d7555fd48861372f901c46e5178c59a897b411616918",
+        "33ee28597cf0f6a11dfe6e23e9aedf2eb04dabb44069cbe317768f4d982d80be",
+        "fbe97ce1136225bdbf8e388bab833a8c51e80bc1b8d94f7d3f8e49b3fad08543",
+        "7d5ad1877643f7d9b32a511ef93a11e8503426baee0f5986d29e3f63a2355d58",
+        "b63738a98927be05fd27f00d208e8703031e45b579d42f776d27234c48a48523",
+        "f1fc74460bd9bbd17140c88dfc0543440f066ffb84849c35c2bb0e331e51cf1c",
+        "6d753db0390e7cec16729fc405bfe41384c93bd79f42b8b8be41b22edbbf1b7c",
+        "36e774350b865752c9d309d518223abf0a60374bae15a1f73dfe4721b5887048",
+        "2e17680cec3e97ff5a6d4db2ba4a376a15f6da143abce690affd800645c6db80",
+        "12faf164aef7b6f91ed918db39f00e19fd3fc527a63f3b2589f43bf30bbaf24b",
+        "d7e34efc128d6a1c84691200f72f83ad9f696e1766f8ce083894f26343fc395f",
+        "faad78023b9391596981ac9a536070a3d7d469d5c6e20c2855b2cfca63c38f59",
+        "8a9df03a1a8f5e9e606e14a97fdfb2097dba062da1b3b2158bbfa7deabeeadfb",
+        "fb4462b86ff8969826fb66dfa0397cd795df9de9769f7a414d368200a8342951",
+        "abb163de1f532c740ee6bb69ccc69a5a55505b5c92979d1f256527833b8dfeca",
     ];
     let mut tx_allowlist: Vec<String> = TX_ALLOWLIST
         .into_iter()
@@ -692,6 +691,10 @@ pub fn accelerate_epoch_migration(updates: &mut Vec<migrations::DbUpdateType>) {
 pub fn shielded_reward_parameters_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
+    // The address of the native token. This is what rewards are denominated in.
+    const NATIVE_TOKEN_BECH32M: AddressBech32m =
+        "tnam1q9gr66cvu4hrzm0sd5kmlnjje82gs3xlfg3v6nu7";
+    // The tokens whose parameters will be set.
     const TOKENS: [(
         Denomination,
         TokenAddress,
@@ -699,7 +702,7 @@ pub fn shielded_reward_parameters_migration(
         TargetLockedAmount,
         KpGain,
         KdGain,
-    ); 6] = [
+    ); 7] = [
         (
             Denomination(0),
             TokenAddress::Ibc("channel-1", "uosmo"),
@@ -743,6 +746,14 @@ pub fn shielded_reward_parameters_migration(
         (
             Denomination(0),
             TokenAddress::Ibc("channel-0", "stutia"),
+            "0.01",
+            1_000_000,
+            "120000",
+            "120000",
+        ),
+        (
+            Denomination(6u8),
+            TokenAddress::Address(NATIVE_TOKEN_BECH32M),
             "0.01",
             1_000_000,
             "120000",

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -40,6 +40,8 @@ use sha2::{Digest, Sha256};
 pub type ChannelId = &'static str;
 /// Represents the base token of an IBC token
 pub type BaseToken = &'static str;
+/// Represents a Namada address in Bech32m encoding
+pub type AddressBech32m = &'static str;
 /// The type hash of the conversion state structure in v0.31.9
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -138,7 +140,7 @@ pub enum TokenAddress {
     // Self::Address variant.
     Ibc(ChannelId, BaseToken),
     // Directly specify a Namada address
-    Address(Address),
+    Address(AddressBech32m),
 }
 
 /// Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
@@ -147,35 +149,57 @@ pub fn shielded_reward_reset_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
     // The address of the native token. This is what rewards are denominated in.
-    const NATIVE_TOKEN_BECH32M: &str =
+    const NATIVE_TOKEN_BECH32M: AddressBech32m =
         "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e";
     let native_token = Address::from_str(NATIVE_TOKEN_BECH32M)
         .expect("unable to construct native token address");
     // The MASP epoch in which this migration will be applied. This number
     // controls the number of epochs of conversions created.
     const TARGET_MASP_EPOCH: MaspEpoch = MaspEpoch::new(2000);
-    // The denomination of the targetted token. Since all tokens here are IBC
-    // tokens, this is 0.
-    const DENOMINATION: Denomination = Denomination(0u8);
     // The tokens whose rewarrds will be reset.
-    const TOKENS: [(TokenAddress, Precision); 6] = [
-        (TokenAddress::Ibc("channel-1", "uosmo"), 1000u128),
-        (TokenAddress::Ibc("channel-2", "uatom"), 1000u128),
-        (TokenAddress::Ibc("channel-3", "utia"), 1000u128),
-        (TokenAddress::Ibc("channel-0", "stuosmo"), 1000u128),
-        (TokenAddress::Ibc("channel-0", "stuatom"), 1000u128),
-        (TokenAddress::Ibc("channel-0", "stutia"), 1000u128),
+    const TOKENS: [(TokenAddress, Denomination, Precision); 6] = [
+        (
+            TokenAddress::Ibc("channel-1", "uosmo"),
+            Denomination(0u8),
+            1000u128,
+        ),
+        (
+            TokenAddress::Ibc("channel-2", "uatom"),
+            Denomination(0u8),
+            1000u128,
+        ),
+        (
+            TokenAddress::Ibc("channel-3", "utia"),
+            Denomination(0u8),
+            1000u128,
+        ),
+        (
+            TokenAddress::Ibc("channel-0", "stuosmo"),
+            Denomination(0u8),
+            1000u128,
+        ),
+        (
+            TokenAddress::Ibc("channel-0", "stuatom"),
+            Denomination(0u8),
+            1000u128,
+        ),
+        (
+            TokenAddress::Ibc("channel-0", "stutia"),
+            Denomination(0u8),
+            1000u128,
+        ),
     ];
 
     // Reset the allowed conversions for the above tokens
-    for (token_address, precision) in TOKENS {
+    for (token_address, denomination, precision) in TOKENS {
         // Compute the Namada address
         let token_address = match token_address {
             TokenAddress::Ibc(channel_id, base_token) => {
                 let ibc_denom = format!("transfer/{channel_id}/{base_token}");
                 ibc_token(&ibc_denom).clone()
             }
-            TokenAddress::Address(addr) => addr,
+            TokenAddress::Address(addr) => Address::from_str(addr)
+                .expect("unable to construct token address"),
         };
         // Erase the TOK rewards that have been distributed so far
         let mut asset_types = BTreeMap::new();
@@ -186,7 +210,7 @@ pub fn shielded_reward_reset_migration(
             *asset_types.entry((epoch, digit)).or_insert_with(|| {
                 encode_asset_type(
                     token_address.clone(),
-                    DENOMINATION,
+                    denomination,
                     digit,
                     Some(epoch),
                 )
@@ -254,7 +278,7 @@ pub fn shielded_reward_reset_migration(
                 // TOK[ep, digit]
                 let asset_type = encode_asset_type(
                     token_address.clone(),
-                    DENOMINATION,
+                    denomination,
                     digit,
                     Some(epoch),
                 )

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -7,12 +7,18 @@ use masp_primitives::ff::PrimeField;
 use masp_primitives::sapling::Node;
 use masp_primitives::transaction::components::I128Sum;
 use namada_core::borsh::BorshSerializeExt;
+use namada_core::chain::BlockHeight;
 use namada_core::hash::Hash;
 use namada_core::masp::{Precision, encode_asset_type};
 use namada_core::storage::Key;
+use namada_core::time::MIN_UTC;
 use namada_macros::BorshDeserializer;
 use namada_migrations::REGISTER_DESERIALIZERS;
-use namada_parameters::storage::get_tx_allowlist_storage_key;
+use namada_parameters::EpochDuration;
+use namada_parameters::storage::{
+    get_epoch_duration_storage_key, get_epochs_per_year_key,
+    get_masp_epoch_multiplier_key, get_tx_allowlist_storage_key,
+};
 use namada_sdk::address::Address;
 use namada_sdk::ibc::trace::ibc_token;
 use namada_sdk::masp_primitives::asset_type::AssetType;
@@ -37,6 +43,12 @@ pub type BaseToken = &'static str;
 /// The type hash of the conversion state structure in v0.31.9
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
+/// Key holding minimum start height for next epoch
+pub const NEXT_EPOCH_MIN_START_HEIGHT_KEY: &str = "next_epoch_min_start_height";
+/// Key holding minimum start time for next epoch
+pub const NEXT_EPOCH_MIN_START_TIME_KEY: &str = "next_epoch_min_start_time";
+/// Key holding number of blocks till next epoch
+pub const UPDATE_EPOCH_BLOCKS_DELAY_KEY: &str = "update_epoch_blocks_delay";
 
 /// The new conversion state structure after the v0.32.0 upgrade
 #[derive(
@@ -563,6 +575,63 @@ pub fn wasm_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
 }
 
+/// Demonstrate accelerating epochs
+pub fn accelerate_epoch_migration(updates: &mut Vec<migrations::DbUpdateType>) {
+    // Set the number of epochs per year to the specified constant
+    const EPOCHS_PER_YEAR: u64 = 175200;
+    let epochs_per_year_key = get_epochs_per_year_key();
+    updates.push(migrations::DbUpdateType::Add {
+        key: epochs_per_year_key,
+        cf: DbColFam::SUBSPACE,
+        value: EPOCHS_PER_YEAR.into(),
+        force: false,
+    });
+    // Set the MASP epoch multiplier to the specified constant
+    const MASP_EPOCH_MULTIPLIER: u64 = 2;
+    let masp_epoch_multiplier_key = get_masp_epoch_multiplier_key();
+    updates.push(migrations::DbUpdateType::Add {
+        key: masp_epoch_multiplier_key,
+        cf: DbColFam::SUBSPACE,
+        value: MASP_EPOCH_MULTIPLIER.into(),
+        force: false,
+    });
+    // Set the epoch duration to the specified constant
+    const MIN_NUM_OF_BLOCKS: u64 = 4;
+    let epy_i64 = i64::try_from(EPOCHS_PER_YEAR)
+        .expect("`epochs_per_year` must not exceed `i64::MAX`");
+    #[allow(clippy::arithmetic_side_effects)]
+    let min_duration: i64 = 60 * 60 * 24 * 365 / epy_i64;
+    let epoch_duration = EpochDuration {
+        min_num_of_blocks: MIN_NUM_OF_BLOCKS,
+        min_duration: namada_sdk::time::Duration::seconds(min_duration).into(),
+    };
+    let epoch_duration_key = get_epoch_duration_storage_key();
+    updates.push(migrations::DbUpdateType::Add {
+        key: epoch_duration_key,
+        cf: DbColFam::SUBSPACE,
+        value: epoch_duration.into(),
+        force: false,
+    });
+    // Set the next epoch's block height to zero in order to force transition
+    updates.push(migrations::DbUpdateType::Add {
+        key: NEXT_EPOCH_MIN_START_HEIGHT_KEY
+            .parse()
+            .expect("unable to construct conversion state key"),
+        cf: DbColFam::STATE,
+        value: BlockHeight(0).into(),
+        force: false,
+    });
+    // Set the next epoch's start time to a minimum in order to force transition
+    updates.push(migrations::DbUpdateType::Add {
+        key: NEXT_EPOCH_MIN_START_TIME_KEY
+            .parse()
+            .expect("unable to construct conversion state key"),
+        cf: DbColFam::STATE,
+        value: MIN_UTC.into(),
+        force: false,
+    });
+}
+
 /// Generate various migrations
 pub fn main() {
     // Write an example migration that updates minted balances
@@ -614,6 +683,15 @@ pub fn main() {
     std::fs::write(
         "pre_phase4_migration.json",
         serde_json::to_string(&pre_phase4_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that accelerates epochs
+    let mut accelerate_epochs_changes =
+        migrations::DbChanges { changes: vec![] };
+    accelerate_epoch_migration(&mut accelerate_epochs_changes.changes);
+    std::fs::write(
+        "accelerate_epochs_migration.json",
+        serde_json::to_string(&accelerate_epochs_changes).unwrap(),
     )
     .unwrap();
 }

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -8,6 +8,7 @@ use masp_primitives::sapling::Node;
 use masp_primitives::transaction::components::I128Sum;
 use namada_core::borsh::BorshSerializeExt;
 use namada_core::chain::BlockHeight;
+use namada_core::dec::Dec;
 use namada_core::hash::Hash;
 use namada_core::masp::{Precision, encode_asset_type};
 use namada_core::storage::Key;
@@ -27,8 +28,9 @@ use namada_sdk::masp_primitives::sapling;
 use namada_sdk::migrations;
 use namada_sdk::storage::DbColFam;
 use namada_shielded_token::storage_key::{
-    masp_assets_hash_key, masp_conversion_key, masp_reward_precision_key,
-    masp_scheduled_base_native_precision_key,
+    masp_assets_hash_key, masp_conversion_key, masp_kd_gain_key,
+    masp_kp_gain_key, masp_locked_amount_target_key, masp_max_reward_rate_key,
+    masp_reward_precision_key, masp_scheduled_base_native_precision_key,
     masp_scheduled_reward_precision_key,
 };
 use namada_shielded_token::{ConversionLeaf, ConversionState, MaspEpoch};
@@ -46,6 +48,14 @@ pub type AddressBech32m = &'static str;
 pub type WasmHash = &'static str;
 /// Represents the bytes of a WASM binary
 pub type WasmBytes = &'static [u8];
+/// Represents a maximum reward rate
+pub type MaxRewardRate = &'static str;
+/// Represents a target locked amount
+pub type TargetLockedAmount = u64;
+/// Represents a nominal proportional gain
+pub type KpGain = &'static str;
+/// Represents a nominal derivative gain
+pub type KdGain = &'static str;
 /// The type hash of the conversion state structure in v0.31.9
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
@@ -105,24 +115,41 @@ pub fn minted_balance_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     ));
 }
 
+/// A convenience data structure to allow token addresses to be more readably
+/// expressed as a channel ID and base token instead of a raw Namada address.
+pub enum TokenAddress {
+    // Specify an IBC address. This can also be done more directly using the
+    // Self::Address variant.
+    Ibc(ChannelId, BaseToken),
+    // Directly specify a Namada address
+    Address(AddressBech32m),
+}
+
 /// Demonstrate how to set the shielded reward precision of IBC tokens using a
 /// migration
 pub fn shielded_reward_precision_migration(
     updates: &mut Vec<migrations::DbUpdateType>,
 ) {
-    const IBC_TOKENS: [(ChannelId, BaseToken, Precision); 6] = [
-        ("channel-1", "uosmo", 1000u128),
-        ("channel-2", "uatom", 1000u128),
-        ("channel-3", "utia", 1000u128),
-        ("channel-0", "stuosmo", 1000u128),
-        ("channel-0", "stuatom", 1000u128),
-        ("channel-0", "stutia", 1000u128),
+    const TOKENS: [(TokenAddress, Precision); 6] = [
+        (TokenAddress::Ibc("channel-1", "uosmo"), 1000u128),
+        (TokenAddress::Ibc("channel-2", "uatom"), 1000u128),
+        (TokenAddress::Ibc("channel-3", "utia"), 1000u128),
+        (TokenAddress::Ibc("channel-0", "stuosmo"), 1000u128),
+        (TokenAddress::Ibc("channel-0", "stuatom"), 1000u128),
+        (TokenAddress::Ibc("channel-0", "stutia"), 1000u128),
     ];
 
     // Set IBC token shielded reward precisions
-    for (channel_id, base_token, precision) in IBC_TOKENS {
-        let ibc_denom = format!("transfer/{channel_id}/{base_token}");
-        let token_address = ibc_token(&ibc_denom).clone();
+    for (token_address, precision) in TOKENS {
+        // Compute the Namada address
+        let token_address = match token_address {
+            TokenAddress::Ibc(channel_id, base_token) => {
+                let ibc_denom = format!("transfer/{channel_id}/{base_token}");
+                ibc_token(&ibc_denom).clone()
+            }
+            TokenAddress::Address(addr) => Address::from_str(addr)
+                .expect("unable to construct token address"),
+        };
 
         // The key holding the shielded reward precision of current token
         let shielded_token_reward_precision_key =
@@ -135,16 +162,6 @@ pub fn shielded_reward_precision_migration(
             force: false,
         });
     }
-}
-
-/// A convenience data structure to allow token addresses to be more readably
-/// expressed as a channel ID and base token instead of a raw Namada address.
-pub enum TokenAddress {
-    // Specify an IBC address. This can also be done more directly using the
-    // Self::Address variant.
-    Ibc(ChannelId, BaseToken),
-    // Directly specify a Namada address
-    Address(AddressBech32m),
 }
 
 /// Demonstrate clearing MASP rewards for the given IBC tokens by overwriting
@@ -670,6 +687,118 @@ pub fn accelerate_epoch_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
 }
 
+/// Demonstrate how to set the shielded reward parameters of IBC tokens using a
+/// migration
+pub fn shielded_reward_parameters_migration(
+    updates: &mut Vec<migrations::DbUpdateType>,
+) {
+    const TOKENS: [(
+        Denomination,
+        TokenAddress,
+        MaxRewardRate,
+        TargetLockedAmount,
+        KpGain,
+        KdGain,
+    ); 6] = [
+        (
+            Denomination(0),
+            TokenAddress::Ibc("channel-1", "uosmo"),
+            "0.01",
+            1_000_000,
+            "120000",
+            "120000",
+        ),
+        (
+            Denomination(0),
+            TokenAddress::Ibc("channel-2", "uatom"),
+            "0.01",
+            1_000_000,
+            "120000",
+            "120000",
+        ),
+        (
+            Denomination(0),
+            TokenAddress::Ibc("channel-3", "utia"),
+            "0.01",
+            1_000_000,
+            "120000",
+            "120000",
+        ),
+        (
+            Denomination(0),
+            TokenAddress::Ibc("channel-0", "stuosmo"),
+            "0.01",
+            1_000_000,
+            "120000",
+            "120000",
+        ),
+        (
+            Denomination(0),
+            TokenAddress::Ibc("channel-0", "stuatom"),
+            "0.01",
+            1_000_000,
+            "120000",
+            "120000",
+        ),
+        (
+            Denomination(0),
+            TokenAddress::Ibc("channel-0", "stutia"),
+            "0.01",
+            1_000_000,
+            "120000",
+            "120000",
+        ),
+    ];
+
+    // Set IBC token shielded reward parameters
+    for (denomination, token_addr, max_reward, lock_target, kp, kd) in TOKENS {
+        // Compute the Namada address
+        let token_address = match token_addr {
+            TokenAddress::Ibc(channel_id, base_token) => {
+                let ibc_denom = format!("transfer/{channel_id}/{base_token}");
+                ibc_token(&ibc_denom).clone()
+            }
+            TokenAddress::Address(addr) => Address::from_str(addr)
+                .expect("unable to construct token address"),
+        };
+
+        // The keys holding the shielded reward parameters of current token
+        let shielded_token_max_rewards_key =
+            masp_max_reward_rate_key::<Store<()>>(&token_address);
+        let shielded_token_target_locked_amount_key =
+            masp_locked_amount_target_key::<Store<()>>(&token_address);
+        let shielded_token_kp_gain_key =
+            masp_kp_gain_key::<Store<()>>(&token_address);
+        let shielded_token_kd_gain_key =
+            masp_kd_gain_key::<Store<()>>(&token_address);
+
+        updates.push(migrations::DbUpdateType::Add {
+            key: shielded_token_max_rewards_key,
+            cf: DbColFam::SUBSPACE,
+            value: Dec::from_str(max_reward).unwrap().into(),
+            force: false,
+        });
+        updates.push(migrations::DbUpdateType::Add {
+            key: shielded_token_target_locked_amount_key,
+            cf: DbColFam::SUBSPACE,
+            value: Amount::from_uint(lock_target, denomination).unwrap().into(),
+            force: false,
+        });
+        updates.push(migrations::DbUpdateType::Add {
+            key: shielded_token_kp_gain_key,
+            cf: DbColFam::SUBSPACE,
+            value: Dec::from_str(kp).unwrap().into(),
+            force: false,
+        });
+        updates.push(migrations::DbUpdateType::Add {
+            key: shielded_token_kd_gain_key,
+            cf: DbColFam::SUBSPACE,
+            value: Dec::from_str(kd).unwrap().into(),
+            force: false,
+        });
+    }
+}
+
 /// Generate various migrations
 pub fn main() {
     // Write an example migration that updates minted balances
@@ -730,6 +859,15 @@ pub fn main() {
     std::fs::write(
         "accelerate_epochs_migration.json",
         serde_json::to_string(&accelerate_epochs_changes).unwrap(),
+    )
+    .unwrap();
+    // Write an example migration that sets shielded reward parameters
+    let mut reward_parameter_changes =
+        migrations::DbChanges { changes: vec![] };
+    shielded_reward_parameters_migration(&mut reward_parameter_changes.changes);
+    std::fs::write(
+        "reward_parameters_migration.json",
+        serde_json::to_string(&reward_parameter_changes).unwrap(),
     )
     .unwrap();
 }

--- a/examples/make-db-migration.rs
+++ b/examples/make-db-migration.rs
@@ -43,12 +43,6 @@ pub type BaseToken = &'static str;
 /// The type hash of the conversion state structure in v0.31.9
 pub const OLD_CONVERSION_STATE_TYPE_HASH: &str =
     "05E2FD0BEBD54A05AAE349BBDE61F90893F09A72850EFD4F69060821EC5DE65F";
-/// Key holding minimum start height for next epoch
-pub const NEXT_EPOCH_MIN_START_HEIGHT_KEY: &str = "next_epoch_min_start_height";
-/// Key holding minimum start time for next epoch
-pub const NEXT_EPOCH_MIN_START_TIME_KEY: &str = "next_epoch_min_start_time";
-/// Key holding number of blocks till next epoch
-pub const UPDATE_EPOCH_BLOCKS_DELAY_KEY: &str = "update_epoch_blocks_delay";
 
 /// The new conversion state structure after the v0.32.0 upgrade
 #[derive(
@@ -614,7 +608,7 @@ pub fn accelerate_epoch_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
     // Set the next epoch's block height to zero in order to force transition
     updates.push(migrations::DbUpdateType::Add {
-        key: NEXT_EPOCH_MIN_START_HEIGHT_KEY
+        key: migrations::NEXT_EPOCH_MIN_START_HEIGHT_KEY
             .parse()
             .expect("unable to construct conversion state key"),
         cf: DbColFam::STATE,
@@ -623,7 +617,7 @@ pub fn accelerate_epoch_migration(updates: &mut Vec<migrations::DbUpdateType>) {
     });
     // Set the next epoch's start time to a minimum in order to force transition
     updates.push(migrations::DbUpdateType::Add {
-        key: NEXT_EPOCH_MIN_START_TIME_KEY
+        key: migrations::NEXT_EPOCH_MIN_START_TIME_KEY
             .parse()
             .expect("unable to construct conversion state key"),
         cf: DbColFam::STATE,


### PR DESCRIPTION
## Describe your changes
Implemented a hard-fork migration that allows shielded reward parameters to be set. This is useful when testing shielded rewards on mainnet clones.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
