### PR TITLE
Murisi/compress hw displays rebased

### DIFF
--- a/.changelog/unreleased/improvements/4436-compress-hw-displays.md
+++ b/.changelog/unreleased/improvements/4436-compress-hw-displays.md
@@ -1,0 +1,3 @@
+- Display payment addresses instead of extended full
+  viewing keys on the hardware wallet to save screen space.
+  ([\#4436](https://github.com/anoma/namada/pull/4436))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ env:
   AWS_REGION: us-west-2
   NIGHTLY: nightly-2025-03-27
   NAMADA_MASP_PARAMS_DIR: /masp/.masp-params
-  LEDGER_APP_VERSION: "3.0.4"
+  LEDGER_APP_VERSION: "3.0.7"
   ROLE: arn:aws:iam::375643557360:role/github-runners-ci-shared
   SCCACHE_ERROR_LOG: /tmp/sccache_log.txt
 

--- a/crates/sdk/src/signing.rs
+++ b/crates/sdk/src/signing.rs
@@ -18,9 +18,7 @@ use namada_core::arith::checked;
 use namada_core::collections::{HashMap, HashSet};
 use namada_core::ibc::primitives::IntoHostTime;
 use namada_core::key::*;
-use namada_core::masp::{
-    AssetData, ExtendedViewingKey, MaspTxId, PaymentAddress,
-};
+use namada_core::masp::{AssetData, MaspTxId, PaymentAddress};
 use namada_core::tendermint::Time as TmTime;
 use namada_core::time::DateTimeUtc;
 use namada_core::token::{Amount, DenominatedAmount};
@@ -837,8 +835,11 @@ async fn make_ledger_token_transfer_endpoints(
     }
     if let Some(builder) = builder {
         for sapling_input in builder.builder.sapling_inputs() {
-            let vk = ExtendedViewingKey::from(*sapling_input.key());
-            output.push(format!("Sender : {}", vk));
+            let pa = sapling_input.address().ok_or_else(|| {
+                Error::Other("unable to load vp code".to_string())
+            })?;
+            let pa = PaymentAddress::from(pa);
+            output.push(format!("Sender : {}", pa));
             make_ledger_amount_asset(
                 tokens,
                 output,


### PR DESCRIPTION
## Describe your changes
This PR was obtained by rebasing #4436 on `main` (ff17969251fbe98bbf43ed0eb5b71e1fd780a1b6). An attempt to reduce the amount of screens clicked through on the hardware wallet for shielded/unshielding transactions. This is done by displaying the payment address of a note as the sender (similar to what the Zcash Ledger app does) instead of the extended full viewing key that owns it. This reduces the number of screens required to display a sender from 8 to 3. I.e. there's now 5 less screens to click though, which reduces the amount of time required to sign a shielded transaction once the display lag is considered. Alternative options were considered like displaying just a full viewing key or an incoming viewing key instead of the extended full viewing key, but these do not already have bech32 encodings in Namada nor can they be used in any of the existing interfaces. See attached what the new test vectors would look like: [testvecs-fmted.json.gz](https://github.com/user-attachments/files/19145646/testvecs-fmted.json.gz) and [testdbgs.txt.gz](https://github.com/user-attachments/files/19145647/testdbgs.txt.gz).

## Checklist before merging 
- [ ] If this PR has some consensus breaking changes, I added the corresponding `breaking::` labels
    - This will require 2 reviewers to approve the changes
- [ ] If this PR requires changes to the docs or specs, a corresponding PR is opened in the `namada-docs` repo
    - Relevant PR if applies: 
- [ ] If this PR affects services such as `namada-indexer` or `namada-masp-indexer`, a corresponding PR is opened in that repo
    - Relevant PR if applies: 
