### PR TITLE
Soft limit the number of wasm transfer targets

### DIFF
--- a/.changelog/unreleased/improvements/4659-soft-limit-tx-transfer-targets.md
+++ b/.changelog/unreleased/improvements/4659-soft-limit-tx-transfer-targets.md
@@ -1,0 +1,2 @@
+- Limit the number of unique transfer targets (sources + targets) to 20, in
+  `tx_transfer`. ([\#4659](https://github.com/anoma/namada/pull/4659))

--- a/crates/tx_prelude/src/token.rs
+++ b/crates/tx_prelude/src/token.rs
@@ -8,7 +8,7 @@ pub use namada_token::testing;
 pub use namada_token::tx::apply_shielded_transfer;
 pub use namada_token::{
     Amount, DenominatedAmount, Denomination, MaspDigitPos, Store, Transfer,
-    storage_key, utils, validate_transfer_targets,
+    storage_key, utils, validate_transfer_in_out,
 };
 use namada_tx::BatchedTx;
 use namada_tx_env::Address;

--- a/crates/tx_prelude/src/token.rs
+++ b/crates/tx_prelude/src/token.rs
@@ -8,7 +8,7 @@ pub use namada_token::testing;
 pub use namada_token::tx::apply_shielded_transfer;
 pub use namada_token::{
     Amount, DenominatedAmount, Denomination, MaspDigitPos, Store, Transfer,
-    storage_key, utils,
+    storage_key, utils, validate_transfer_targets,
 };
 use namada_tx::BatchedTx;
 use namada_tx_env::Address;

--- a/wasm/tx_ibc/src/lib.rs
+++ b/wasm/tx_ibc/src/lib.rs
@@ -16,7 +16,7 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
         if let Some(transfers) = data.transparent {
             let (_debited_accounts, tokens) =
                 if let Some(transparent) = transfers.transparent_part() {
-                    token::validate_transfer_targets(
+                    token::validate_transfer_in_out(
                         transparent.sources,
                         transparent.targets,
                     )

--- a/wasm/tx_ibc/src/lib.rs
+++ b/wasm/tx_ibc/src/lib.rs
@@ -16,6 +16,12 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
         if let Some(transfers) = data.transparent {
             let (_debited_accounts, tokens) =
                 if let Some(transparent) = transfers.transparent_part() {
+                    token::validate_transfer_targets(
+                        transparent.sources,
+                        transparent.targets,
+                    )
+                    .map_err(Error::new_alloc)?;
+
                     token::apply_transparent_transfers(ctx, transparent)
                         .wrap_err("Transparent token transfer failed")?
                 } else {

--- a/wasm/tx_transfer/src/lib.rs
+++ b/wasm/tx_transfer/src/lib.rs
@@ -10,7 +10,7 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
         .wrap_err("Failed to decode token::TransparentTransfer tx data")?;
     debug_log!("apply_tx called with transfer: {:#?}", transfers);
 
-    token::validate_transfer_targets(&transfers.sources, &transfers.targets)
+    token::validate_transfer_in_out(&transfers.sources, &transfers.targets)
         .map_err(Error::new_alloc)?;
     token::multi_transfer(ctx, transfers, &tx_data)
 }

--- a/wasm/tx_transfer/src/lib.rs
+++ b/wasm/tx_transfer/src/lib.rs
@@ -10,5 +10,7 @@ fn apply_tx(ctx: &mut Ctx, tx_data: BatchedTx) -> TxResult {
         .wrap_err("Failed to decode token::TransparentTransfer tx data")?;
     debug_log!("apply_tx called with transfer: {:#?}", transfers);
 
+    token::validate_transfer_targets(&transfers.sources, &transfers.targets)
+        .map_err(Error::new_alloc)?;
     token::multi_transfer(ctx, transfers, &tx_data)
 }


### PR DESCRIPTION
## Describe your changes

Limit the number of unique transfer targets (sources + targets) to 20, in `tx_transfer` and `tx_ibc`.

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
