### PR TITLE
Add registering fmds keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,7 +1740,9 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
+ "rand_core",
  "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -5624,6 +5626,7 @@ dependencies = [
  "arbitrary",
  "assert_matches",
  "bech32 0.11.0",
+ "bincode",
  "borsh",
  "chrono",
  "data-encoding",
@@ -5647,6 +5650,7 @@ dependencies = [
  "num-traits",
  "num256",
  "num_enum",
+ "polyfuzzy",
  "primitive-types 0.13.1",
  "proptest",
  "prost-types 0.13.5",
@@ -7299,6 +7303,19 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "polyfuzzy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ad377e0383a3332e1deb427b97c8670a954efa00add87d2071daab421dae24"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "sha2 0.10.8",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1132,18 +1132,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1171,6 +1172,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1200,15 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "codepage"
@@ -1684,6 +1706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -2140,7 +2163,7 @@ dependencies = [
  "chrono",
  "rust_decimal",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "winnow 0.6.26",
 ]
@@ -2309,7 +2332,7 @@ dependencies = [
  "byteorder",
  "heapless 0.8.0",
  "num-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2994,7 +3017,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serdect",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "thiserror-nostd-notrait",
  "visibility",
  "zeroize",
@@ -3476,6 +3499,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "winapi",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
 ]
 
 [[package]]
@@ -4780,6 +4812,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "kassandra-client"
+version = "0.0.11-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e59f26661380a4758cc7c7a0b8887218677ee76be33a279205fb9cee9a4a492"
+dependencies = [
+ "chacha20poly1305",
+ "clap",
+ "curve25519-dalek",
+ "hex",
+ "hkdf",
+ "kassandra-shared",
+ "polyfuzzy",
+ "rand_core",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror 2.0.12",
+ "toml",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "kassandra-shared"
+version = "0.0.3-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d0b36e1bea0a4147d47b33e8770253f6101d6efd3f0a89f522b999947ce834"
+dependencies = [
+ "borsh",
+ "chacha20poly1305",
+ "cobs 0.3.0",
+ "hex",
+ "once_cell",
+ "polyfuzzy",
+ "rand_core",
+ "serde",
+ "serde_cbor",
+ "sha2 0.10.8",
+ "tdx-quote",
+ "thiserror 2.0.12",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "kdam"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5387,7 +5466,7 @@ dependencies = [
  "nam-ledger-proto",
  "once_cell",
  "strum 0.26.3",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5422,7 +5501,7 @@ dependencies = [
  "displaydoc",
  "encdec",
  "num_enum",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5449,7 +5528,7 @@ dependencies = [
  "pasta_curves",
  "rand_core",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "zeroize",
 ]
 
@@ -5547,6 +5626,7 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.14.0",
+ "kassandra-client",
  "kdam",
  "lazy_static",
  "ledger-transport",
@@ -5577,7 +5657,7 @@ dependencies = [
  "tendermint-config",
  "tendermint-rpc",
  "textwrap-macros",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
  "tracing",
@@ -5616,7 +5696,7 @@ version = "0.149.1"
 dependencies = [
  "namada_core",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5664,7 +5744,7 @@ dependencies = [
  "smooth-operator",
  "tendermint 0.40.3",
  "tendermint-proto 0.40.3",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tiny-keccak",
  "tokio",
  "toml",
@@ -5725,7 +5805,7 @@ dependencies = [
  "rand",
  "serde",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "toml",
  "tracing",
 ]
@@ -5741,7 +5821,7 @@ dependencies = [
  "namada_migrations",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -5797,7 +5877,7 @@ dependencies = [
  "namada_migrations",
  "proptest",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5829,7 +5909,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -5874,7 +5954,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -5886,7 +5966,7 @@ dependencies = [
  "kdam",
  "namada_core",
  "tendermint-rpc",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -5931,7 +6011,7 @@ dependencies = [
  "namada_migrations",
  "proptest",
  "prost 0.13.5",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5966,6 +6046,7 @@ dependencies = [
  "eyre",
  "futures",
  "itertools 0.14.0",
+ "kassandra-client",
  "lazy_static",
  "linkme",
  "masp_primitives",
@@ -5999,7 +6080,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-log",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-test",
  "toml",
@@ -6022,7 +6103,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6055,7 +6136,7 @@ dependencies = [
  "serde",
  "smooth-operator",
  "test-log",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
  "yansi 1.0.1",
@@ -6135,7 +6216,7 @@ dependencies = [
  "smooth-operator",
  "tempfile",
  "tendermint-rpc",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tiny-bip39",
  "tokio",
  "toml",
@@ -6154,6 +6235,7 @@ dependencies = [
  "flume",
  "futures",
  "itertools 0.14.0",
+ "kassandra-client",
  "lazy_static",
  "linkme",
  "masp_primitives",
@@ -6189,7 +6271,7 @@ dependencies = [
  "tempfile",
  "tendermint-rpc",
  "test-log",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "typed-builder",
@@ -6222,7 +6304,7 @@ dependencies = [
  "proptest",
  "smooth-operator",
  "test-log",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -6242,7 +6324,7 @@ dependencies = [
  "regex",
  "serde",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -6368,7 +6450,7 @@ dependencies = [
  "namada_vp",
  "namada_vp_env",
  "proptest",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -6402,7 +6484,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tonic-build",
 ]
 
@@ -6460,7 +6542,7 @@ dependencies = [
  "smooth-operator",
  "tempfile",
  "test-log",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "wasm-instrument",
  "wasmer",
@@ -6504,7 +6586,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -6568,7 +6650,7 @@ dependencies = [
  "serde",
  "slip10_ed25519",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tiny-bip39",
  "toml",
  "zeroize",
@@ -6776,9 +6858,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
@@ -6907,6 +6989,18 @@ name = "owo-colors"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "pairing"
@@ -7108,7 +7202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -7330,7 +7424,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
 dependencies = [
- "cobs",
+ "cobs 0.2.3",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "heapless 0.7.17",
@@ -7403,6 +7497,15 @@ checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -7739,7 +7842,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8413,9 +8516,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -8461,9 +8564,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8483,9 +8586,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -8677,7 +8780,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -9062,6 +9165,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "tdx-quote"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbbeffe2d73f07728bcbb581f8faa9098d813ba0fafbcab5e763a2fa4491e80"
+dependencies = [
+ "nom",
+ "p256",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9360,11 +9474,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -9380,9 +9494,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11032,6 +11146,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ test-log = {version = "0.2", default-features = false, features = ["trace"]}
 textwrap-macros = "0.3"
 tiny-bip39 = {version = "2.0"}
 tiny-hderive = {package = "nam-tiny-hderive", version = "0.3.1-nam.0"}
-tiny-keccak = { version = "2.0", features = ["keccak"] }
+tiny-keccak = { version = "2.0", features = ["keccak", "k12"] }
 thiserror = "2.0"
 tokio = {version = "1.8", default-features = false}
 tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,12 +170,12 @@ ibc-middleware-overflow-receive = { version = "0.5.0" }
 ibc-middleware-packet-forward = { version = "0.10.0", features = ["borsh"] }
 ibc-testkit = { version = "0.57.0", default-features = false }
 ics23 = "0.12"
-usize-set = { version = "0.10", features = ["serialize-borsh", "serialize-serde"] }
 impl-num-traits = "0.2"
 indexmap = { package = "nam-indexmap", version = "2.7.1-nam.0", features = ["borsh-schema", "serde"] }
 init-once = "0.6"
 itertools = "0.14"
 jubjub = { package = "nam-jubjub", version = "0.10.1-nam.0" }
+kassandra-client = "0.0.11-alpha"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa", "pkcs8", "precomputed-tables", "serde", "std"]}
 kdam = "0.6"
 konst = { version = "0.3", default-features = false }
@@ -263,6 +263,7 @@ tracing-log = "0.2"
 tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}
 typed-builder = "0.20"
 uint = "0.10"
+usize-set = { version = "0.10", features = ["serialize-borsh", "serialize-serde"] }
 warp = "0.3"
 wasmparser = "0.121"
 wasm-instrument = {version = "0.4.0", features = ["sign_ext"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ owo-colors = "4.1"
 parity-wasm = { version = "0.45", features = ["sign_ext"] }
 paste = "1.0"
 patricia_tree = "0.8"
+polyfuzzy = "0.5.0"
 pretty_assertions = "1.4"
 primitive-types = "0.13"
 proc-macro2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,13 +117,14 @@ base58 = "0.2"
 base64 = "0.22"
 bech32 = "0.11"
 bimap = {version = "0.6", features = ["serde"]}
+bincode = "1.3.3"
 bit-set = "0.8"
 bitflags = { version = "2.5", features = ["serde"] }
 blake2b-rs = "0.2"
+borsh = {version = "1.2", features = ["unstable__schema", "derive"]}
 byte-unit = "5.1"
 byteorder = "1.4"
 bytes = "1.1"
-borsh = {version = "1.2", features = ["unstable__schema", "derive"]}
 cargo_metadata = "0.19"
 chrono = {version = "0.4", default-features = false, features = ["clock", "std"]}
 circular-queue = "0.2"

--- a/crates/apps_lib/Cargo.toml
+++ b/crates/apps_lib/Cargo.toml
@@ -49,6 +49,7 @@ flate2.workspace = true
 futures.workspace = true
 itertools.workspace = true
 jubjub.workspace = true
+kassandra-client.workspace = true
 kdam.workspace = true
 lazy_static = { workspace = true, optional = true }
 linkme = { workspace = true, optional = true }

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -500,6 +500,7 @@ pub mod cmds {
     }
 
     #[derive(Clone, Debug)]
+    #[allow(clippy::large_enum_variant)]
     pub enum NamadaClientWithContext {
         // Ledger cmds
         TxCustom(TxCustom),

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -3631,6 +3631,7 @@ pub mod args {
     pub const PAYMENT_ADDRESS_TARGET: Arg<WalletPaymentAddr> = arg("target");
     pub const PAYMENT_ADDRESS_TARGET_OPT: ArgOpt<WalletPaymentAddr> =
         arg_opt("target-pa");
+    pub const PAYMENT_ADDRESS_V0: ArgFlag = flag("v0");
     pub const PORT_ID: ArgDefault<PortId> = arg_default(
         "port-id",
         DefaultFn(|| PortId::from_str("transfer").unwrap()),
@@ -7980,6 +7981,7 @@ pub mod args {
             _ctx: &mut Context,
         ) -> Result<PayAddressGen, Self::Error> {
             Ok(PayAddressGen {
+                v0: self.v0,
                 alias: self.alias,
                 alias_force: self.alias_force,
                 viewing_key: self.viewing_key,
@@ -7994,11 +7996,13 @@ pub mod args {
             let alias_force = ALIAS_FORCE.parse(matches);
             let diversifier_index = DIVERSIFIER_INDEX.parse(matches);
             let viewing_key = VIEWING_KEY_ALIAS.parse(matches);
+            let v0 = PAYMENT_ADDRESS_V0.parse(matches);
             Self {
                 alias,
                 alias_force,
                 diversifier_index,
                 viewing_key,
+                v0,
             }
         }
 
@@ -8013,6 +8017,10 @@ pub mod args {
                 "Set the viewing key's current diversifier index beforehand."
             )))
             .arg(VIEWING_KEY.def().help(wrap!("The viewing key.")))
+            .arg(PAYMENT_ADDRESS_V0.def().help(wrap!(
+                "Force generating a v0 payment address. Not compatible with \
+                 FMD."
+            )))
         }
     }
 

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -3402,7 +3402,9 @@ pub mod args {
 
     use data_encoding::HEXUPPER;
     use either::Either;
-    use namada_core::masp::{DiversifierIndex, MaspEpoch, PaymentAddress};
+    use namada_core::masp::{
+        DiversifierIndex, MaspEpoch, UnifiedPaymentAddress,
+    };
     use namada_sdk::address::{Address, EstablishedAddress};
     pub use namada_sdk::args::*;
     use namada_sdk::chain::{ChainId, ChainIdPrefix};
@@ -3653,8 +3655,9 @@ pub mod args {
     pub const RAW_ADDRESS_ESTABLISHED: Arg<EstablishedAddress> = arg("address");
     pub const RAW_ADDRESS_OPT: ArgOpt<Address> = RAW_ADDRESS.opt();
     pub const RAW_KEY_GEN: ArgFlag = flag("raw");
-    pub const RAW_PAYMENT_ADDRESS: Arg<PaymentAddress> = arg("payment-address");
-    pub const RAW_PAYMENT_ADDRESS_OPT: ArgOpt<PaymentAddress> =
+    pub const RAW_PAYMENT_ADDRESS: Arg<UnifiedPaymentAddress> =
+        arg("payment-address");
+    pub const RAW_PAYMENT_ADDRESS_OPT: ArgOpt<UnifiedPaymentAddress> =
         RAW_PAYMENT_ADDRESS.opt();
     pub const RAW_PUBLIC_KEY: Arg<common::PublicKey> = arg("public-key");
     pub const RAW_PUBLIC_KEY_OPT: ArgOpt<common::PublicKey> =

--- a/crates/apps_lib/src/cli/client.rs
+++ b/crates/apps_lib/src/cli/client.rs
@@ -1,8 +1,10 @@
 use std::io::Read;
 
 use color_eyre::eyre::Result;
+use namada_sdk::args::FmdCommandType;
 use namada_sdk::io::{Io, NamadaIo, display_line};
 use namada_sdk::masp::ShieldedContext;
+use namada_sdk::masp::fs::FsShieldedUtils;
 use namada_sdk::wallet::DatedViewingKey;
 use namada_sdk::{Namada, NamadaImpl};
 
@@ -385,6 +387,28 @@ impl CliApi {
                             &io,
                         )
                         .await?;
+                    }
+                    Sub::Fmd(FmdCommand(args)) => {
+                        use crate::client::masp::fmd;
+                        let args = args.to_sdk(&mut ctx)?;
+                        let chain_ctx = ctx.take_chain_or_exit();
+                        match args.command {
+                            FmdCommandType::RegisterKey => {
+                                fmd::register_keys::<FsShieldedUtils>(
+                                    args.viewing_key,
+                                )
+                                .await;
+                            }
+                            FmdCommandType::AddService => {
+                                fmd::add_service(
+                                    ShieldedContext::new(chain_ctx.shielded)
+                                        .into(),
+                                    args.viewing_key,
+                                    args.service.as_ref().unwrap(),
+                                )
+                                .await
+                            }
+                        }
                     }
                     Sub::GenIbcShieldingTransfer(GenIbcShieldingTransfer(
                         args,

--- a/crates/apps_lib/src/cli/context.rs
+++ b/crates/apps_lib/src/cli/context.rs
@@ -12,8 +12,8 @@ use masp_primitives::zip32::{
     ExtendedSpendingKey as MaspExtendedSpendingKey,
 };
 use namada_core::masp::{
-    BalanceOwner, ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress,
-    TransferSource, TransferTarget,
+    BalanceOwner, ExtendedSpendingKey, ExtendedViewingKey, TransferSource,
+    TransferTarget, UnifiedPaymentAddress,
 };
 use namada_sdk::address::{Address, InternalAddress};
 use namada_sdk::chain::ChainId;
@@ -60,7 +60,7 @@ pub type WalletDatedSpendingKey = FromContext<DatedSpendingKey>;
 
 /// A raw payment address (bech32m encoding) or an alias of a payment address
 /// in the wallet
-pub type WalletPaymentAddr = FromContext<PaymentAddress>;
+pub type WalletPaymentAddr = FromContext<UnifiedPaymentAddress>;
 
 /// A raw full viewing key (bech32m encoding) or an alias of a full viewing key
 /// in the wallet
@@ -388,10 +388,11 @@ impl FromContext<TransferTarget> {
         }
     }
 
-    /// Converts this TransferTarget argument to a PaymentAddress. Call this
-    /// function only when certain that raw represents a PaymentAddress.
-    pub fn to_payment_address(&self) -> FromContext<PaymentAddress> {
-        FromContext::<PaymentAddress> {
+    /// Converts this TransferTarget argument to a UnifiedPaymentAddress. Call
+    /// this function only when certain that raw represents a
+    /// UnifiedPaymentAddress.
+    pub fn to_payment_address(&self) -> FromContext<UnifiedPaymentAddress> {
+        FromContext::<UnifiedPaymentAddress> {
             raw: self.raw.clone(),
             phantom: PhantomData,
         }
@@ -690,7 +691,7 @@ impl ArgFromMutContext for DatedViewingKey {
     }
 }
 
-impl ArgFromContext for PaymentAddress {
+impl ArgFromContext for UnifiedPaymentAddress {
     fn arg_from_ctx(
         ctx: &ChainContext,
         raw: impl AsRef<str>,
@@ -743,7 +744,8 @@ impl ArgFromContext for TransferTarget {
         Address::arg_from_ctx(ctx, raw)
             .map(Self::Address)
             .or_else(|_| {
-                PaymentAddress::arg_from_ctx(ctx, raw).map(Self::PaymentAddress)
+                UnifiedPaymentAddress::arg_from_ctx(ctx, raw)
+                    .map(Self::PaymentAddress)
             })
     }
 }

--- a/crates/apps_lib/src/cli/wallet.rs
+++ b/crates/apps_lib/src/cli/wallet.rs
@@ -403,6 +403,7 @@ fn payment_address_gen(
         alias_force,
         viewing_key: viewing_key_alias,
         diversifier_index,
+        v0,
     }: args::PayAddressGen,
 ) {
     let mut wallet = load_wallet(ctx);
@@ -421,8 +422,11 @@ fn payment_address_gen(
             .copied()
             .unwrap_or_default()
     });
-    let (diversifier_index, payment_addr) =
-        UnifiedPaymentAddress::v1_from_zip32(viewing_key, diversifier_index);
+    let (diversifier_index, payment_addr) = if v0 {
+        UnifiedPaymentAddress::v0_from_zip32(viewing_key, diversifier_index)
+    } else {
+        UnifiedPaymentAddress::v1_from_zip32(viewing_key, diversifier_index)
+    };
     let mut next_div_idx = diversifier_index;
     next_div_idx.increment();
     let alias = wallet

--- a/crates/apps_lib/src/cli/wallet.rs
+++ b/crates/apps_lib/src/cli/wallet.rs
@@ -12,7 +12,7 @@ use ledger_transport_hid::hidapi::HidApi;
 use masp_primitives::zip32::ExtendedFullViewingKey;
 use namada_core::chain::BlockHeight;
 use namada_core::masp::{
-    DiversifierIndex, ExtendedSpendingKey, MaspValue, PaymentAddress,
+    ExtendedSpendingKey, MaspValue, UnifiedPaymentAddress,
 };
 use namada_sdk::address::{Address, DecodeError};
 use namada_sdk::borsh::{BorshDeserialize, BorshSerializeExt};
@@ -421,23 +421,18 @@ fn payment_address_gen(
             .copied()
             .unwrap_or_default()
     });
-    let (diversifier_index, masp_payment_addr) =
-        ExtendedFullViewingKey::from(viewing_key)
-            .find_address(diversifier_index.into())
-            .expect("exhausted payment addresses");
+    let (diversifier_index, payment_addr) =
+        UnifiedPaymentAddress::v1_from_zip32(viewing_key, diversifier_index);
     let mut next_div_idx = diversifier_index;
-    next_div_idx
-        .increment()
-        .expect("exhausted payment addresses");
-    let payment_addr = PaymentAddress::from(masp_payment_addr);
+    next_div_idx.increment();
     let alias = wallet
-        .insert_payment_addr(alias, payment_addr, alias_force)
+        .insert_payment_addr(alias, payment_addr.clone(), alias_force)
         .unwrap_or_else(|| {
             edisplay_line!(io, "Payment address not added");
             cli::safe_exit(1);
         });
     wallet
-        .insert_diversifier_index(viewing_key_alias, next_div_idx.into())
+        .insert_diversifier_index(viewing_key_alias, next_div_idx)
         .expect(
             "must be able to save next diversifier index under the alias of \
              the viewing key",
@@ -447,7 +442,7 @@ fn payment_address_gen(
         io,
         "Successfully generated payment address {} at index {} with alias {}",
         payment_addr,
-        DiversifierIndex::from(diversifier_index),
+        diversifier_index,
         alias,
     );
 }
@@ -1095,7 +1090,7 @@ fn payment_address_or_alias_find(
     ctx: Context,
     io: &impl Io,
     alias: Option<String>,
-    payment_address: Option<PaymentAddress>,
+    payment_address: Option<UnifiedPaymentAddress>,
 ) {
     let wallet = load_wallet(ctx);
     if payment_address.is_some() && alias.is_some() {

--- a/crates/apps_lib/src/client/masp.rs
+++ b/crates/apps_lib/src/client/masp.rs
@@ -148,3 +148,46 @@ pub async fn syncing<
 
     Ok(shielded)
 }
+
+/// CLI commands for FMD key management.
+pub mod fmd {
+    use namada_core::key::FmdKeyHash;
+    use namada_sdk::{ShieldedUtils, ShieldedWallet};
+    use namada_wallet::DatedViewingKey;
+
+    /// Add an FMD key derived from the viewing key
+    /// to the config file. This file will be used
+    /// for registering and querying data from Kassandra
+    /// services.
+    pub async fn add_service<U: ShieldedUtils>(
+        wallet: ShieldedWallet<U>,
+        DatedViewingKey { key, .. }: DatedViewingKey,
+        url: &str,
+    ) {
+        let uuid = kassandra_client::get_host_uuid(url);
+        let fmd_key =
+            namada_core::masp::FmdSecretKey::from(&key).fmd_secret_key();
+        let enc_key = kassandra_client::encryption_key(&fmd_key, &uuid);
+        let key_hash = FmdKeyHash::from(fmd_key).to_string();
+        let mut config = U::fmd_config_load().await.unwrap();
+        config.add_service(key_hash, url, enc_key);
+        wallet.utils.fmd_config_save(&mut config).await.unwrap();
+    }
+
+    /// Register FND keys with Kassandra services as specified in the
+    /// config file.
+    pub async fn register_keys<U: ShieldedUtils>(
+        DatedViewingKey { key, birthday }: DatedViewingKey,
+    ) {
+        let config = U::fmd_config_load().await.unwrap();
+        let fmd_key =
+            namada_core::masp::FmdSecretKey::from(&key).fmd_secret_key();
+        let key_hash = FmdKeyHash::from(&fmd_key).to_string();
+        kassandra_client::register_fmd_key(
+            &config,
+            key_hash,
+            &fmd_key,
+            Some(birthday.0),
+        );
+    }
+}

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -1935,7 +1935,8 @@ pub async fn gen_ibc_shielding_transfer(
 ) -> Result<(), error::Error> {
     let output_folder = args.output_folder.clone();
 
-    if let Some(masp_tx) = tx::gen_ibc_shielding_transfer(context, args).await?
+    if let Some((masp_tx, fmd_flags)) =
+        tx::gen_ibc_shielding_transfer(context, args).await?
     {
         let tx_id = masp_tx.txid().to_string();
         let filename = format!("ibc_masp_tx_{}.memo", tx_id);
@@ -1945,11 +1946,7 @@ pub async fn gen_ibc_shielding_transfer(
         };
         let mut out = File::create(&output_path)
             .expect("Creating a new file for IBC MASP transaction failed.");
-        let bytes = convert_masp_tx_to_ibc_memo(
-            masp_tx,
-            // TODO: add actual flag ciphertext
-            Default::default(),
-        );
+        let bytes = convert_masp_tx_to_ibc_memo(masp_tx, fmd_flags);
         out.write_all(bytes.as_bytes())
             .expect("Writing IBC MASP transaction file failed.");
         println!(

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -1945,7 +1945,11 @@ pub async fn gen_ibc_shielding_transfer(
         };
         let mut out = File::create(&output_path)
             .expect("Creating a new file for IBC MASP transaction failed.");
-        let bytes = convert_masp_tx_to_ibc_memo(&masp_tx);
+        let bytes = convert_masp_tx_to_ibc_memo(
+            masp_tx,
+            // TODO: add actual flag ciphertext
+            Default::default(),
+        );
         out.write_all(bytes.as_bytes())
             .expect("Writing IBC MASP transaction file failed.");
         println!(

--- a/crates/benches/native_vps.rs
+++ b/crates/benches/native_vps.rs
@@ -572,7 +572,7 @@ fn setup_storage_for_masp_verification(
     let (shielded_ctx, shield_tx) = shielded_ctx.generate_masp_tx(
         amount,
         TransferSource::Address(defaults::albert_address()),
-        TransferTarget::PaymentAddress(albert_payment_addr),
+        TransferTarget::PaymentAddress(albert_payment_addr.clone()),
     );
 
     shielded_ctx.shell.write().execute_tx(&shield_tx.to_ref());

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -39,6 +39,7 @@ namada_migrations = { workspace = true, optional = true }
 arbitrary = { workspace = true, optional = true }
 arse-merkle-tree.workspace = true
 bech32.workspace = true
+bincode.workspace = true
 borsh.workspace = true
 chrono.workspace = true
 data-encoding.workspace = true
@@ -60,6 +61,7 @@ num_enum.workspace = true
 num-integer.workspace = true
 num-rational.workspace = true
 num-traits.workspace = true
+polyfuzzy = { workspace = true, features = ["serde"] }
 primitive-types.workspace = true
 proptest = { workspace = true, optional = true }
 prost-types.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,8 +16,8 @@ rust-version.workspace = true
 [features]
 default = []
 mainnet = []
-rand = ["dep:rand", "dep:rand_core"]
-default-flag-ciphertext = ["dep:rand_core", "polyfuzzy/random-flag-ciphertexts"]
+rand = ["dep:rand", "dep:rand_core", "polyfuzzy/random-flag-ciphertexts"]
+default-flag-ciphertext = ["rand"]
 ethers-derive = ["ethbridge-structs/ethers-derive"]
 # for tests and test utilities
 testing = ["rand", "proptest"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,13 +16,14 @@ rust-version.workspace = true
 [features]
 default = []
 mainnet = []
-rand = ["dep:rand", "rand_core"]
+rand = ["dep:rand", "dep:rand_core"]
+default-flag-ciphertext = ["dep:rand_core", "polyfuzzy/random-flag-ciphertexts"]
 ethers-derive = ["ethbridge-structs/ethers-derive"]
 # for tests and test utilities
 testing = ["rand", "proptest"]
 migrations = ["namada_migrations", "linkme"]
 benches = ["proptest"]
-control_flow = ["lazy_static", "tokio", "wasmtimer"]
+control_flow = ["dep:lazy_static", "tokio", "wasmtimer"]
 arbitrary = [
   "dep:arbitrary",
   "chrono/arbitrary",

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -22,7 +22,9 @@ use ripemd::Digest as RipemdDigest;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::Sha256;
 
-pub use self::fmd::FlagCiphertext;
+pub use self::fmd::{
+    FlagCiphertext, PublicKey as FmdPublicKey, SecretKey as FmdSecretKey,
+};
 use crate::address::{Address, DecodeError, HASH_HEX_LEN, IBC, MASP};
 use crate::borsh::BorshSerializeExt;
 use crate::chain::Epoch;

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -23,6 +23,7 @@ use sha2::Sha256;
 use crate::address::{Address, DecodeError, HASH_HEX_LEN, IBC, MASP};
 use crate::borsh::BorshSerializeExt;
 use crate::chain::Epoch;
+use crate::hash::Hash;
 use crate::impl_display_and_from_str_via_format;
 use crate::string_encoding::{
     self, MASP_EXT_FULL_VIEWING_KEY_HRP, MASP_EXT_SPENDING_KEY_HRP,
@@ -82,6 +83,44 @@ impl From<TxIdInner> for MaspTxId {
 impl Display for MaspTxId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+/// Pointers to MASP data included in Namada transactions.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Debug,
+    Eq,
+    PartialEq,
+    Copy,
+    Ord,
+    PartialOrd,
+    Hash,
+)]
+pub struct MaspTxData {
+    /// Id of the MASP transaction.
+    ///
+    /// This is used to look-up a MASP transaction section.
+    pub masp_tx_id: MaspTxId,
+    /// Section hash of the FMD flag ciphertext.
+    ///
+    /// This is used to look-up a transaction data section
+    /// containing an FMD flag ciphertext.
+    pub flag_ciphertext_sechash: Hash,
+}
+
+impl Display for MaspTxData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("")
+            .field("masp_tx_id", &self.masp_tx_id)
+            .field("flag_ciphertext_sechash", &self.flag_ciphertext_sechash)
+            .finish()
     }
 }
 

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -140,6 +140,8 @@ impl Display for MaspTxData {
     PartialOrd,
     Hash,
 )]
+// TODO: remove Default derive
+#[derive(Default)]
 pub struct FlagCiphertext {
     inner: Vec<u8>,
 }

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -124,6 +124,26 @@ impl Display for MaspTxData {
     }
 }
 
+/// FMD flag ciphertexts.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+)]
+pub struct FlagCiphertext {
+    inner: Vec<u8>,
+}
+
 /// Wrapper type around `Epoch` for type safe operations involving the masp
 /// epoch
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::Sha256;
 
 pub use self::fmd::{
-    FlagCiphertext, PublicKey as FmdPublicKey,
+    FlagCiphertext, GAMMA, PublicKey as FmdPublicKey,
     PublicKeyBytes as FmdPublicKeyBytes, SecretKey as FmdSecretKey,
 };
 use crate::address::{Address, DecodeError, HASH_HEX_LEN, IBC, MASP};

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -1017,6 +1017,22 @@ pub enum UnifiedPaymentAddress {
 }
 
 impl UnifiedPaymentAddress {
+    /// Generate a [`FlagCiphertext`] from this payment address.
+    ///
+    /// Returns [`None`] if the FMD public key in the
+    /// [`UnifiedPaymentAddress::V1`] variant is invalid, and a random flag
+    /// ciphertext for the [`UnifiedPaymentAddress::V0`] variant.
+    #[cfg(feature = "rand")]
+    pub fn flag<R>(&self, rng: &mut R) -> Option<FlagCiphertext>
+    where
+        R: rand_core::CryptoRng + rand_core::RngCore,
+    {
+        match self {
+            Self::V0(_) => Some(FlagCiphertext::random(rng)),
+            Self::V1(pa) => pa.to_fmd_public_key().map(|pk| pk.flag(rng)),
+        }
+    }
+
     /// Create a v0 payment address.
     pub fn v0_from_zip32(
         vk: ExtendedViewingKey,

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -23,7 +23,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::Sha256;
 
 pub use self::fmd::{
-    FlagCiphertext, PublicKey as FmdPublicKey, SecretKey as FmdSecretKey,
+    FlagCiphertext, PublicKey as FmdPublicKey,
+    PublicKeyBytes as FmdPublicKeyBytes, SecretKey as FmdSecretKey,
 };
 use crate::address::{Address, DecodeError, HASH_HEX_LEN, IBC, MASP};
 use crate::borsh::BorshSerializeExt;

--- a/crates/core/src/masp.rs
+++ b/crates/core/src/masp.rs
@@ -1,5 +1,7 @@
 //! MASP types
 
+mod fmd;
+
 use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::num::ParseIntError;
@@ -20,6 +22,7 @@ use ripemd::Digest as RipemdDigest;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::Sha256;
 
+pub use self::fmd::FlagCiphertext;
 use crate::address::{Address, DecodeError, HASH_HEX_LEN, IBC, MASP};
 use crate::borsh::BorshSerializeExt;
 use crate::chain::Epoch;
@@ -122,28 +125,6 @@ impl Display for MaspTxData {
             .field("flag_ciphertext_sechash", &self.flag_ciphertext_sechash)
             .finish()
     }
-}
-
-/// FMD flag ciphertexts.
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Serialize,
-    Deserialize,
-    Clone,
-    BorshSerialize,
-    BorshDeserialize,
-    BorshSchema,
-    Debug,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-)]
-// TODO: remove Default derive
-#[derive(Default)]
-pub struct FlagCiphertext {
-    inner: Vec<u8>,
 }
 
 /// Wrapper type around `Epoch` for type safe operations involving the masp

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -7,14 +7,14 @@ use borsh::schema::Definition;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use masp_primitives::sapling::SaplingIvk;
 use masp_primitives::zip32::{ExtendedKey, PseudoExtendedKey};
-use polyfuzzy::fmd2_compact::{
-    CompactSecretKey as PolyfuzzyCompactSecretKey,
-    FlagCiphertexts as PolyfuzzyFlagCiphertext,
-};
 #[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, IntoXof, KangarooTwelve, Xof};
+
+mod polyfuzzy {
+    pub(super) use ::polyfuzzy::fmd2_compact::*;
+}
 
 #[allow(dead_code)]
 pub mod parameters {
@@ -59,7 +59,7 @@ pub mod parameters {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct SecretKey {
-    inner: PolyfuzzyCompactSecretKey,
+    inner: polyfuzzy::CompactSecretKey,
 }
 
 impl SecretKey {
@@ -80,7 +80,7 @@ impl From<&SaplingIvk> for SecretKey {
         };
 
         Self {
-            inner: PolyfuzzyCompactSecretKey::derive_from_xof_stream(
+            inner: polyfuzzy::CompactSecretKey::derive_from_xof_stream(
                 parameters::THRESHOLD,
                 |buf| {
                     xof_stream.squeeze(buf);
@@ -114,7 +114,7 @@ impl From<PseudoExtendedKey> for SecretKey {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct FlagCiphertext {
-    inner: PolyfuzzyFlagCiphertext,
+    inner: polyfuzzy::FlagCiphertexts,
 }
 
 impl FlagCiphertext {
@@ -132,27 +132,27 @@ impl FlagCiphertext {
         R: CryptoRng + RngCore,
     {
         Self {
-            inner: PolyfuzzyFlagCiphertext::random(rng, parameters::GAMMA),
+            inner: polyfuzzy::FlagCiphertexts::random(rng, parameters::GAMMA),
         }
     }
 }
 
-impl From<PolyfuzzyFlagCiphertext> for FlagCiphertext {
-    fn from(flag_ciphertext: PolyfuzzyFlagCiphertext) -> Self {
+impl From<polyfuzzy::FlagCiphertexts> for FlagCiphertext {
+    fn from(flag_ciphertext: polyfuzzy::FlagCiphertexts) -> Self {
         Self {
             inner: flag_ciphertext,
         }
     }
 }
 
-impl From<FlagCiphertext> for PolyfuzzyFlagCiphertext {
+impl From<FlagCiphertext> for polyfuzzy::FlagCiphertexts {
     fn from(flag_ciphertext: FlagCiphertext) -> Self {
         flag_ciphertext.inner
     }
 }
 
-impl AsRef<PolyfuzzyFlagCiphertext> for FlagCiphertext {
-    fn as_ref(&self) -> &PolyfuzzyFlagCiphertext {
+impl AsRef<polyfuzzy::FlagCiphertexts> for FlagCiphertext {
+    fn as_ref(&self) -> &polyfuzzy::FlagCiphertexts {
         &self.inner
     }
 }

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -56,7 +56,7 @@ pub mod parameters {
 
 /// FMD secret key.
 //#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct SecretKey {
     inner: polyfuzzy::CompactSecretKey,

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -63,6 +63,8 @@ mod parameters {
     }
 }
 
+pub use parameters::GAMMA;
+
 /// FMD public key bytes.
 #[derive(
     Clone,

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -75,6 +75,30 @@ mod parameters {
 #[repr(transparent)]
 pub struct PublicKeyBytes(Box<[u8; parameters::PUBLIC_KEY_LEN]>);
 
+impl PublicKeyBytes {
+    /// Length of the byte payload.
+    pub const LENGTH: usize = parameters::PUBLIC_KEY_LEN;
+}
+
+impl TryFrom<&[u8]> for PublicKeyBytes {
+    type Error = String;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        if slice.len() != parameters::PUBLIC_KEY_LEN {
+            return Err(format!(
+                "FMD public key length must be {}",
+                parameters::PUBLIC_KEY_LEN
+            ));
+        }
+
+        let mut bytes =
+            PublicKeyBytes(Box::new([0u8; parameters::PUBLIC_KEY_LEN]));
+        bytes.0.copy_from_slice(slice);
+
+        Ok(bytes)
+    }
+}
+
 impl Deref for PublicKeyBytes {
     type Target = [u8];
 

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -8,13 +8,22 @@ use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use polyfuzzy::fmd2_compact::FlagCiphertexts as PolyfuzzyFlagCiphertext;
 use serde::{Deserialize, Serialize};
 
+#[allow(dead_code)]
 pub mod parameters {
     //! Fuzzy message detection parameters used by Namada.
 
     /// Gamma parameter.
+    ///
+    /// This parameter defines the minimum false positive rate,
+    /// which is given by `2^-GAMMA`.
     pub const GAMMA: usize = 20;
 
     /// Threshold parameter.
+    ///
+    /// This parameter affects the length of payment addresses.
+    /// The raw data of payment addresses will contain `THRESHOLD + 1`
+    /// extra compressed curve points (32 bytes each), to allow
+    /// flagging note ownership to their respective owner.
     pub const THRESHOLD: usize = 1;
 }
 

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -193,6 +193,23 @@ mod tests {
 
     #[test]
     #[cfg(feature = "default-flag-ciphertext")]
+    fn test_flag_ciphertext_borsh_roundtrip() {
+        use crate::borsh::BorshSerializeExt;
+
+        // run this test a couple of times
+        for _ in 0..5 {
+            let random_flag_ciphertext = FlagCiphertext::default();
+
+            let serialized = random_flag_ciphertext.serialize_to_vec();
+            let deserialized =
+                FlagCiphertext::try_from_slice(&serialized).unwrap();
+
+            assert_eq!(random_flag_ciphertext, deserialized);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "default-flag-ciphertext")]
     fn test_random_flag_ciphertext_is_valid() {
         // run this test a couple of times
         for _ in 0..5 {

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -51,22 +51,14 @@ impl PartialEq for FlagCiphertext {
     }
 }
 
-#[cfg(feature = "rand")]
+#[cfg(feature = "default-flag-ciphertext")]
 impl Default for FlagCiphertext {
-    // TODO: improve this default impl
     fn default() -> Self {
-        use polyfuzzy::fmd2_compact::MultiFmd2CompactScheme;
-        use polyfuzzy::{FmdKeyGen, MultiFmdScheme};
-        use rand_core::OsRng;
-
-        let mut scheme = MultiFmd2CompactScheme::new(
-            parameters::GAMMA,
-            parameters::THRESHOLD,
-        );
-        let (_sk, pk) = scheme.generate_keys(&mut OsRng);
-
         Self {
-            inner: scheme.flag(&pk, &mut OsRng),
+            inner: PolyfuzzyFlagCiphertext::random(
+                &mut rand_core::OsRng,
+                parameters::GAMMA,
+            ),
         }
     }
 }

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -76,6 +76,20 @@ impl FlagCiphertext {
     }
 }
 
+impl From<PolyfuzzyFlagCiphertext> for FlagCiphertext {
+    fn from(flag_ciphertext: PolyfuzzyFlagCiphertext) -> Self {
+        Self {
+            inner: flag_ciphertext,
+        }
+    }
+}
+
+impl From<FlagCiphertext> for PolyfuzzyFlagCiphertext {
+    fn from(flag_ciphertext: FlagCiphertext) -> Self {
+        flag_ciphertext.inner
+    }
+}
+
 impl AsRef<PolyfuzzyFlagCiphertext> for FlagCiphertext {
     fn as_ref(&self) -> &PolyfuzzyFlagCiphertext {
         &self.inner

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -6,6 +6,7 @@ use std::io;
 use borsh::schema::Definition;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use masp_primitives::sapling::SaplingIvk;
+use masp_primitives::zip32::{ExtendedKey, PseudoExtendedKey};
 use polyfuzzy::fmd2_compact::{
     CompactSecretKey as PolyfuzzyCompactSecretKey,
     FlagCiphertexts as PolyfuzzyFlagCiphertext,
@@ -93,6 +94,18 @@ impl From<SaplingIvk> for SecretKey {
     #[inline]
     fn from(ivk: SaplingIvk) -> Self {
         (&ivk).into()
+    }
+}
+
+impl From<&PseudoExtendedKey> for SecretKey {
+    fn from(psk: &PseudoExtendedKey) -> Self {
+        psk.to_viewing_key().fvk.vk.ivk().into()
+    }
+}
+
+impl From<PseudoExtendedKey> for SecretKey {
+    fn from(psk: PseudoExtendedKey) -> Self {
+        (&psk).into()
     }
 }
 

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -48,7 +48,7 @@ pub mod parameters {
 
 /// FMD flag ciphertexts.
 //#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct FlagCiphertext {
     inner: PolyfuzzyFlagCiphertext,
@@ -57,17 +57,6 @@ pub struct FlagCiphertext {
 impl AsRef<PolyfuzzyFlagCiphertext> for FlagCiphertext {
     fn as_ref(&self) -> &PolyfuzzyFlagCiphertext {
         &self.inner
-    }
-}
-
-// TODO: use polyfuzzy PartialEq impl once available,
-// and simply derive it in FlagCiphertext
-impl PartialEq for FlagCiphertext {
-    fn eq(&self, other: &Self) -> bool {
-        let this = bincode::serialize(&self.inner).unwrap();
-        let other = bincode::serialize(&other.inner).unwrap();
-
-        this == other
     }
 }
 

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -6,6 +6,8 @@ use std::io;
 use borsh::schema::Definition;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 use polyfuzzy::fmd2_compact::FlagCiphertexts as PolyfuzzyFlagCiphertext;
+#[cfg(feature = "rand")]
+use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 #[allow(dead_code)]
@@ -61,6 +63,17 @@ impl FlagCiphertext {
     pub fn is_valid(&self) -> bool {
         parameters::valid_compressed_bit_ciphertext(self.inner.bits())
     }
+
+    /// Generate a random [`FlagCiphertext`].
+    #[cfg(feature = "rand")]
+    pub fn random<R>(rng: &mut R) -> Self
+    where
+        R: CryptoRng + RngCore,
+    {
+        Self {
+            inner: PolyfuzzyFlagCiphertext::random(rng, parameters::GAMMA),
+        }
+    }
 }
 
 impl AsRef<PolyfuzzyFlagCiphertext> for FlagCiphertext {
@@ -71,13 +84,9 @@ impl AsRef<PolyfuzzyFlagCiphertext> for FlagCiphertext {
 
 #[cfg(feature = "default-flag-ciphertext")]
 impl Default for FlagCiphertext {
+    #[inline]
     fn default() -> Self {
-        Self {
-            inner: PolyfuzzyFlagCiphertext::random(
-                &mut rand_core::OsRng,
-                parameters::GAMMA,
-            ),
-        }
+        Self::random(&mut rand_core::OsRng)
     }
 }
 

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -18,8 +18,7 @@ mod polyfuzzy {
     pub(super) use ::polyfuzzy::fmd2_compact::*;
 }
 
-#[allow(dead_code)]
-pub mod parameters {
+mod parameters {
     //! Fuzzy message detection parameters used by Namada.
 
     /// Gamma parameter.

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -1,26 +1,113 @@
 //! Fuzzy message detection MASP primitives.
 
+use std::collections::BTreeMap;
+use std::io;
+
+use borsh::schema::Definition;
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use polyfuzzy::fmd2_compact::FlagCiphertexts as PolyfuzzyFlagCiphertext;
 use serde::{Deserialize, Serialize};
 
+pub mod parameters {
+    //! Fuzzy message detection parameters used by Namada.
+
+    /// Gamma parameter.
+    pub const GAMMA: usize = 20;
+
+    /// Threshold parameter.
+    pub const THRESHOLD: usize = 1;
+}
+
 /// FMD flag ciphertexts.
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Serialize,
-    Deserialize,
-    Clone,
-    BorshSerialize,
-    BorshDeserialize,
-    BorshSchema,
-    Debug,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-)]
-// TODO: remove Default derive
-#[derive(Default)]
+//#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct FlagCiphertext {
-    inner: Vec<u8>,
+    inner: PolyfuzzyFlagCiphertext,
+}
+
+impl AsRef<PolyfuzzyFlagCiphertext> for FlagCiphertext {
+    fn as_ref(&self) -> &PolyfuzzyFlagCiphertext {
+        &self.inner
+    }
+}
+
+// TODO: use polyfuzzy PartialEq impl once available,
+// and simply derive it in FlagCiphertext
+impl PartialEq for FlagCiphertext {
+    fn eq(&self, other: &Self) -> bool {
+        let this = bincode::serialize(&self.inner).unwrap();
+        let other = bincode::serialize(&other.inner).unwrap();
+
+        this == other
+    }
+}
+
+#[cfg(feature = "rand")]
+impl Default for FlagCiphertext {
+    // TODO: improve this default impl
+    fn default() -> Self {
+        use polyfuzzy::fmd2_compact::MultiFmd2CompactScheme;
+        use polyfuzzy::{FmdKeyGen, MultiFmdScheme};
+        use rand_core::OsRng;
+
+        let mut scheme = MultiFmd2CompactScheme::new(
+            parameters::GAMMA,
+            parameters::THRESHOLD,
+        );
+        let (_sk, pk) = scheme.generate_keys(&mut OsRng);
+
+        Self {
+            inner: scheme.flag(&pk, &mut OsRng),
+        }
+    }
+}
+
+impl BorshSerialize for FlagCiphertext {
+    #[inline]
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        // NOTE: serialize the size. borsh will only see an
+        // opaque vector of bytes
+        let size: u32 = bincode::serialized_size(&self.inner)
+            .map_err(from_bincode_err)?
+            .try_into()
+            .map_err(io::Error::other)?;
+        writer.write_all(&size.to_le_bytes())?;
+
+        bincode::serialize_into(writer, &self.inner).map_err(from_bincode_err)
+    }
+}
+
+impl BorshDeserialize for FlagCiphertext {
+    #[inline]
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        // NOTE: skip the length of the fake vector of bytes
+        reader.read_exact(&mut [0u8; 4])?;
+
+        bincode::deserialize_from(reader).map_err(from_bincode_err)
+    }
+}
+
+impl BorshSchema for FlagCiphertext {
+    fn add_definitions_recursively(
+        definitions: &mut BTreeMap<String, Definition>,
+    ) {
+        let def = {
+            <Vec<u8>>::add_definitions_recursively(definitions);
+            definitions.get(&<Vec<u8>>::declaration()).unwrap().clone()
+        };
+
+        definitions.insert(Self::declaration(), def);
+    }
+
+    fn declaration() -> String {
+        std::any::type_name::<Self>().into()
+    }
+}
+
+#[allow(clippy::boxed_local)]
+fn from_bincode_err(err: bincode::Error) -> io::Error {
+    match *err {
+        bincode::ErrorKind::Io(err) => err,
+        other => io::Error::other(other),
+    }
 }

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -54,6 +54,15 @@ pub struct FlagCiphertext {
     inner: PolyfuzzyFlagCiphertext,
 }
 
+impl FlagCiphertext {
+    /// Check if the flag ciphertext is valid, according to Namada's consensus
+    /// rules.
+    #[inline]
+    pub fn is_valid(&self) -> bool {
+        parameters::valid_compressed_bit_ciphertext(self.inner.bits())
+    }
+}
+
 impl AsRef<PolyfuzzyFlagCiphertext> for FlagCiphertext {
     fn as_ref(&self) -> &PolyfuzzyFlagCiphertext {
         &self.inner
@@ -125,6 +134,16 @@ fn from_bincode_err(err: bincode::Error) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(feature = "default-flag-ciphertext")]
+    fn test_random_flag_ciphertext_is_valid() {
+        // run this test a couple of times
+        for _ in 0..5 {
+            let random_flag_ciphertext = FlagCiphertext::default();
+            assert!(random_flag_ciphertext.is_valid());
+        }
+    }
 
     #[test]
     fn test_flag_ciphertext_bits_validation() {

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -1,0 +1,26 @@
+//! Fuzzy message detection MASP primitives.
+
+use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+/// FMD flag ciphertexts.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    BorshSchema,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+)]
+// TODO: remove Default derive
+#[derive(Default)]
+pub struct FlagCiphertext {
+    inner: Vec<u8>,
+}

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -49,6 +49,7 @@ pub mod parameters {
 /// FMD flag ciphertexts.
 //#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[repr(transparent)]
 pub struct FlagCiphertext {
     inner: PolyfuzzyFlagCiphertext,
 }

--- a/crates/core/src/masp/fmd.rs
+++ b/crates/core/src/masp/fmd.rs
@@ -104,54 +104,87 @@ impl Default for FlagCiphertext {
     }
 }
 
-impl BorshSerialize for FlagCiphertext {
-    #[inline]
-    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+mod borsh_impls {
+    use super::*;
+
+    macro_rules! borsh_derive_from_bincode {
+        ($($type:ty),+) => {
+            $(
+                impl BorshSerialize for $type {
+                    #[inline]
+                    fn serialize<W: io::Write>(
+                        &self,
+                        writer: &mut W,
+                    ) -> io::Result<()> {
+                        bincode_as_borsh_serialize(writer, self)
+                    }
+                }
+
+                impl BorshDeserialize for $type {
+                    #[inline]
+                    fn deserialize_reader<R: io::Read>(
+                        reader: &mut R,
+                    ) -> io::Result<Self> {
+                        bincode_as_borsh_deserialize(reader)
+                    }
+                }
+
+                impl BorshSchema for $type {
+                    fn add_definitions_recursively(
+                        definitions: &mut BTreeMap<String, Definition>,
+                    ) {
+                        let def = {
+                            <Vec<u8>>::add_definitions_recursively(definitions);
+                            definitions.get(&<Vec<u8>>::declaration()).unwrap().clone()
+                        };
+
+                        definitions.insert(Self::declaration(), def);
+                    }
+
+                    fn declaration() -> String {
+                        std::any::type_name::<Self>().into()
+                    }
+                }
+            )+
+        };
+    }
+
+    fn bincode_as_borsh_serialize<W: io::Write, T: Serialize>(
+        writer: &mut W,
+        data: &T,
+    ) -> io::Result<()> {
         // NOTE: serialize the size. borsh will only see an
         // opaque vector of bytes
-        let size: u32 = bincode::serialized_size(&self.inner)
+        let size: u32 = bincode::serialized_size(data)
             .map_err(from_bincode_err)?
             .try_into()
             .map_err(io::Error::other)?;
         writer.write_all(&size.to_le_bytes())?;
 
-        bincode::serialize_into(writer, &self.inner).map_err(from_bincode_err)
+        bincode::serialize_into(writer, data).map_err(from_bincode_err)
     }
-}
 
-impl BorshDeserialize for FlagCiphertext {
-    #[inline]
-    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+    fn bincode_as_borsh_deserialize<
+        R: io::Read,
+        T: for<'de> Deserialize<'de>,
+    >(
+        reader: &mut R,
+    ) -> io::Result<T> {
         // NOTE: skip the length of the fake vector of bytes
         reader.read_exact(&mut [0u8; 4])?;
 
         bincode::deserialize_from(reader).map_err(from_bincode_err)
     }
-}
 
-impl BorshSchema for FlagCiphertext {
-    fn add_definitions_recursively(
-        definitions: &mut BTreeMap<String, Definition>,
-    ) {
-        let def = {
-            <Vec<u8>>::add_definitions_recursively(definitions);
-            definitions.get(&<Vec<u8>>::declaration()).unwrap().clone()
-        };
-
-        definitions.insert(Self::declaration(), def);
+    #[allow(clippy::boxed_local)]
+    fn from_bincode_err(err: bincode::Error) -> io::Error {
+        match *err {
+            bincode::ErrorKind::Io(err) => err,
+            other => io::Error::other(other),
+        }
     }
 
-    fn declaration() -> String {
-        std::any::type_name::<Self>().into()
-    }
-}
-
-#[allow(clippy::boxed_local)]
-fn from_bincode_err(err: bincode::Error) -> io::Error {
-    match *err {
-        bincode::ErrorKind::Io(err) => err,
-        other => io::Error::other(other),
-    }
+    borsh_derive_from_bincode!(FlagCiphertext);
 }
 
 #[cfg(test)]

--- a/crates/core/src/string_encoding.rs
+++ b/crates/core/src/string_encoding.rs
@@ -27,6 +27,8 @@ pub const ADDRESS_HRP: &str = "tnam";
 pub const MASP_EXT_FULL_VIEWING_KEY_HRP: &str = "zvknam";
 /// MASP payment address human-readable part
 pub const MASP_PAYMENT_ADDRESS_HRP: &str = "znam";
+/// MASP payment address with FMD public key human-readable part
+pub const MASP_FMD_PAYMENT_ADDRESS_HRP: &str = "zfnam";
 /// MASP extended spending key human-readable part
 pub const MASP_EXT_SPENDING_KEY_HRP: &str = "zsknam";
 /// `common::PublicKey` human-readable part

--- a/crates/ibc/src/msg.rs
+++ b/crates/ibc/src/msg.rs
@@ -238,6 +238,7 @@ impl<Transfer: BorshSchema> BorshSchema for MsgNftTransfer<Transfer> {
 
 /// Shielding data in IBC packet memo
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+// TODO: add flag ciphertext here
 pub struct IbcShieldingData(pub MaspTransaction);
 
 impl From<&IbcShieldingData> for String {

--- a/crates/light_sdk/src/transaction/transfer.rs
+++ b/crates/light_sdk/src/transaction/transfer.rs
@@ -2,7 +2,7 @@ use namada_sdk::address::Address;
 use namada_sdk::hash::Hash;
 use namada_sdk::key::common;
 pub use namada_sdk::token::{
-    DenominatedAmount, MaspTransaction, MaspTxId, Transfer,
+    DenominatedAmount, MaspTransaction, MaspTxData, MaspTxId, Transfer,
 };
 use namada_sdk::tx::data::GasLimit;
 use namada_sdk::tx::{Authorization, TX_TRANSFER_WASM, Tx, TxError};
@@ -27,10 +27,14 @@ impl TransferBuilder {
     /// Build a shielded transfer transaction from the given parameters
     pub fn shielded(
         shielded_section_hash: MaspTxId,
+        flag_ciphertext_sechash: Hash,
         transaction: MaspTransaction,
         args: GlobalArgs,
     ) -> Self {
-        let data = Transfer::masp(shielded_section_hash);
+        let data = Transfer::masp(MaspTxData {
+            masp_tx_id: shielded_section_hash,
+            flag_ciphertext_sechash,
+        });
         let mut tx =
             transaction::build_tx(args, data, TX_TRANSFER_WASM.to_string());
         tx.add_masp_tx_section(transaction);

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -64,6 +64,7 @@ ethbridge-events.workspace = true
 eyre.workspace = true
 futures.workspace = true
 itertools.workspace = true
+kassandra-client.workspace = true
 lazy_static = { workspace = true, optional = true }
 linkme = { workspace = true, optional = true }
 masp_primitives = { workspace = true, features = ["transparent-inputs"] }

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -1280,6 +1280,7 @@ impl BenchShieldedCtx {
                      masp_tx,
                      metadata: _,
                      epoch: _,
+                     fmd_flags: _,
                  }| masp_tx,
             )
             .expect("MASP must have shielded part");

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -147,6 +147,8 @@ const SPECULATIVE_FILE_NAME: &str = "speculative_shielded.dat";
 const SPECULATIVE_TMP_FILE_NAME: &str = "speculative_shielded.tmp";
 const CACHE_FILE_NAME: &str = "shielded_sync.cache";
 const CACHE_FILE_TMP_PREFIX: &str = "shielded_sync.cache.tmp";
+const FMD_CONF_FILE_NAME: &str = "fmd_config.toml";
+const FMD_CONF_FILE_TMP_PREFIX: &str = "fmd_config.toml.tmp";
 
 /// For `tracing_subscriber`, which fails if called more than once in the same
 /// process
@@ -887,6 +889,22 @@ impl ShieldedUtils for BenchShieldedUtils {
         let file_name = self.context_dir.0.path().join(CACHE_FILE_NAME);
         let mut file = File::open(file_name)?;
         DispatcherCache::try_from_reader(&mut file)
+    }
+
+    async fn fmd_config_save(
+        &self,
+        config: &mut kassandra_client::config::Config,
+    ) -> std::io::Result<()> {
+        config.save(FMD_CONF_FILE_TMP_PREFIX)?;
+        std::fs::rename(
+            FMD_CONF_FILE_TMP_PREFIX,
+            self.context_dir.0.path().join(FMD_CONF_FILE_NAME),
+        )
+    }
+
+    async fn fmd_config_load()
+    -> std::io::Result<kassandra_client::config::Config> {
+        kassandra_client::config::Config::load_or_new(FMD_CONF_FILE_NAME)
     }
 }
 

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -116,7 +116,8 @@ pub use namada_sdk::tx::{
 use namada_sdk::wallet::{DatedSpendingKey, Wallet};
 use namada_sdk::{
     FlagCiphertext, Namada, NamadaImpl, PaymentAddress, TransferSource,
-    TransferTarget, parameters, proof_of_stake, tendermint,
+    TransferTarget, UnifiedPaymentAddress, parameters, proof_of_stake,
+    tendermint,
 };
 use namada_test_utils::tx_data::TxWriteData;
 use namada_vm::wasm::run;
@@ -1188,7 +1189,9 @@ impl Default for BenchShieldedCtx {
                 .wallet
                 .insert_payment_addr(
                     alias,
-                    PaymentAddress::from(payment_addr),
+                    UnifiedPaymentAddress::V0(PaymentAddress::from(
+                        payment_addr,
+                    )),
                     true,
                 )
                 .unwrap();

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -72,7 +72,7 @@ migrations = [
 
 [dependencies]
 namada_account.workspace = true
-namada_core.workspace = true
+namada_core = { workspace = true, features = ["default-flag-ciphertext"] }
 namada_ethereum_bridge.workspace = true
 namada_events.workspace = true
 namada_gas.workspace = true
@@ -150,7 +150,7 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 
 [dev-dependencies]
 namada_account = { path = "../account", features = ["testing"] }
-namada_core = { path = "../core", features = ["rand", "testing"] }
+namada_core = { path = "../core", features = ["default-flag-ciphertext", "rand", "testing"] }
 namada_ethereum_bridge = { path = "../ethereum_bridge", features = ["testing"] }
 namada_governance = { path = "../governance", features = ["testing"] }
 namada_ibc = { path = "../ibc", features = ["testing"] }

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -752,7 +752,11 @@ impl TxOsmosisSwap<SdkTypes> {
                     serde_json::to_value(&NamadaMemo {
                         namada: NamadaMemoData::OsmosisSwap {
                             shielding_data: StringEncoded::new(
-                                IbcShieldingData(shielding_tx),
+                                IbcShieldingData {
+                                    masp_tx: shielding_tx,
+                                    // TODO: add actual flag ciphertext here
+                                    flag_ciphertext: Default::default(),
+                                },
                             ),
                             shielded_amount: amount_to_shield,
                             overflow_receiver,

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -2520,6 +2520,39 @@ pub struct ShieldedSync<C: NamadaTypes = SdkTypes> {
     pub retry_strategy: RetryStrategy,
 }
 
+/// The type of FMD key management command
+#[derive(Copy, Clone, Debug)]
+pub enum FmdCommandType {
+    /// Register a key with a Kassandra services configured
+    RegisterKey,
+    /// Add a Kassandra service to the configuration file
+    AddService,
+}
+
+impl FromStr for FmdCommandType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "register" => Ok(Self::RegisterKey),
+            "add" => Ok(Self::AddService),
+            _ => Err("Could not parse {s} as a valid FMD command".to_string()),
+        }
+    }
+}
+
+/// An FMD key management command for interacting with
+/// Kassandra services
+#[derive(Clone, Debug)]
+pub struct FmdCommand<C: NamadaTypes = SdkTypes> {
+    /// The type of command
+    pub command: FmdCommandType,
+    /// The key that is being managed
+    pub viewing_key: C::DatedViewingKey,
+    /// A url for a Kassandra service
+    pub service: Option<String>,
+}
+
 /// Query PoS commission rate
 #[derive(Clone, Debug)]
 pub struct QueryCommissionRate<C: NamadaTypes = SdkTypes> {

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -3021,6 +3021,12 @@ pub struct KeyAddressRemove {
 /// Generate payment address arguments
 #[derive(Clone, Debug)]
 pub struct PayAddressGen {
+    /// Force generating a v0 payment address.
+    ///
+    /// This does not include an FMD public key, therefore
+    /// should not be shared as a payment target if you
+    /// intend to use FMD to speed up shielded sync.
+    pub v0: bool,
     /// Payment address alias
     pub alias: String,
     /// Whether to force overwrite the alias

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -15,7 +15,7 @@ use namada_core::dec::Dec;
 use namada_core::ethereum_events::EthAddress;
 use namada_core::keccak::KeccakHash;
 use namada_core::key::{SchemeType, common};
-use namada_core::masp::{DiversifierIndex, MaspEpoch, PaymentAddress};
+use namada_core::masp::{DiversifierIndex, MaspEpoch};
 use namada_core::string_encoding::StringEncoded;
 use namada_core::time::DateTimeUtc;
 use namada_core::token::Amount;
@@ -131,7 +131,7 @@ impl NamadaTypes for SdkTypes {
     type EthereumAddress = ();
     type Keypair = namada_core::key::common::SecretKey;
     type MaspIndexerAddress = String;
-    type PaymentAddress = namada_core::masp::PaymentAddress;
+    type PaymentAddress = namada_core::masp::UnifiedPaymentAddress;
     type PublicKey = namada_core::key::common::PublicKey;
     type SpendingKey = PseudoExtendedKey;
     type TendermintAddress = tendermint_rpc::Url;
@@ -2956,7 +2956,7 @@ pub struct KeyAddressFind {
     /// Public key hash to lookup keypair with
     pub public_key_hash: Option<String>,
     /// Payment address to find
-    pub payment_address: Option<PaymentAddress>,
+    pub payment_address: Option<namada_core::masp::UnifiedPaymentAddress>,
     /// Find keys only
     pub keys_only: bool,
     /// Find addresses only

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -718,7 +718,7 @@ impl TxOsmosisSwap<SdkTypes> {
                     ),
                 };
 
-                let shielding_tx = tx::gen_ibc_shielding_transfer(
+                let (shielding_tx, fmd_flags) = tx::gen_ibc_shielding_transfer(
                     ctx,
                     GenIbcShieldingTransfer {
                         query: Query {
@@ -754,8 +754,7 @@ impl TxOsmosisSwap<SdkTypes> {
                             shielding_data: StringEncoded::new(
                                 IbcShieldingData {
                                     masp_tx: shielding_tx,
-                                    // TODO: add actual flag ciphertext here
-                                    flag_ciphertext: Default::default(),
+                                    flag_ciphertexts: fmd_flags,
                                 },
                             ),
                             shielded_amount: amount_to_shield,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -52,8 +52,8 @@ use namada_core::ethereum_events::EthAddress;
 use namada_core::ibc::core::host::types::identifiers::{ChannelId, PortId};
 use namada_core::key::*;
 pub use namada_core::masp::{
-    ExtendedSpendingKey, ExtendedViewingKey, FlagCiphertext, PaymentAddress,
-    TransferSource, TransferTarget,
+    ExtendedSpendingKey, ExtendedViewingKey, FlagCiphertext, FmdPaymentAddress,
+    PaymentAddress, TransferSource, TransferTarget, UnifiedPaymentAddress,
 };
 pub use namada_core::{control_flow, task_env};
 use namada_io::{Client, Io, NamadaIo};
@@ -189,7 +189,7 @@ pub trait Namada: NamadaIo {
     /// arguments
     fn new_shielding_transfer(
         &self,
-        target: PaymentAddress,
+        target: UnifiedPaymentAddress,
         data: Vec<args::TxShieldingTransferData>,
     ) -> args::TxShieldingTransfer {
         args::TxShieldingTransfer {

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -901,7 +901,7 @@ pub mod testing {
         arb_withdraw,
     };
     use crate::tx::{
-        Authorization, Code, Commitment, Header, MaspBuilder, Section,
+        Authorization, Code, Commitment, Data, Header, MaspBuilder, Section,
         TxCommitments,
     };
 
@@ -1146,6 +1146,11 @@ pub mod testing {
             if let Some((shielded_transfer, asset_types, build_params)) = aux {
                 let shielded_section_hash =
                     tx.add_masp_tx_section(shielded_transfer.masp_tx).1;
+                tx.add_section(
+                    Section::Data(
+                        Data::from_borsh_encoded(&shielded_transfer.fmd_flags),
+                    ),
+                );
                 tx.add_masp_builder(MaspBuilder {
                     asset_types: asset_types.into_keys().collect(),
                     // Store how the Info objects map to Descriptors/Outputs

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -52,8 +52,8 @@ use namada_core::ethereum_events::EthAddress;
 use namada_core::ibc::core::host::types::identifiers::{ChannelId, PortId};
 use namada_core::key::*;
 pub use namada_core::masp::{
-    ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress, TransferSource,
-    TransferTarget,
+    ExtendedSpendingKey, ExtendedViewingKey, FlagCiphertext, PaymentAddress,
+    TransferSource, TransferTarget,
 };
 pub use namada_core::{control_flow, task_env};
 use namada_io::{Client, Io, NamadaIo};

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -901,7 +901,7 @@ pub mod testing {
         arb_withdraw,
     };
     use crate::tx::{
-        Authorization, Code, Commitment, Data, Header, MaspBuilder, Section,
+        Authorization, Code, Commitment, Header, MaspBuilder, Section,
         TxCommitments,
     };
 
@@ -1146,10 +1146,8 @@ pub mod testing {
             if let Some((shielded_transfer, asset_types, build_params)) = aux {
                 let shielded_section_hash =
                     tx.add_masp_tx_section(shielded_transfer.masp_tx).1;
-                tx.add_section(
-                    Section::Data(
-                        Data::from_borsh_encoded(&shielded_transfer.fmd_flags),
-                    ),
+                tx.add_fmd_flag_ciphertexts(
+                    &shielded_transfer.fmd_flags,
                 );
                 tx.add_masp_builder(MaspBuilder {
                     asset_types: asset_types.into_keys().collect(),

--- a/crates/sdk/src/masp.rs
+++ b/crates/sdk/src/masp.rs
@@ -19,7 +19,7 @@ use namada_ibc::{IbcMessage, decode_message, extract_masp_tx_from_envelope};
 use namada_io::client::Client;
 use namada_token::masp::shielded_wallet::ShieldedQueries;
 pub use namada_token::masp::{utils, *};
-use namada_tx::event::{MaspEvent, MaspEventKind, MaspTxRef};
+use namada_tx::event::{MaspTxEvent, MaspTxKind, MaspTxRef};
 use namada_tx::{IndexedTx, Tx};
 pub use utilities::{IndexerMaspClient, LedgerMaspClient};
 
@@ -92,10 +92,10 @@ fn extract_masp_tx(
 }
 
 // Retrieves all the masp events at the specified height.
-async fn get_indexed_masp_events_at_height<C: Client + Sync>(
+async fn get_indexed_masp_txs_at_height<C: Client + Sync>(
     client: &C,
     height: BlockHeight,
-) -> Result<Vec<MaspEvent>, Error> {
+) -> Result<Vec<MaspTxEvent>, Error> {
     let maybe_masp_events: Result<Vec<_>, Error> = client
         .block_results(height.0)
         .await
@@ -111,9 +111,9 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
             };
 
             let kind = if kind == namada_tx::event::masp_types::TRANSFER {
-                MaspEventKind::Transfer
+                MaspTxKind::Transfer
             } else if kind == namada_tx::event::masp_types::FEE_PAYMENT {
-                MaspEventKind::FeePayment
+                MaspTxKind::FeePayment
             } else {
                 return Ok(None);
             };
@@ -125,7 +125,7 @@ async fn get_indexed_masp_events_at_height<C: Client + Sync>(
             let tx_index =
                 IndexedTx::read_from_event_attributes(&event.attributes)?;
 
-            Ok(Some(MaspEvent {
+            Ok(Some(MaspTxEvent {
                 tx_index,
                 kind,
                 data,

--- a/crates/sdk/src/masp/utilities.rs
+++ b/crates/sdk/src/masp/utilities.rs
@@ -18,12 +18,12 @@ use namada_token::masp::utils::{
     IndexedNoteEntry, MaspClient, MaspClientCapabilities, MaspIndexedTx,
     MaspTxKind,
 };
-use namada_tx::event::MaspEvent;
+use namada_tx::event::MaspTxEvent;
 use namada_tx::{IndexedTx, Tx};
 use tokio::sync::Semaphore;
 
 use crate::error::{Error, QueryError};
-use crate::masp::{extract_masp_tx, get_indexed_masp_events_at_height};
+use crate::masp::{extract_masp_tx, get_indexed_masp_txs_at_height};
 
 struct LedgerMaspClientInner<C> {
     client: C,
@@ -82,7 +82,7 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
 
         for height in from.0..=to.0 {
             let maybe_txs_results = async {
-                get_indexed_masp_events_at_height(
+                get_indexed_masp_txs_at_height(
                     &self.inner.client,
                     height.into(),
                 )
@@ -109,7 +109,7 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
             // Cache the last tx seen to avoid multiple deserializations
             let mut last_tx: Option<(Tx, TxIndex)> = None;
 
-            for MaspEvent {
+            for MaspTxEvent {
                 tx_index,
                 kind,
                 data,
@@ -133,7 +133,7 @@ impl<C: Client + Send + Sync> LedgerMaspClient<C> {
                 txs.push((
                     MaspIndexedTx {
                         indexed_tx: tx_index,
-                        kind: kind.into(),
+                        kind,
                     },
                     extracted_masp_tx,
                 ));

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -41,7 +41,9 @@ use namada_core::ibc::core::client::types::Height as IbcHeight;
 use namada_core::ibc::core::host::types::identifiers::{ChannelId, PortId};
 use namada_core::ibc::primitives::{IntoTimestamp, Timestamp as IbcTimestamp};
 use namada_core::key::{self, *};
-use namada_core::masp::{AssetData, MaspEpoch, TransferSource, TransferTarget};
+use namada_core::masp::{
+    AssetData, MaspEpoch, MaspTxData, TransferSource, TransferTarget,
+};
 use namada_core::storage;
 use namada_core::time::DateTimeUtc;
 use namada_events::extend::EventAttributeEntry;
@@ -2819,7 +2821,12 @@ pub async fn build_ibc_transfer(
         .map(|(shielded_transfer, asset_types)| {
             let masp_tx_hash =
                 tx.add_masp_tx_section(shielded_transfer.masp_tx.clone()).1;
-            transfer.shielded_section_hash = Some(masp_tx_hash);
+            transfer.shielded_data = Some(MaspTxData {
+                masp_tx_id: masp_tx_hash,
+                // TODO: change this to the actual sechash
+                // of the fmd flag
+                flag_ciphertext_sechash: Hash::zero(),
+            });
             signing_data.shielded_hash = Some(masp_tx_hash);
             tx.add_masp_builder(MaspBuilder {
                 asset_types,
@@ -3265,7 +3272,12 @@ pub async fn build_shielded_transfer<N: Namada>(
             target: section_hash,
         });
 
-        data.shielded_section_hash = Some(section_hash);
+        data.shielded_data = Some(MaspTxData {
+            masp_tx_id: section_hash,
+            // TODO: change this to the actual sechash
+            // of the fmd flag
+            flag_ciphertext_sechash: Hash::zero(),
+        });
         signing_data.shielded_hash = Some(section_hash);
         tracing::debug!("Transfer data {data:?}");
         Ok(())
@@ -3435,7 +3447,12 @@ pub async fn build_shielding_transfer<N: Namada>(
             target: shielded_section_hash,
         });
 
-        data.shielded_section_hash = Some(shielded_section_hash);
+        data.shielded_data = Some(MaspTxData {
+            masp_tx_id: shielded_section_hash,
+            // TODO: change this to the actual sechash
+            // of the fmd flag
+            flag_ciphertext_sechash: Hash::zero(),
+        });
         signing_data.shielded_hash = Some(shielded_section_hash);
         tracing::debug!("Transfer data {data:?}");
         Ok(())
@@ -3558,7 +3575,12 @@ pub async fn build_unshielding_transfer<N: Namada>(
             target: shielded_section_hash,
         });
 
-        data.shielded_section_hash = Some(shielded_section_hash);
+        data.shielded_data = Some(MaspTxData {
+            masp_tx_id: shielded_section_hash,
+            // TODO: change this to the actual sechash
+            // of the fmd flag
+            flag_ciphertext_sechash: Hash::zero(),
+        });
         signing_data.shielded_hash = Some(shielded_section_hash);
         tracing::debug!("Transfer data {data:?}");
         Ok(())

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -3397,7 +3397,7 @@ pub async fn build_shielding_transfer<N: Namada>(
 
         transfer_data.push(MaspTransferData {
             source: TransferSource::Address(source.to_owned()),
-            target: TransferTarget::PaymentAddress(args.target),
+            target: TransferTarget::PaymentAddress(args.target.clone()),
             token: token.to_owned(),
             amount: validated_amount,
         });
@@ -4184,8 +4184,8 @@ async fn get_refund_target(
     match (source, refund_target) {
         (_, Some(TransferTarget::PaymentAddress(pa))) => {
             Err(Error::Other(format!(
-                "Supporting only a transparent address as a refund target: {}",
-                pa,
+                "Supporting only a transparent address as a refund target: \
+                 {pa}"
             )))
         }
         (

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -3981,7 +3981,7 @@ pub async fn build_custom(
 pub async fn gen_ibc_shielding_transfer<N: Namada>(
     context: &N,
     args: args::GenIbcShieldingTransfer,
-) -> Result<Option<MaspTransaction>> {
+) -> Result<Option<(MaspTransaction, Vec<FlagCiphertext>)>> {
     let source = IBC;
 
     let token = match args.asset {
@@ -4043,7 +4043,7 @@ pub async fn gen_ibc_shielding_transfer<N: Namada>(
             .map_err(|err| TxSubmitError::MaspError(err.to_string()))?
     };
 
-    Ok(shielded_transfer.map(|st| st.masp_tx))
+    Ok(shielded_transfer.map(|st| (st.masp_tx, st.fmd_flags)))
 }
 
 pub(crate) async fn get_ibc_src_port_channel(

--- a/crates/sdk/src/tx.rs
+++ b/crates/sdk/src/tx.rs
@@ -4351,7 +4351,7 @@ fn proposal_to_vec(proposal: OnChainProposal) -> Result<Vec<u8>> {
 }
 
 fn create_fmd_section(fmd_flags: Vec<FlagCiphertext>) -> (Section, Hash) {
-    let fmd_section = Section::Data(Data::from_borsh_encoded(&fmd_flags));
+    let fmd_section = Section::ExtraData(Code::from_borsh_encoded(&fmd_flags));
     let fmd_sechash = fmd_section.get_hash();
 
     (fmd_section, fmd_sechash)

--- a/crates/shielded_token/Cargo.toml
+++ b/crates/shielded_token/Cargo.toml
@@ -58,6 +58,7 @@ eyre.workspace = true
 futures.workspace = true
 flume = { workspace = true, optional = true }
 itertools.workspace = true
+kassandra-client.workspace = true
 lazy_static.workspace = true
 linkme = { workspace = true, optional = true }
 masp_primitives.workspace = true

--- a/crates/shielded_token/src/lib.rs
+++ b/crates/shielded_token/src/lib.rs
@@ -31,7 +31,9 @@ use std::str::FromStr;
 
 use namada_core::borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 pub use namada_core::dec::Dec;
-pub use namada_core::masp::{MaspEpoch, MaspTransaction, MaspTxId, MaspValue};
+pub use namada_core::masp::{
+    MaspEpoch, MaspTransaction, MaspTxData, MaspTxId, MaspValue,
+};
 pub use namada_state::{
     ConversionLeaf, ConversionState, Error, Key, OptionExt, Result, ResultExt,
     StorageRead, StorageWrite, WithConversionState,

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -74,6 +74,11 @@ pub struct ShieldedTransfer {
     pub metadata: SaplingMetadata,
     /// Epoch in which the transaction was created
     pub epoch: MaspEpoch,
+    /// Vector of FMD flag ciphertexts.
+    ///
+    /// There must be a flag ciphertext per shielded output
+    /// in the `builder`.
+    pub fmd_flags: Vec<FlagCiphertext>,
 }
 
 /// The data for a masp fee payment
@@ -191,6 +196,9 @@ pub enum TransferErr {
     /// Insufficient funds error
     #[error("Insufficient funds: {0}")]
     InsufficientFunds(MaspDataLog),
+    /// Invalid FMD public key
+    #[error("FMD public key included in the payment address is not valid")]
+    InvalidFmdPublicKey,
     /// Generic error
     #[error("{0}")]
     General(String),

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -261,6 +261,16 @@ pub trait ShieldedUtils:
     /// Load a cache of data as part of shielded sync if that
     /// process gets interrupted.
     async fn cache_load(&self) -> std::io::Result<DispatcherCache>;
+
+    /// Save the configuration file for fuzzy message detection
+    async fn fmd_config_save(
+        &self,
+        _config: &mut kassandra_client::config::Config,
+    ) -> std::io::Result<()>;
+
+    /// Load the fuzzy messaged detection configuration file
+    async fn fmd_config_load()
+    -> std::io::Result<kassandra_client::config::Config>;
 }
 
 /// Make a ViewingKey that can view notes encrypted by given ExtendedSpendingKey
@@ -992,7 +1002,8 @@ pub mod fs {
     const SPECULATIVE_TMP_FILE_PREFIX: &str = "speculative_shielded.tmp";
     const CACHE_FILE_NAME: &str = "shielded_sync.cache";
     const CACHE_FILE_TMP_PREFIX: &str = "shielded_sync.cache.tmp";
-
+    const FMD_CONF_FILE_NAME: &str = "fmd_config.toml";
+    const FMD_CONF_FILE_TMP_PREFIX: &str = "fmd_config.toml.tmp";
     #[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
     /// An implementation of ShieldedUtils for standard filesystems
     pub struct FsShieldedUtils {
@@ -1193,6 +1204,22 @@ pub mod fs {
             let file_name = self.context_dir.join(CACHE_FILE_NAME);
             let mut file = File::open(file_name)?;
             DispatcherCache::try_from_reader(&mut file)
+        }
+
+        async fn fmd_config_save(
+            &self,
+            config: &mut kassandra_client::config::Config,
+        ) -> std::io::Result<()> {
+            config.save(FMD_CONF_FILE_TMP_PREFIX)?;
+            std::fs::rename(
+                FMD_CONF_FILE_TMP_PREFIX,
+                self.context_dir.join(FMD_CONF_FILE_NAME),
+            )
+        }
+
+        async fn fmd_config_load()
+        -> std::io::Result<kassandra_client::config::Config> {
+            kassandra_client::config::Config::load_or_new(FMD_CONF_FILE_NAME)
         }
     }
 }

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -12,41 +12,8 @@ use namada_core::chain::BlockHeight;
 use namada_core::collections::HashMap;
 use namada_state::TxIndex;
 use namada_tx::IndexedTx;
-use namada_tx::event::MaspEventKind;
+pub use namada_tx::event::MaspTxKind;
 use serde::{Deserialize, Serialize};
-
-/// The type of a MASP transaction
-#[derive(
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    BorshSerialize,
-    BorshDeserialize,
-    PartialOrd,
-    PartialEq,
-    Eq,
-    Ord,
-    Serialize,
-    Deserialize,
-    Hash,
-)]
-pub enum MaspTxKind {
-    /// A MASP transaction used for fee payment
-    FeePayment,
-    /// A general MASP transfer
-    #[default]
-    Transfer,
-}
-
-impl From<MaspEventKind> for MaspTxKind {
-    fn from(value: MaspEventKind) -> Self {
-        match value {
-            MaspEventKind::FeePayment => Self::FeePayment,
-            MaspEventKind::Transfer => Self::Transfer,
-        }
-    }
-}
 
 /// An indexed masp tx carrying information on whether it was a fee paying tx or
 /// a normal transfer

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -32,7 +32,7 @@ use namada_core::collections::{HashMap, HashSet};
 use namada_core::control_flow;
 use namada_core::masp::{
     AssetData, FlagCiphertext, FmdSecretKey, MaspEpoch, TransferSource,
-    TransferTarget, UnifiedPaymentAddress, encode_asset_type,
+    TransferTarget, encode_asset_type,
 };
 use namada_core::task_env::TaskEnvironment;
 use namada_core::time::{DateTimeUtc, DurationSecs};
@@ -1775,17 +1775,9 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
                             error: builder::Error::SaplingBuild(e),
                         })?;
 
-                    fmd_flags.push({
-                        match pa {
-                            UnifiedPaymentAddress::V0(_) => {
-                                FlagCiphertext::random(rng)
-                            }
-                            UnifiedPaymentAddress::V1(pa) => pa
-                                .to_fmd_public_key()
-                                .ok_or(TransferErr::InvalidFmdPublicKey)?
-                                .flag(rng),
-                        }
-                    });
+                    fmd_flags.push(
+                        pa.flag(rng).ok_or(TransferErr::InvalidFmdPublicKey)?,
+                    );
                 } else if let Some(t_addr_data) = target.t_addr_data() {
                     // If there is a transparent output
                     builder

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -1724,7 +1724,7 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
                 });
                 // Make transaction output tied to the current token,
                 // denomination, and epoch.
-                if let Some(pa) = payment_address {
+                if let Some(ref pa) = payment_address {
                     // If there is a shielded output
                     builder
                         .add_sapling_output(

--- a/crates/systems/src/ibc.rs
+++ b/crates/systems/src/ibc.rs
@@ -6,16 +6,21 @@ use masp_primitives::transaction::TransparentAddress;
 use masp_primitives::transaction::components::ValueSum;
 use namada_core::address::Address;
 use namada_core::borsh::BorshDeserialize;
-use namada_core::masp::TAddrData;
+use namada_core::masp::{FlagCiphertext, TAddrData};
 use namada_core::{masp_primitives, storage, token};
 pub use namada_storage::Result;
 
 /// Abstract IBC storage read interface
 pub trait Read<S> {
-    /// Extract MASP transaction from IBC envelope
-    fn try_extract_masp_tx_from_envelope<Transfer: BorshDeserialize>(
+    /// Extract shielding data from IBC envelope
+    fn try_extract_shielding_data_from_envelope<Transfer: BorshDeserialize>(
         tx_data: &[u8],
-    ) -> Result<Option<masp_primitives::transaction::Transaction>>;
+    ) -> Result<
+        Option<(
+            masp_primitives::transaction::Transaction,
+            Vec<FlagCiphertext>,
+        )>,
+    >;
 
     /// Apply relevant IBC packets to the changed balances structure
     fn apply_ibc_packet<Transfer: BorshDeserialize>(

--- a/crates/tests/src/integration/masp.rs
+++ b/crates/tests/src/integration/masp.rs
@@ -748,7 +748,7 @@ fn values_spanning_multiple_masp_digits() -> Result<()> {
                 "--node",
                 RPC,
                 "--gas-limit",
-                "65000",
+                "75000",
             ]),
         )
     });
@@ -867,7 +867,7 @@ fn values_spanning_multiple_masp_digits() -> Result<()> {
                 "--gas-spending-key",
                 C_SPENDING_KEY,
                 "--gas-limit",
-                "65000",
+                "75000",
             ]),
         )
     });

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -536,8 +536,8 @@ pub mod testing {
             .take(builder.sapling_outputs().len())
             .collect();
             let fmd_sechash = {
-                let sec = namada_tx::Section::Data(
-                    namada_tx::Data::from_borsh_encoded(&fmd_flags),
+                let sec = namada_tx::Section::ExtraData(
+                    namada_tx::Code::from_borsh_encoded(&fmd_flags),
                 );
                 sec.get_hash()
             };

--- a/crates/token/src/lib.rs
+++ b/crates/token/src/lib.rs
@@ -357,9 +357,8 @@ pub mod testing {
     use namada_core::address::testing::arb_non_internal_address;
     use namada_core::address::{Address, MASP};
     use namada_core::collections::HashMap;
-    use namada_core::hash::Hash;
     use namada_core::masp::{
-        AssetData, MaspTxData, TAddrData, encode_asset_type,
+        AssetData, FlagCiphertext, MaspTxData, TAddrData, encode_asset_type,
     };
     pub use namada_core::token::*;
     use namada_shielded_token::masp::testing::{
@@ -531,15 +530,27 @@ pub mod testing {
                 &mut rng,
                 &mut rng_build_params,
             ).unwrap();
+            let fmd_flags = std::iter::repeat_with(
+                || FlagCiphertext::random(&mut rng)
+            )
+            .take(builder.sapling_outputs().len())
+            .collect();
+            let fmd_sechash = {
+                let sec = namada_tx::Section::Data(
+                    namada_tx::Data::from_borsh_encoded(&fmd_flags),
+                );
+                sec.get_hash()
+            };
             transfer.shielded_data = Some(MaspTxData {
                 masp_tx_id: masp_tx.txid().into(),
-                flag_ciphertext_sechash: Hash::zero(),
+                flag_ciphertext_sechash: fmd_sechash,
             });
             (transfer, ShieldedTransfer {
                 builder: builder.map_builder(WalletMap),
                 metadata,
                 masp_tx,
                 epoch,
+                fmd_flags,
             }, asset_types, rng_build_params.to_stored().unwrap())
         }
     }

--- a/crates/token/src/tx.rs
+++ b/crates/token/src/tx.rs
@@ -42,10 +42,10 @@ where
         };
 
     // Apply the shielded transfer if there is a link to one
-    if let Some(masp_section_ref) = transfers.shielded_section_hash {
+    if let Some(shielded_data) = transfers.shielded_data {
         apply_shielded_transfer(
             env,
-            masp_section_ref,
+            shielded_data.masp_tx_id,
             debited_accounts,
             tokens,
             tx_data,

--- a/crates/token/src/tx.rs
+++ b/crates/token/src/tx.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use namada_core::arith::CheckedSub;
 use namada_core::collections::HashSet;
+use namada_core::hash::Hash;
 use namada_core::masp::encode_asset_type;
 use namada_core::masp_primitives::transaction::Transaction;
 use namada_core::token::MaspDigitPos;
@@ -46,6 +47,7 @@ where
         apply_shielded_transfer(
             env,
             shielded_data.masp_tx_id,
+            shielded_data.flag_ciphertext_sechash,
             debited_accounts,
             tokens,
             tx_data,
@@ -157,6 +159,7 @@ where
 pub fn apply_shielded_transfer<ENV>(
     env: &mut ENV,
     masp_section_ref: MaspTxId,
+    fmd_flags_section_ref: Hash,
     debited_accounts: HashSet<Address>,
     tokens: HashSet<Address>,
     tx_data: &BatchedTx,
@@ -179,6 +182,9 @@ where
 
     env.push_action(Action::Masp(MaspAction::MaspSectionRef(
         masp_section_ref,
+    )))?;
+    env.push_action(Action::Masp(MaspAction::FmdSectionRef(
+        fmd_flags_section_ref,
     )))?;
     update_undated_balances(env, &shielded, tokens)?;
     // Extract the debited accounts for the masp part of the transfer and

--- a/crates/tx/src/section.rs
+++ b/crates/tx/src/section.rs
@@ -277,7 +277,7 @@ impl Data {
 
     /// Make a new data section with the given borsh encodable data
     #[inline]
-    pub fn from_borsh_encoded<T: BorshSerialize>(data: &T) -> Self {
+    pub fn from_borsh_encoded<T: BorshSerialize + ?Sized>(data: &T) -> Self {
         Self::new(data.serialize_to_vec())
     }
 
@@ -374,6 +374,21 @@ impl Code {
             code: Commitment::Id(code),
             tag,
         }
+    }
+
+    /// Return the code data, if it is present verbatim.
+    pub fn id(&self) -> Option<&[u8]> {
+        if let Commitment::Id(code) = &self.code {
+            Some(&code[..])
+        } else {
+            None
+        }
+    }
+
+    /// Make a new code section with the given borsh encodable data
+    #[inline]
+    pub fn from_borsh_encoded<T: BorshSerialize + ?Sized>(data: &T) -> Self {
+        Self::new(data.serialize_to_vec(), None)
     }
 
     /// Make a new code section with the given hash

--- a/crates/tx/src/section.rs
+++ b/crates/tx/src/section.rs
@@ -275,6 +275,12 @@ impl Data {
         }
     }
 
+    /// Make a new data section with the given borsh encodable data
+    #[inline]
+    pub fn from_borsh_encoded<T: BorshSerialize>(data: &T) -> Self {
+        Self::new(data.serialize_to_vec())
+    }
+
     /// Hash this data section
     pub fn hash<'a>(&self, hasher: &'a mut Sha256) -> &'a mut Sha256 {
         hasher.update(self.serialize_to_vec());

--- a/crates/tx/src/types.rs
+++ b/crates/tx/src/types.rs
@@ -6,6 +6,7 @@ use std::io;
 use std::ops::{Bound, RangeBounds};
 use std::str::FromStr;
 
+use data_encoding::HEXUPPER;
 use masp_primitives::transaction::Transaction;
 use namada_account::AccountPublicKeysMap;
 use namada_core::address::Address;
@@ -15,7 +16,7 @@ use namada_core::borsh::{
 use namada_core::chain::{BlockHeight, ChainId};
 use namada_core::collections::{HashMap, HashSet};
 use namada_core::key::*;
-use namada_core::masp::MaspTxId;
+use namada_core::masp::{FlagCiphertext, MaspTxId};
 use namada_core::storage::TxIndex;
 use namada_core::time::DateTimeUtc;
 use namada_macros::BorshDeserializer;
@@ -46,6 +47,8 @@ pub enum DecodeError {
     InvalidTimestamp(prost_types::TimestampError),
     #[error("Couldn't serialize transaction from JSON at {0}")]
     InvalidJSONDeserialization(String),
+    #[error("Could not decode FMD flag ciphertexts from tx section {0}")]
+    InvalidFlagCiphertexts(String),
 }
 
 #[allow(missing_docs)]
@@ -285,6 +288,31 @@ impl Tx {
             }
         }
         None
+    }
+
+    /// Get the FMD flag ciphertext with the given hash
+    pub fn get_fmd_flag_ciphertexts(
+        &self,
+        hash: &namada_core::hash::Hash,
+    ) -> Result<Option<Vec<FlagCiphertext>>, DecodeError> {
+        let maybe_section = self.get_section(hash);
+
+        let data = match maybe_section.as_ref().map(Cow::as_ref) {
+            Some(Section::Data(Data { data, .. })) => data,
+            Some(_) => {
+                return Err(DecodeError::InvalidFlagCiphertexts(
+                    HEXUPPER.encode(&hash.0),
+                ));
+            }
+            None => return Ok(None),
+        };
+
+        let decoded =
+            BorshDeserialize::try_from_slice(data).map_err(|_err| {
+                DecodeError::InvalidFlagCiphertexts(HEXUPPER.encode(&hash.0))
+            })?;
+
+        Ok(Some(decoded))
     }
 
     /// Remove the transaction section with the given hash

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -443,6 +443,17 @@ impl<U> Wallet<U> {
         })
     }
 
+    /// Find the hash of an FMD secret key from the alias of the viewing
+    /// key it was derived from.
+    pub fn find_fmd_key_hash(
+        &self,
+        alias: impl AsRef<str>,
+    ) -> Result<&FmdKeyHash, FindKeyError> {
+        self.store.find_fmd_key_hash(alias.as_ref()).ok_or_else(|| {
+            FindKeyError::KeyNotFound(alias.as_ref().to_string())
+        })
+    }
+
     /// Find the birthday of the given alias
     pub fn find_birthday(
         &self,

--- a/crates/wallet/src/lib.rs
+++ b/crates/wallet/src/lib.rs
@@ -20,7 +20,8 @@ use namada_core::chain::BlockHeight;
 use namada_core::collections::{HashMap, HashSet};
 use namada_core::key::*;
 use namada_core::masp::{
-    DiversifierIndex, ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress,
+    DiversifierIndex, ExtendedSpendingKey, ExtendedViewingKey,
+    UnifiedPaymentAddress,
 };
 use namada_core::time::DateTimeUtc;
 use namada_ibc::trace::is_ibc_denom;
@@ -463,14 +464,14 @@ impl<U> Wallet<U> {
     pub fn find_payment_addr(
         &self,
         alias: impl AsRef<str>,
-    ) -> Option<&PaymentAddress> {
+    ) -> Option<&UnifiedPaymentAddress> {
         self.store.find_payment_addr(alias.as_ref())
     }
 
     /// Find an alias by the payment address if it's in the wallet.
     pub fn find_alias_by_payment_addr(
         &self,
-        payment_address: &PaymentAddress,
+        payment_address: &UnifiedPaymentAddress,
     ) -> Option<&Alias> {
         self.store.find_alias_by_payment_addr(payment_address)
     }
@@ -508,11 +509,11 @@ impl<U> Wallet<U> {
     }
 
     /// Get all known payment addresses by their alias
-    pub fn get_payment_addrs(&self) -> HashMap<String, PaymentAddress> {
+    pub fn get_payment_addrs(&self) -> HashMap<String, UnifiedPaymentAddress> {
         self.store
             .get_payment_addrs()
             .iter()
-            .map(|(alias, value)| (alias.into(), *value))
+            .map(|(alias, value)| (alias.into(), value.clone()))
             .collect()
     }
 
@@ -1231,7 +1232,7 @@ impl<U: WalletIo> Wallet<U> {
     pub fn insert_payment_addr(
         &mut self,
         alias: String,
-        payment_addr: PaymentAddress,
+        payment_addr: UnifiedPaymentAddress,
         force_alias: bool,
     ) -> Option<String> {
         self.store

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -102,10 +102,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -899,21 +943,36 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -933,6 +992,15 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "coins-bip32"
@@ -985,6 +1053,12 @@ dependencies = [
  "sha3",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "concat-idents"
@@ -1281,6 +1355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -1313,6 +1388,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1596,7 +1672,7 @@ dependencies = [
  "chrono",
  "rust_decimal",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "winnow 0.6.26",
 ]
@@ -2355,7 +2431,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serdect",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "thiserror-nostd-notrait",
  "visibility",
  "zeroize",
@@ -2652,6 +2728,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,6 +2806,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -3877,6 +3968,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,6 +4066,53 @@ dependencies = [
  "serdect",
  "sha2 0.10.8",
  "signature",
+]
+
+[[package]]
+name = "kassandra-client"
+version = "0.0.11-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e59f26661380a4758cc7c7a0b8887218677ee76be33a279205fb9cee9a4a492"
+dependencies = [
+ "chacha20poly1305",
+ "clap",
+ "curve25519-dalek",
+ "hex",
+ "hkdf",
+ "kassandra-shared",
+ "polyfuzzy",
+ "rand_core",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror 2.0.12",
+ "toml",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "kassandra-shared"
+version = "0.0.3-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d0b36e1bea0a4147d47b33e8770253f6101d6efd3f0a89f522b999947ce834"
+dependencies = [
+ "borsh",
+ "chacha20poly1305",
+ "cobs 0.3.0",
+ "hex",
+ "once_cell",
+ "polyfuzzy",
+ "rand_core",
+ "serde",
+ "serde_cbor",
+ "sha2 0.10.8",
+ "tdx-quote",
+ "thiserror 2.0.12",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -4376,7 +4520,7 @@ dependencies = [
  "pasta_curves",
  "rand_core",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "zeroize",
 ]
 
@@ -4437,7 +4581,7 @@ version = "0.149.1"
 dependencies = [
  "namada_core",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4481,7 +4625,7 @@ dependencies = [
  "smooth-operator",
  "tendermint 0.40.3",
  "tendermint-proto 0.40.3",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tiny-keccak",
  "tokio",
  "tracing",
@@ -4516,7 +4660,7 @@ dependencies = [
  "namada_vp_env",
  "serde",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -4529,7 +4673,7 @@ dependencies = [
  "namada_macros",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -4542,7 +4686,7 @@ dependencies = [
  "namada_events",
  "namada_macros",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4564,7 +4708,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -4600,7 +4744,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -4612,7 +4756,7 @@ dependencies = [
  "kdam",
  "namada_core",
  "tendermint-rpc",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -4638,7 +4782,7 @@ dependencies = [
  "namada_core",
  "namada_macros",
  "prost",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4652,7 +4796,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4675,7 +4819,7 @@ dependencies = [
  "proptest",
  "serde",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -4749,7 +4893,7 @@ dependencies = [
  "smooth-operator",
  "tempfile",
  "tendermint-rpc",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tiny-bip39",
  "tokio",
  "toml",
@@ -4768,6 +4912,7 @@ dependencies = [
  "flume",
  "futures",
  "itertools 0.14.0",
+ "kassandra-client",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
@@ -4793,7 +4938,7 @@ dependencies = [
  "sha2 0.10.8",
  "smooth-operator",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "typed-builder",
  "xorf",
@@ -4818,7 +4963,7 @@ dependencies = [
  "patricia_tree",
  "proptest",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -4836,7 +4981,7 @@ dependencies = [
  "regex",
  "serde",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -4925,7 +5070,7 @@ dependencies = [
  "namada_tx",
  "namada_tx_env",
  "namada_vp_env",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -4954,7 +5099,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tonic-build",
 ]
 
@@ -5007,7 +5152,7 @@ dependencies = [
  "rayon",
  "smooth-operator",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "wasm-instrument",
  "wasmer",
@@ -5046,7 +5191,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -5107,7 +5252,7 @@ dependencies = [
  "serde",
  "slip10_ed25519",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tiny-bip39",
  "toml",
  "zeroize",
@@ -5166,6 +5311,16 @@ name = "nonempty"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -5277,9 +5432,18 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2611b99ab098a31bdc8be48b4f1a285ca0ced28bd5b4f23e45efa8c63b09efa5"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -5376,10 +5540,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "owo-colors"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "pairing"
@@ -5724,7 +5906,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
 dependencies = [
- "cobs",
+ "cobs 0.2.3",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "heapless",
@@ -5760,6 +5942,15 @@ checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -6623,9 +6814,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -6660,10 +6851,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.217"
+name = "serde_cbor"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6683,9 +6884,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -6865,7 +7066,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -7205,6 +7406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "tdx-quote"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbbeffe2d73f07728bcbb581f8faa9098d813ba0fafbcab5e763a2fa4491e80"
+dependencies = [
+ "nom",
+ "p256",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7435,11 +7647,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -7455,9 +7667,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7828,6 +8040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -7841,18 +8054,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -8276,6 +8503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8290,6 +8523,12 @@ name = "uuid"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -9044,6 +9283,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -487,6 +487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bip0039"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1297,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rand_core",
+ "rustc_version",
+ "serde",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4409,6 +4445,7 @@ name = "namada_core"
 version = "0.149.1"
 dependencies = [
  "bech32 0.11.0",
+ "bincode",
  "borsh",
  "chrono",
  "data-encoding",
@@ -4430,6 +4467,7 @@ dependencies = [
  "num-traits",
  "num256",
  "num_enum",
+ "polyfuzzy",
  "primitive-types 0.13.1",
  "proptest",
  "prost-types",
@@ -5662,6 +5700,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyfuzzy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ad377e0383a3332e1deb427b97c8670a954efa00add87d2071daab421dae24"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "sha2 0.10.8",
+ "subtle",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5816,7 +5867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5836,7 +5887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",

--- a/wasm/tx_ibc/src/lib.rs
+++ b/wasm/tx_ibc/src/lib.rs
@@ -12,7 +12,7 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
         .execute::<token::Transfer>(&data)
         .into_storage_result()?;
 
-    let (masp_section_ref, mut token_addrs) =
+    let (maybe_masp_refs, mut token_addrs) =
         if let Some(transfers) = data.transparent {
             let (_debited_accounts, tokens) =
                 if let Some(transparent) = transfers.transparent_part() {
@@ -22,18 +22,18 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
                     Default::default()
                 };
 
-            (transfers.masp_tx_id(), tokens)
+            (transfers.shielded_data, tokens)
         } else {
             (None, Default::default())
         };
 
     token_addrs.extend(data.ibc_tokens);
 
-    let shielded = if let Some(masp_section_ref) = masp_section_ref {
+    let maybe_masp_tx = if let Some(shielded) = maybe_masp_refs {
         Some(
             tx_data
                 .tx
-                .get_masp_section(&masp_section_ref)
+                .get_masp_section(&shielded.masp_tx_id)
                 .cloned()
                 .ok_or_err_msg(
                     "Unable to find required shielded section in tx data",
@@ -44,20 +44,25 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
         )
     } else {
         data.shielded
+            .map(|ibc_shielding_data| ibc_shielding_data.masp_tx)
     };
-    if let Some(shielded) = shielded {
-        token::utils::handle_masp_tx(ctx, &shielded)
+
+    if let Some(masp_tx) = maybe_masp_tx {
+        token::utils::handle_masp_tx(ctx, &masp_tx)
             .wrap_err("Encountered error while handling MASP transaction")?;
-        update_masp_note_commitment_tree(&shielded)
+        update_masp_note_commitment_tree(&masp_tx)
             .wrap_err("Failed to update the MASP commitment tree")?;
-        if let Some(masp_section_ref) = masp_section_ref {
+        if let Some(masp_refs) = maybe_masp_refs {
             ctx.push_action(Action::Masp(MaspAction::MaspSectionRef(
-                masp_section_ref,
+                masp_refs.masp_tx_id,
+            )))?;
+            ctx.push_action(Action::Masp(MaspAction::FmdSectionRef(
+                masp_refs.flag_ciphertext_sechash,
             )))?;
         } else {
             ctx.push_action(Action::IbcShielding)?;
         }
-        token::update_undated_balances(ctx, &shielded, token_addrs)?;
+        token::update_undated_balances(ctx, &masp_tx, token_addrs)?;
     }
 
     Ok(())

--- a/wasm/tx_ibc/src/lib.rs
+++ b/wasm/tx_ibc/src/lib.rs
@@ -22,7 +22,7 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
                     Default::default()
                 };
 
-            (transfers.shielded_section_hash, tokens)
+            (transfers.masp_tx_id(), tokens)
         } else {
             (None, Default::default())
         };

--- a/wasm/vp_implicit/src/lib.rs
+++ b/wasm/vp_implicit/src/lib.rs
@@ -113,7 +113,9 @@ fn validate_tx(
                     cmt,
                     &addr,
                 )?,
-            Action::Masp(MaspAction::MaspSectionRef(_)) => (),
+            Action::Masp(
+                MaspAction::MaspSectionRef(_) | MaspAction::FmdSectionRef(_),
+            ) => (),
             Action::IbcShielding => (),
         }
     }

--- a/wasm/vp_user/src/lib.rs
+++ b/wasm/vp_user/src/lib.rs
@@ -112,7 +112,9 @@ fn validate_tx(
                     cmt,
                     &addr,
                 )?,
-            Action::Masp(MaspAction::MaspSectionRef(_)) => (),
+            Action::Masp(
+                MaspAction::MaspSectionRef(_) | MaspAction::FmdSectionRef(_),
+            ) => (),
             Action::IbcShielding => (),
         }
     }

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -298,6 +298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bip0039"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +731,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rand_core",
+ "rustc_version",
+ "serde",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1138,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fixed-hash"
@@ -2486,6 +2528,7 @@ name = "namada_core"
 version = "0.149.1"
 dependencies = [
  "bech32",
+ "bincode",
  "borsh",
  "chrono",
  "data-encoding",
@@ -2506,6 +2549,7 @@ dependencies = [
  "num-traits",
  "num256",
  "num_enum",
+ "polyfuzzy",
  "primitive-types 0.13.1",
  "prost-types",
  "rayon",
@@ -3178,6 +3222,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyfuzzy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ad377e0383a3332e1deb427b97c8670a954efa00add87d2071daab421dae24"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "sha2 0.10.8",
+ "subtle",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,7 +3332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -3295,7 +3352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",

--- a/wasm_for_tests/Cargo.lock
+++ b/wasm_for_tests/Cargo.lock
@@ -77,6 +77,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +624,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +674,21 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "const-crc32-nostd"
@@ -727,6 +832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -744,6 +850,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1209,7 +1316,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serdect",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "thiserror-nostd-notrait",
  "visibility",
  "zeroize",
@@ -1370,6 +1477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1534,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -2167,6 +2289,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2354,53 @@ dependencies = [
  "once_cell",
  "serdect",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "kassandra-client"
+version = "0.0.11-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e59f26661380a4758cc7c7a0b8887218677ee76be33a279205fb9cee9a4a492"
+dependencies = [
+ "chacha20poly1305",
+ "clap",
+ "curve25519-dalek",
+ "hex",
+ "hkdf",
+ "kassandra-shared",
+ "polyfuzzy",
+ "rand_core",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror 2.0.12",
+ "toml",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "kassandra-shared"
+version = "0.0.3-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d0b36e1bea0a4147d47b33e8770253f6101d6efd3f0a89f522b999947ce834"
+dependencies = [
+ "borsh",
+ "chacha20poly1305",
+ "cobs 0.3.0",
+ "hex",
+ "once_cell",
+ "polyfuzzy",
+ "rand_core",
+ "serde",
+ "serde_cbor",
+ "sha2 0.10.8",
+ "tdx-quote",
+ "thiserror 2.0.12",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -2473,7 +2648,7 @@ dependencies = [
  "pasta_curves",
  "rand_core",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "zeroize",
 ]
 
@@ -2520,7 +2695,7 @@ version = "0.149.1"
 dependencies = [
  "namada_core",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2560,7 +2735,7 @@ dependencies = [
  "smooth-operator",
  "tendermint",
  "tendermint-proto",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tiny-keccak",
  "tracing",
  "uint 0.10.0",
@@ -2577,7 +2752,7 @@ dependencies = [
  "namada_macros",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2590,7 +2765,7 @@ dependencies = [
  "namada_events",
  "namada_macros",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2611,7 +2786,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2645,7 +2820,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2671,7 +2846,7 @@ dependencies = [
  "namada_core",
  "namada_macros",
  "prost",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2685,7 +2860,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2707,7 +2882,7 @@ dependencies = [
  "once_cell",
  "serde",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2727,6 +2902,7 @@ dependencies = [
  "eyre",
  "futures",
  "itertools 0.14.0",
+ "kassandra-client",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
@@ -2748,7 +2924,7 @@ dependencies = [
  "sha2 0.10.8",
  "smooth-operator",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "typed-builder",
  "xorf",
@@ -2772,7 +2948,7 @@ dependencies = [
  "namada_tx",
  "patricia_tree",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2790,7 +2966,7 @@ dependencies = [
  "regex",
  "serde",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2843,7 +3019,7 @@ dependencies = [
  "namada_tx",
  "namada_tx_env",
  "namada_vp_env",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2871,7 +3047,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tonic-build",
 ]
 
@@ -2923,7 +3099,7 @@ dependencies = [
  "namada_tx",
  "namada_vp_env",
  "smooth-operator",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -2984,6 +3160,16 @@ name = "nonempty"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -3076,9 +3262,18 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2611b99ab098a31bdc8be48b4f1a285ca0ced28bd5b4f23e45efa8c63b09efa5"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -3091,6 +3286,24 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "pairing"
@@ -3240,7 +3453,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
 dependencies = [
- "cobs",
+ "cobs 0.2.3",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "heapless",
@@ -3270,6 +3483,15 @@ checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3710,9 +3932,9 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -3736,10 +3958,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.217"
+name = "serde_cbor"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3759,9 +3991,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3778,6 +4010,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3825,6 +4066,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3854,6 +4104,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smooth-operator"
@@ -3905,6 +4161,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -3989,6 +4251,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tdx-quote"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecbbeffe2d73f07728bcbb581f8faa9098d813ba0fafbcab5e763a2fa4491e80"
+dependencies = [
+ "nom",
+ "p256",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "tempfile"
@@ -4077,11 +4350,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -4097,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4124,6 +4397,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -4181,21 +4464,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.8"
+name = "toml"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic-build"
@@ -4240,6 +4547,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4483,10 +4816,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -4653,6 +4998,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4802,9 +5169,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -4825,6 +5192,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]


### PR DESCRIPTION
## Describe your changes
Partially closes #4645 

This PR allows the namada client to perform two key management actions: 
 - add to a config file 
 - use the config file to register fmd keys with Kassandra services

 Furthermore, it adds hashes of FMD keys derived from viewing keys to the wallet file under the viewing key alias. This PR does not handle querying the services or updating the shielded context accordingly.
## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
