### PR TITLE
Update the tx expiration example format

### DIFF
--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -7232,7 +7232,7 @@ pub mod args {
                             "The expiration datetime of the masp transaction, \
                              after which the tx won't be accepted anymore. If \
                              not provided, a default will be set. Example: \
-                             2012-12-12T12:12:12Z"
+                             2012-12-12T12:12:00.000000000+00:00"
                         ))
                         .conflicts_with_all([NO_EXPIRATION.name]),
                 )


### PR DESCRIPTION
the parser expects the full .nnnnnnnnn+00:00 suffix and finds the input string too short when it hits the Z, if the example format is used

## Changes
i've updated the CLI format example so that the user can follow a format that the parser will accept