### PR TITLE
feat: add custom queries for calculating validators specific epoch reward

### DIFF
--- a/crates/apps_lib/src/client/rpc.rs
+++ b/crates/apps_lib/src/client/rpc.rs
@@ -1508,6 +1508,20 @@ pub async fn query_rewards<C: Client + Sync>(
     )
 }
 
+/// Query validator rewards products for a given validator and epoch.
+pub async fn query_validator_rewards_product<C: Client + Sync>(
+    client: &C,
+    validator: &Address,
+    epoch: Option<Epoch>,
+) -> Vec<(Epoch, Dec)> {
+    unwrap_client_response::<C, _>(
+        RPC.vp()
+            .pos()
+            .rewards_products(client, validator, &epoch)
+            .await,
+    )
+}
+
 /// Query token total supply.
 pub async fn query_total_supply<N: Namada>(
     context: &N,

--- a/crates/proof_of_stake/src/lib.rs
+++ b/crates/proof_of_stake/src/lib.rs
@@ -2874,6 +2874,46 @@ where
     Ok(res)
 }
 
+/// Query the  validator's reward product for a given epoch.
+pub fn query_validator_rewards_products<S, Gov>(
+    storage: &S,
+    validator: &Address,
+    epoch: Option<Epoch>,
+) -> Result<Vec<(Epoch, Dec)>>
+where
+    S: StorageRead,
+    Gov: governance::Read<S>,
+{
+    let rewards_products = validator_rewards_products_handle(validator);
+    // Query for a specific epoch or all epochs
+    let result = if let Some(epoch) = epoch {
+        tracing::debug!("Querying rewards product for epoch {:?}", epoch);
+        rewards_products
+            .get(storage, &epoch)?
+            .map(|product| vec![(epoch, product)])
+            .unwrap_or_else(|| {
+                tracing::debug!(
+                    "No rewards product found for epoch {:?}",
+                    epoch
+                );
+                vec![]
+            })
+    } else {
+        tracing::debug!("Querying rewards products for all epochs");
+        rewards_products
+            .iter(storage)?
+            .filter_map(|res| match res {
+                Ok((epoch, product)) => Some(Ok((epoch, product))),
+                Err(e) => {
+                    tracing::error!("Failed to read rewards product: {:?}", e);
+                    None
+                }
+            })
+            .collect::<Result<Vec<_>>>()?
+    };
+    Ok(result)
+}
+
 /// Jail a validator by removing it from and updating the validator sets and
 /// changing a its state to `Jailed`. Validators are jailed for liveness and for
 /// misbehaving.

--- a/crates/sdk/src/queries/shell.rs
+++ b/crates/sdk/src/queries/shell.rs
@@ -79,6 +79,9 @@ router! {SHELL,
     // First block height of the current epoch
     ( "first_block_height_of_current_epoch" ) -> BlockHeight = first_block_height_of_current_epoch,
 
+    // First block height of the current epoch
+    ( "first_block_height_by_epoch" / [epoch: Epoch] ) -> Option<BlockHeight> = first_block_height_by_epoch,
+
     // Raw storage access - read value
     ( "value" / [storage_key: storage::Key] )
         -> Vec<u8> = (with_options storage_value),
@@ -425,6 +428,22 @@ where
             "The pred_epochs is unexpectedly empty",
         )))
         .cloned()
+}
+
+fn first_block_height_by_epoch<D, H, V, T>(
+    ctx: RequestCtx<'_, D, H, V, T>,
+    epoch: Epoch,
+) -> namada_storage::Result<Option<BlockHeight>>
+where
+    D: 'static + DB + for<'iter> DBIter<'iter> + Sync,
+    H: 'static + StorageHasher + Sync,
+{
+    Ok(ctx
+        .state
+        .in_mem()
+        .block
+        .pred_epochs
+        .get_start_height_of_epoch(epoch))
 }
 
 /// Returns data with `vec![]` when the storage key is not found. For all


### PR DESCRIPTION
## Describe your changes

Add some custom rpc queries for extracting onchain data for validators and delegators.

1. First one is for getting first block height by epoch

```rust 
    // First block height of the current epoch
    ( "first_block_height_by_epoch" / [epoch: Epoch] ) -> Option<BlockHeight> = first_block_height_by_epoch,
```

2. Second one is for getting validators' reward products by epoch. 
```rust
    ( "rewards_products" / [validator: Address] / [epoch: opt Epoch])
    -> Vec<(Epoch, Dec)> = rewards_products,
```
Actually, some of validators like us want to make specific epoch reward for validators and delegator. At that time, both of queries will be very useful. If your team want, I can attach calculating logic with that. 

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
