### PR TITLE
Fix to receive IBC denom when the base denom has slash

### DIFF
--- a/crates/ibc/src/storage.rs
+++ b/crates/ibc/src/storage.rs
@@ -500,7 +500,8 @@ pub fn ibc_trace_key(
     addr: impl AsRef<str>,
     token_hash: impl AsRef<str>,
 ) -> Key {
-    ibc_trace_key_prefix(Some(addr.as_ref().to_string()))
+    // Remove '/' because IBC denom could have '/'
+    ibc_trace_key_prefix(Some(addr.as_ref().replace('/', "")))
         .push(&token_hash.as_ref().to_string().to_db_key())
         .expect("Cannot obtain a storage key")
 }

--- a/crates/ibc/src/trace.rs
+++ b/crates/ibc/src/trace.rs
@@ -88,7 +88,7 @@ pub fn convert_to_address(ibc_trace: impl AsRef<str>) -> Result<Address> {
 pub fn is_ibc_denom(denom: impl AsRef<str>) -> Option<(TracePath, String)> {
     let prefixed_denom = PrefixedDenom::from_str(denom.as_ref()).ok()?;
     let base_denom = prefixed_denom.base_denom.to_string();
-    if prefixed_denom.trace_path.is_empty() || base_denom.contains('/') {
+    if prefixed_denom.trace_path.is_empty() {
         // The denom is just a token or an NFT trace
         return None;
     }


### PR DESCRIPTION
## Describe your changes
Namada couldn't receive some tokes including `/` in the base denom, e.g. `factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/dust` or Eureka token `transfer/08-wasm-1369/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2`.
- Fixed to relax the condition in `is_ibc_denom`
- Remove `/` from the storage key of IBC trace

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
