### PR TITLE
Murisi/set masp params migration

### DIFF
--- a/.changelog/unreleased/testing/4589-set-masp-params-migration.md
+++ b/.changelog/unreleased/testing/4589-set-masp-params-migration.md
@@ -1,0 +1,2 @@
+- Implemented a migration that sets shielded reward parameters.
+  ([\#4589](https://github.com/anoma/namada/pull/4589))


### PR DESCRIPTION
## Describe your changes
Implemented a hard-fork migration that allows shielded reward parameters to be set. This is useful when testing shielded rewards on mainnet clones.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
