### PR TITLE
Combined transfer inputs and outputs.

### DIFF
--- a/.changelog/unreleased/improvements/4651-combine-inputs.md
+++ b/.changelog/unreleased/improvements/4651-combine-inputs.md
@@ -1,0 +1,3 @@
+- Compute transaction change to a shielded account only after all shielded
+  inputs from it have been constructed. The intent of this is to reduce wasted
+  change. ([\#4651](https://github.com/anoma/namada/pull/4651))

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -4752,12 +4752,19 @@ pub mod args {
             ctx: &mut Context,
         ) -> Result<TxTransparentTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
-            let mut data = vec![];
+            let mut sources = vec![];
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
-            for transfer_data in self.data {
-                data.push(TxTransparentTransferData {
+            for transfer_data in self.sources {
+                sources.push(TxShieldingTransferData {
                     source: chain_ctx.get(&transfer_data.source),
+                    token: chain_ctx.get(&transfer_data.token),
+                    amount: transfer_data.amount,
+                });
+            }
+            let mut targets = vec![];
+            for transfer_data in self.targets {
+                targets.push(TxUnshieldingTransferData {
                     target: chain_ctx.get(&transfer_data.target),
                     token: chain_ctx.get(&transfer_data.token),
                     amount: transfer_data.amount,
@@ -4766,7 +4773,8 @@ pub mod args {
 
             Ok(TxTransparentTransfer::<SdkTypes> {
                 tx,
-                data,
+                sources,
+                targets,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
         }
@@ -4780,8 +4788,12 @@ pub mod args {
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let tx_code_path = PathBuf::from(TX_TRANSFER_WASM);
-            let data = vec![TxTransparentTransferData {
+            let sources = vec![TxShieldingTransferData {
                 source,
+                token: token.clone(),
+                amount,
+            }];
+            let targets = vec![TxUnshieldingTransferData {
                 target,
                 token,
                 amount,
@@ -4789,7 +4801,8 @@ pub mod args {
 
             Self {
                 tx,
-                data,
+                sources,
+                targets,
                 tx_code_path,
             }
         }
@@ -4818,12 +4831,20 @@ pub mod args {
             ctx: &mut Context,
         ) -> Result<TxShieldedTransfer<SdkTypes>, Self::Error> {
             let tx = self.tx.to_sdk(ctx)?;
-            let mut data = vec![];
+            let mut sources = vec![];
+            let mut targets = vec![];
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
-            for transfer_data in self.data {
-                data.push(TxShieldedTransferData {
+            for transfer_data in self.sources {
+                sources.push(TxShieldedSource {
                     source: chain_ctx.get_cached(&transfer_data.source),
+                    token: chain_ctx.get(&transfer_data.token),
+                    amount: transfer_data.amount,
+                });
+            }
+
+            for transfer_data in self.targets {
+                targets.push(TxShieldedTarget {
                     target: chain_ctx.get(&transfer_data.target),
                     token: chain_ctx.get(&transfer_data.token),
                     amount: transfer_data.amount,
@@ -4835,7 +4856,8 @@ pub mod args {
 
             Ok(TxShieldedTransfer::<SdkTypes> {
                 tx,
-                data,
+                sources,
+                targets,
                 gas_spending_key,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
@@ -4850,8 +4872,12 @@ pub mod args {
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let tx_code_path = PathBuf::from(TX_TRANSFER_WASM);
-            let data = vec![TxShieldedTransferData {
+            let sources = vec![TxShieldedSource {
                 source,
+                token: token.clone(),
+                amount,
+            }];
+            let targets = vec![TxShieldedTarget {
                 target,
                 token,
                 amount,
@@ -4860,7 +4886,8 @@ pub mod args {
 
             Self {
                 tx,
-                data,
+                sources,
+                targets,
                 gas_spending_key,
                 tx_code_path,
             }
@@ -4911,10 +4938,19 @@ pub mod args {
                 });
             }
 
+            let mut targets = vec![];
+            for transfer_data in self.target {
+                targets.push(TxShieldedTarget {
+                    target: chain_ctx.get(&transfer_data.target),
+                    token: chain_ctx.get(&transfer_data.token),
+                    amount: transfer_data.amount,
+                });
+            }
+
             Ok(TxShieldingTransfer::<SdkTypes> {
                 tx,
                 data,
-                target: chain_ctx.get(&self.target),
+                target: targets,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
         }
@@ -4930,6 +4966,11 @@ pub mod args {
             let tx_code_path = PathBuf::from(TX_TRANSFER_WASM);
             let data = vec![TxShieldingTransferData {
                 source,
+                token: token.clone(),
+                amount,
+            }];
+            let targets = vec![TxShieldedTarget {
+                target,
                 token,
                 amount,
             }];
@@ -4937,7 +4978,7 @@ pub mod args {
             Self {
                 tx,
                 data,
-                target,
+                target: targets,
                 tx_code_path,
             }
         }
@@ -4982,6 +5023,15 @@ pub mod args {
                     amount: transfer_data.amount,
                 });
             }
+
+            let mut sources = vec![];
+            for transfer_data in self.source {
+                sources.push(TxShieldedSource {
+                    source: chain_ctx.get_cached(&transfer_data.source),
+                    token: chain_ctx.get(&transfer_data.token),
+                    amount: transfer_data.amount,
+                });
+            }
             let gas_spending_key =
                 self.gas_spending_key.map(|key| chain_ctx.get_cached(&key));
 
@@ -4989,7 +5039,7 @@ pub mod args {
                 tx,
                 data,
                 gas_spending_key,
-                source: chain_ctx.get_cached(&self.source),
+                source: sources,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
         }
@@ -5005,6 +5055,11 @@ pub mod args {
             let tx_code_path = PathBuf::from(TX_TRANSFER_WASM);
             let data = vec![TxUnshieldingTransferData {
                 target,
+                token: token.clone(),
+                amount,
+            }];
+            let sources = vec![TxShieldedSource {
+                source,
                 token,
                 amount,
             }];
@@ -5012,7 +5067,7 @@ pub mod args {
 
             Self {
                 tx,
-                source,
+                source: sources,
                 data,
                 gas_spending_key,
                 tx_code_path,

--- a/crates/apps_lib/src/cli.rs
+++ b/crates/apps_lib/src/cli.rs
@@ -4756,7 +4756,7 @@ pub mod args {
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
             for transfer_data in self.sources {
-                sources.push(TxShieldingTransferData {
+                sources.push(TxTransparentSource {
                     source: chain_ctx.get(&transfer_data.source),
                     token: chain_ctx.get(&transfer_data.token),
                     amount: transfer_data.amount,
@@ -4764,7 +4764,7 @@ pub mod args {
             }
             let mut targets = vec![];
             for transfer_data in self.targets {
-                targets.push(TxUnshieldingTransferData {
+                targets.push(TxTransparentTarget {
                     target: chain_ctx.get(&transfer_data.target),
                     token: chain_ctx.get(&transfer_data.token),
                     amount: transfer_data.amount,
@@ -4788,12 +4788,12 @@ pub mod args {
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let tx_code_path = PathBuf::from(TX_TRANSFER_WASM);
-            let sources = vec![TxShieldingTransferData {
+            let sources = vec![TxTransparentSource {
                 source,
                 token: token.clone(),
                 amount,
             }];
-            let targets = vec![TxUnshieldingTransferData {
+            let targets = vec![TxTransparentTarget {
                 target,
                 token,
                 amount,
@@ -4930,8 +4930,8 @@ pub mod args {
             let mut data = vec![];
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
-            for transfer_data in self.data {
-                data.push(TxShieldingTransferData {
+            for transfer_data in self.sources {
+                data.push(TxTransparentSource {
                     source: chain_ctx.get(&transfer_data.source),
                     token: chain_ctx.get(&transfer_data.token),
                     amount: transfer_data.amount,
@@ -4939,7 +4939,7 @@ pub mod args {
             }
 
             let mut targets = vec![];
-            for transfer_data in self.target {
+            for transfer_data in self.targets {
                 targets.push(TxShieldedTarget {
                     target: chain_ctx.get(&transfer_data.target),
                     token: chain_ctx.get(&transfer_data.token),
@@ -4949,8 +4949,8 @@ pub mod args {
 
             Ok(TxShieldingTransfer::<SdkTypes> {
                 tx,
-                data,
-                target: targets,
+                sources: data,
+                targets,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
         }
@@ -4964,7 +4964,7 @@ pub mod args {
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let tx_code_path = PathBuf::from(TX_TRANSFER_WASM);
-            let data = vec![TxShieldingTransferData {
+            let data = vec![TxTransparentSource {
                 source,
                 token: token.clone(),
                 amount,
@@ -4977,8 +4977,8 @@ pub mod args {
 
             Self {
                 tx,
-                data,
-                target: targets,
+                sources: data,
+                targets,
                 tx_code_path,
             }
         }
@@ -5016,8 +5016,8 @@ pub mod args {
             let mut data = vec![];
             let chain_ctx = ctx.borrow_mut_chain_or_exit();
 
-            for transfer_data in self.data {
-                data.push(TxUnshieldingTransferData {
+            for transfer_data in self.targets {
+                data.push(TxTransparentTarget {
                     target: chain_ctx.get(&transfer_data.target),
                     token: chain_ctx.get(&transfer_data.token),
                     amount: transfer_data.amount,
@@ -5025,7 +5025,7 @@ pub mod args {
             }
 
             let mut sources = vec![];
-            for transfer_data in self.source {
+            for transfer_data in self.sources {
                 sources.push(TxShieldedSource {
                     source: chain_ctx.get_cached(&transfer_data.source),
                     token: chain_ctx.get(&transfer_data.token),
@@ -5037,9 +5037,9 @@ pub mod args {
 
             Ok(TxUnshieldingTransfer::<SdkTypes> {
                 tx,
-                data,
+                targets: data,
                 gas_spending_key,
-                source: sources,
+                sources,
                 tx_code_path: self.tx_code_path.to_path_buf(),
             })
         }
@@ -5053,7 +5053,7 @@ pub mod args {
             let token = TOKEN.parse(matches);
             let amount = InputAmount::Unvalidated(AMOUNT.parse(matches));
             let tx_code_path = PathBuf::from(TX_TRANSFER_WASM);
-            let data = vec![TxUnshieldingTransferData {
+            let data = vec![TxTransparentTarget {
                 target,
                 token: token.clone(),
                 amount,
@@ -5067,8 +5067,8 @@ pub mod args {
 
             Self {
                 tx,
-                source: sources,
-                data,
+                sources,
+                targets: data,
                 gas_spending_key,
                 tx_code_path,
             }

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -854,7 +854,7 @@ pub async fn submit_transparent_transfer(
     namada: &impl Namada,
     args: args::TxTransparentTransfer,
 ) -> Result<(), error::Error> {
-    if args.data.len() > 1 {
+    if args.sources.len() > 1 || args.targets.len() > 1 {
         // TODO(namada#3379): Vectorized transfers are not yet supported in the
         // CLI
         return Err(error::Error::Other(
@@ -868,7 +868,7 @@ pub async fn submit_transparent_transfer(
         tx::dump_tx(namada.io(), &args.tx, transfer_data.0)?;
     } else {
         let reveal_pks: Vec<_> =
-            args.data.iter().map(|datum| &datum.source).collect();
+            args.sources.iter().map(|datum| &datum.source).collect();
         batch_opt_reveal_pk_and_submit(
             namada,
             &args.tx,
@@ -1232,7 +1232,7 @@ pub async fn submit_shielded_transfer(
     );
 
     let sources = args
-        .data
+        .sources
         .iter_mut()
         .map(|x| &mut x.source)
         .chain(args.gas_spending_key.iter_mut());
@@ -1394,7 +1394,10 @@ pub async fn submit_unshielding_transfer(
          this command.",
     );
 
-    let sources = std::iter::once(&mut args.source)
+    let sources = args
+        .source
+        .iter_mut()
+        .map(|x| &mut x.source)
         .chain(args.gas_spending_key.iter_mut());
     let shielded_hw_keys =
         augment_masp_hardware_keys(namada, &args.tx, sources).await?;

--- a/crates/apps_lib/src/client/tx.rs
+++ b/crates/apps_lib/src/client/tx.rs
@@ -1323,7 +1323,7 @@ pub async fn submit_shielding_transfer(
         let wrapper_hash = tx.wrapper_hash();
 
         let reveal_pks: Vec<_> =
-            args.data.iter().map(|datum| &datum.source).collect();
+            args.sources.iter().map(|datum| &datum.source).collect();
         let result = batch_opt_reveal_pk_and_submit(
             namada,
             &args.tx,
@@ -1395,7 +1395,7 @@ pub async fn submit_unshielding_transfer(
     );
 
     let sources = args
-        .source
+        .sources
         .iter_mut()
         .map(|x| &mut x.source)
         .chain(args.gas_spending_key.iter_mut());

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -1248,12 +1248,12 @@ impl BenchShieldedCtx {
             native_token,
         );
         let masp_transfer_data = MaspTransferData {
-            source: vec![(
+            sources: vec![(
                 source.clone(),
                 address::testing::nam(),
                 denominated_amount,
             )],
-            target: vec![(
+            targets: vec![(
                 target.clone(),
                 address::testing::nam(),
                 denominated_amount,

--- a/crates/node/src/bench_utils.rs
+++ b/crates/node/src/bench_utils.rs
@@ -1248,10 +1248,16 @@ impl BenchShieldedCtx {
             native_token,
         );
         let masp_transfer_data = MaspTransferData {
-            source: source.clone(),
-            target: target.clone(),
-            token: address::testing::nam(),
-            amount: denominated_amount,
+            source: vec![(
+                source.clone(),
+                address::testing::nam(),
+                denominated_amount,
+            )],
+            target: vec![(
+                target.clone(),
+                address::testing::nam(),
+                denominated_amount,
+            )],
         };
         let shielded = async_runtime
             .block_on(async {
@@ -1261,7 +1267,7 @@ impl BenchShieldedCtx {
                 shielded_ctx
                     .gen_shielded_transfer(
                         &namada,
-                        vec![masp_transfer_data],
+                        masp_transfer_data,
                         None,
                         expiration,
                         &mut RngBuildParams::new(OsRng),

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -261,26 +261,15 @@ impl From<token::DenominatedAmount> for InputAmount {
     }
 }
 
-/// Transparent transfer-specific arguments
-#[derive(Clone, Debug)]
-pub struct TxTransparentTransferData<C: NamadaTypes = SdkTypes> {
-    /// Transfer source address
-    pub source: C::Address,
-    /// Transfer target address
-    pub target: C::Address,
-    /// Transferred token address
-    pub token: C::Address,
-    /// Transferred token amount
-    pub amount: InputAmount,
-}
-
 /// Transparent transfer transaction arguments
 #[derive(Clone, Debug)]
 pub struct TxTransparentTransfer<C: NamadaTypes = SdkTypes> {
     /// Common tx arguments
     pub tx: Tx<C>,
     /// The transfer specific data
-    pub data: Vec<TxTransparentTransferData<C>>,
+    pub sources: Vec<TxShieldingTransferData<C>>,
+    /// The transfer specific data
+    pub targets: Vec<TxUnshieldingTransferData<C>>,
     /// Path to the TX WASM code file
     pub tx_code_path: PathBuf,
 }
@@ -294,28 +283,6 @@ impl<C: NamadaTypes> TxBuilder<C> for TxTransparentTransfer<C> {
             tx: func(self.tx),
             ..self
         }
-    }
-}
-
-impl<C: NamadaTypes> TxTransparentTransferData<C> {
-    /// Transfer source address
-    pub fn source(self, source: C::Address) -> Self {
-        Self { source, ..self }
-    }
-
-    /// Transfer target address
-    pub fn receiver(self, target: C::Address) -> Self {
-        Self { target, ..self }
-    }
-
-    /// Transferred token address
-    pub fn token(self, token: C::Address) -> Self {
-        Self { token, ..self }
-    }
-
-    /// Transferred token amount
-    pub fn amount(self, amount: InputAmount) -> Self {
-        Self { amount, ..self }
     }
 }
 
@@ -341,9 +308,18 @@ impl TxTransparentTransfer {
 
 /// Shielded transfer-specific arguments
 #[derive(Clone, Debug)]
-pub struct TxShieldedTransferData<C: NamadaTypes = SdkTypes> {
+pub struct TxShieldedSource<C: NamadaTypes = SdkTypes> {
     /// Transfer source spending key
     pub source: C::SpendingKey,
+    /// Transferred token address
+    pub token: C::Address,
+    /// Transferred token amount
+    pub amount: InputAmount,
+}
+
+/// Shielded transfer-specific arguments
+#[derive(Clone, Debug)]
+pub struct TxShieldedTarget<C: NamadaTypes = SdkTypes> {
     /// Transfer target address
     pub target: C::PaymentAddress,
     /// Transferred token address
@@ -358,7 +334,9 @@ pub struct TxShieldedTransfer<C: NamadaTypes = SdkTypes> {
     /// Common tx arguments
     pub tx: Tx<C>,
     /// Transfer-specific data
-    pub data: Vec<TxShieldedTransferData<C>>,
+    pub sources: Vec<TxShieldedSource<C>>,
+    /// Transfer-specific data
+    pub targets: Vec<TxShieldedTarget<C>>,
     /// Optional additional keys for gas payment
     pub gas_spending_key: Option<C::SpendingKey>,
     /// Path to the TX WASM code file
@@ -405,7 +383,7 @@ pub struct TxShieldingTransfer<C: NamadaTypes = SdkTypes> {
     /// Common tx arguments
     pub tx: Tx<C>,
     /// Transfer target address
-    pub target: C::PaymentAddress,
+    pub target: Vec<TxShieldedTarget<C>>,
     /// Transfer-specific data
     pub data: Vec<TxShieldingTransferData<C>>,
     /// Path to the TX WASM code file
@@ -452,7 +430,7 @@ pub struct TxUnshieldingTransfer<C: NamadaTypes = SdkTypes> {
     /// Common tx arguments
     pub tx: Tx<C>,
     /// Transfer source spending key
-    pub source: C::SpendingKey,
+    pub source: Vec<TxShieldedSource<C>>,
     /// Transfer-specific data
     pub data: Vec<TxUnshieldingTransferData<C>>,
     /// Optional additional keys for gas payment

--- a/crates/sdk/src/args.rs
+++ b/crates/sdk/src/args.rs
@@ -267,9 +267,9 @@ pub struct TxTransparentTransfer<C: NamadaTypes = SdkTypes> {
     /// Common tx arguments
     pub tx: Tx<C>,
     /// The transfer specific data
-    pub sources: Vec<TxShieldingTransferData<C>>,
+    pub sources: Vec<TxTransparentSource<C>>,
     /// The transfer specific data
-    pub targets: Vec<TxUnshieldingTransferData<C>>,
+    pub targets: Vec<TxTransparentTarget<C>>,
     /// Path to the TX WASM code file
     pub tx_code_path: PathBuf,
 }
@@ -368,7 +368,7 @@ impl TxShieldedTransfer {
 
 /// Shielding transfer-specific arguments
 #[derive(Clone, Debug)]
-pub struct TxShieldingTransferData<C: NamadaTypes = SdkTypes> {
+pub struct TxTransparentSource<C: NamadaTypes = SdkTypes> {
     /// Transfer source spending key
     pub source: C::Address,
     /// Transferred token address
@@ -383,9 +383,9 @@ pub struct TxShieldingTransfer<C: NamadaTypes = SdkTypes> {
     /// Common tx arguments
     pub tx: Tx<C>,
     /// Transfer target address
-    pub target: Vec<TxShieldedTarget<C>>,
+    pub targets: Vec<TxShieldedTarget<C>>,
     /// Transfer-specific data
-    pub data: Vec<TxShieldingTransferData<C>>,
+    pub sources: Vec<TxTransparentSource<C>>,
     /// Path to the TX WASM code file
     pub tx_code_path: PathBuf,
 }
@@ -415,7 +415,7 @@ impl TxShieldingTransfer {
 
 /// Unshielding transfer-specific arguments
 #[derive(Clone, Debug)]
-pub struct TxUnshieldingTransferData<C: NamadaTypes = SdkTypes> {
+pub struct TxTransparentTarget<C: NamadaTypes = SdkTypes> {
     /// Transfer target address
     pub target: C::Address,
     /// Transferred token address
@@ -430,12 +430,11 @@ pub struct TxUnshieldingTransfer<C: NamadaTypes = SdkTypes> {
     /// Common tx arguments
     pub tx: Tx<C>,
     /// Transfer source spending key
-    pub source: Vec<TxShieldedSource<C>>,
+    pub sources: Vec<TxShieldedSource<C>>,
     /// Transfer-specific data
-    pub data: Vec<TxUnshieldingTransferData<C>>,
+    pub targets: Vec<TxTransparentTarget<C>>,
     /// Optional additional keys for gas payment
     pub gas_spending_key: Option<C::SpendingKey>,
-
     /// Path to the TX WASM code file
     pub tx_code_path: PathBuf,
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -157,8 +157,8 @@ pub trait Namada: NamadaIo {
     /// arguments
     fn new_transparent_transfer(
         &self,
-        sources: Vec<args::TxShieldingTransferData>,
-        targets: Vec<args::TxUnshieldingTransferData>,
+        sources: Vec<args::TxTransparentSource>,
+        targets: Vec<args::TxTransparentTarget>,
     ) -> args::TxTransparentTransfer {
         args::TxTransparentTransfer {
             sources,
@@ -189,12 +189,12 @@ pub trait Namada: NamadaIo {
     /// arguments
     fn new_shielding_transfer(
         &self,
-        target: Vec<args::TxShieldedTarget>,
-        data: Vec<args::TxShieldingTransferData>,
+        targets: Vec<args::TxShieldedTarget>,
+        sources: Vec<args::TxTransparentSource>,
     ) -> args::TxShieldingTransfer {
         args::TxShieldingTransfer {
-            data,
-            target,
+            sources,
+            targets,
             tx_code_path: PathBuf::from(TX_TRANSFER_WASM),
             tx: self.tx_builder(),
         }
@@ -204,13 +204,13 @@ pub trait Namada: NamadaIo {
     /// arguments
     fn new_unshielding_transfer(
         &self,
-        source: Vec<args::TxShieldedSource>,
-        data: Vec<args::TxUnshieldingTransferData>,
+        sources: Vec<args::TxShieldedSource>,
+        targets: Vec<args::TxTransparentTarget>,
         gas_spending_key: Option<PseudoExtendedKey>,
     ) -> args::TxUnshieldingTransfer {
         args::TxUnshieldingTransfer {
-            source,
-            data,
+            sources,
+            targets,
             gas_spending_key,
             tx_code_path: PathBuf::from(TX_TRANSFER_WASM),
             tx: self.tx_builder(),

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -157,10 +157,12 @@ pub trait Namada: NamadaIo {
     /// arguments
     fn new_transparent_transfer(
         &self,
-        data: Vec<args::TxTransparentTransferData>,
+        sources: Vec<args::TxShieldingTransferData>,
+        targets: Vec<args::TxUnshieldingTransferData>,
     ) -> args::TxTransparentTransfer {
         args::TxTransparentTransfer {
-            data,
+            sources,
+            targets,
             tx_code_path: PathBuf::from(TX_TRANSFER_WASM),
             tx: self.tx_builder(),
         }
@@ -170,11 +172,13 @@ pub trait Namada: NamadaIo {
     /// arguments
     fn new_shielded_transfer(
         &self,
-        data: Vec<args::TxShieldedTransferData>,
+        sources: Vec<args::TxShieldedSource>,
+        targets: Vec<args::TxShieldedTarget>,
         gas_spending_key: Option<PseudoExtendedKey>,
     ) -> args::TxShieldedTransfer {
         args::TxShieldedTransfer {
-            data,
+            sources,
+            targets,
             gas_spending_key,
             tx_code_path: PathBuf::from(TX_TRANSFER_WASM),
             tx: self.tx_builder(),
@@ -185,7 +189,7 @@ pub trait Namada: NamadaIo {
     /// arguments
     fn new_shielding_transfer(
         &self,
-        target: PaymentAddress,
+        target: Vec<args::TxShieldedTarget>,
         data: Vec<args::TxShieldingTransferData>,
     ) -> args::TxShieldingTransfer {
         args::TxShieldingTransfer {
@@ -200,7 +204,7 @@ pub trait Namada: NamadaIo {
     /// arguments
     fn new_unshielding_transfer(
         &self,
-        source: PseudoExtendedKey,
+        source: Vec<args::TxShieldedSource>,
         data: Vec<args::TxUnshieldingTransferData>,
         gas_spending_key: Option<PseudoExtendedKey>,
     ) -> args::TxUnshieldingTransfer {

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -90,8 +90,8 @@ pub struct MaspFeeData {
 #[allow(missing_docs)]
 #[derive(Debug, Default)]
 pub struct MaspTransferData {
-    pub source: Vec<(TransferSource, Address, token::DenominatedAmount)>,
-    pub target: Vec<(TransferTarget, Address, token::DenominatedAmount)>,
+    pub sources: Vec<(TransferSource, Address, token::DenominatedAmount)>,
+    pub targets: Vec<(TransferTarget, Address, token::DenominatedAmount)>,
 }
 
 /// Data to log the error of a single masp transaction
@@ -142,10 +142,13 @@ impl fmt::Display for MaspDataLog {
     }
 }
 
-#[allow(missing_docs)]
-pub struct MaspTxReorderedData {
+/// Represents the data used to construct a MASP Transfer
+pub struct MaspTxCombinedData {
+    /// Sources of assets going into the transfer
     source_data: HashMap<TransferSource, ValueSum<Address, token::Amount>>,
+    /// Destinations of assets going out of the transfer
     target_data: HashMap<TransferTarget, ValueSum<Address, token::Amount>>,
+    /// The denominations of the various tokens used in the transfer
     denoms: HashMap<Address, Denomination>,
 }
 

--- a/crates/shielded_token/src/masp.rs
+++ b/crates/shielded_token/src/masp.rs
@@ -88,27 +88,10 @@ pub struct MaspFeeData {
 
 /// The data for a single masp transfer
 #[allow(missing_docs)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MaspTransferData {
-    pub source: TransferSource,
-    pub target: TransferTarget,
-    pub token: Address,
-    pub amount: token::DenominatedAmount,
-}
-
-/// The data for a masp transfer relative to a given source
-#[derive(Hash, Eq, PartialEq)]
-pub struct MaspSourceTransferData {
-    source: TransferSource,
-    token: Address,
-}
-
-/// The data for a masp transfer relative to a given target
-#[derive(Debug, Hash, Eq, PartialEq)]
-pub struct MaspTargetTransferData {
-    source: TransferSource,
-    target: TransferTarget,
-    token: Address,
+    pub source: Vec<(TransferSource, Address, token::DenominatedAmount)>,
+    pub target: Vec<(TransferTarget, Address, token::DenominatedAmount)>,
 }
 
 /// Data to log the error of a single masp transaction
@@ -161,8 +144,8 @@ impl fmt::Display for MaspDataLog {
 
 #[allow(missing_docs)]
 pub struct MaspTxReorderedData {
-    source_data: HashMap<MaspSourceTransferData, token::Amount>,
-    target_data: HashMap<MaspTargetTransferData, token::Amount>,
+    source_data: HashMap<TransferSource, ValueSum<Address, token::Amount>>,
+    target_data: HashMap<TransferTarget, ValueSum<Address, token::Amount>>,
     denoms: HashMap<Address, Denomination>,
 }
 

--- a/crates/shielded_token/src/masp/shielded_wallet.rs
+++ b/crates/shielded_token/src/masp/shielded_wallet.rs
@@ -51,10 +51,9 @@ use super::utils::MaspIndexedTx;
 use crate::masp::utils::MaspClient;
 use crate::masp::{
     ContextSyncStatus, Conversions, MaspAmount, MaspDataLogEntry, MaspFeeData,
-    MaspSourceTransferData, MaspTargetTransferData, MaspTransferData,
-    MaspTxReorderedData, NETWORK, NoteIndex, ShieldedSyncConfig,
-    ShieldedTransfer, ShieldedUtils, SpentNotesTracker, TransferErr, WalletMap,
-    WitnessMap,
+    MaspTransferData, MaspTxReorderedData, NETWORK, NoteIndex,
+    ShieldedSyncConfig, ShieldedTransfer, ShieldedUtils, SpentNotesTracker,
+    TransferErr, WalletMap, WitnessMap,
 };
 #[cfg(any(test, feature = "testing"))]
 use crate::masp::{ENV_VAR_MASP_TEST_SEED, testing};
@@ -1115,7 +1114,7 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
     async fn gen_shielded_transfer(
         &mut self,
         context: &impl NamadaIo,
-        data: Vec<MaspTransferData>,
+        data: MaspTransferData,
         fee_data: Option<MaspFeeData>,
         expiration: Option<DateTimeUtc>,
         bparams: &mut impl BuildParams,
@@ -1207,7 +1206,7 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
             source_data,
             target_data,
             mut denoms,
-        }) = Self::reorder_data_for_masp_transfer(context, data, fee_data)
+        }) = Self::combine_data_for_masp_transfer(context, data, fee_data)
             .await?
         else {
             // No shielded components are needed when neither source nor
@@ -1215,12 +1214,11 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
             return Ok(None);
         };
 
-        for (MaspSourceTransferData { source, token }, amount) in &source_data {
+        for (source, amount) in &source_data {
             self.add_inputs(
                 context,
                 &mut builder,
                 source,
-                token,
                 amount,
                 epoch,
                 &mut denoms,
@@ -1229,21 +1227,11 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
             .await?;
         }
 
-        for (
-            MaspTargetTransferData {
-                source,
-                target,
-                token,
-            },
-            amount,
-        ) in target_data
-        {
+        for (target, amount) in target_data {
             self.add_outputs(
                 context,
                 &mut builder,
-                &source,
                 &target,
-                token,
                 amount,
                 epoch,
                 &mut denoms,
@@ -1346,13 +1334,15 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
     /// and pass it to the appropriate function so that notes can be
     /// collected based on the correct amount.
     #[allow(async_fn_in_trait)]
-    async fn reorder_data_for_masp_transfer(
+    async fn combine_data_for_masp_transfer(
         context: &impl NamadaIo,
-        data: Vec<MaspTransferData>,
+        data: MaspTransferData,
         fee_data: Option<MaspFeeData>,
     ) -> Result<Option<MaspTxReorderedData>, TransferErr> {
-        let mut source_data = HashMap::<MaspSourceTransferData, Amount>::new();
-        let mut target_data = HashMap::<MaspTargetTransferData, Amount>::new();
+        let mut source_data =
+            HashMap::<TransferSource, ValueSum<Address, Amount>>::new();
+        let mut target_data =
+            HashMap::<TransferTarget, ValueSum<Address, Amount>>::new();
         let mut denoms = HashMap::new();
 
         // If present, add the fee data to the rest of the transfer data
@@ -1366,37 +1356,22 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
                 .map_err(|e| TransferErr::General(e.to_string()))?
                 .amount();
 
-            source_data.insert(
-                MaspSourceTransferData {
-                    source: TransferSource::ExtendedKey(fee_data.source),
-                    token: fee_data.token.clone(),
-                },
-                amount,
-            );
-            target_data.insert(
-                MaspTargetTransferData {
-                    source: TransferSource::ExtendedKey(fee_data.source),
-                    target: TransferTarget::Address(fee_data.target),
-                    token: fee_data.token,
-                },
-                amount,
-            );
+            let acc = source_data
+                .entry(TransferSource::ExtendedKey(fee_data.source))
+                .or_insert(ValueSum::zero());
+            *acc = checked!(
+                ValueSum::from_pair(fee_data.token.clone(), amount) + acc
+            )
+            .map_err(|e| TransferErr::General(e.to_string()))?;
+            let acc = target_data
+                .entry(TransferTarget::Address(fee_data.target))
+                .or_insert(ValueSum::zero());
+            *acc = checked!(
+                ValueSum::from_pair(fee_data.token.clone(), amount) + acc
+            )
+            .map_err(|e| TransferErr::General(e.to_string()))?;
         }
-        for MaspTransferData {
-            source,
-            target,
-            token,
-            amount,
-        } in data
-        {
-            let spending_key = source.spending_key();
-            let payment_address = target.payment_address();
-            // No shielded components are needed when neither source nor
-            // destination are shielded
-            if spending_key.is_none() && payment_address.is_none() {
-                return Ok(None);
-            }
-
+        for (source, token, amount) in data.source {
             let denom =
                 Self::get_denom(context.client(), &mut denoms, &token).await?;
             let amount = amount
@@ -1404,34 +1379,25 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
                 .map_err(|e| TransferErr::General(e.to_string()))?
                 .amount();
 
-            let key = MaspSourceTransferData {
-                source: source.clone(),
-                token: token.clone(),
-            };
-            match source_data.get_mut(&key) {
-                Some(prev_amount) => {
-                    *prev_amount = checked!(prev_amount.to_owned() + amount)
-                        .map_err(|e| TransferErr::General(e.to_string()))?;
-                }
-                None => {
-                    source_data.insert(key, amount);
-                }
-            }
+            let acc = source_data
+                .entry(source.clone())
+                .or_insert(ValueSum::zero());
+            *acc = checked!(ValueSum::from_pair(token.clone(), amount) + acc)
+                .map_err(|e| TransferErr::General(e.to_string()))?;
+        }
+        for (target, token, amount) in data.target {
+            let denom =
+                Self::get_denom(context.client(), &mut denoms, &token).await?;
+            let amount = amount
+                .increase_precision(denom)
+                .map_err(|e| TransferErr::General(e.to_string()))?
+                .amount();
 
-            let key = MaspTargetTransferData {
-                source,
-                target,
-                token,
-            };
-            match target_data.get_mut(&key) {
-                Some(prev_amount) => {
-                    *prev_amount = checked!(prev_amount.to_owned() + amount)
-                        .map_err(|e| TransferErr::General(e.to_string()))?;
-                }
-                None => {
-                    target_data.insert(key, amount);
-                }
-            }
+            let acc = target_data
+                .entry(target.clone())
+                .or_insert(ValueSum::zero());
+            *acc = checked!(ValueSum::from_pair(token.clone(), amount) + acc)
+                .map_err(|e| TransferErr::General(e.to_string()))?;
         }
 
         Ok(Some(MaspTxReorderedData {
@@ -1513,8 +1479,7 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
         context: &impl NamadaIo,
         builder: &mut Builder<Network, PseudoExtendedKey>,
         source: &TransferSource,
-        token: &Address,
-        amount: &Amount,
+        amount: &ValueSum<Address, Amount>,
         epoch: MaspEpoch,
         denoms: &mut HashMap<Address, Denomination>,
         notes_tracker: &mut SpentNotesTracker,
@@ -1526,20 +1491,22 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
 
         // Compute transparent output asset types in case they are required and
         // save them to facilitate decodings.
-        let denom = denoms.get(token).unwrap();
-        let mut transparent_asset_types = Vec::new();
-        for digit in MaspDigitPos::iter() {
-            let mut pre_asset_type = AssetData {
-                epoch: Some(epoch),
-                token: token.clone(),
-                denom: *denom,
-                position: digit,
-            };
-            let asset_type = self
-                .get_asset_type(context.client(), &mut pre_asset_type)
-                .await
-                .map_err(|e| TransferErr::General(e.to_string()))?;
-            transparent_asset_types.push((digit, asset_type));
+        let mut transparent_asset_types = BTreeMap::new();
+        for token in amount.asset_types() {
+            let denom = denoms.get(token).unwrap();
+            for digit in MaspDigitPos::iter() {
+                let mut pre_asset_type = AssetData {
+                    epoch: Some(epoch),
+                    token: token.clone(),
+                    denom: *denom,
+                    position: digit,
+                };
+                let asset_type = self
+                    .get_asset_type(context.client(), &mut pre_asset_type)
+                    .await
+                    .map_err(|e| TransferErr::General(e.to_string()))?;
+                transparent_asset_types.insert((token, digit), asset_type);
+            }
         }
         let _ = self.save().await;
 
@@ -1550,26 +1517,25 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
             // collect all words from the namada amount
             // whose values are non-zero, and pair them
             // with their corresponding masp digit position.
-            let required_amt = amount
-                .iter_words()
-                .zip(MaspDigitPos::iter())
-                .filter_map(|(value, masp_digit_pos)| {
-                    if value != 0 {
-                        Some((masp_digit_pos, i128::from(value)))
-                    } else {
-                        None
-                    }
-                })
-                .fold(
-                    ValueSum::zero(),
-                    |mut accum, (masp_digit_pos, value)| {
-                        accum += ValueSum::from_pair(
-                            (masp_digit_pos, token.clone()),
-                            value,
-                        );
-                        accum
-                    },
-                );
+            let required_amt = amount.components().fold(
+                ValueSum::zero(),
+                |accum, (token, amount)| {
+                    amount.iter_words().zip(MaspDigitPos::iter()).fold(
+                        accum,
+                        |accum, (value, masp_digit_pos)| {
+                            if value != 0 {
+                                accum
+                                    + ValueSum::from_pair(
+                                        (masp_digit_pos, token.clone()),
+                                        i128::from(value),
+                                    )
+                            } else {
+                                accum
+                            }
+                        },
+                    )
+                },
+            );
             // Locate unspent notes that can help us meet the transaction
             // amount
             let (added_amt, unspent_notes, used_convs) = self
@@ -1643,19 +1609,22 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
                 })?
                 .taddress();
 
-            for (digit, asset_type) in transparent_asset_types {
-                let amount_part = digit.denominate(amount);
-                // Skip adding an input if its value is 0
-                if amount_part != 0 {
-                    builder
-                        .add_transparent_input(TxOut {
-                            asset_type,
-                            value: amount_part,
-                            address: script,
-                        })
-                        .map_err(|e| TransferErr::Build {
-                            error: builder::Error::TransparentBuild(e),
-                        })?;
+            for (token, amount) in amount.components() {
+                for digit in MaspDigitPos::iter() {
+                    let asset_type = transparent_asset_types[&(token, digit)];
+                    let amount_part = digit.denominate(amount);
+                    // Skip adding an input if its value is 0
+                    if amount_part != 0 {
+                        builder
+                            .add_transparent_input(TxOut {
+                                asset_type,
+                                value: amount_part,
+                                address: script,
+                            })
+                            .map_err(|e| TransferErr::Build {
+                                error: builder::Error::TransparentBuild(e),
+                            })?;
+                    }
                 }
             }
 
@@ -1672,10 +1641,8 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
         &mut self,
         context: &impl NamadaIo,
         builder: &mut Builder<Network, PseudoExtendedKey>,
-        source: &TransferSource,
         target: &TransferTarget,
-        token: Address,
-        amount: Amount,
+        amount: ValueSum<Address, Amount>,
         epoch: MaspEpoch,
         denoms: &mut HashMap<Address, Denomination>,
     ) -> Result<(), TransferErr> {
@@ -1691,85 +1658,87 @@ pub trait ShieldedApi<U: ShieldedUtils + MaybeSend + MaybeSync>:
 
         let payment_address = target.payment_address();
 
-        // This indicates how many more assets need to be sent to the
-        // receiver in order to satisfy the requested transfer
-        // amount.
-        let mut rem_amount = amount.raw_amount().0;
+        for (token, amount) in amount.components() {
+            // This indicates how many more assets need to be sent to the
+            // receiver in order to satisfy the requested transfer
+            // amount.
+            let mut rem_amount = amount.raw_amount().0;
 
-        let denom = Self::get_denom(context.client(), denoms, &token).await?;
-        // Now handle the outputs of this transaction
-        // Loop through the value balance components and see which
-        // ones can be given to the receiver
-        for ((asset_type, decoded), val) in value_balance.components() {
-            let rem_amount = &mut rem_amount[decoded.position as usize];
-            // Only asset types with the correct token can contribute. But
-            // there must be a demonstrated need for it.
-            if decoded.token == token
-                && decoded.denom == denom
-                && decoded.epoch.is_none_or(|vbal_epoch| vbal_epoch <= epoch)
-                && *rem_amount > 0
-            {
-                let val = u128::try_from(*val).expect(
-                    "value balance in absence of output descriptors should be \
-                     non-negative",
-                );
-                // We want to take at most the remaining quota for the
-                // current denomination to the receiver
-                let contr = std::cmp::min(u128::from(*rem_amount), val) as u64;
-                // If we are sending to a shielded address, we need the outgoing
-                // viewing key in the following computations.
-                let ovk_opt =
-                    source.spending_key().map(|x| x.to_viewing_key().fvk.ovk);
-                // Make transaction output tied to the current token,
-                // denomination, and epoch.
-                if let Some(pa) = payment_address {
-                    // If there is a shielded output
-                    builder
-                        .add_sapling_output(
-                            ovk_opt,
-                            pa.into(),
-                            *asset_type,
-                            contr,
-                            MemoBytes::empty(),
-                        )
-                        .map_err(|e| TransferErr::Build {
-                            error: builder::Error::SaplingBuild(e),
-                        })?;
-                } else if let Some(t_addr_data) = target.t_addr_data() {
-                    // If there is a transparent output
-                    builder
-                        .add_transparent_output(
-                            &t_addr_data.taddress(),
-                            *asset_type,
-                            contr,
-                        )
-                        .map_err(|e| TransferErr::Build {
-                            error: builder::Error::TransparentBuild(e),
-                        })?;
-                } else {
-                    return Result::Err(TransferErr::General(
-                        "Transaction target must be a payment address or \
-                         Namada address or IBC address"
-                            .to_string(),
-                    ));
+            let denom =
+                Self::get_denom(context.client(), denoms, token).await?;
+            // Now handle the outputs of this transaction
+            // Loop through the value balance components and see which
+            // ones can be given to the receiver
+            for ((asset_type, decoded), val) in value_balance.components() {
+                let rem_amount = &mut rem_amount[decoded.position as usize];
+                // Only asset types with the correct token can contribute. But
+                // there must be a demonstrated need for it.
+                if decoded.token == *token
+                    && decoded.denom == denom
+                    && decoded
+                        .epoch
+                        .is_none_or(|vbal_epoch| vbal_epoch <= epoch)
+                    && *rem_amount > 0
+                {
+                    let val = u128::try_from(*val).expect(
+                        "value balance in absence of output descriptors \
+                         should be non-negative",
+                    );
+                    // We want to take at most the remaining quota for the
+                    // current denomination to the receiver
+                    let contr =
+                        std::cmp::min(u128::from(*rem_amount), val) as u64;
+                    // Make transaction output tied to the current token,
+                    // denomination, and epoch.
+                    if let Some(pa) = payment_address {
+                        // If there is a shielded output
+                        builder
+                            .add_sapling_output(
+                                None,
+                                pa.into(),
+                                *asset_type,
+                                contr,
+                                MemoBytes::empty(),
+                            )
+                            .map_err(|e| TransferErr::Build {
+                                error: builder::Error::SaplingBuild(e),
+                            })?;
+                    } else if let Some(t_addr_data) = target.t_addr_data() {
+                        // If there is a transparent output
+                        builder
+                            .add_transparent_output(
+                                &t_addr_data.taddress(),
+                                *asset_type,
+                                contr,
+                            )
+                            .map_err(|e| TransferErr::Build {
+                                error: builder::Error::TransparentBuild(e),
+                            })?;
+                    } else {
+                        return Result::Err(TransferErr::General(
+                            "Transaction target must be a payment address or \
+                             Namada address or IBC address"
+                                .to_string(),
+                        ));
+                    }
+                    // Lower what is required of the remaining contribution
+                    *rem_amount -= contr;
                 }
-                // Lower what is required of the remaining contribution
-                *rem_amount -= contr;
             }
-        }
 
-        // Nothing must remain to be included in output
-        if rem_amount != [0; 4] {
-            return Result::Err(TransferErr::InsufficientFunds(
-                vec![MaspDataLogEntry {
-                    token,
-                    shortfall: DenominatedAmount::new(
-                        namada_core::uint::Uint(rem_amount).into(),
-                        denom,
-                    ),
-                }]
-                .into(),
-            ));
+            // Nothing must remain to be included in output
+            if rem_amount != [0; 4] {
+                return Result::Err(TransferErr::InsufficientFunds(
+                    vec![MaspDataLogEntry {
+                        token: token.clone(),
+                        shortfall: DenominatedAmount::new(
+                            namada_core::uint::Uint(rem_amount).into(),
+                            denom,
+                        ),
+                    }]
+                    .into(),
+                ));
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Describe your changes
This PR vectorizes the processing of shielded transfer inputs to reduce the chances that change is unnecessarily sent back to the sender. More precisely, for a given extended spending key, the required amount is now a (exhaustive) vector of the amounts of each token that are required. This way the note accumulator now has to exceed this vectorial amount before the change computations even begin.

Additionally, analogous to https://github.com/anoma/namada/pull/3459 , this PR supports a CLI where the number of inputs to a transfer do not match the number of its outputs. Furthermore this PR allows for a CLI where transfer inputs and outputs do not occur in balancing pairs.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
