### PR TITLE
Forbid targeting MASP payment addresses in IBC transfers

### DIFF
--- a/crates/tests/src/e2e/helpers.rs
+++ b/crates/tests/src/e2e/helpers.rs
@@ -130,6 +130,7 @@ pub fn find_address(test: &Test, alias: impl AsRef<str>) -> Result<Address> {
 }
 
 /// Find the address of an account by its alias from the wallet
+#[allow(dead_code)]
 pub fn find_payment_address(
     test: &Test,
     alias: impl AsRef<str>,

--- a/crates/tests/src/e2e/ibc_tests.rs
+++ b/crates/tests/src/e2e/ibc_tests.rs
@@ -53,8 +53,8 @@ use sha2::{Digest, Sha256};
 
 use crate::e2e::helpers::{
     epoch_sleep, epochs_per_year_from_min_duration, find_address,
-    find_cosmos_address, find_payment_address, get_actor_rpc,
-    get_cosmos_gov_address, get_cosmos_rpc_address, get_epoch,
+    find_cosmos_address, get_actor_rpc, get_cosmos_gov_address,
+    get_cosmos_rpc_address, get_epoch,
 };
 use crate::e2e::ledger_tests::{
     start_namada_ledger_node_wait_wasm, write_json_file,
@@ -255,12 +255,10 @@ fn ibc_transfers() -> Result<()> {
         &port_id_namada,
         &channel_id_namada,
     )?;
-    let masp_receiver =
-        find_payment_address(&test, AA_PAYMENT_ADDRESS)?.to_string();
     transfer_from_cosmos(
         &test_gaia,
         COSMOS_USER,
-        masp_receiver.clone(),
+        MASP.to_string(),
         COSMOS_COIN,
         100,
         &port_id_gaia,
@@ -327,12 +325,10 @@ fn ibc_transfers() -> Result<()> {
         &port_id_namada,
         &channel_id_namada,
     )?;
-    let masp_receiver =
-        find_payment_address(&test, AA_PAYMENT_ADDRESS)?.to_string();
     transfer_from_cosmos(
         &test_gaia,
         COSMOS_USER,
-        masp_receiver,
+        MASP.to_string(),
         get_gaia_denom_hash(&ibc_denom_on_gaia),
         1_000_000,
         &port_id_gaia,
@@ -480,12 +476,10 @@ fn ibc_transfers() -> Result<()> {
     check_cosmos_balance(&test_gaia, COSMOS_USER, COSMOS_COIN, 810)?;
 
     // Missing memo
-    let masp_receiver =
-        find_payment_address(&test, AA_PAYMENT_ADDRESS)?.to_string();
     transfer_from_cosmos(
         &test_gaia,
         COSMOS_USER,
-        masp_receiver,
+        MASP.to_string(),
         COSMOS_COIN,
         100,
         &port_id_gaia,
@@ -513,12 +507,10 @@ fn ibc_transfers() -> Result<()> {
         &port_id_namada,
         &channel_id_namada,
     )?;
-    let masp_receiver =
-        find_payment_address(&test, AA_PAYMENT_ADDRESS)?.to_string();
     transfer_from_cosmos(
         &test_gaia,
         COSMOS_USER,
-        masp_receiver,
+        MASP.to_string(),
         COSMOS_COIN,
         101,
         &port_id_gaia,
@@ -632,12 +624,10 @@ fn ibc_nft_transfers() -> Result<()> {
         &port_id_namada,
         &channel_id_namada,
     )?;
-    let masp_receiver =
-        find_payment_address(&test, AA_PAYMENT_ADDRESS)?.to_string();
     nft_transfer_from_cosmos(
         &test_cosmwasm,
         COSMOS_USER,
-        masp_receiver,
+        MASP.to_string(),
         NFT_ID,
         &cw721_contract,
         &ics721_contract,
@@ -970,12 +960,10 @@ fn ibc_token_inflation() -> Result<()> {
         &port_id_namada,
         &channel_id_namada,
     )?;
-    let masp_receiver =
-        find_payment_address(&test, AA_PAYMENT_ADDRESS)?.to_string();
     transfer_from_cosmos(
         &test_gaia,
         COSMOS_USER,
-        masp_receiver,
+        MASP.to_string(),
         COSMOS_COIN,
         1,
         &port_id_gaia,


### PR DESCRIPTION
## Describe your changes

Closes #4591

Targeting MASP payment addresses leaks some information about the receiver. With the changes in this PR, the MASP transparent address is used as an alternative target for shieldings over IBC.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
