### PR TITLE
Don't update witness maps of unowned notes

### DIFF
--- a/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/dispatcher.rs
@@ -409,7 +409,11 @@ where
             if needs_witness_map_update
                 && Some(&masp_indexed_tx) > last_witnessed_tx.as_ref()
             {
-                self.ctx.update_witness_map(masp_indexed_tx, &stx_batch)?;
+                self.ctx.update_witness_map(
+                    masp_indexed_tx,
+                    &stx_batch,
+                    &self.cache.trial_decrypted,
+                )?;
             }
             let first_note_pos = self.ctx.note_index[&masp_indexed_tx];
             let mut vk_heights = BTreeMap::new();

--- a/crates/shielded_token/src/masp/shielded_sync/utils.rs
+++ b/crates/shielded_token/src/masp/shielded_sync/utils.rs
@@ -233,6 +233,11 @@ impl TrialDecrypted {
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
+
+    /// Check if the tx with  [`MaspIndexedTx`] was successfully decrypted
+    pub fn has_indexed_tx(&self, ix: &MaspIndexedTx) -> bool {
+        self.inner.contains_key(ix)
+    }
 }
 
 /// A cache of fetched indexed transactions.


### PR DESCRIPTION
## Describe your changes
When using the ledger client, we update witness maps manually. We now add notes to the witness map if there were successfully trial decrypted. 
## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
