### PR TITLE
chore(ci): bump codecov/codecov-action from v4 -> v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,7 @@ jobs:
           name: wasm-cov-${{ github.event.pull_request.head.sha || github.sha }}
           path: wasm-cov
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: integration-cov/lcov.info, unit-cov/lcov.info, wasm-cov/lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
## Describe your changes

- update `.github/workflows/ci.yml` to `codecov/codecov-action@v5`
- v5 runs on the new Codecov Wrapper → quicker updates & recent bug-fixes
- v4 now maintenance-only
[Reference](https://github.com/codecov/codecov-action/blob/main/CHANGELOG.md#v5-release) 

## Checklist before merging 
- [x] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
