### PR TITLE
fix: remove redundant reads from governance vp

### DIFF
--- a/.changelog/unreleased/bug-fixes/4684-fix-gov-gas-cost.md
+++ b/.changelog/unreleased/bug-fixes/4684-fix-gov-gas-cost.md
@@ -1,0 +1,2 @@
+- Fixed the gov VP gas cost to match v101.0.0
+  ([\#4684](https://github.com/anoma/namada/pull/4684))

--- a/crates/governance/src/vp/mod.rs
+++ b/crates/governance/src/vp/mod.rs
@@ -1149,7 +1149,7 @@ impl KeyType {
             KeyType::COUNTER
         } else if gov_storage::is_parameter_key(key) {
             KeyType::PARAMETER
-        } else if let Some([token, &ADDRESS]) =
+        } else if let Some([token, _]) =
             TokenKeys::is_any_token_balance_key(key)
         {
             KeyType::BALANCE(token.clone())

--- a/crates/governance/src/vp/mod.rs
+++ b/crates/governance/src/vp/mod.rs
@@ -896,6 +896,9 @@ where
             ctx.pre().read(&balance_key)?.unwrap_or_default();
         let post_balance: token::Amount =
             Self::force_read(ctx, &balance_key, ReadType::Post)?;
+        let min_funds_parameter_key = gov_storage::get_min_proposal_fund_key();
+        let min_funds_parameter: token::Amount =
+            Self::force_read(ctx, &min_funds_parameter_key, ReadType::Pre)?;
 
         let is_valid_balance = if is_proposal {
             if !native_token_address.eq(token) {
@@ -903,19 +906,6 @@ where
                     "Governance deposit must be paid in native token",
                 ));
             }
-
-            let balance_key = TokenKeys::balance_key(token, &ADDRESS);
-            let min_funds_parameter_key =
-                gov_storage::get_min_proposal_fund_key();
-
-            let pre_balance: token::Amount =
-                ctx.pre().read(&balance_key)?.unwrap_or_default();
-
-            let min_funds_parameter: token::Amount =
-                Self::force_read(ctx, &min_funds_parameter_key, ReadType::Pre)?;
-            let post_balance: token::Amount =
-                Self::force_read(ctx, &balance_key, ReadType::Post)?;
-
             checked!(post_balance - pre_balance)? >= min_funds_parameter
         } else {
             post_balance >= pre_balance


### PR DESCRIPTION
## Describe your changes

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
