### PR TITLE
CI: fix can-backport

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.MAINT_LIBS_BRANCH }}
+      - name: Copy the current folder to be the baseline for semver-checks
+        run: cp -r "$GITHUB_WORKSPACE" ../baseline
       - name: Backport PR to libs maintenance branch
         run: |
           git config user.email "bing@bong.com"
@@ -65,9 +67,13 @@ jobs:
       - name: Check semver
         id: semver
         continue-on-error: true
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+        # TODO: Temp using fork for baseline args support.
+        # Switch back once is merged and released https://github.com/obi1kenobi/cargo-semver-checks-action/pull/96
+        # uses: obi1kenobi/cargo-semver-checks-action@v2
+        uses: anoma/cargo-semver-checks-action@8ce111a9587c085c03ca615d22a585da0ce31a93
         with:
           exclude: namada_apps, namada_benchmarks, namada_light_sdk, namada_examples, namada_fuzz
+          baseline-root: ../baseline
       - name: Label PR on success
         uses: actions-ecosystem/action-add-labels@v1
         if: >-


### PR DESCRIPTION
## Describe your changes

Fixes the can-backport job, which may be affected by PRs previously backported to the lib maint branch. To avoid this issue, the `cargo-semver-checks` is set to use `--baseline-root` directory to the maint branch used as a base so that the previously merged PRs don't affected the results of the PR that's being checked.

Note that I had to switch to a fork of the github action (https://github.com/anoma/cargo-semver-checks-action) as the support for `--baseline-root` is not yet merged upstream (the functionality is implemented but it still needs some tests).

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
